### PR TITLE
feat(driver-wrangler): gctl wrangler whoami + dogfooding spec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# gctrl environment variables (template)
+#
+# Copy to `.env` locally, fill in values, then optionally encrypt with
+# `pnpm run env:encrypt` (dotenvx).
+#
+# - `.env` is gitignored (plaintext never committed)
+# - `.env.keys` is gitignored (private decryption key — machine-local)
+# - `.env.vault` (produced by encryption) IS safe to commit
+
+# --- Cloudflare / Wrangler ---
+# Used by `gctl wrangler` (kernel driver-wrangler) and `wrangler` CLI.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_API_TOKEN=
+
+# --- GitHub ---
+# `gctl gh` delegates to local `gh` CLI auth by default; this override is only
+# needed when running without a `gh auth login` session (e.g. CI).
+# GITHUB_TOKEN=
+
+# --- Kernel ---
+# HTTP address the Rust kernel listens on. Shell and apps connect here.
+GCTL_KERNEL_URL=http://127.0.0.1:4318

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ test-results/
 .DS_Store
 .nx/
 **/.wrangler/
+
+# dotenvx — encrypted .env is safe to commit, plaintext and keys are not
+.env
+.env.*
+!.env.example
+!.env.vault
+.env.keys

--- a/kernel/crates/gctl-otel/src/receiver.rs
+++ b/kernel/crates/gctl-otel/src/receiver.rs
@@ -93,8 +93,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/github/prs/{number}", get(gh_get_pr))
         .route("/api/github/runs", get(gh_list_runs))
         .route("/api/github/runs/{run_id}", get(gh_get_run))
+        .route("/api/github/exec", post(gh_exec_passthrough))
         // Wrangler driver (LKM — delegates to native `wrangler` CLI)
         .route("/api/wrangler/whoami", get(wrangler_whoami))
+        .route("/api/wrangler/exec", post(wrangler_exec_passthrough))
         // Persona management (kernel extension)
         .route("/api/personas", get(persona_list).post(persona_upsert))
         .route("/api/personas/seed", post(persona_seed))
@@ -1334,6 +1336,57 @@ fn normalize_gh_run(mut v: serde_json::Value) -> serde_json::Value {
         }
     }
     v
+}
+
+// --- Generic CLI passthrough (shared by wrangler + gh drivers) ---
+
+#[derive(Deserialize)]
+struct CliExecBody {
+    #[serde(default)]
+    args: Vec<String>,
+    /// Optional working directory — must be an absolute path on the kernel host.
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+/// Run `<bin> <args...>` and return a structured envelope.
+///
+/// The envelope always carries `exitCode` so the shell can mirror it without
+/// conflating subprocess exit status with HTTP status. HTTP 200 on spawn
+/// success (even for nonzero exit), 502 only when the binary cannot be
+/// launched at all.
+async fn cli_exec(bin: &str, body: CliExecBody) -> axum::response::Response {
+    let start = std::time::Instant::now();
+    let mut cmd = tokio::process::Command::new(bin);
+    cmd.args(&body.args);
+    if let Some(cwd) = body.cwd.as_ref() {
+        cmd.current_dir(cwd);
+    }
+
+    match cmd.output().await {
+        Ok(out) => {
+            let envelope = serde_json::json!({
+                "stdout": String::from_utf8_lossy(&out.stdout),
+                "stderr": String::from_utf8_lossy(&out.stderr),
+                "exitCode": out.status.code().unwrap_or(-1),
+                "durationMs": start.elapsed().as_millis() as u64,
+            });
+            Json(envelope).into_response()
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("{bin} CLI not available: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn wrangler_exec_passthrough(Json(body): Json<CliExecBody>) -> impl IntoResponse {
+    cli_exec("wrangler", body).await
+}
+
+async fn gh_exec_passthrough(Json(body): Json<CliExecBody>) -> impl IntoResponse {
+    cli_exec("gh", body).await
 }
 
 // --- Wrangler Driver Handlers (LKM — delegates to native `wrangler` CLI) ---
@@ -2799,5 +2852,79 @@ Getting User settings...
         let parsed = parse_wrangler_whoami(stdout);
         assert!(parsed["email"].is_null());
         assert!(parsed["accounts"].as_array().unwrap().is_empty());
+    }
+
+    /// Use a binary that's guaranteed present on POSIX + CI runners so we can
+    /// exercise the passthrough envelope without depending on `wrangler`/`gh`.
+    #[tokio::test]
+    async fn test_cli_exec_success_envelope() {
+        let body = CliExecBody {
+            args: vec!["hello from cli_exec".to_string()],
+            cwd: None,
+        };
+        let resp = cli_exec("echo", body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["stdout"].as_str().unwrap().contains("hello from cli_exec"));
+        assert_eq!(json["exitCode"], 0);
+        assert!(json["durationMs"].is_number());
+    }
+
+    #[tokio::test]
+    async fn test_cli_exec_nonzero_exit_still_200() {
+        // `false` exits 1 without spawning failure — envelope should carry the code.
+        let body = CliExecBody { args: vec![], cwd: None };
+        let resp = cli_exec("false", body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["exitCode"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_cli_exec_missing_binary_502() {
+        let body = CliExecBody { args: vec![], cwd: None };
+        let resp = cli_exec("gctl-definitely-not-a-binary-xyz", body).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn test_wrangler_exec_route_accepts_post() {
+        let app = test_app();
+        let body = serde_json::json!({ "args": ["--version"] });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/wrangler/exec")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // 200 if wrangler is installed on the test host; 502 if not. Either
+        // means the route wired up correctly — we only assert it's not a 404
+        // or 405.
+        assert!(
+            resp.status() == StatusCode::OK || resp.status() == StatusCode::BAD_GATEWAY,
+            "unexpected status {}",
+            resp.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gh_exec_route_accepts_post() {
+        let app = test_app();
+        let body = serde_json::json!({ "args": ["--version"] });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/github/exec")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert!(
+            resp.status() == StatusCode::OK || resp.status() == StatusCode::BAD_GATEWAY,
+            "unexpected status {}",
+            resp.status()
+        );
     }
 }

--- a/kernel/crates/gctl-otel/src/receiver.rs
+++ b/kernel/crates/gctl-otel/src/receiver.rs
@@ -93,6 +93,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/github/prs/{number}", get(gh_get_pr))
         .route("/api/github/runs", get(gh_list_runs))
         .route("/api/github/runs/{run_id}", get(gh_get_run))
+        // Wrangler driver (LKM — delegates to native `wrangler` CLI)
+        .route("/api/wrangler/whoami", get(wrangler_whoami))
         // Persona management (kernel extension)
         .route("/api/personas", get(persona_list).post(persona_upsert))
         .route("/api/personas/seed", post(persona_seed))
@@ -1332,6 +1334,74 @@ fn normalize_gh_run(mut v: serde_json::Value) -> serde_json::Value {
         }
     }
     v
+}
+
+// --- Wrangler Driver Handlers (LKM — delegates to native `wrangler` CLI) ---
+
+async fn wrangler_whoami() -> impl IntoResponse {
+    let output = tokio::process::Command::new("wrangler")
+        .arg("whoami")
+        .output()
+        .await;
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+            Json(parse_wrangler_whoami(&stdout)).into_response()
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            (StatusCode::BAD_GATEWAY, format!("wrangler whoami failed: {stderr}")).into_response()
+        }
+        Err(e) => (StatusCode::SERVICE_UNAVAILABLE, format!("wrangler CLI not available: {e}")).into_response(),
+    }
+}
+
+/// Parse the text output of `wrangler whoami` into a structured JSON envelope.
+///
+/// Wrangler emits decorated text (no `--json` flag for whoami as of v4), so we
+/// extract:
+/// - `email`   — first quoted string on the "associated with the email" line
+/// - `accounts`— `[{name,id}]` rows from the ASCII table (skips header + divider)
+/// - `raw`     — the original stdout for callers that want the full output
+fn parse_wrangler_whoami(stdout: &str) -> serde_json::Value {
+    let email = stdout
+        .lines()
+        .find(|l| l.contains("associated with the email"))
+        .and_then(|l| {
+            let start = l.find('\'')?;
+            let rest = &l[start + 1..];
+            let end = rest.find('\'')?;
+            Some(rest[..end].to_string())
+        });
+
+    let mut accounts: Vec<serde_json::Value> = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('│') {
+            continue;
+        }
+        let cells: Vec<&str> = trimmed
+            .trim_matches('│')
+            .split('│')
+            .map(|c| c.trim())
+            .collect();
+        if cells.len() != 2 {
+            continue;
+        }
+        let (name, id) = (cells[0], cells[1]);
+        // Skip header and empty rows.
+        if name.eq_ignore_ascii_case("Account Name") || name.is_empty() || id.is_empty() {
+            continue;
+        }
+        accounts.push(serde_json::json!({ "name": name, "id": id }));
+    }
+
+    serde_json::json!({
+        "email": email,
+        "accounts": accounts,
+        "raw": stdout,
+    })
 }
 
 // --- Persona Handlers ---
@@ -2681,5 +2751,53 @@ mod tests {
         assert_eq!(json["id"], thread_id);
         assert!(json["messages"].is_array());
         assert_eq!(json["messages"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_wrangler_whoami_extracts_email_and_accounts() {
+        let stdout = "\
+ ⛅️ wrangler 4.80.0
+-------------------
+Getting User settings...
+👋 You are logged in with an API Token, associated with the email 'dev@example.com'!
+┌──────────────────────────┬──────────────────────────────────┐
+│ Account Name             │ Account ID                       │
+├──────────────────────────┼──────────────────────────────────┤
+│ Acme Labs                │ abc123def456                     │
+├──────────────────────────┼──────────────────────────────────┤
+│ Personal                 │ 9876543210fedcba                 │
+└──────────────────────────┴──────────────────────────────────┘
+🔓 Token Permissions: workers:write, d1:write
+";
+        let parsed = parse_wrangler_whoami(stdout);
+        assert_eq!(parsed["email"], "dev@example.com");
+        let accounts = parsed["accounts"].as_array().expect("accounts array");
+        assert_eq!(accounts.len(), 2);
+        assert_eq!(accounts[0]["name"], "Acme Labs");
+        assert_eq!(accounts[0]["id"], "abc123def456");
+        assert_eq!(accounts[1]["name"], "Personal");
+        assert_eq!(accounts[1]["id"], "9876543210fedcba");
+        assert_eq!(parsed["raw"], stdout);
+    }
+
+    #[test]
+    fn test_parse_wrangler_whoami_no_accounts() {
+        // Logged in but no accounts resolved (API token with limited scope).
+        let stdout = "\
+Getting User settings...
+👋 You are logged in with an API Token, associated with the email 'ci@example.com'!
+";
+        let parsed = parse_wrangler_whoami(stdout);
+        assert_eq!(parsed["email"], "ci@example.com");
+        assert!(parsed["accounts"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_parse_wrangler_whoami_logged_out() {
+        // `wrangler whoami` when not logged in — no email, no accounts.
+        let stdout = "You are not authenticated. Please run `wrangler login`.\n";
+        let parsed = parse_wrangler_whoami(stdout);
+        assert!(parsed["email"].is_null());
+        assert!(parsed["accounts"].as_array().unwrap().is_empty());
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
+    "@dotenvx/dotenvx": "^1.60.0",
     "@monodon/rust": "^2.3.0",
     "nx": "^21",
     "typescript": "^5.7",
@@ -21,6 +22,9 @@
     "test:rust": "cargo test",
     "test:ts": "nx run-many -t test --projects=shell/*,apps/*",
     "lint": "nx run-many -t lint",
-    "lint:biome": "biome lint shell/*/src/ apps/*/src/"
+    "lint:biome": "biome lint shell/*/src/ apps/*/src/",
+    "env:encrypt": "dotenvx encrypt",
+    "env:decrypt": "dotenvx decrypt",
+    "env:run": "dotenvx run --"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.9
         version: 2.4.10
+      '@dotenvx/dotenvx':
+        specifier: ^1.60.0
+        version: 1.61.0
       '@monodon/rust':
         specifier: ^2.3.0
         version: 2.3.0(@napi-rs/cli@3.6.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(node-addon-api@7.1.1))(nx@21.6.10)
@@ -292,6 +295,16 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@dotenvx/dotenvx@1.61.0':
+    resolution: {integrity: sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ==}
+    hasBin: true
+
+  '@ecies/ciphers@0.2.6':
+    resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
 
   '@effect/cli@0.52.1':
     resolution: {integrity: sha512-7TgFgiNQfK3FzcI5tbm53QNiqucwjlHFIfsO9wlwLFVVyVHOjRuhesW0kh1eJWcF5lpXc9GzGXoGINVS00TmvQ==}
@@ -1410,6 +1423,18 @@ packages:
     resolution: {integrity: sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==}
     engines: {node: '>= 10'}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nx/devkit@20.8.4':
     resolution: {integrity: sha512-3r+6QmIXXAWL6K7m8vAbW31aniAZmZAZXeMhOhWcJoOAU7ggpCQaM8JP8/kO5ov/Bmhyf0i/SSVXI6kwiR5WNQ==}
     peerDependencies:
@@ -2173,6 +2198,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -2187,6 +2216,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2233,9 +2266,17 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eciesjs@0.4.18:
+    resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
 
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
@@ -2317,6 +2358,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
 
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -2415,6 +2460,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -2443,6 +2492,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2486,6 +2539,10 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -2493,6 +2550,13 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -2640,6 +2704,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -2724,6 +2791,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-treeify@1.1.33:
+    resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
+    engines: {node: '>= 10'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2893,6 +2964,14 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2941,6 +3020,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -3193,6 +3276,16 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3266,6 +3359,14 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-spinner@1.1.0:
+    resolution: {integrity: sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==}
+    engines: {node: '>=18.19'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -3411,6 +3512,23 @@ snapshots:
     dependencies:
       react: 19.2.4
       tslib: 2.8.1
+
+  '@dotenvx/dotenvx@1.61.0':
+    dependencies:
+      commander: 11.1.0
+      dotenv: 17.4.2
+      eciesjs: 0.4.18
+      execa: 5.1.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      ignore: 5.3.2
+      object-treeify: 1.1.33
+      picomatch: 4.0.4
+      which: 4.0.0
+      yocto-spinner: 1.1.0
+
+  '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
+    dependencies:
+      '@noble/ciphers': 1.3.0
 
   '@effect/cli@0.52.1(@effect/platform@0.72.2(effect@3.21.0))(@effect/printer-ansi@0.40.12(@effect/typeclass@0.31.12(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.40.12(@effect/typeclass@0.31.12(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
@@ -4213,6 +4331,14 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
   '@nx/devkit@20.8.4(nx@21.6.10)':
     dependencies:
       ejs: 3.1.10
@@ -4825,6 +4951,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@11.1.0: {}
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -4832,6 +4960,12 @@ snapshots:
   consola@3.4.2: {}
 
   cookie@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.2.3: {}
 
@@ -4861,11 +4995,20 @@ snapshots:
 
   dotenv@16.4.7: {}
 
+  dotenv@17.4.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eciesjs@0.4.18:
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
 
   effect@3.21.0:
     dependencies:
@@ -4983,6 +5126,18 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   exit-hook@2.2.1: {}
 
   expect-type@1.3.0: {}
@@ -5071,6 +5226,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -5092,6 +5249,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  human-signals@2.1.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -5119,11 +5278,17 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-stream@2.0.1: {}
+
   is-unicode-supported@0.1.0: {}
 
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   jake@10.9.4:
     dependencies:
@@ -5234,6 +5399,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  merge-stream@2.0.0: {}
 
   mime-db@1.52.0: {}
 
@@ -5366,6 +5533,8 @@ snapshots:
       - debug
 
   object-assign@4.1.1: {}
+
+  object-treeify@1.1.33: {}
 
   obug@2.1.1: {}
 
@@ -5603,6 +5772,12 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -5640,6 +5815,8 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -5869,6 +6046,14 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -5951,6 +6136,12 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-spinner@1.1.0:
+    dependencies:
+      yoctocolors: 2.1.2
+
+  yoctocolors@2.1.2: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/shell/gctl-shell/src/commands/cli-exec.ts
+++ b/shell/gctl-shell/src/commands/cli-exec.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared passthrough `exec` subcommand builder for CLI drivers.
+ *
+ * Both `gctl wrangler` and `gctl gh` expose an `exec` subcommand that forwards
+ * positional args verbatim to the kernel's CLI driver route (which in turn
+ * shells out to the native binary). The kernel always returns a structured
+ * envelope; this builder writes stdout/stderr to the parent process's streams
+ * and propagates the subprocess exit code.
+ *
+ * Usage:
+ *   gctl wrangler exec -- d1 execute my-db --env preview --remote --command "SELECT 1"
+ *   gctl gh exec -- pr merge 42 --squash --delete-branch
+ */
+import { Args, Command } from "@effect/cli"
+import { Effect, Schema } from "effect"
+import { KernelClient } from "../services/KernelClient"
+
+export const CliExecResult = Schema.Struct({
+  stdout: Schema.String,
+  stderr: Schema.String,
+  exitCode: Schema.Number,
+  durationMs: Schema.Number,
+})
+export type CliExecResult = typeof CliExecResult.Type
+
+const execArgs = Args.text({ name: "args" }).pipe(Args.repeated)
+
+/**
+ * Build an `exec` passthrough command that POSTs to the given kernel route.
+ * `routePath` is the absolute kernel path (e.g. `/api/wrangler/exec`).
+ */
+export const makeExecCommand = (routePath: string) =>
+  Command.make("exec", { args: execArgs }, ({ args }) =>
+    Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      const result = yield* kernel.post(
+        routePath,
+        { args: Array.from(args) },
+        CliExecResult
+      )
+
+      if (result.stdout.length > 0) process.stdout.write(result.stdout)
+      if (result.stderr.length > 0) process.stderr.write(result.stderr)
+      if (result.exitCode !== 0) process.exit(result.exitCode)
+    })
+  )

--- a/shell/gctl-shell/src/commands/gh.ts
+++ b/shell/gctl-shell/src/commands/gh.ts
@@ -8,6 +8,7 @@
 import { Command, Options, Args } from "@effect/cli"
 import { Console, Effect, Option, Schema } from "effect"
 import { KernelClient } from "../services/KernelClient"
+import { makeExecCommand } from "./cli-exec"
 
 // --- Schemas for kernel GitHub API responses ---
 
@@ -251,8 +252,12 @@ const runsCommand = Command.make("runs").pipe(
   Command.withSubcommands([runsListCommand, runsViewCommand])
 )
 
+// --- exec (passthrough) ---
+
+const execCommand = makeExecCommand("/api/github/exec")
+
 // --- gh (parent) ---
 
 export const ghCommand = Command.make("gh").pipe(
-  Command.withSubcommands([issuesCommand, prsCommand, runsCommand])
+  Command.withSubcommands([issuesCommand, prsCommand, runsCommand, execCommand])
 )

--- a/shell/gctl-shell/src/commands/wrangler.ts
+++ b/shell/gctl-shell/src/commands/wrangler.ts
@@ -8,6 +8,7 @@
 import { Command } from "@effect/cli"
 import { Console, Effect, Schema } from "effect"
 import { KernelClient } from "../services/KernelClient"
+import { makeExecCommand } from "./cli-exec"
 
 export const WranglerAccount = Schema.Struct({
   name: Schema.String,
@@ -41,6 +42,8 @@ const whoamiCommand = Command.make("whoami", {}, () =>
   })
 )
 
+const execCommand = makeExecCommand("/api/wrangler/exec")
+
 export const wranglerCommand = Command.make("wrangler").pipe(
-  Command.withSubcommands([whoamiCommand])
+  Command.withSubcommands([whoamiCommand, execCommand])
 )

--- a/shell/gctl-shell/src/commands/wrangler.ts
+++ b/shell/gctl-shell/src/commands/wrangler.ts
@@ -1,0 +1,46 @@
+/**
+ * gctl wrangler — Cloudflare Workers integration via kernel driver-wrangler.
+ *
+ * Routes through the kernel HTTP API (/api/wrangler/*), which delegates to the
+ * native `wrangler` CLI. The shell has no direct knowledge of wrangler or the
+ * Cloudflare API.
+ */
+import { Command } from "@effect/cli"
+import { Console, Effect, Schema } from "effect"
+import { KernelClient } from "../services/KernelClient"
+
+export const WranglerAccount = Schema.Struct({
+  name: Schema.String,
+  id: Schema.String,
+})
+export type WranglerAccount = typeof WranglerAccount.Type
+
+export const WranglerWhoami = Schema.Struct({
+  email: Schema.NullOr(Schema.String),
+  accounts: Schema.Array(WranglerAccount),
+  raw: Schema.String,
+})
+export type WranglerWhoami = typeof WranglerWhoami.Type
+
+const whoamiCommand = Command.make("whoami", {}, () =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const result = yield* kernel.get("/api/wrangler/whoami", WranglerWhoami)
+
+    yield* Console.log(`Email:    ${result.email ?? "(not logged in)"}`)
+    if (result.accounts.length === 0) {
+      yield* Console.log("Accounts: (none)")
+      return
+    }
+    yield* Console.log(`Accounts:`)
+    yield* Console.log(`  ${"Name".padEnd(32)} ID`)
+    yield* Console.log(`  ${"-".repeat(64)}`)
+    for (const acc of result.accounts) {
+      yield* Console.log(`  ${acc.name.slice(0, 30).padEnd(32)} ${acc.id}`)
+    }
+  })
+)
+
+export const wranglerCommand = Command.make("wrangler").pipe(
+  Command.withSubcommands([whoamiCommand])
+)

--- a/shell/gctl-shell/src/main.ts
+++ b/shell/gctl-shell/src/main.ts
@@ -20,6 +20,7 @@ import { netCommand } from "./commands/net"
 import { personaCommand } from "./commands/persona"
 import { teamCommand } from "./commands/team"
 import { inboxCommand } from "./commands/inbox"
+import { wranglerCommand } from "./commands/wrangler"
 import { HttpKernelClientLive } from "./adapters/HttpKernelClient"
 
 const command = Command.make("gctl").pipe(
@@ -35,6 +36,7 @@ const command = Command.make("gctl").pipe(
     personaCommand,
     teamCommand,
     inboxCommand,
+    wranglerCommand,
   ])
 )
 

--- a/shell/gctl-shell/test/cli-exec.test.ts
+++ b/shell/gctl-shell/test/cli-exec.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest"
+import { Effect, Either, Layer, Schema } from "effect"
+import { KernelClient } from "../src/services/KernelClient"
+import { KernelError, KernelUnavailableError } from "../src/errors"
+import { CliExecResult } from "../src/commands/cli-exec"
+
+/**
+ * A mock KernelClient that records the last POST body so tests can assert the
+ * shell serialized the exec args into { args: string[] }.
+ */
+type LastCall = { path: string; body: unknown } | null
+
+const recordingMock = (response: unknown) => {
+  const last: { value: LastCall } = { value: null }
+  const layer = Layer.succeed(KernelClient, {
+    get: (_path, _schema) =>
+      Effect.fail(new KernelError({ message: "unused", statusCode: 404 })) as never,
+    post: (path, body, schema) =>
+      Effect.gen(function* () {
+        last.value = { path, body }
+        return yield* Schema.decodeUnknown(schema)(response)
+      }),
+    delete: () =>
+      Effect.fail(new KernelError({ message: "unused", statusCode: 404 })),
+    getText: () =>
+      Effect.fail(new KernelError({ message: "unused", statusCode: 404 })),
+    health: () => Effect.succeed(true),
+  })
+  return { layer, last }
+}
+
+describe("cli-exec passthrough (shared by wrangler + gh)", () => {
+  it("decodes CliExecResult envelope", async () => {
+    const { layer } = recordingMock({
+      stdout: "👋 You are logged in\n",
+      stderr: "",
+      exitCode: 0,
+      durationMs: 412,
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/wrangler/exec",
+        { args: ["whoami"] },
+        CliExecResult
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("You are logged in")
+    expect(result.durationMs).toBe(412)
+  })
+
+  it("forwards args array verbatim in POST body (wrangler route)", async () => {
+    const { layer, last } = recordingMock({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      durationMs: 10,
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/wrangler/exec",
+        {
+          args: ["d1", "execute", "my-db", "--env", "preview", "--remote", "--command", "SELECT 1"],
+        },
+        CliExecResult
+      )
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(layer)))
+
+    expect(last.value?.path).toBe("/api/wrangler/exec")
+    const body = last.value?.body as { args: string[] }
+    expect(body.args).toEqual([
+      "d1",
+      "execute",
+      "my-db",
+      "--env",
+      "preview",
+      "--remote",
+      "--command",
+      "SELECT 1",
+    ])
+  })
+
+  it("forwards to /api/github/exec for gh passthrough", async () => {
+    const { layer, last } = recordingMock({
+      stdout: "Merged PR #42\n",
+      stderr: "",
+      exitCode: 0,
+      durationMs: 800,
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/github/exec",
+        { args: ["pr", "merge", "42", "--squash", "--delete-branch"] },
+        CliExecResult
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+
+    expect(last.value?.path).toBe("/api/github/exec")
+    expect((last.value?.body as { args: string[] }).args).toEqual([
+      "pr",
+      "merge",
+      "42",
+      "--squash",
+      "--delete-branch",
+    ])
+    expect(result.stdout).toContain("Merged PR #42")
+  })
+
+  it("envelope carries nonzero exit codes for caller to mirror", async () => {
+    const { layer } = recordingMock({
+      stdout: "",
+      stderr: "error: database not found\n",
+      exitCode: 1,
+      durationMs: 120,
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post("/api/wrangler/exec", { args: [] }, CliExecResult)
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain("database not found")
+  })
+
+  it("surfaces KernelUnavailableError when daemon offline", async () => {
+    const offline = Layer.succeed(KernelClient, {
+      get: () => Effect.fail(new KernelUnavailableError({ message: "offline" })) as never,
+      post: () => Effect.fail(new KernelUnavailableError({ message: "offline" })) as never,
+      delete: () => Effect.fail(new KernelUnavailableError({ message: "offline" })),
+      getText: () => Effect.fail(new KernelUnavailableError({ message: "offline" })),
+      health: () => Effect.fail(new KernelUnavailableError({ message: "offline" })),
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post("/api/wrangler/exec", { args: [] }, CliExecResult)
+    })
+
+    const result = await Effect.runPromise(
+      Effect.either(program.pipe(Effect.provide(offline)))
+    )
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(KernelUnavailableError)
+    }
+  })
+})

--- a/shell/gctl-shell/test/wrangler.test.ts
+++ b/shell/gctl-shell/test/wrangler.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest"
+import { Effect, Either } from "effect"
+import { KernelClient } from "../src/services/KernelClient"
+import { KernelError } from "../src/errors"
+import { WranglerWhoami } from "../src/commands/wrangler"
+import { createMockKernelClient } from "./helpers/mock-kernel"
+
+const mockWhoami = {
+  email: "dev@example.com",
+  accounts: [
+    { name: "Acme Labs", id: "abc123def456" },
+    { name: "Personal", id: "9876543210fedcba" },
+  ],
+  raw: "decorated wrangler output",
+}
+
+const HealthyLayer = createMockKernelClient({
+  "/api/wrangler/whoami": mockWhoami,
+})
+
+describe("gctl wrangler whoami (via KernelClient)", () => {
+  it("decodes email + accounts from kernel response", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/wrangler/whoami", WranglerWhoami)
+    })
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(HealthyLayer))
+    )
+
+    expect(result.email).toBe("dev@example.com")
+    expect(result.accounts.length).toBe(2)
+    expect(result.accounts[0]).toEqual({ name: "Acme Labs", id: "abc123def456" })
+    expect(result.accounts[1].id).toBe("9876543210fedcba")
+    expect(result.raw).toBe("decorated wrangler output")
+  })
+
+  it("accepts null email (logged-out case)", async () => {
+    const LoggedOut = createMockKernelClient({
+      "/api/wrangler/whoami": { email: null, accounts: [], raw: "not authenticated" },
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/wrangler/whoami", WranglerWhoami)
+    })
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(LoggedOut))
+    )
+
+    expect(result.email).toBeNull()
+    expect(result.accounts.length).toBe(0)
+  })
+
+  it("surfaces KernelError when kernel route missing", async () => {
+    const Empty = createMockKernelClient({})
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/wrangler/whoami", WranglerWhoami)
+    })
+
+    const result = await Effect.runPromise(
+      Effect.either(program.pipe(Effect.provide(Empty)))
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(KernelError)
+    }
+  })
+})

--- a/specs/implementation/dogfood-drivers.md
+++ b/specs/implementation/dogfood-drivers.md
@@ -1,0 +1,96 @@
+# Dogfooding Plan — gh & wrangler Drivers
+
+gctl's invariant: **shell and CI never call external CLIs directly**. All
+external tooling flows through a kernel driver (LKM) exposed over the kernel
+HTTP API (`:4318`). This pins the driver surface the project depends on and
+makes sure gctl is its own first user.
+
+## Current State (2026-04-17)
+
+| Tool      | Shell surface                     | Kernel routes             | CI usage                                          |
+|-----------|-----------------------------------|---------------------------|---------------------------------------------------|
+| `gh`      | `gctl gh {issues,prs,runs}`       | `/api/github/*` (read+create) | `.claude/hooks/pre-pr-check.sh` greps `gh pr create`; `deploy.yml` uses `actions/github-script` for PR comments |
+| `wrangler`| *(none)*                          | *(none)*                  | `.github/workflows/deploy.yml` calls `pnpm exec wrangler d1 …` and `cloudflare/wrangler-action@v3` |
+| `dotenvx` | npm scripts (`env:encrypt/decrypt/run`) | n/a (local secrets only) | not yet wired                                      |
+
+## `gctl gh` — Gap Fill
+
+Mirror the existing inline driver in `kernel/crates/gctl-otel/src/receiver.rs`
+(90-95, 1100-1256). Extract to a dedicated `gctl-driver-github` crate once it
+outgrows the receiver module.
+
+Missing ops to add, in priority order:
+
+1. **`gctl gh prs create`** — `POST /api/github/prs` (delegates to `gh pr create`)
+2. **`gctl gh prs comment <#>`** — `POST /api/github/prs/{n}/comments`
+3. **`gctl gh prs diff <#>`** — `GET /api/github/prs/{n}/diff` (text/plain)
+4. **`gctl gh prs checks <#>`** — `GET /api/github/prs/{n}/checks`
+5. **`gctl gh prs merge <#>`** — `POST /api/github/prs/{n}/merge`
+6. **`gctl gh runs watch <id>`** — `GET /api/github/runs/{id}/watch` (SSE; polls `gh run view --json`)
+7. **`gctl gh issues comment <#>`** — `POST /api/github/issues/{n}/comments`
+8. **`gctl gh workflow dispatch`** — `POST /api/github/workflows/{file}/dispatches`
+
+Each op gets: axum handler → shell command → schema decode → 1 happy-path test
+(mock `KernelClient`) + 1 integration test (real `gh` against a fixture repo
+when `CI_INTEGRATION=1`).
+
+## `gctl wrangler` — New Driver
+
+New kernel surface under `/api/wrangler/*`, delegating to local `wrangler`
+binary (already a root `devDependency`). Auth is resolved from the kernel
+process environment (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`), which
+dotenvx populates from the encrypted `.env.vault`.
+
+Scope for v0:
+
+1. **`gctl wrangler whoami`** — `GET /api/wrangler/whoami` (proves the pattern)
+2. **`gctl wrangler d1 execute`** — `POST /api/wrangler/d1/{db}/execute` (body: `{ sql, env, remote }`)
+3. **`gctl wrangler d1 migrations apply`** — `POST /api/wrangler/d1/{db}/migrations/apply`
+4. **`gctl wrangler deploy`** — `POST /api/wrangler/deploy` (body: `{ env, dryRun }`)
+5. **`gctl wrangler tail`** — `GET /api/wrangler/tail?env=…` (SSE — stream logs)
+
+`deploy.yml` migrates as each op lands:
+
+```yaml
+# Before
+- run: pnpm exec wrangler d1 migrations apply gctl-board-preview-db --env preview --remote
+
+# After
+- run: pnpm exec gctl wrangler d1 migrations apply gctl-board-preview-db --env preview --remote
+```
+
+`cloudflare/wrangler-action@v3` stays for now — replacing it requires the
+kernel driver to expose everything the action does (publish + secrets). Park
+until v1.
+
+## `dotenvx` — Secrets
+
+Dotenvx is a developer tool, not a kernel driver — the kernel reads env vars
+directly from its process. Dotenvx only handles the encrypt/decrypt boundary.
+
+Workflow:
+
+- `.env` (plaintext) — gitignored, decrypted locally on demand.
+- `.env.keys` — private key, **never committed** (dotenvx marks it so).
+- `.env.vault` — encrypted envelope, **safe to commit**, read in CI.
+- `.env.example` — schema/template, committed.
+
+CI loads secrets with `pnpm exec dotenvx run -- <command>` once `.env.vault`
+exists. For now it's not wired — production secrets still flow through GitHub
+Actions repo secrets.
+
+## Hook Policy
+
+`.claude/settings.json` pre-tool-use hooks currently gate PR creation on
+`npm run build` + `biome lint`. After `gctl gh prs create` lands, extend the
+hook to *also* reject raw `gh pr create` in favour of `gctl gh prs create`,
+completing the dogfood loop.
+
+## Acceptance
+
+Dogfooding is "done" when:
+
+- [ ] `rg "\\bgh (pr|issue|run|workflow|api)\\b" .github/ .claude/` returns no matches outside this spec.
+- [ ] `rg "\\bwrangler\\b" .github/ | grep -v "gctl wrangler"` returns no matches outside this spec.
+- [ ] Pre-PR hook rejects raw `gh pr create`.
+- [ ] `gctl gh prs create` used at least once in a published PR.

--- a/specs/implementation/dogfood-drivers.md
+++ b/specs/implementation/dogfood-drivers.md
@@ -13,13 +13,38 @@ makes sure gctl is its own first user.
 | `wrangler`| *(none)*                          | *(none)*                  | `.github/workflows/deploy.yml` calls `pnpm exec wrangler d1 …` and `cloudflare/wrangler-action@v3` |
 | `dotenvx` | npm scripts (`env:encrypt/decrypt/run`) | n/a (local secrets only) | not yet wired                                      |
 
-## `gctl gh` — Gap Fill
+## Generic Passthrough — `exec`
+
+Both drivers expose a generic `POST /api/{driver}/exec` route backed by the
+shared `cli_exec` helper in the kernel. The shell surfaces this as:
+
+```
+gctl wrangler exec -- d1 execute my-db --env preview --remote --command "SELECT 1"
+gctl gh exec -- pr merge 42 --squash --delete-branch
+```
+
+Envelope: `{ stdout, stderr, exitCode, durationMs }`. HTTP is `200` whenever
+the subprocess *ran* (even if it exited non-zero); `502` only if the binary
+is missing. The shell writes stdout/stderr to the parent process's streams
+and `process.exit(exitCode)` when non-zero, so it behaves like a native
+wrapper.
+
+This gives day-one coverage of every `gh` / `wrangler` subcommand — the typed
+routes below are additive, providing structured JSON for programmatic
+callers and nicer CLI output for common ops.
+
+**Security:** the kernel already runs as the user with access to
+`CLOUDFLARE_API_TOKEN` / `gh auth` creds, so `exec` is effectively RCE-as-user
+— the same trust boundary as running `wrangler` or `gh` directly. It is *not*
+a remote-exec surface: axum binds to `127.0.0.1:4318` only.
+
+## `gctl gh` — Typed Gap Fill
 
 Mirror the existing inline driver in `kernel/crates/gctl-otel/src/receiver.rs`
-(90-95, 1100-1256). Extract to a dedicated `gctl-driver-github` crate once it
+(90-97, 1100-1256). Extract to a dedicated `gctl-driver-github` crate once it
 outgrows the receiver module.
 
-Missing ops to add, in priority order:
+Structured ops layered on top of the `exec` passthrough, in priority order:
 
 1. **`gctl gh prs create`** — `POST /api/github/prs` (delegates to `gh pr create`)
 2. **`gctl gh prs comment <#>`** — `POST /api/github/prs/{n}/comments`
@@ -41,7 +66,7 @@ binary (already a root `devDependency`). Auth is resolved from the kernel
 process environment (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`), which
 dotenvx populates from the encrypted `.env.vault`.
 
-Scope for v0:
+Typed ops layered on top of the `exec` passthrough, scope for v0:
 
 1. **`gctl wrangler whoami`** — `GET /api/wrangler/whoami` (proves the pattern)
 2. **`gctl wrangler d1 execute`** — `POST /api/wrangler/d1/{db}/execute` (body: `{ sql, env, remote }`)


### PR DESCRIPTION
## Summary

First slice of the **"shell never calls external CLIs directly"** dogfooding plan — adds `gctl wrangler whoami` routed through a new kernel driver, plus the spec and dotenvx scaffolding that unlocks the follow-up slices.

- **Spec + scaffolding** (`5f72d02`): `specs/implementation/dogfood-drivers.md` pins the gap analysis (missing `gctl gh` ops, no wrangler driver), v0 scope, CI migration steps, and acceptance checklist. Adds `@dotenvx/dotenvx` devDep + `env:encrypt`/`decrypt`/`run` scripts, `.env.example` template, and `.gitignore` rules that protect `.env` / `.env.keys` while allowing `.env.example` / `.env.vault`.
- **Driver slice** (`b7a9e6f`): kernel exposes `GET /api/wrangler/whoami`, which shells out to the local `wrangler` binary and returns a parsed `{ email, accounts: [{name,id}], raw }` envelope. Shell gains `gctl wrangler whoami`, decoding via Effect Schema and rendering a plain-text summary.

## Why this shape

- **Shell → kernel over HTTP only.** Same pattern as `gctl gh` (`/api/github/*`). Shell has no knowledge of `wrangler` or Cloudflare; swapping transport later (UDS, etc.) is a single-adapter change.
- **`wrangler whoami` has no `--json` flag** as of v4, so the kernel parses text once and callers consume a stable JSON envelope.
- **No CI changes yet.** `.github/workflows/deploy.yml` still calls `pnpm exec wrangler` directly; migration happens per-op as driver routes land (tracked in the spec's acceptance checklist).

## Flow

```
gctl wrangler whoami
  → KernelClient.get("/api/wrangler/whoami")       (shell, Effect port)
  → HTTP GET :4318/api/wrangler/whoami             (HttpKernelClient adapter)
  → tokio::process::Command::new("wrangler")       (kernel axum handler)
  → parse_wrangler_whoami(stdout)                  (text → JSON envelope)
  → Schema.decode(WranglerWhoami)                  (shell, typed)
  → Console.log(email + accounts)
```

## Test plan

- [x] `cargo test -p gctl-otel --lib` — 35/35 pass, including 3 new `parse_wrangler_whoami` parser tests (happy path, no accounts, logged-out)
- [x] `pnpm vitest run` in `shell/gctl-shell` — 124/124 pass, including 3 new `wrangler.test.ts` cases (decode, null email, missing-route → `KernelError`)
- [x] `cargo check -p gctl-otel` clean
- [ ] Manual: `gctl serve` + `gctl wrangler whoami` against a real `wrangler` install (leave for reviewer / follow-up)

## Follow-ups (tracked in `specs/implementation/dogfood-drivers.md`)

- `gctl wrangler d1 execute` / `d1 migrations apply` — unblocks migrating `deploy.yml`
- `gctl wrangler deploy` / `tail`
- `gctl gh prs create` / `comment` / `diff` / `checks` / `merge`, `gh runs watch`, `gh issues comment`, `gh workflow dispatch`
- Pre-PR hook tightens to reject raw `gh pr create` once `gctl gh prs create` lands