### PR TITLE
feat(board): navigation sidebar + Inbox page

### DIFF
--- a/apps/gctl-board/web/src/App.tsx
+++ b/apps/gctl-board/web/src/App.tsx
@@ -1,12 +1,15 @@
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { useProjects, useIssues } from "./hooks/useBoard"
 import { useProjectRoute } from "./hooks/useProjectRoute"
+import { useRoute } from "./hooks/useRoute"
 import { KanbanBoard } from "./components/KanbanBoard"
 import { IssueDetailPanel } from "./components/IssueDetailPanel"
 import { CreateIssueDialog } from "./components/CreateIssueDialog"
 import { ProjectSelector } from "./components/ProjectSelector"
+import { NavSidebar } from "./components/NavSidebar"
+import { InboxPage } from "./pages/InboxPage"
 import { api } from "./api/client"
-import type { Issue } from "./types"
+import type { Issue, InboxStats } from "./types"
 
 interface Toast {
   id: string
@@ -15,6 +18,7 @@ interface Toast {
 }
 
 export function App() {
+  const { route, navigate } = useRoute()
   const { projects, loading: projectsLoading, create: createProject } = useProjects()
   const { selectedProjectId, selectProject: setSelectedProjectId } = useProjectRoute(projects)
   const {
@@ -27,8 +31,24 @@ export function App() {
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [toasts, setToasts] = useState<Toast[]>([])
+  const [inboxStats, setInboxStats] = useState<InboxStats | null>(null)
   const issuesRef = useRef(issues)
   issuesRef.current = issues
+
+  // Fetch inbox unread count periodically
+  useEffect(() => {
+    let cancelled = false
+    const fetchStats = () => {
+      api.inbox.stats().then((stats) => {
+        if (!cancelled) setInboxStats(stats)
+      }).catch(() => {
+        // Inbox API may not be available yet — silently ignore
+      })
+    }
+    fetchStats()
+    const interval = setInterval(fetchStats, 30_000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
 
   const addToast = useCallback((message: string, type: "error" | "success" = "error") => {
     const id = crypto.randomUUID()
@@ -202,70 +222,95 @@ export function App() {
 
   const selectedProject = projects.find((p) => p.id === selectedProjectId)
 
-  return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-200 font-body grid-bg">
-      {/* ── Header ── */}
-      <header className="h-14 border-b border-zinc-800/80 flex items-center justify-between px-5 bg-zinc-950/90 backdrop-blur-sm sticky top-0 z-30">
-        <div className="flex items-center gap-4">
-          <h1 className="font-display font-semibold text-[15px] tracking-wider text-zinc-100 uppercase select-none">
-            gctl<span className="text-emerald-400">.</span>board
-          </h1>
-          <div className="w-px h-5 bg-zinc-800" />
-          <ProjectSelector
-            projects={projects}
-            selectedId={selectedProjectId}
-            onSelect={setSelectedProjectId}
-            onCreate={handleCreateProject}
-            loading={projectsLoading}
-          />
-        </div>
-        <div className="flex items-center gap-4">
-          {selectedProject && (
-            <span className="text-xs font-mono text-zinc-500 tracking-wide">
-              {selectedProject.key} / {issues.length} issues
-            </span>
-          )}
-          <button
-            onClick={() => setShowCreateDialog(true)}
-            disabled={!selectedProjectId}
-            className="px-3 py-1.5 text-[13px] font-display font-medium tracking-wide
-              bg-emerald-500/10 text-emerald-400 border border-emerald-500/25
-              hover:bg-emerald-500/20 hover:border-emerald-500/40
-              disabled:opacity-25 disabled:cursor-not-allowed
-              transition-all duration-150 cursor-pointer"
-          >
-            + NEW ISSUE
-          </button>
-        </div>
-      </header>
+  const pageTitle = route.page === "inbox" ? "inbox" : "board"
 
-      {/* ── Board ── */}
-      <KanbanBoard
-        issues={issues}
-        loading={issuesLoading}
-        hasProject={!!selectedProjectId}
-        onMoveIssue={handleMoveIssue}
-        onSelectIssue={setSelectedIssue}
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-200 font-body grid-bg flex">
+      {/* ── Nav Sidebar ── */}
+      <NavSidebar
+        route={route}
+        navigate={navigate}
+        unreadCount={inboxStats?.unread ?? 0}
       />
 
-      {/* ── Detail Panel ── */}
-      {selectedIssue && (
-        <IssueDetailPanel
-          issue={selectedIssue}
-          onClose={() => setSelectedIssue(null)}
-          onUpdate={refresh}
-        />
-      )}
+      {/* ── Main Content ── */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* ── Header ── */}
+        <header className="h-14 border-b border-zinc-800/80 flex items-center justify-between px-5 bg-zinc-950/90 backdrop-blur-sm sticky top-0 z-30">
+          <div className="flex items-center gap-4">
+            <h1 className="font-display font-semibold text-[15px] tracking-wider text-zinc-100 uppercase select-none">
+              gctl<span className="text-emerald-400">.</span>{pageTitle}
+            </h1>
+            {route.page === "board" && (
+              <>
+                <div className="w-px h-5 bg-zinc-800" />
+                <ProjectSelector
+                  projects={projects}
+                  selectedId={selectedProjectId}
+                  onSelect={setSelectedProjectId}
+                  onCreate={handleCreateProject}
+                  loading={projectsLoading}
+                />
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-4">
+            {route.page === "board" && selectedProject && (
+              <span className="text-xs font-mono text-zinc-500 tracking-wide">
+                {selectedProject.key} / {issues.length} issues
+              </span>
+            )}
+            {route.page === "board" && (
+              <button
+                onClick={() => setShowCreateDialog(true)}
+                disabled={!selectedProjectId}
+                className="px-3 py-1.5 text-[13px] font-display font-medium tracking-wide
+                  bg-emerald-500/10 text-emerald-400 border border-emerald-500/25
+                  hover:bg-emerald-500/20 hover:border-emerald-500/40
+                  disabled:opacity-25 disabled:cursor-not-allowed
+                  transition-all duration-150 cursor-pointer"
+              >
+                + NEW ISSUE
+              </button>
+            )}
+          </div>
+        </header>
 
-      {/* ── Create Dialog ── */}
-      {showCreateDialog && (
-        <CreateIssueDialog
-          onSubmit={handleCreateIssue}
-          onClose={() => setShowCreateDialog(false)}
-        />
-      )}
+        {/* ── Page Content ── */}
+        {route.page === "board" ? (
+          <>
+            {/* ── Board ── */}
+            <KanbanBoard
+              issues={issues}
+              loading={issuesLoading}
+              hasProject={!!selectedProjectId}
+              onMoveIssue={handleMoveIssue}
+              onSelectIssue={setSelectedIssue}
+            />
 
-      {/* Dispatch is now automatic — no dialog needed */}
+            {/* ── Detail Panel ── */}
+            {selectedIssue && (
+              <IssueDetailPanel
+                issue={selectedIssue}
+                onClose={() => setSelectedIssue(null)}
+                onUpdate={refresh}
+              />
+            )}
+
+            {/* ── Create Dialog ── */}
+            {showCreateDialog && (
+              <CreateIssueDialog
+                onSubmit={handleCreateIssue}
+                onClose={() => setShowCreateDialog(false)}
+              />
+            )}
+
+            {/* Dispatch is now automatic — no dialog needed */}
+          </>
+        ) : (
+          <InboxPage />
+        )}
+      </div>
 
       {/* ── Toasts ── */}
       <div className="fixed top-16 right-4 z-50 flex flex-col gap-2 pointer-events-none">

--- a/apps/gctl-board/web/src/api/client.ts
+++ b/apps/gctl-board/web/src/api/client.ts
@@ -1,4 +1,15 @@
-import type { Issue, Project, Comment, IssueEvent, TeamRecommendation, TeamRenderResult } from "../types"
+import type {
+  Issue,
+  Project,
+  Comment,
+  IssueEvent,
+  TeamRecommendation,
+  TeamRenderResult,
+  InboxMessage,
+  InboxThread,
+  InboxAction,
+  InboxStats,
+} from "../types"
 
 const BASE = "/api/board"
 
@@ -128,5 +139,68 @@ export const api = {
         body: JSON.stringify(body),
       })
     },
+  },
+
+  inbox: {
+    messages: (params?: {
+      status?: string
+      urgency?: string
+      kind?: string
+      project?: string
+      requires_action?: boolean
+      limit?: number
+    }) => {
+      const qs = new URLSearchParams()
+      if (params?.status) qs.set("status", params.status)
+      if (params?.urgency) qs.set("urgency", params.urgency)
+      if (params?.kind) qs.set("kind", params.kind)
+      if (params?.project) qs.set("project", params.project)
+      if (params?.requires_action !== undefined)
+        qs.set("requires_action", String(params.requires_action))
+      if (params?.limit !== undefined) qs.set("limit", String(params.limit))
+      const q = qs.toString()
+      return request<InboxMessage[]>(`/api/inbox/messages${q ? `?${q}` : ""}`)
+    },
+
+    getMessage: (id: string) => request<InboxMessage>(`/api/inbox/messages/${id}`),
+
+    threads: (params?: {
+      project?: string
+      has_pending?: boolean
+      limit?: number
+    }) => {
+      const qs = new URLSearchParams()
+      if (params?.project) qs.set("project", params.project)
+      if (params?.has_pending !== undefined)
+        qs.set("has_pending", String(params.has_pending))
+      if (params?.limit !== undefined) qs.set("limit", String(params.limit))
+      const q = qs.toString()
+      return request<InboxThread[]>(`/api/inbox/threads${q ? `?${q}` : ""}`)
+    },
+
+    getThread: (id: string) =>
+      request<InboxThread & { messages: InboxMessage[] }>(`/api/inbox/threads/${id}`),
+
+    createAction: (body: {
+      message_id: string
+      action_type: string
+      reason?: string
+    }) =>
+      request<InboxAction>("/api/inbox/actions", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+
+    batchAction: (body: {
+      message_ids: string[]
+      action_type: string
+      reason?: string
+    }) =>
+      request<InboxAction[]>("/api/inbox/actions/batch", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+
+    stats: () => request<InboxStats>("/api/inbox/stats"),
   },
 }

--- a/apps/gctl-board/web/src/components/MessageCard.tsx
+++ b/apps/gctl-board/web/src/components/MessageCard.tsx
@@ -1,0 +1,87 @@
+import type { InboxMessage } from "../types"
+
+const URGENCY_DOT: Record<string, string> = {
+  urgent: "#f43f5e",
+  high: "#f97316",
+  medium: "#fbbf24",
+  low: "#38bdf8",
+}
+
+const KIND_LABEL: Record<string, string> = {
+  permission_request: "Permission",
+  budget_warning: "Budget",
+  agent_question: "Question",
+  status_update: "Status",
+  error_report: "Error",
+  review_request: "Review",
+}
+
+interface Props {
+  message: InboxMessage
+  selected: boolean
+  onClick: () => void
+}
+
+export function MessageCard({ message, selected, onClick }: Props) {
+  const urgencyColor = URGENCY_DOT[message.urgency] ?? URGENCY_DOT.low
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full text-left px-3 py-2.5 border transition-all duration-100 cursor-pointer ${
+        selected
+          ? "bg-emerald-500/8 border-emerald-500/30"
+          : "bg-zinc-900/60 border-zinc-800/60 hover:border-zinc-700 hover:bg-zinc-900"
+      }`}
+    >
+      {/* Top row: urgency dot + title + time */}
+      <div className="flex items-start gap-2">
+        <span
+          className="w-2 h-2 rounded-full mt-1.5 shrink-0"
+          style={{ backgroundColor: urgencyColor }}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <p className={`text-[13px] leading-snug line-clamp-1 font-medium ${
+              message.status === "unread" ? "text-zinc-100" : "text-zinc-400"
+            }`}>
+              {message.title}
+            </p>
+            {message.requires_action && (
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0"
+                title="Requires action"
+              />
+            )}
+          </div>
+
+          {/* Second row: source + kind badge + time */}
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-[11px] font-mono text-zinc-500 truncate">
+              {message.source_name}
+            </span>
+            <span className="text-[10px] font-mono px-1.5 py-0.5 bg-zinc-800/80 text-zinc-500 border border-zinc-700/40 leading-none">
+              {KIND_LABEL[message.kind] ?? message.kind}
+            </span>
+            <span className="text-[10px] font-mono text-zinc-600 ml-auto shrink-0">
+              {formatTimeAgo(message.created_at)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function formatTimeAgo(iso: string): string {
+  const now = Date.now()
+  const then = new Date(iso).getTime()
+  const diffSec = Math.floor((now - then) / 1000)
+
+  if (diffSec < 60) return "now"
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d`
+  return new Date(iso).toLocaleDateString()
+}

--- a/apps/gctl-board/web/src/components/MessageDetail.tsx
+++ b/apps/gctl-board/web/src/components/MessageDetail.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react"
+import type { InboxMessage } from "../types"
+
+const URGENCY_DOT: Record<string, string> = {
+  urgent: "#f43f5e",
+  high: "#f97316",
+  medium: "#fbbf24",
+  low: "#38bdf8",
+}
+
+const URGENCY_LABEL: Record<string, string> = {
+  urgent: "Urgent",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+}
+
+const KIND_LABEL: Record<string, string> = {
+  permission_request: "Permission Request",
+  budget_warning: "Budget Warning",
+  agent_question: "Agent Question",
+  status_update: "Status Update",
+  error_report: "Error Report",
+  review_request: "Review Request",
+}
+
+interface Props {
+  message: InboxMessage
+  onAction: (actionType: string, reason?: string) => Promise<void>
+}
+
+export function MessageDetail({ message, onAction }: Props) {
+  const [acting, setActing] = useState<string | null>(null)
+  const [contextOpen, setContextOpen] = useState(false)
+
+  const urgencyColor = URGENCY_DOT[message.urgency] ?? URGENCY_DOT.low
+
+  const handleAction = async (actionType: string) => {
+    if (acting) return
+    setActing(actionType)
+    try {
+      await onAction(actionType)
+    } finally {
+      setActing(null)
+    }
+  }
+
+  const contextEntries = message.context ? Object.entries(message.context) : []
+
+  return (
+    <div className="flex flex-col h-full animate-fade-in">
+      {/* Header */}
+      <div className="px-5 py-4 border-b border-zinc-800/50 shrink-0">
+        <div className="flex items-center gap-2 mb-2">
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: urgencyColor }}
+          />
+          <span className="text-[10px] font-mono text-zinc-500 uppercase tracking-wider">
+            {URGENCY_LABEL[message.urgency] ?? message.urgency}
+          </span>
+          <span className="text-zinc-800">|</span>
+          <span className="text-[10px] font-mono text-zinc-500 uppercase tracking-wider">
+            {KIND_LABEL[message.kind] ?? message.kind}
+          </span>
+          {message.requires_action && (
+            <>
+              <span className="text-zinc-800">|</span>
+              <span className="text-[10px] font-mono text-emerald-400/80 uppercase tracking-wider">
+                Action Required
+              </span>
+            </>
+          )}
+        </div>
+        <h2 className="text-lg font-display font-semibold text-zinc-100 leading-snug">
+          {message.title}
+        </h2>
+        <div className="flex items-center gap-3 mt-2 text-[11px] text-zinc-500 font-mono">
+          <span>from {message.source_name}</span>
+          <span className="text-zinc-700">{message.source_type}</span>
+          <span className="ml-auto text-zinc-600">
+            {new Date(message.created_at).toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-5 py-4 space-y-4">
+          {/* Message body */}
+          <div>
+            <p className="text-sm text-zinc-300 leading-relaxed whitespace-pre-wrap">
+              {message.body}
+            </p>
+          </div>
+
+          {/* Context section */}
+          {contextEntries.length > 0 && (
+            <div className="border border-zinc-800/50">
+              <button
+                type="button"
+                onClick={() => setContextOpen(!contextOpen)}
+                className="w-full flex items-center justify-between px-3 py-2 text-[10px] font-mono text-zinc-500 uppercase tracking-wider hover:text-zinc-400 transition-colors cursor-pointer"
+              >
+                <span>Context ({contextEntries.length} fields)</span>
+                <svg
+                  className={`w-3.5 h-3.5 transition-transform duration-150 ${contextOpen ? "rotate-180" : ""}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="square" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {contextOpen && (
+                <div className="border-t border-zinc-800/50 px-3 py-2 space-y-1.5">
+                  {contextEntries.map(([key, value]) => (
+                    <div key={key} className="flex items-start gap-3">
+                      <span className="text-[11px] font-mono text-zinc-600 shrink-0 w-32 truncate">
+                        {key}
+                      </span>
+                      <span className="text-[11px] font-mono text-zinc-400 break-all">
+                        {typeof value === "object" ? JSON.stringify(value) : String(value)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Thread ID reference */}
+          {message.thread_id && (
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] font-mono text-zinc-600 uppercase tracking-wider">Thread</span>
+              <span className="text-xs font-mono text-emerald-400/70 bg-emerald-500/10 px-1.5 py-0.5 border border-emerald-500/20">
+                {message.thread_id}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Action bar */}
+      <div className="px-5 py-3 border-t border-zinc-800/50 flex items-center gap-2 shrink-0">
+        <ActionButton
+          label="Approve"
+          actionType="approve"
+          acting={acting}
+          onClick={handleAction}
+          className="bg-emerald-500/10 text-emerald-400 border-emerald-500/25 hover:bg-emerald-500/20"
+        />
+        <ActionButton
+          label="Reject"
+          actionType="reject"
+          acting={acting}
+          onClick={handleAction}
+          className="bg-rose-500/10 text-rose-400 border-rose-500/25 hover:bg-rose-500/20"
+        />
+        <ActionButton
+          label="Acknowledge"
+          actionType="acknowledge"
+          acting={acting}
+          onClick={handleAction}
+          className="bg-zinc-500/10 text-zinc-400 border-zinc-500/25 hover:bg-zinc-500/20"
+        />
+        <ActionButton
+          label="Snooze"
+          actionType="snooze"
+          acting={acting}
+          onClick={handleAction}
+          className="bg-amber-500/10 text-amber-400 border-amber-500/25 hover:bg-amber-500/20"
+        />
+      </div>
+    </div>
+  )
+}
+
+function ActionButton({
+  label,
+  actionType,
+  acting,
+  onClick,
+  className,
+}: {
+  label: string
+  actionType: string
+  acting: string | null
+  onClick: (actionType: string) => void
+  className: string
+}) {
+  const isActive = acting === actionType
+  const isDisabled = acting !== null
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(actionType)}
+      disabled={isDisabled}
+      className={`px-3 py-1.5 text-[13px] font-display font-medium tracking-wide border transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed ${className}`}
+    >
+      {isActive ? `${label.toUpperCase()}...` : label.toUpperCase()}
+    </button>
+  )
+}

--- a/apps/gctl-board/web/src/components/NavSidebar.tsx
+++ b/apps/gctl-board/web/src/components/NavSidebar.tsx
@@ -1,0 +1,91 @@
+import type { Route } from "../hooks/useRoute"
+
+interface NavSidebarProps {
+  route: Route
+  navigate: (path: string) => void
+  unreadCount: number
+}
+
+function BoardIcon({ active }: { active: boolean }) {
+  const color = active ? "text-emerald-400" : "text-zinc-500"
+  return (
+    <svg
+      className={`w-5 h-5 ${color} transition-colors duration-150`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      {/* 2x2 grid icon */}
+      <rect x="2" y="2" width="7" height="7" rx="1.5" />
+      <rect x="11" y="2" width="7" height="7" rx="1.5" />
+      <rect x="2" y="11" width="7" height="7" rx="1.5" />
+      <rect x="11" y="11" width="7" height="7" rx="1.5" />
+    </svg>
+  )
+}
+
+function InboxIcon({ active }: { active: boolean }) {
+  const color = active ? "text-emerald-400" : "text-zinc-500"
+  return (
+    <svg
+      className={`w-5 h-5 ${color} transition-colors duration-150`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      {/* Envelope icon */}
+      <path d="M2 5a2 2 0 012-2h12a2 2 0 012 2v1.2l-8 4.8-8-4.8V5z" />
+      <path d="M2 8.2l8 4.8 8-4.8V15a2 2 0 01-2 2H4a2 2 0 01-2-2V8.2z" />
+    </svg>
+  )
+}
+
+function GctlMark() {
+  return (
+    <div className="flex items-center justify-center">
+      <svg className="w-6 h-6 text-zinc-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 3v18M3 12h18" strokeOpacity="0.4" />
+        <circle cx="12" cy="12" r="3" fill="currentColor" fillOpacity="0.6" stroke="none" />
+      </svg>
+    </div>
+  )
+}
+
+export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
+  const isBoardActive = route.page === "board"
+  const isInboxActive = route.page === "inbox"
+
+  return (
+    <nav className="w-14 min-h-screen bg-zinc-950 border-r border-zinc-800 flex flex-col items-center py-4 gap-1 shrink-0">
+      {/* Board nav item */}
+      <button
+        onClick={() => navigate("/")}
+        className={`w-10 h-10 flex items-center justify-center rounded-md transition-all duration-150 cursor-pointer
+          ${isBoardActive ? "bg-emerald-500/10" : "hover:bg-zinc-800/60"}`}
+        title="Board"
+      >
+        <BoardIcon active={isBoardActive} />
+      </button>
+
+      {/* Inbox nav item */}
+      <button
+        onClick={() => navigate("/inbox")}
+        className={`w-10 h-10 flex items-center justify-center rounded-md transition-all duration-150 cursor-pointer relative
+          ${isInboxActive ? "bg-emerald-500/10" : "hover:bg-zinc-800/60"}`}
+        title="Inbox"
+      >
+        <InboxIcon active={isInboxActive} />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-emerald-500 text-zinc-950 text-[10px] font-mono font-bold leading-none">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Logo mark at bottom */}
+      <GctlMark />
+    </nav>
+  )
+}

--- a/apps/gctl-board/web/src/hooks/useInbox.ts
+++ b/apps/gctl-board/web/src/hooks/useInbox.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useCallback } from "react"
+import type { InboxMessage, InboxThread, InboxStats } from "../types"
+import { api } from "../api/client"
+
+interface UseInboxFilters {
+  status?: string
+  urgency?: string
+  kind?: string
+}
+
+interface UseInboxResult {
+  messages: InboxMessage[]
+  threads: InboxThread[]
+  stats: InboxStats | null
+  loading: boolean
+  refresh: () => void
+  createAction: (messageId: string, actionType: string, reason?: string) => Promise<void>
+  batchAction: (messageIds: string[], actionType: string, reason?: string) => Promise<void>
+}
+
+export function useInbox(filters?: UseInboxFilters): UseInboxResult {
+  const [messages, setMessages] = useState<InboxMessage[]>([])
+  const [threads, setThreads] = useState<InboxThread[]>([])
+  const [stats, setStats] = useState<InboxStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [revision, setRevision] = useState(0)
+
+  const refresh = useCallback(() => setRevision((r) => r + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+
+    const params: Record<string, string> = {}
+    if (filters?.status) params.status = filters.status
+    if (filters?.urgency) params.urgency = filters.urgency
+    if (filters?.kind) params.kind = filters.kind
+
+    Promise.all([
+      api.inbox.messages(params),
+      api.inbox.threads(params),
+      api.inbox.stats(),
+    ])
+      .then(([msgs, thrds, st]) => {
+        if (cancelled) return
+        setMessages(msgs)
+        setThreads(thrds)
+        setStats(st)
+      })
+      .catch(() => {
+        // errors surfaced via empty state
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [filters?.status, filters?.urgency, filters?.kind, revision])
+
+  const createAction = useCallback(
+    async (messageId: string, actionType: string, reason?: string) => {
+      await api.inbox.createAction({ message_id: messageId, action_type: actionType, reason })
+      refresh()
+    },
+    [refresh]
+  )
+
+  const batchAction = useCallback(
+    async (messageIds: string[], actionType: string, reason?: string) => {
+      await api.inbox.batchAction({ message_ids: messageIds, action_type: actionType, reason })
+      refresh()
+    },
+    [refresh]
+  )
+
+  return { messages, threads, stats, loading, refresh, createAction, batchAction }
+}

--- a/apps/gctl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctl-board/web/src/hooks/useRoute.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback, useEffect } from "react"
+
+export type Route =
+  | { page: "board"; projectKey: string | null }
+  | { page: "inbox"; threadId: string | null }
+
+function parseRoute(pathname: string): Route {
+  // /inbox/:threadId
+  const inboxThread = pathname.match(/^\/inbox\/([^/]+)/)
+  if (inboxThread) {
+    return { page: "inbox", threadId: inboxThread[1] }
+  }
+
+  // /inbox
+  if (pathname === "/inbox" || pathname === "/inbox/") {
+    return { page: "inbox", threadId: null }
+  }
+
+  // /projects/:key
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)/)
+  if (projectMatch) {
+    return { page: "board", projectKey: projectMatch[1] }
+  }
+
+  // / or anything else — board with no project selected
+  return { page: "board", projectKey: null }
+}
+
+export function useRoute(): { route: Route; navigate: (path: string) => void } {
+  const [route, setRoute] = useState<Route>(() => parseRoute(window.location.pathname))
+
+  const navigate = useCallback((path: string) => {
+    window.history.pushState(null, "", path)
+    setRoute(parseRoute(path))
+  }, [])
+
+  useEffect(() => {
+    const onPopState = () => {
+      setRoute(parseRoute(window.location.pathname))
+    }
+    window.addEventListener("popstate", onPopState)
+    return () => window.removeEventListener("popstate", onPopState)
+  }, [])
+
+  return { route, navigate }
+}

--- a/apps/gctl-board/web/src/pages/InboxPage.tsx
+++ b/apps/gctl-board/web/src/pages/InboxPage.tsx
@@ -1,0 +1,196 @@
+import { useState, useCallback } from "react"
+import { useInbox } from "../hooks/useInbox"
+import { MessageCard } from "../components/MessageCard"
+import { MessageDetail } from "../components/MessageDetail"
+import type { InboxMessage } from "../types"
+
+const URGENCY_OPTIONS = [
+  { value: "", label: "All urgency" },
+  { value: "urgent", label: "Urgent" },
+  { value: "high", label: "High" },
+  { value: "medium", label: "Medium" },
+  { value: "low", label: "Low" },
+]
+
+const KIND_OPTIONS = [
+  { value: "", label: "All kinds" },
+  { value: "permission_request", label: "Permission Request" },
+  { value: "budget_warning", label: "Budget Warning" },
+  { value: "agent_question", label: "Agent Question" },
+  { value: "status_update", label: "Status Update" },
+  { value: "error_report", label: "Error Report" },
+  { value: "review_request", label: "Review Request" },
+]
+
+const STATUS_OPTIONS = [
+  { value: "", label: "All status" },
+  { value: "unread", label: "Unread" },
+  { value: "acknowledged", label: "Acknowledged" },
+  { value: "resolved", label: "Resolved" },
+]
+
+export function InboxPage() {
+  const [urgencyFilter, setUrgencyFilter] = useState("")
+  const [kindFilter, setKindFilter] = useState("")
+  const [statusFilter, setStatusFilter] = useState("")
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const filters = {
+    urgency: urgencyFilter || undefined,
+    kind: kindFilter || undefined,
+    status: statusFilter || undefined,
+  }
+
+  const { messages, stats, loading, createAction } = useInbox(filters)
+
+  const selectedMessage = messages.find((m) => m.id === selectedId) ?? null
+
+  const handleSelectMessage = useCallback((msg: InboxMessage) => {
+    setSelectedId(msg.id)
+  }, [])
+
+  const handleAction = useCallback(
+    async (actionType: string, reason?: string) => {
+      if (!selectedMessage) return
+      await createAction(selectedMessage.id, actionType, reason)
+    },
+    [selectedMessage, createAction]
+  )
+
+  const unreadCount = stats?.unread ?? 0
+  const actionCount = stats?.requires_action ?? 0
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="shrink-0 px-5 py-3 border-b border-zinc-800/80 bg-zinc-950/90 backdrop-blur-sm">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <h1 className="font-display font-semibold text-[15px] tracking-wider text-zinc-100 uppercase">
+              Inbox
+            </h1>
+            {stats && (
+              <span className="text-xs font-mono text-zinc-500 tracking-wide">
+                {unreadCount > 0 && (
+                  <span className="text-zinc-400">{unreadCount} unread</span>
+                )}
+                {unreadCount > 0 && actionCount > 0 && (
+                  <span className="text-zinc-700"> {"\u00b7"} </span>
+                )}
+                {actionCount > 0 && (
+                  <span className="text-amber-400/80">{actionCount} require action</span>
+                )}
+                {unreadCount === 0 && actionCount === 0 && (
+                  <span className="text-zinc-600">all clear</span>
+                )}
+              </span>
+            )}
+          </div>
+          <span className="text-xs font-mono text-zinc-600">
+            {messages.length} message{messages.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+
+        {/* Filter bar */}
+        <div className="flex items-center gap-2">
+          <FilterSelect
+            options={URGENCY_OPTIONS}
+            value={urgencyFilter}
+            onChange={setUrgencyFilter}
+          />
+          <FilterSelect
+            options={KIND_OPTIONS}
+            value={kindFilter}
+            onChange={setKindFilter}
+          />
+          <FilterSelect
+            options={STATUS_OPTIONS}
+            value={statusFilter}
+            onChange={setStatusFilter}
+          />
+        </div>
+      </div>
+
+      {/* Two-panel layout */}
+      <div className="flex flex-1 min-h-0">
+        {/* Left panel: message list */}
+        <div className="w-80 shrink-0 border-r border-zinc-800/60 overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center gap-3 p-5">
+              <div className="w-4 h-4 border-2 border-emerald-500/30 border-t-emerald-400 rounded-full animate-spin" />
+              <span className="text-sm text-zinc-400 font-mono">Loading messages...</span>
+            </div>
+          ) : messages.length === 0 ? (
+            <div className="p-5 text-center">
+              <div className="text-sm text-zinc-500 font-mono">No messages</div>
+              <div className="text-xs text-zinc-600 mt-1">
+                {urgencyFilter || kindFilter || statusFilter
+                  ? "Try adjusting your filters"
+                  : "Inbox is empty"}
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {messages.map((msg) => (
+                <MessageCard
+                  key={msg.id}
+                  message={msg}
+                  selected={msg.id === selectedId}
+                  onClick={() => handleSelectMessage(msg)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Right panel: message detail */}
+        <div className="flex-1 min-w-0 overflow-hidden">
+          {selectedMessage ? (
+            <MessageDetail
+              message={selectedMessage}
+              onAction={handleAction}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center space-y-2">
+                <div className="text-zinc-700">
+                  <svg className="w-10 h-10 mx-auto" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M2 5a2 2 0 012-2h12a2 2 0 012 2v1.2l-8 4.8-8-4.8V5z" />
+                    <path d="M2 8.2l8 4.8 8-4.8V15a2 2 0 01-2 2H4a2 2 0 01-2-2V8.2z" />
+                  </svg>
+                </div>
+                <p className="text-sm font-mono text-zinc-600">
+                  Select a message to view details
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FilterSelect({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: string; label: string }[]
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="px-2 py-1 text-[12px] font-mono bg-zinc-900 border border-zinc-800 text-zinc-400 focus:border-emerald-500/40 focus:outline-none appearance-none cursor-pointer hover:border-zinc-700 transition-colors"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/apps/gctl-board/web/src/types.ts
+++ b/apps/gctl-board/web/src/types.ts
@@ -122,3 +122,56 @@ export interface RenderedPrompt {
 export interface TeamRenderResult {
   agents: RenderedPrompt[]
 }
+
+/* ── Inbox types ── */
+
+export interface InboxMessage {
+  id: string
+  thread_id: string
+  source: string
+  kind: string
+  urgency: string
+  title: string
+  body?: string
+  context: Record<string, unknown>
+  status: string
+  requires_action: boolean
+  payload?: Record<string, unknown>
+  duplicate_count: number
+  snoozed_until?: string
+  expires_at?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface InboxThread {
+  id: string
+  context_type: string
+  context_ref: string
+  title: string
+  project_key?: string
+  pending_count: number
+  latest_urgency: string
+  created_at: string
+  updated_at: string
+}
+
+export interface InboxAction {
+  id: string
+  message_id: string
+  thread_id: string
+  actor_id: string
+  actor_name: string
+  action_type: string
+  reason?: string
+  metadata?: Record<string, unknown>
+  created_at: string
+}
+
+export interface InboxStats {
+  total: number
+  unread: number
+  requires_action: number
+  by_urgency: Record<string, number>
+  by_kind: Record<string, number>
+}


### PR DESCRIPTION
## Summary

Closes #6 — adds navigation sidebar and Inbox page to gctl-board web UI.

- **NavSidebar**: collapsed left sidebar (`w-14`) with Board and Inbox icons, active state highlighting (emerald-400), unread count badge polling from `/api/inbox/stats`
- **SPA routing**: `useRoute` hook with `history.pushState` — supports `/`, `/projects/:key`, `/inbox`, `/inbox/:threadId`
- **InboxPage**: two-panel layout with filter bar (urgency/kind/status dropdowns), scrollable message list (left), message detail with action buttons (right)
- **MessageCard**: urgency-colored dot, title, source, kind badge, time ago, action-required indicator
- **MessageDetail**: full message content, collapsible context metadata, Approve/Reject/Acknowledge/Snooze action buttons with loading states
- **API client**: `api.inbox.*` namespace with 7 endpoints consuming kernel `/api/inbox/*` routes
- **Types**: `InboxMessage`, `InboxThread`, `InboxAction`, `InboxStats` matching kernel `gctl-core` structs

### Architecture

```
NavSidebar ─┬─ Board page (existing kanban)
             └─ Inbox page (new)
                  ├── useInbox hook → /api/inbox/*
                  ├── MessageCard (list)
                  └── MessageDetail (actions → POST /api/inbox/actions)
```

## Test plan
- [ ] Navigate between Board and Inbox via sidebar
- [ ] `/inbox` route loads Inbox page with filters
- [ ] Messages render with urgency colors and kind badges
- [ ] Approve/Reject/Acknowledge actions call kernel API and refresh list
- [ ] Unread badge on sidebar updates from inbox stats polling
- [x] `pnpm build:web` passes (verified locally)
- [ ] Back/forward browser navigation works (popstate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
