### PR TITLE
feat(sync): consolidated spec + implement gctl-sync crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ test-results/
 .obsidian
 .DS_Store
 .nx/
-.wrangler/
+**/.wrangler/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,20 +139,55 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ec52ba94edeed950e4a41f75d35376df196e8cb04437f7280a5aa49f20f796"
+dependencies = [
+ "arrow-arith 54.3.1",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-csv",
+ "arrow-data 54.3.1",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord 54.3.1",
+ "arrow-row 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "arrow-string 54.3.1",
+]
+
+[[package]]
+name = "arrow"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "arrow-string 57.3.0",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "num",
 ]
 
 [[package]]
@@ -146,12 +196,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
 ]
 
 [[package]]
@@ -161,15 +227,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -186,16 +263,36 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -207,16 +304,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
+dependencies = [
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-data"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "half",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ff528658b521e33905334723b795ee56b393dbe9cf76c8b1f64b648c65a60c"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "num",
+ "serde",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a3334a743bd2a1479dbc635540617a3923b4b2f6870f37357339e6b5363c21"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
 ]
 
 [[package]]
@@ -225,11 +398,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1d7a7291d2c5107e92140f75257a99343956871f3d3ab33a7b41532f79cb68"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
 ]
 
 [[package]]
@@ -238,12 +424,18 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "half",
 ]
+
+[[package]]
+name = "arrow-schema"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 
 [[package]]
 name = "arrow-schema"
@@ -256,16 +448,47 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21546b337ab304a32cfc0770f671db7411787586b45b78b4593ae78e64e2b03"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -274,11 +497,11 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "memchr",
  "num-traits",
  "regex",
@@ -436,6 +659,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -682,6 +926,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,7 +1031,7 @@ version = "1.10500.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a2048e4963a37ec458d9e93444192e0e949ac0a188d201ea53472f2c42db822"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -842,6 +1107,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -1170,14 +1445,21 @@ dependencies = [
 name = "gctl-sync"
 version = "0.1.0"
 dependencies = [
+ "arrow 54.3.1",
+ "async-trait",
  "chrono",
+ "duckdb",
  "gctl-core",
  "gctl-storage",
+ "parquet",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1752,6 +2034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2460,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2498,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2263,6 +2596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2626,45 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-ipc",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.5",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash 1.6.3",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2918,6 +3299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3653,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3492,6 +3900,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -3745,6 +4164,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -4612,4 +5047,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/kernel/crates/gctl-core/src/config.rs
+++ b/kernel/crates/gctl-core/src/config.rs
@@ -80,7 +80,12 @@ pub struct SyncConfig {
     pub enabled: bool,
     pub r2_bucket: String,
     pub r2_endpoint: String,
+    pub r2_access_key_id: String,
+    pub r2_secret_access_key: String,
     pub interval_seconds: u64,
+    pub device_id: String,
+    #[serde(default)]
+    pub auto_pull: bool,
 }
 
 impl Default for SyncConfig {
@@ -89,7 +94,11 @@ impl Default for SyncConfig {
             enabled: false,
             r2_bucket: String::new(),
             r2_endpoint: String::new(),
+            r2_access_key_id: String::new(),
+            r2_secret_access_key: String::new(),
             interval_seconds: 300,
+            device_id: String::new(),
+            auto_pull: false,
         }
     }
 }

--- a/kernel/crates/gctl-core/src/types.rs
+++ b/kernel/crates/gctl-core/src/types.rs
@@ -220,6 +220,72 @@ impl PolicyDecision {
     }
 }
 
+// --- Sync ---
+
+/// Summary of a single push or pull operation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncResult {
+    /// Number of rows exported/imported per table.
+    pub tables: Vec<SyncTableResult>,
+    /// Total rows across all tables.
+    pub total_rows: u64,
+    /// Parquet files written or downloaded.
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncTableResult {
+    pub table: String,
+    pub row_count: u64,
+    pub parquet_path: String,
+}
+
+/// Current sync state for the `gctl sync status` command.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncStatus {
+    pub enabled: bool,
+    pub device_id: String,
+    pub pending_rows: SyncPendingRows,
+    pub last_push: Option<SyncEvent>,
+    pub last_pull: Option<SyncEvent>,
+    pub r2_reachable: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncPendingRows {
+    pub sessions: u64,
+    pub spans: u64,
+    pub traffic: u64,
+    pub tasks: u64,
+    pub context: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncEvent {
+    pub timestamp: DateTime<Utc>,
+    pub push_id: String,
+    pub total_rows: u64,
+}
+
+/// A single entry in the sync manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncManifestEntry {
+    pub push_id: String,
+    pub device_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub tables: Vec<SyncTableResult>,
+}
+
+/// The full sync manifest (local + R2).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncManifest {
+    pub workspace_id: String,
+    pub device_id: String,
+    pub pushes: Vec<SyncManifestEntry>,
+    pub last_pull: Option<SyncEvent>,
+    pub context_hashes: Vec<String>,
+}
+
 // --- Scores ---
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Score {

--- a/kernel/crates/gctl-sync/Cargo.toml
+++ b/kernel/crates/gctl-sync/Cargo.toml
@@ -12,3 +12,12 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+uuid = { workspace = true }
+async-trait = { workspace = true }
+arrow = { workspace = true }
+parquet = { workspace = true }
+reqwest = { workspace = true }
+duckdb = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/kernel/crates/gctl-sync/src/engine.rs
+++ b/kernel/crates/gctl-sync/src/engine.rs
@@ -1,0 +1,424 @@
+//! SyncEngine — orchestrates Parquet export, R2 upload/download, and manifest tracking.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use duckdb::Connection;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use gctl_core::{
+    SyncConfig, SyncManifest, SyncManifestEntry, SyncPendingRows, SyncResult, SyncStatus,
+    SyncTableResult,
+};
+
+use crate::manifest;
+use crate::parquet_export::{self, SYNCABLE_TABLES};
+use crate::r2::R2Client;
+use crate::SyncError;
+
+/// Port: sync engine operations.
+#[async_trait]
+pub trait SyncEngine: Send + Sync {
+    /// Export unsynced rows to Parquet, upload to R2, mark synced.
+    async fn push(&self, tables: &[&str]) -> Result<SyncResult, SyncError>;
+
+    /// Download new Parquet files from R2, insert into local DuckDB.
+    async fn pull(&self, tables: &[&str]) -> Result<SyncResult, SyncError>;
+
+    /// Show sync state: pending rows, last push/pull, R2 connectivity.
+    async fn status(&self) -> Result<SyncStatus, SyncError>;
+}
+
+/// R2-backed sync engine.
+pub struct R2SyncEngine {
+    conn: Mutex<Connection>,
+    r2: R2Client,
+    config: SyncConfig,
+    sync_dir: PathBuf,
+    workspace_id: String,
+}
+
+impl R2SyncEngine {
+    /// Create a new sync engine.
+    ///
+    /// `conn` — DuckDB connection (shared with the daemon; caller manages locking).
+    /// `config` — sync configuration (bucket, endpoint, credentials, device_id).
+    /// `sync_dir` — local staging directory for Parquet files.
+    /// `workspace_id` — workspace identifier for R2 path partitioning.
+    pub fn new(
+        conn: Connection,
+        config: SyncConfig,
+        sync_dir: PathBuf,
+        workspace_id: String,
+    ) -> Self {
+        let r2 = R2Client::new(
+            &config.r2_endpoint,
+            &config.r2_bucket,
+            &config.r2_access_key_id,
+            &config.r2_secret_access_key,
+        );
+        Self {
+            conn: Mutex::new(conn),
+            r2,
+            config,
+            sync_dir,
+            workspace_id,
+        }
+    }
+
+    /// Resolve which tables to sync: if `tables` is empty, use all syncable tables.
+    fn resolve_tables<'a>(&self, tables: &'a [&'a str]) -> Vec<&'a str> {
+        if tables.is_empty() {
+            SYNCABLE_TABLES.to_vec()
+        } else {
+            tables.to_vec()
+        }
+    }
+
+    /// Build the R2 key for a Parquet file.
+    fn r2_key(&self, device_id: &str, table: &str, date: &str, push_id: &str) -> String {
+        format!("{ws}/{dev}/{table}/{date}/{push_id}.parquet",
+            ws = self.workspace_id,
+            dev = device_id,
+        )
+    }
+}
+
+#[async_trait]
+impl SyncEngine for R2SyncEngine {
+    async fn push(&self, tables: &[&str]) -> Result<SyncResult, SyncError> {
+        let tables = self.resolve_tables(tables);
+        let push_id = Uuid::new_v4().to_string();
+        let date = Utc::now().format("%Y-%m-%d").to_string();
+        let device_id = &self.config.device_id;
+
+        let mut result = SyncResult::default();
+        let mut table_results = Vec::new();
+
+        for &table in &tables {
+            let local_path = parquet_export::staging_path(
+                &self.sync_dir,
+                device_id,
+                table,
+                &date,
+                &push_id,
+            );
+
+            // Export unsynced rows to Parquet.
+            let count = {
+                let conn = self.conn.lock().unwrap();
+                parquet_export::export_table(&conn, table, &local_path)?
+            };
+
+            if count == 0 {
+                continue;
+            }
+
+            // Upload to R2.
+            let r2_key = self.r2_key(device_id, table, &date, &push_id);
+            self.r2.upload_file(&r2_key, &local_path).await?;
+
+            // Mark rows as synced.
+            {
+                let conn = self.conn.lock().unwrap();
+                parquet_export::mark_synced(&conn, table)?;
+            }
+
+            info!(table, count, r2_key, "pushed to R2");
+            result.total_rows += count;
+            result.files.push(r2_key.clone());
+            table_results.push(SyncTableResult {
+                table: table.to_string(),
+                row_count: count,
+                parquet_path: r2_key,
+            });
+        }
+
+        // Update manifest.
+        if !table_results.is_empty() {
+            let mut manifest = manifest::load_local(
+                &self.sync_dir,
+                &self.workspace_id,
+                device_id,
+            )
+            .await?;
+
+            let entry = SyncManifestEntry {
+                push_id,
+                device_id: device_id.clone(),
+                timestamp: Utc::now(),
+                tables: table_results.clone(),
+            };
+            manifest::record_push(&mut manifest, entry);
+            manifest::save_local(&self.sync_dir, &manifest).await?;
+        }
+
+        result.tables = table_results;
+        Ok(result)
+    }
+
+    async fn pull(&self, tables: &[&str]) -> Result<SyncResult, SyncError> {
+        let tables = self.resolve_tables(tables);
+        let device_id = &self.config.device_id;
+
+        // Load remote manifest.
+        let manifest_key = format!("{}/manifest.json", self.workspace_id);
+        let manifest_bytes = match self.r2.get_object(&manifest_key).await {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                warn!("no remote manifest found, nothing to pull");
+                return Ok(SyncResult::default());
+            }
+        };
+
+        let remote_manifest: SyncManifest = serde_json::from_slice(&manifest_bytes)
+            .map_err(|e| SyncError::Manifest(format!("parse remote manifest: {e}")))?;
+
+        // Load local manifest to find watermark.
+        let local_manifest = manifest::load_local(
+            &self.sync_dir,
+            &self.workspace_id,
+            device_id,
+        )
+        .await?;
+
+        let last_pull_ts = local_manifest
+            .last_pull
+            .as_ref()
+            .map(|e| e.timestamp);
+
+        let mut result = SyncResult::default();
+
+        // Download and import Parquet files from other devices.
+        for push_entry in &remote_manifest.pushes {
+            // Skip our own pushes.
+            if push_entry.device_id == *device_id {
+                continue;
+            }
+            // Skip pushes before our last pull watermark.
+            if let Some(ts) = last_pull_ts {
+                if push_entry.timestamp <= ts {
+                    continue;
+                }
+            }
+
+            for table_result in &push_entry.tables {
+                if !tables.contains(&table_result.table.as_str()) {
+                    continue;
+                }
+
+                let local_path = self
+                    .sync_dir
+                    .join("pull")
+                    .join(&table_result.parquet_path);
+
+                // Download Parquet file.
+                self.r2
+                    .download_file(&table_result.parquet_path, &local_path)
+                    .await?;
+
+                // Import into DuckDB with INSERT OR IGNORE.
+                let path_str = local_path.to_string_lossy().to_string();
+                let table_name = &table_result.table;
+                let sql = format!(
+                    "INSERT OR IGNORE INTO {table_name} SELECT * FROM read_parquet('{path_str}')"
+                );
+                {
+                    let conn = self.conn.lock().unwrap();
+                    conn.execute_batch(&sql)
+                        .map_err(|e| SyncError::Import(format!("import {table_name}: {e}")))?;
+                }
+
+                info!(table = %table_name, rows = table_result.row_count, "pulled from R2");
+                result.total_rows += table_result.row_count;
+                result.files.push(table_result.parquet_path.clone());
+                result.tables.push(table_result.clone());
+            }
+        }
+
+        // Update local manifest watermark.
+        if !result.tables.is_empty() {
+            let mut local_manifest = manifest::load_local(
+                &self.sync_dir,
+                &self.workspace_id,
+                device_id,
+            )
+            .await?;
+
+            local_manifest.last_pull = Some(gctl_core::SyncEvent {
+                timestamp: Utc::now(),
+                push_id: "pull".into(),
+                total_rows: result.total_rows,
+            });
+            manifest::save_local(&self.sync_dir, &local_manifest).await?;
+        }
+
+        Ok(result)
+    }
+
+    async fn status(&self) -> Result<SyncStatus, SyncError> {
+        let device_id = &self.config.device_id;
+
+        // Count pending rows per table.
+        let pending = {
+            let conn = self.conn.lock().unwrap();
+            SyncPendingRows {
+                sessions: parquet_export::pending_count(&conn, "sessions").unwrap_or(0),
+                spans: parquet_export::pending_count(&conn, "spans").unwrap_or(0),
+                traffic: parquet_export::pending_count(&conn, "traffic").unwrap_or(0),
+                tasks: parquet_export::pending_count(&conn, "tasks").unwrap_or(0),
+                context: 0, // TODO: context pending count from context_entries table
+            }
+        };
+
+        // Load manifest for last push/pull info.
+        let manifest = manifest::load_local(
+            &self.sync_dir,
+            &self.workspace_id,
+            device_id,
+        )
+        .await?;
+
+        let last_push = manifest.pushes.last().map(|entry| gctl_core::SyncEvent {
+            timestamp: entry.timestamp,
+            push_id: entry.push_id.clone(),
+            total_rows: entry.tables.iter().map(|t| t.row_count).sum(),
+        });
+
+        // Check R2 connectivity.
+        let r2_reachable = if self.config.enabled {
+            Some(self.r2.health_check().await)
+        } else {
+            None
+        };
+
+        Ok(SyncStatus {
+            enabled: self.config.enabled,
+            device_id: device_id.clone(),
+            pending_rows: pending,
+            last_push,
+            last_pull: manifest.last_pull,
+            r2_reachable,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> SyncConfig {
+        SyncConfig {
+            enabled: false,
+            r2_bucket: "test-bucket".into(),
+            r2_endpoint: "https://test.r2.cloudflarestorage.com".into(),
+            r2_access_key_id: "test-key".into(),
+            r2_secret_access_key: "test-secret".into(),
+            interval_seconds: 300,
+            device_id: "test-dev".into(),
+            auto_pull: false,
+        }
+    }
+
+    #[test]
+    fn resolve_tables_empty_returns_all() {
+        let conn = Connection::open_in_memory().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        );
+        let tables = engine.resolve_tables(&[]);
+        assert_eq!(tables, SYNCABLE_TABLES);
+    }
+
+    #[test]
+    fn resolve_tables_specific() {
+        let conn = Connection::open_in_memory().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        );
+        let tables = engine.resolve_tables(&["sessions"]);
+        assert_eq!(tables, vec!["sessions"]);
+    }
+
+    #[test]
+    fn r2_key_format() {
+        let conn = Connection::open_in_memory().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        );
+        let key = engine.r2_key("dev1", "sessions", "2026-04-06", "push-abc");
+        assert_eq!(key, "ws1/dev1/sessions/2026-04-06/push-abc.parquet");
+    }
+
+    #[tokio::test]
+    async fn status_with_empty_db() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Create tables so pending_count queries work.
+        conn.execute_batch(
+            "CREATE TABLE sessions (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE spans (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE traffic (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE tasks (id VARCHAR, synced BOOLEAN DEFAULT FALSE);",
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        );
+        let status = engine.status().await.unwrap();
+        assert!(!status.enabled);
+        assert_eq!(status.device_id, "test-dev");
+        assert_eq!(status.pending_rows.sessions, 0);
+        assert_eq!(status.pending_rows.spans, 0);
+        assert!(status.last_push.is_none());
+        assert!(status.last_pull.is_none());
+    }
+
+    #[tokio::test]
+    async fn status_counts_pending_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE spans (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE traffic (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE tasks (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             INSERT INTO sessions VALUES ('s1', FALSE);
+             INSERT INTO sessions VALUES ('s2', TRUE);
+             INSERT INTO spans VALUES ('sp1', FALSE);
+             INSERT INTO spans VALUES ('sp2', FALSE);
+             INSERT INTO spans VALUES ('sp3', FALSE);",
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        );
+        let status = engine.status().await.unwrap();
+        assert_eq!(status.pending_rows.sessions, 1);
+        assert_eq!(status.pending_rows.spans, 3);
+        assert_eq!(status.pending_rows.traffic, 0);
+        assert_eq!(status.pending_rows.tasks, 0);
+    }
+}

--- a/kernel/crates/gctl-sync/src/lib.rs
+++ b/kernel/crates/gctl-sync/src/lib.rs
@@ -1,9 +1,41 @@
-//! R2 sync engine: Parquet export from DuckDB, upload to Cloudflare R2.
-//! Phase 4: Will use arrow + parquet crates for export and S3-compatible API for upload.
+//! gctl-sync — R2 sync engine for local-first, cloud-optional telemetry sync.
+//!
+//! Exports unsynced DuckDB rows as Parquet, uploads to Cloudflare R2 via
+//! S3-compatible API, and imports remote Parquet files from other devices.
+//!
+//! See `specs/architecture/kernel/sync.md` for the full design.
 
-pub struct SyncStatus {
-    pub last_push: Option<String>,
-    pub pending_rows: u64,
+pub mod engine;
+pub mod manifest;
+pub mod parquet_export;
+pub mod r2;
+
+pub use engine::{R2SyncEngine, SyncEngine};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SyncError {
+    #[error("export error: {0}")]
+    Export(String),
+
+    #[error("import error: {0}")]
+    Import(String),
+
+    #[error("R2 error: {0}")]
+    R2(String),
+
+    #[error("manifest error: {0}")]
+    Manifest(String),
+
+    #[error("I/O error: {0}")]
+    Io(String),
+}
+
+impl From<SyncError> for gctl_core::GctlError {
+    fn from(e: SyncError) -> Self {
+        gctl_core::GctlError::Sync(e.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -11,11 +43,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_sync_status() {
-        let status = SyncStatus {
-            last_push: None,
-            pending_rows: 0,
-        };
-        assert!(status.last_push.is_none());
+    fn sync_error_converts_to_gctl_error() {
+        let err = SyncError::R2("connection refused".into());
+        let gctl_err: gctl_core::GctlError = err.into();
+        assert!(gctl_err.to_string().contains("connection refused"));
+    }
+
+    #[test]
+    fn sync_error_display() {
+        let err = SyncError::Export("table not found".into());
+        assert_eq!(err.to_string(), "export error: table not found");
     }
 }

--- a/kernel/crates/gctl-sync/src/manifest.rs
+++ b/kernel/crates/gctl-sync/src/manifest.rs
@@ -1,0 +1,122 @@
+//! Sync manifest — tracks push/pull state on disk and in R2.
+
+use gctl_core::{SyncEvent, SyncManifest, SyncManifestEntry};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+use crate::SyncError;
+
+/// Default manifest filename.
+const MANIFEST_FILE: &str = "manifest.json";
+
+/// Load a manifest from a local directory, or return a default.
+pub async fn load_local(
+    sync_dir: &Path,
+    workspace_id: &str,
+    device_id: &str,
+) -> Result<SyncManifest, SyncError> {
+    let path = sync_dir.join(MANIFEST_FILE);
+    if !path.exists() {
+        return Ok(SyncManifest {
+            workspace_id: workspace_id.to_string(),
+            device_id: device_id.to_string(),
+            ..Default::default()
+        });
+    }
+    let data = fs::read_to_string(&path)
+        .await
+        .map_err(|e| SyncError::Io(format!("read manifest: {e}")))?;
+    serde_json::from_str(&data).map_err(|e| SyncError::Manifest(format!("parse manifest: {e}")))
+}
+
+/// Save a manifest to the local sync directory.
+pub async fn save_local(sync_dir: &Path, manifest: &SyncManifest) -> Result<(), SyncError> {
+    fs::create_dir_all(sync_dir)
+        .await
+        .map_err(|e| SyncError::Io(format!("create sync dir: {e}")))?;
+    let path = sync_dir.join(MANIFEST_FILE);
+    let data = serde_json::to_string_pretty(manifest)
+        .map_err(|e| SyncError::Manifest(format!("serialize manifest: {e}")))?;
+    fs::write(&path, data)
+        .await
+        .map_err(|e| SyncError::Io(format!("write manifest: {e}")))?;
+    Ok(())
+}
+
+/// Append a push entry to the manifest.
+pub fn record_push(manifest: &mut SyncManifest, entry: SyncManifestEntry) {
+    let event = SyncEvent {
+        timestamp: entry.timestamp,
+        push_id: entry.push_id.clone(),
+        total_rows: entry.tables.iter().map(|t| t.row_count).sum(),
+    };
+    manifest.pushes.push(entry);
+    manifest.last_pull = manifest.last_pull.take(); // preserve
+    // Update implicit "last push" by looking at pushes
+    let _ = event; // event is embedded in pushes vec
+}
+
+/// Get the path where a manifest would live in the local sync directory.
+pub fn manifest_path(sync_dir: &Path) -> PathBuf {
+    sync_dir.join(MANIFEST_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use gctl_core::SyncTableResult;
+
+    #[tokio::test]
+    async fn load_missing_manifest_returns_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = load_local(dir.path(), "ws1", "dev1").await.unwrap();
+        assert_eq!(m.workspace_id, "ws1");
+        assert_eq!(m.device_id, "dev1");
+        assert!(m.pushes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = SyncManifest {
+            workspace_id: "ws1".into(),
+            device_id: "dev1".into(),
+            pushes: vec![SyncManifestEntry {
+                push_id: "p1".into(),
+                device_id: "dev1".into(),
+                timestamp: Utc::now(),
+                tables: vec![SyncTableResult {
+                    table: "sessions".into(),
+                    row_count: 3,
+                    parquet_path: "dev1/sessions/2026-04-06/p1.parquet".into(),
+                }],
+            }],
+            last_pull: None,
+            context_hashes: vec!["abc".into()],
+        };
+        save_local(dir.path(), &manifest).await.unwrap();
+        let loaded = load_local(dir.path(), "ws1", "dev1").await.unwrap();
+        assert_eq!(loaded.pushes.len(), 1);
+        assert_eq!(loaded.pushes[0].push_id, "p1");
+        assert_eq!(loaded.context_hashes, vec!["abc"]);
+    }
+
+    #[test]
+    fn record_push_appends_entry() {
+        let mut m = SyncManifest::default();
+        let entry = SyncManifestEntry {
+            push_id: "p1".into(),
+            device_id: "dev1".into(),
+            timestamp: Utc::now(),
+            tables: vec![SyncTableResult {
+                table: "spans".into(),
+                row_count: 10,
+                parquet_path: "path.parquet".into(),
+            }],
+        };
+        record_push(&mut m, entry);
+        assert_eq!(m.pushes.len(), 1);
+        assert_eq!(m.pushes[0].tables[0].row_count, 10);
+    }
+}

--- a/kernel/crates/gctl-sync/src/parquet_export.rs
+++ b/kernel/crates/gctl-sync/src/parquet_export.rs
@@ -1,0 +1,206 @@
+//! Parquet export — DuckDB COPY to Parquet for unsynced rows.
+//!
+//! Uses DuckDB's native `COPY ... TO ... (FORMAT PARQUET)` which leverages
+//! the built-in Arrow/Parquet support for zero-copy export.
+
+use duckdb::Connection;
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+use crate::SyncError;
+
+/// The set of tables that support sync (have a `synced` column).
+pub const SYNCABLE_TABLES: &[&str] = &["sessions", "spans", "traffic", "tasks"];
+
+/// Export unsynced rows from a table to a Parquet file using DuckDB's COPY.
+///
+/// Returns the number of rows exported. If no unsynced rows exist, no file is
+/// written and 0 is returned.
+pub fn export_table(
+    conn: &Connection,
+    table: &str,
+    output_path: &Path,
+) -> Result<u64, SyncError> {
+    validate_table_name(table)?;
+
+    // Count unsynced rows first to avoid writing empty files.
+    let count: u64 = conn
+        .query_row(
+            &format!("SELECT COUNT(*) FROM {table} WHERE synced = FALSE"),
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| SyncError::Export(format!("count {table}: {e}")))?;
+
+    if count == 0 {
+        debug!(table, "no unsynced rows, skipping export");
+        return Ok(0);
+    }
+
+    // Ensure parent directory exists.
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| SyncError::Io(format!("mkdir {}: {e}", parent.display())))?;
+    }
+
+    let path_str = output_path.to_string_lossy();
+    let sql = format!(
+        "COPY (SELECT * FROM {table} WHERE synced = FALSE) TO '{path_str}' (FORMAT PARQUET)"
+    );
+    conn.execute_batch(&sql)
+        .map_err(|e| SyncError::Export(format!("COPY {table}: {e}")))?;
+
+    debug!(table, count, path = %path_str, "exported to Parquet");
+    Ok(count)
+}
+
+/// Mark rows as synced after a successful push.
+pub fn mark_synced(
+    conn: &Connection,
+    table: &str,
+) -> Result<u64, SyncError> {
+    validate_table_name(table)?;
+    let updated = conn
+        .execute(
+            &format!("UPDATE {table} SET synced = TRUE WHERE synced = FALSE"),
+            [],
+        )
+        .map_err(|e| SyncError::Export(format!("mark synced {table}: {e}")))?;
+    debug!(table, updated, "marked rows synced");
+    Ok(updated as u64)
+}
+
+/// Count unsynced rows for a table.
+pub fn pending_count(conn: &Connection, table: &str) -> Result<u64, SyncError> {
+    validate_table_name(table)?;
+    conn.query_row(
+        &format!("SELECT COUNT(*) FROM {table} WHERE synced = FALSE"),
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|e| SyncError::Export(format!("pending count {table}: {e}")))
+}
+
+/// Build the staging path for a table export.
+pub fn staging_path(
+    sync_dir: &Path,
+    device_id: &str,
+    table: &str,
+    date: &str,
+    push_id: &str,
+) -> PathBuf {
+    sync_dir
+        .join(device_id)
+        .join(table)
+        .join(date)
+        .join(format!("{push_id}.parquet"))
+}
+
+/// Validate table name against the allowlist to prevent SQL injection.
+fn validate_table_name(table: &str) -> Result<(), SyncError> {
+    if SYNCABLE_TABLES.contains(&table) {
+        Ok(())
+    } else {
+        Err(SyncError::Export(format!(
+            "table '{table}' is not syncable (allowed: {SYNCABLE_TABLES:?})"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_table_name_rejects_unknown() {
+        assert!(validate_table_name("sessions").is_ok());
+        assert!(validate_table_name("spans").is_ok());
+        assert!(validate_table_name("traffic").is_ok());
+        assert!(validate_table_name("tasks").is_ok());
+        assert!(validate_table_name("users").is_err());
+        assert!(validate_table_name("'; DROP TABLE sessions; --").is_err());
+    }
+
+    #[test]
+    fn staging_path_structure() {
+        let dir = PathBuf::from("/tmp/sync");
+        let path = staging_path(&dir, "dev1", "sessions", "2026-04-06", "push-abc");
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/sync/dev1/sessions/2026-04-06/push-abc.parquet")
+        );
+    }
+
+    #[test]
+    fn export_empty_table_returns_zero() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id VARCHAR PRIMARY KEY,
+                workspace_id VARCHAR,
+                device_id VARCHAR,
+                agent_name VARCHAR,
+                started_at VARCHAR,
+                ended_at VARCHAR,
+                status VARCHAR DEFAULT 'active',
+                total_cost_usd DOUBLE DEFAULT 0.0,
+                total_input_tokens BIGINT DEFAULT 0,
+                total_output_tokens BIGINT DEFAULT 0,
+                synced BOOLEAN DEFAULT FALSE
+            )"
+        ).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.parquet");
+        let count = export_table(&conn, "sessions", &path).unwrap();
+        assert_eq!(count, 0);
+        assert!(!path.exists()); // no file written for empty export
+    }
+
+    #[test]
+    fn export_and_mark_synced() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                id VARCHAR PRIMARY KEY,
+                workspace_id VARCHAR,
+                device_id VARCHAR,
+                agent_name VARCHAR,
+                started_at VARCHAR,
+                ended_at VARCHAR,
+                status VARCHAR DEFAULT 'active',
+                total_cost_usd DOUBLE DEFAULT 0.0,
+                total_input_tokens BIGINT DEFAULT 0,
+                total_output_tokens BIGINT DEFAULT 0,
+                synced BOOLEAN DEFAULT FALSE
+            );
+            INSERT INTO sessions (id, workspace_id, device_id, agent_name, started_at, status)
+                VALUES ('s1', 'ws1', 'dev1', 'claude', '2026-04-06T00:00:00Z', 'completed');
+            INSERT INTO sessions (id, workspace_id, device_id, agent_name, started_at, status)
+                VALUES ('s2', 'ws1', 'dev1', 'claude', '2026-04-06T01:00:00Z', 'active');
+            "
+        ).unwrap();
+
+        // Export
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.parquet");
+        let count = export_table(&conn, "sessions", &path).unwrap();
+        assert_eq!(count, 2);
+        assert!(path.exists());
+
+        // Pending count before marking
+        assert_eq!(pending_count(&conn, "sessions").unwrap(), 2);
+
+        // Mark synced
+        let marked = mark_synced(&conn, "sessions").unwrap();
+        assert_eq!(marked, 2);
+
+        // Pending count after marking
+        assert_eq!(pending_count(&conn, "sessions").unwrap(), 0);
+
+        // Second export should return 0
+        let path2 = dir.path().join("sessions2.parquet");
+        let count2 = export_table(&conn, "sessions", &path2).unwrap();
+        assert_eq!(count2, 0);
+    }
+}

--- a/kernel/crates/gctl-sync/src/r2.rs
+++ b/kernel/crates/gctl-sync/src/r2.rs
@@ -1,0 +1,173 @@
+//! R2 client — S3-compatible upload/download to Cloudflare R2.
+//!
+//! Uses reqwest with AWS Signature V4 style auth headers.
+//! R2 supports the S3 PutObject/GetObject/ListObjectsV2 API subset.
+
+use chrono::Utc;
+use reqwest::Client;
+use std::path::Path;
+use tokio::fs;
+use tracing::{debug, warn};
+
+use crate::SyncError;
+
+/// S3-compatible client for Cloudflare R2.
+#[derive(Debug, Clone)]
+pub struct R2Client {
+    client: Client,
+    endpoint: String,
+    bucket: String,
+    access_key_id: String,
+    secret_access_key: String,
+}
+
+impl R2Client {
+    pub fn new(
+        endpoint: &str,
+        bucket: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+    ) -> Self {
+        Self {
+            client: Client::new(),
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            bucket: bucket.to_string(),
+            access_key_id: access_key_id.to_string(),
+            secret_access_key: secret_access_key.to_string(),
+        }
+    }
+
+    /// Build the full URL for an object key.
+    fn object_url(&self, key: &str) -> String {
+        format!("{}/{}/{}", self.endpoint, self.bucket, key)
+    }
+
+    /// Upload a file to R2.
+    pub async fn put_object(&self, key: &str, body: Vec<u8>) -> Result<(), SyncError> {
+        let url = self.object_url(key);
+        debug!(key, url, size = body.len(), "R2 PUT");
+
+        let resp = self
+            .client
+            .put(&url)
+            .header("x-amz-date", Utc::now().format("%Y%m%dT%H%M%SZ").to_string())
+            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| SyncError::R2(format!("PUT {key}: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(SyncError::R2(format!("PUT {key}: HTTP {status} — {body}")));
+        }
+        Ok(())
+    }
+
+    /// Upload a local file to R2.
+    pub async fn upload_file(&self, key: &str, local_path: &Path) -> Result<(), SyncError> {
+        let body = fs::read(local_path)
+            .await
+            .map_err(|e| SyncError::Io(format!("read {}: {e}", local_path.display())))?;
+        self.put_object(key, body).await
+    }
+
+    /// Download an object from R2 and return its bytes.
+    pub async fn get_object(&self, key: &str) -> Result<Vec<u8>, SyncError> {
+        let url = self.object_url(key);
+        debug!(key, url, "R2 GET");
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("x-amz-date", Utc::now().format("%Y%m%dT%H%M%SZ").to_string())
+            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .send()
+            .await
+            .map_err(|e| SyncError::R2(format!("GET {key}: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(SyncError::R2(format!("GET {key}: HTTP {status} — {body}")));
+        }
+
+        resp.bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| SyncError::R2(format!("GET {key} body: {e}")))
+    }
+
+    /// Download an object from R2 to a local file.
+    pub async fn download_file(&self, key: &str, local_path: &Path) -> Result<(), SyncError> {
+        let bytes = self.get_object(key).await?;
+        if let Some(parent) = local_path.parent() {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| SyncError::Io(format!("mkdir {}: {e}", parent.display())))?;
+        }
+        fs::write(local_path, &bytes)
+            .await
+            .map_err(|e| SyncError::Io(format!("write {}: {e}", local_path.display())))?;
+        Ok(())
+    }
+
+    /// Check if R2 is reachable by issuing a HEAD on the bucket.
+    pub async fn health_check(&self) -> bool {
+        let url = format!("{}/{}", self.endpoint, self.bucket);
+        match self.client
+            .head(&url)
+            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let ok = resp.status().is_success() || resp.status().as_u16() == 404;
+                if !ok {
+                    warn!(status = %resp.status(), "R2 health check failed");
+                }
+                ok
+            }
+            Err(e) => {
+                warn!(error = %e, "R2 health check unreachable");
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_url_construction() {
+        let client = R2Client::new(
+            "https://abc.r2.cloudflarestorage.com",
+            "gctl-sync",
+            "key",
+            "secret",
+        );
+        assert_eq!(
+            client.object_url("ws1/dev1/sessions/2026-04-06/p1.parquet"),
+            "https://abc.r2.cloudflarestorage.com/gctl-sync/ws1/dev1/sessions/2026-04-06/p1.parquet"
+        );
+    }
+
+    #[test]
+    fn object_url_strips_trailing_slash() {
+        let client = R2Client::new(
+            "https://abc.r2.cloudflarestorage.com/",
+            "gctl-sync",
+            "key",
+            "secret",
+        );
+        assert_eq!(
+            client.object_url("test.parquet"),
+            "https://abc.r2.cloudflarestorage.com/gctl-sync/test.parquet"
+        );
+    }
+}

--- a/specs/architecture/domain-model.md
+++ b/specs/architecture/domain-model.md
@@ -223,6 +223,8 @@ Built-in policies:
 
 ### SyncEngine
 
+> Full design: [kernel/sync.md](kernel/sync.md) — manifest format, R2 paths, conflict resolution, context sync.
+
 ```rust
 #[async_trait]
 pub trait SyncEngine: Send + Sync {

--- a/specs/architecture/kernel/sync.md
+++ b/specs/architecture/kernel/sync.md
@@ -1,0 +1,194 @@
+# Cloud Sync (Kernel Primitive)
+
+> Canonical spec for gctl's local-first sync engine. Supersedes scattered references in
+> [os.md §12](../os.md), [domain-model.md §SyncEngine](../domain-model.md), and
+> [ROADMAP.md M3](../../gctl/ROADMAP.md).
+
+## 1. Design Principles
+
+1. **Local-first, cloud-optional.** The kernel MUST work fully offline. Sync is opt-in (`sync.enabled = true` in config). No feature degrades when R2 is unreachable.
+2. **Kernel owns all I/O.** Applications write rows through DuckDB. The kernel handles serialization, partitioning, upload, and conflict resolution — apps never touch Parquet or R2.
+3. **Device-partitioned, conflict-free.** Each device writes to its own partition in R2. No concurrent writes to the same partition → no row-level merge needed.
+4. **Append-friendly data model.** Spans and events are immutable after creation. Sessions and tasks are mutable but scoped to one device at a time.
+
+## 2. Data Flow
+
+```mermaid
+flowchart TD
+    DuckDB["DuckDB (local, single-writer)"]
+    Staging["Parquet files (~/.local/share/gctl/sync/)"]
+    R2["R2 bucket (Cloudflare)"]
+    Consumers["Remote consumers (Workers, dashboards, other devices)"]
+
+    DuckDB -->|"COPY … TO … FORMAT PARQUET"| Staging
+    Staging -->|"PUT (S3-compatible API)"| R2
+    R2 -->|"GET → INSERT INTO"| DuckDB
+    R2 -->|"Workers / Analytics Engine"| Consumers
+```
+
+### 2.1 Push (Local → R2)
+
+1. Query unsynced rows: `SELECT * FROM {table} WHERE synced = FALSE`
+2. Export to Parquet: `COPY (...) TO '{staging_path}' (FORMAT PARQUET)`
+3. Upload to R2 via S3-compatible PUT
+4. On success, mark rows: `UPDATE {table} SET synced = TRUE WHERE id IN (...)`
+5. Write manifest entry to `sync_manifest.json`
+
+### 2.2 Pull (R2 → Local)
+
+1. Read remote manifest to discover new Parquet files since last pull
+2. Download Parquet files to staging directory
+3. Insert into DuckDB: `INSERT OR IGNORE INTO {table} SELECT * FROM read_parquet('{path}')`
+4. Update local manifest with pull watermark
+
+### 2.3 Context Sync (Filesystem)
+
+Context entries have hybrid storage: DuckDB metadata + filesystem markdown content.
+
+- **Push**: upload markdown files from `~/.local/share/gctl/context/` to R2 `knowledge/context/`, keyed by `content_hash`. Mark `synced = TRUE` in DuckDB.
+- **Pull**: download new/changed files by comparing remote manifest hashes against local `content_hash` values. Write to local filesystem + upsert DuckDB metadata.
+- **Dedup**: content-addressable by SHA-256 hash — identical content is never re-uploaded.
+
+## 3. R2 Path Layout
+
+```
+{bucket}/
+  {workspace_id}/
+    {device_id}/
+      sessions/
+        {YYYY-MM-DD}/
+          {push_id}.parquet         # sessions exported in this push
+      spans/
+        {YYYY-MM-DD}/
+          {push_id}.parquet
+      traffic/
+        {YYYY-MM-DD}/
+          {push_id}.parquet
+      tasks/
+        {YYYY-MM-DD}/
+          {push_id}.parquet
+    knowledge/
+      context/
+        {content_hash}.md           # content-addressable markdown
+      crawls/
+        {domain}/
+          {page_hash}.md
+    manifest.json                   # workspace-level sync manifest
+```
+
+- **`push_id`**: UUID generated per push operation, ensuring unique filenames.
+- **Date partitioning**: by the date of the push, not the row timestamp. Simplifies cleanup and retention.
+- **`knowledge/`**: shared across devices (not device-partitioned) since content is content-addressable.
+
+## 4. Sync Manifest
+
+The manifest tracks what has been pushed and pulled. Stored both locally (`~/.local/share/gctl/sync/manifest.json`) and in R2 (`{workspace}/manifest.json`).
+
+```json
+{
+  "workspace_id": "ws_abc",
+  "device_id": "dev_123",
+  "pushes": [
+    {
+      "push_id": "push_uuid",
+      "device_id": "dev_123",
+      "timestamp": "2026-04-06T12:00:00Z",
+      "tables": {
+        "sessions": { "row_count": 5, "path": "dev_123/sessions/2026-04-06/push_uuid.parquet" },
+        "spans": { "row_count": 42, "path": "dev_123/spans/2026-04-06/push_uuid.parquet" }
+      }
+    }
+  ],
+  "last_pull": {
+    "timestamp": "2026-04-06T11:00:00Z",
+    "watermark": "push_uuid_from_other_device"
+  },
+  "context_hashes": ["sha256_abc", "sha256_def"]
+}
+```
+
+## 5. Conflict Resolution
+
+| Data type | Strategy | Rationale |
+|-----------|----------|-----------|
+| **Spans** | Append-only, `INSERT OR IGNORE` | Immutable after creation. Duplicate span_id = same span, skip. |
+| **Sessions** | Last-write-wins by `ended_at` / `updated_at` | A session runs on one device at a time. If same ID appears from two devices, latest timestamp wins. |
+| **Tasks** | Last-write-wins by `updated_at` | Same as sessions — a task is actively worked by one agent on one device. |
+| **Traffic** | Append-only, `INSERT OR IGNORE` | Immutable log entries. |
+| **Context** | Content-addressable (SHA-256) | Same hash = same content, skip. Different hash for same path = latest `updated_at` wins. |
+
+**Tie-breaking**: if two rows have identical `updated_at`, the device with the lexicographically greater `device_id` wins. This is deterministic and rare (sub-second concurrent edits across devices).
+
+## 6. Syncable Tables
+
+Tables with `synced BOOLEAN DEFAULT FALSE`:
+
+| Table | Key | Mutable | Sync strategy |
+|-------|-----|---------|---------------|
+| `sessions` | `id` (VARCHAR) | Yes (status, cost, tokens) | Last-write-wins |
+| `spans` | `span_id` (VARCHAR) | No | Append-only |
+| `traffic` | `id` (VARCHAR) | No | Append-only |
+| `tasks` | `id` (VARCHAR) | Yes (status, result) | Last-write-wins |
+| `context_entries` | `id` (VARCHAR) | Yes (content, tags) | Content-addressable |
+
+## 7. SyncEngine Port
+
+```rust
+#[async_trait]
+pub trait SyncEngine: Send + Sync {
+    /// Export unsynced rows to Parquet, upload to R2, mark synced.
+    async fn push(&self, tables: &[&str]) -> Result<SyncResult>;
+
+    /// Download new Parquet files from R2, insert into local DuckDB.
+    async fn pull(&self, tables: &[&str]) -> Result<SyncResult>;
+
+    /// Show sync state: pending rows, last push/pull, R2 connectivity.
+    async fn status(&self) -> Result<SyncStatus>;
+}
+```
+
+## 8. Configuration
+
+```rust
+pub struct SyncConfig {
+    pub enabled: bool,              // default: false
+    pub r2_bucket: String,          // R2 bucket name
+    pub r2_endpoint: String,        // S3-compatible endpoint URL
+    pub r2_access_key_id: String,   // R2 API token (read from env or config)
+    pub r2_secret_access_key: String,
+    pub interval_seconds: u64,      // default: 300 (5 min)
+    pub device_id: String,          // unique per device, auto-generated on first run
+}
+```
+
+Credentials priority: CLI flags > env vars (`GCTL_R2_ACCESS_KEY_ID`, `GCTL_R2_SECRET_ACCESS_KEY`) > config file.
+
+## 9. CLI Commands
+
+```sh
+gctl sync status                  # pending rows, last push/pull, R2 reachability
+gctl sync push                    # push all syncable tables
+gctl sync push --table sessions   # push specific table
+gctl sync pull                    # pull all tables from all devices
+gctl sync pull --since 7d         # pull only recent data
+```
+
+## 10. Scheduler Integration
+
+When `sync.enabled = true` and `sync.interval_seconds > 0`:
+
+- The kernel's scheduler runs `sync push` on the configured interval.
+- Push also fires on session end (`status` transitions to `completed`/`failed`/`cancelled`).
+- Pull is manual-only by default. Automatic pull can be enabled via `sync.auto_pull = true`.
+
+## 11. Error Handling
+
+- **Network failure**: push/pull retries 3 times with exponential backoff (1s, 4s, 16s). On exhaustion, logs warning and leaves rows as `synced = FALSE` for next attempt.
+- **Partial push**: if upload succeeds but marking synced fails (unlikely — local DB), the next push re-exports those rows. Duplicate Parquet files in R2 are harmless (append-only consumers use `INSERT OR IGNORE`).
+- **Corrupt Parquet**: pull validates Parquet metadata before inserting. Corrupt files are skipped and logged.
+
+## 12. Security
+
+- R2 credentials are never stored in the DuckDB database or Parquet files.
+- Optional: client-side encryption before upload (deferred — see Request.md Phase 4).
+- Parquet files contain telemetry data (costs, tokens, operation names). Users should scope R2 bucket access to trusted team members.

--- a/specs/architecture/os.md
+++ b/specs/architecture/os.md
@@ -700,6 +700,8 @@ gctl session kill --group <session_id>   # kill the whole group
 
 Unix's most powerful abstraction is that every resource — devices, sockets, pipes, proc state — is a file. gctl applies this principle to its storage model: **everything the kernel persists is a file**, owned and managed by the kernel, not by individual applications.
 
+> **Full sync spec:** See [kernel/sync.md](kernel/sync.md) for the authoritative design — manifest format, R2 path layout, conflict resolution, context sync, and scheduler integration. This section is a summary.
+
 #### 12.1 DuckDB → Parquet → R2
 
 DuckDB is gctl's filesystem. But DuckDB files are local, mutable, and single-writer. To cross device and team boundaries, the kernel serializes state as **Parquet** — the universal, columnar, open format that both DuckDB and Cloudflare Workers can read natively.


### PR DESCRIPTION
Consolidate scattered sync design (os.md, domain-model.md, ROADMAP.md) into a single authoritative spec at specs/architecture/kernel/sync.md. Fills previously missing gaps: manifest format, R2 path layout, conflict resolution per table type, context/markdown sync, scheduler triggers.

Implement gctl-sync crate with 4 modules and 16 tests:
- engine: SyncEngine trait + R2SyncEngine (push/pull/status)
- parquet_export: DuckDB COPY to Parquet, mark_synced, pending_count
- r2: S3-compatible R2 client (PUT/GET/HEAD via reqwest)
- manifest: local manifest load/save/append

Update gctl-core: add device_id/credentials to SyncConfig, add SyncResult/SyncStatus/SyncManifest types.