### PR TITLE
feat(kernel): memory subsystem with SQLite→D1 sync

### DIFF
--- a/kernel/crates/gctl-core/src/lib.rs
+++ b/kernel/crates/gctl-core/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod context;
 pub mod error;
+pub mod memory;
 pub mod types;
 
 pub use config::*;
 pub use context::*;
 pub use error::*;
+pub use memory::*;
 pub use types::*;

--- a/kernel/crates/gctl-core/src/memory.rs
+++ b/kernel/crates/gctl-core/src/memory.rs
@@ -1,0 +1,139 @@
+//! Memory subsystem domain types.
+//!
+//! Memory is long-lived knowledge that follows the user across sessions and devices.
+//! It is distinct from `context` (larger markdown documents) and `sessions` (ephemeral).
+//!
+//! The taxonomy mirrors the auto-memory system used by Claude Code:
+//!   - User        — who the user is, how they collaborate
+//!   - Feedback    — rules/preferences from explicit correction or confirmation
+//!   - Project     — facts/decisions about ongoing work, stakeholders, deadlines
+//!   - Reference   — pointers to external systems (Linear, Grafana, Slack)
+//!
+//! Every row carries the D1 sync contract (`device_id`, `updated_at`, `synced`) so
+//! it can round-trip to Cloudflare D1 via `gctl-sync`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MemoryEntryId(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryType {
+    /// Who the user is, their role, knowledge, preferences.
+    User,
+    /// Rules/preferences derived from explicit correction or confirmation.
+    Feedback,
+    /// Facts about ongoing work: decisions, stakeholders, deadlines.
+    Project,
+    /// Pointers to external resources (Linear project, Grafana dashboard, etc).
+    Reference,
+}
+
+impl MemoryType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Feedback => "feedback",
+            Self::Project => "project",
+            Self::Reference => "reference",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "user" => Some(Self::User),
+            "feedback" => Some(Self::Feedback),
+            "project" => Some(Self::Project),
+            "reference" => Some(Self::Reference),
+            _ => None,
+        }
+    }
+}
+
+/// A single memory entry. Short-form knowledge stored in SQLite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryEntry {
+    pub id: MemoryEntryId,
+    #[serde(rename = "type")]
+    pub memory_type: MemoryType,
+    /// Short stable name, e.g. "user_role", "feedback_no_bun".
+    pub name: String,
+    /// One-line description used to decide relevance at recall time.
+    pub description: String,
+    /// The memory body (rule/fact/pointer). Plain text; small (KB scale).
+    pub body: String,
+    pub tags: Vec<String>,
+    /// Device that last wrote this row — required by the D1 sync protocol
+    /// (pulls exclude rows with `device_id == self.device_id`).
+    pub device_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub synced: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MemoryFilter {
+    #[serde(rename = "type")]
+    pub memory_type: Option<MemoryType>,
+    pub tag: Option<String>,
+    pub search: Option<String>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MemoryStats {
+    pub total_entries: u64,
+    pub by_type: Vec<(String, u64)>,
+    pub unsynced: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_type_roundtrip() {
+        for ty in [
+            MemoryType::User,
+            MemoryType::Feedback,
+            MemoryType::Project,
+            MemoryType::Reference,
+        ] {
+            assert_eq!(MemoryType::from_str(ty.as_str()), Some(ty));
+        }
+    }
+
+    #[test]
+    fn memory_type_unknown_returns_none() {
+        assert!(MemoryType::from_str("episodic").is_none());
+    }
+
+    #[test]
+    fn memory_entry_serialization() {
+        let entry = MemoryEntry {
+            id: MemoryEntryId("mem-1".into()),
+            memory_type: MemoryType::Feedback,
+            name: "no_bun".into(),
+            description: "use pnpm not bun".into(),
+            body: "Always use pnpm; user explicitly rejected bun.".into(),
+            tags: vec!["tooling".into()],
+            device_id: "dev-a".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            synced: false,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: MemoryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, entry.id);
+        assert_eq!(parsed.memory_type, MemoryType::Feedback);
+        assert_eq!(parsed.name, "no_bun");
+    }
+
+    #[test]
+    fn memory_type_serializes_snake_case() {
+        let json = serde_json::to_string(&MemoryType::Reference).unwrap();
+        assert_eq!(json, "\"reference\"");
+    }
+}

--- a/kernel/crates/gctl-core/src/types.rs
+++ b/kernel/crates/gctl-core/src/types.rs
@@ -262,6 +262,8 @@ pub struct SyncPendingRows {
     pub traffic: u64,
     pub tasks: u64,
     pub context: u64,
+    #[serde(default)]
+    pub memory: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/kernel/crates/gctl-otel/src/receiver.rs
+++ b/kernel/crates/gctl-otel/src/receiver.rs
@@ -113,6 +113,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/inbox/actions", get(inbox_list_actions).post(inbox_create_action))
         .route("/api/inbox/batch-action", post(inbox_batch_action))
         .route("/api/inbox/stats", get(inbox_stats))
+        // Memory (D1-syncable long-lived knowledge)
+        .route("/api/memory", get(memory_list).post(memory_upsert))
+        .route("/api/memory/stats", get(memory_stats))
+        .route("/api/memory/{id}", get(memory_get).delete(memory_delete))
         // Health
         .route("/health", get(health))
         .with_state(state)
@@ -662,6 +666,122 @@ async fn context_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse 
         return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
     };
     match ctx.stats() {
+        Ok(stats) => Json(serde_json::to_value(&stats).unwrap()).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// --- Memory Handlers ---
+
+#[derive(Deserialize)]
+struct MemoryListParams {
+    #[serde(rename = "type")]
+    memory_type: Option<String>,
+    tag: Option<String>,
+    search: Option<String>,
+    #[serde(default = "default_memory_limit")]
+    limit: usize,
+}
+
+fn default_memory_limit() -> usize {
+    100
+}
+
+async fn memory_list(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<MemoryListParams>,
+) -> impl IntoResponse {
+    let filter = gctl_core::memory::MemoryFilter {
+        memory_type: params.memory_type.as_deref().and_then(gctl_core::memory::MemoryType::from_str),
+        tag: params.tag,
+        search: params.search,
+        limit: Some(params.limit),
+    };
+    match state.sqlite.list_memories(&filter) {
+        Ok(entries) => Json(serde_json::to_value(&entries).unwrap()).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct MemoryUpsertBody {
+    #[serde(rename = "type")]
+    memory_type: String,
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    device_id: String,
+    /// Optional — if omitted, we generate a UUID. On conflict with (device_id, name) the
+    /// existing id is preserved regardless.
+    #[serde(default)]
+    id: Option<String>,
+}
+
+async fn memory_upsert(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<MemoryUpsertBody>,
+) -> impl IntoResponse {
+    let memory_type = match gctl_core::memory::MemoryType::from_str(&body.memory_type) {
+        Some(t) => t,
+        None => return (StatusCode::BAD_REQUEST, format!("invalid type: {}", body.memory_type)).into_response(),
+    };
+    if body.name.trim().is_empty() {
+        return (StatusCode::BAD_REQUEST, "name is required").into_response();
+    }
+    if body.device_id.trim().is_empty() {
+        return (StatusCode::BAD_REQUEST, "device_id is required").into_response();
+    }
+
+    let now = chrono::Utc::now();
+    let entry = gctl_core::memory::MemoryEntry {
+        id: gctl_core::memory::MemoryEntryId(
+            body.id.unwrap_or_else(|| format!("mem-{}", uuid::Uuid::new_v4())),
+        ),
+        memory_type,
+        name: body.name,
+        description: body.description,
+        body: body.body,
+        tags: body.tags,
+        device_id: body.device_id,
+        created_at: now,
+        updated_at: now,
+        synced: false,
+    };
+
+    match state.sqlite.upsert_memory(&entry) {
+        Ok(_) => (StatusCode::CREATED, Json(serde_json::to_value(&entry).unwrap())).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn memory_get(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.get_memory(&id) {
+        Ok(Some(entry)) => Json(serde_json::to_value(&entry).unwrap()).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, format!("not found: {}", id)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn memory_delete(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.remove_memory(&id) {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => (StatusCode::NOT_FOUND, format!("not found: {}", id)).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn memory_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.sqlite.get_memory_stats() {
         Ok(stats) => Json(serde_json::to_value(&stats).unwrap()).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }

--- a/kernel/crates/gctl-otel/tests/memory_routes.rs
+++ b/kernel/crates/gctl-otel/tests/memory_routes.rs
@@ -1,0 +1,156 @@
+//! Integration tests for /api/memory/* routes.
+
+use axum::body::Body;
+use gctl_otel::create_router;
+use gctl_storage::DuckDbStore;
+use http::Request;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+fn test_app() -> axum::Router {
+    let store = DuckDbStore::open(":memory:").unwrap();
+    create_router(store)
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: serde_json::Value) -> (u16, serde_json::Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+async fn get_json(app: &axum::Router, uri: &str) -> (u16, serde_json::Value) {
+    let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+async fn delete_req(app: &axum::Router, uri: &str) -> u16 {
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    app.clone().oneshot(req).await.unwrap().status().as_u16()
+}
+
+#[tokio::test]
+async fn memory_upsert_get_list_delete() {
+    let app = test_app();
+
+    // Create
+    let (status, created) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "feedback",
+        "name": "no_bun",
+        "description": "use pnpm not bun",
+        "body": "User explicitly rejected bun — always use pnpm.",
+        "tags": ["tooling"],
+        "device_id": "dev-test",
+    })).await;
+    assert_eq!(status, 201);
+    let id = created["id"].as_str().unwrap().to_string();
+    assert!(id.starts_with("mem-"));
+    assert_eq!(created["type"], "feedback");
+    assert_eq!(created["synced"], false);
+
+    // Get
+    let (status, fetched) = get_json(&app, &format!("/api/memory/{id}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(fetched["name"], "no_bun");
+    assert_eq!(fetched["device_id"], "dev-test");
+
+    // List
+    let (status, all) = get_json(&app, "/api/memory").await;
+    assert_eq!(status, 200);
+    assert_eq!(all.as_array().unwrap().len(), 1);
+
+    // Filter by type
+    let (_, filtered) = get_json(&app, "/api/memory?type=feedback").await;
+    assert_eq!(filtered.as_array().unwrap().len(), 1);
+    let (_, none) = get_json(&app, "/api/memory?type=user").await;
+    assert_eq!(none.as_array().unwrap().len(), 0);
+
+    // Stats
+    let (status, stats) = get_json(&app, "/api/memory/stats").await;
+    assert_eq!(status, 200);
+    assert_eq!(stats["total_entries"], 1);
+    assert_eq!(stats["unsynced"], 1);
+
+    // Delete
+    let status = delete_req(&app, &format!("/api/memory/{id}")).await;
+    assert_eq!(status, 204);
+    let (status, _) = get_json(&app, &format!("/api/memory/{id}")).await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn memory_upsert_rejects_bad_input() {
+    let app = test_app();
+
+    let (status, _) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "invalid_type",
+        "name": "x",
+        "device_id": "dev-1",
+    })).await;
+    assert_eq!(status, 400);
+
+    let (status, _) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "user",
+        "name": "",
+        "device_id": "dev-1",
+    })).await;
+    assert_eq!(status, 400);
+
+    let (status, _) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "user",
+        "name": "ok",
+        "device_id": "",
+    })).await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn memory_upsert_same_device_name_updates() {
+    let app = test_app();
+
+    let (_, first) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "project",
+        "name": "sprint_goal",
+        "body": "ship memory v1",
+        "device_id": "dev-A",
+    })).await;
+    let id = first["id"].as_str().unwrap().to_string();
+
+    let (_, _) = post_json(&app, "/api/memory", serde_json::json!({
+        "type": "project",
+        "name": "sprint_goal",
+        "body": "ship memory v1 + D1 sync",
+        "device_id": "dev-A",
+    })).await;
+
+    // First id should still be the canonical one because upsert matches (device_id, name)
+    let (status, fetched) = get_json(&app, &format!("/api/memory/{id}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(fetched["body"], "ship memory v1 + D1 sync");
+
+    let (_, all) = get_json(&app, "/api/memory").await;
+    assert_eq!(all.as_array().unwrap().len(), 1, "upsert should not create a duplicate row");
+}

--- a/kernel/crates/gctl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctl-storage/src/sqlite_store.rs
@@ -1,7 +1,7 @@
-//! SQLite-backed store for board, inbox, persona, and context data.
+//! SQLite-backed store for board, inbox, persona, context, and memory data.
 //!
 //! This is a mechanical port of the relevant DuckDB methods from `duckdb_store.rs`,
-//! using `rusqlite` instead of `duckdb`. SQLite handles board/inbox/persona/context
+//! using `rusqlite` instead of `duckdb`. SQLite handles board/inbox/persona/context/memory
 //! while DuckDB continues to handle OTel/analytics. This enables Cloudflare D1
 //! portability since D1 IS SQLite.
 
@@ -14,6 +14,7 @@ use gctl_core::{
     InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
     PersonaDefinition, PersonaReviewRule,
     context::{ContextEntry, ContextEntryId, ContextFilter, ContextKind, ContextSource},
+    memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
 };
 
 // ═══════════════════════════════════════════════════════════════
@@ -190,6 +191,25 @@ CREATE TABLE IF NOT EXISTS context_entries (
 )
 "#;
 
+// Memory: D1-syncable table. `device_id` + `updated_at` + `synced` are mandatory
+// for the `gctl-sync` D1 contract (see kernel/crates/gctl-sync/src/d1.rs).
+// `name` is unique per device — upserting the same (device_id, name) overwrites.
+const CREATE_MEMORY_ENTRIES: &str = r#"
+CREATE TABLE IF NOT EXISTS memory_entries (
+    id              TEXT PRIMARY KEY,
+    type            TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    body            TEXT NOT NULL DEFAULT '',
+    tags            TEXT NOT NULL DEFAULT '[]',
+    device_id       TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    synced          INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(device_id, name)
+)
+"#;
+
 const CREATE_INDEXES: &[&str] = &[
     // Board indexes
     "CREATE INDEX IF NOT EXISTS idx_board_issues_project ON board_issues(project_id)",
@@ -216,6 +236,11 @@ const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_context_source ON context_entries(source_type)",
     "CREATE INDEX IF NOT EXISTS idx_context_path ON context_entries(path)",
     "CREATE INDEX IF NOT EXISTS idx_context_synced ON context_entries(synced)",
+    // Memory indexes
+    "CREATE INDEX IF NOT EXISTS idx_memory_type ON memory_entries(type)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_synced ON memory_entries(synced)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_device ON memory_entries(device_id)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_updated ON memory_entries(updated_at)",
 ];
 
 // ═══════════════════════════════════════════════════════════════
@@ -262,6 +287,7 @@ impl SqliteStore {
             CREATE_INBOX_ACTIONS,
             CREATE_INBOX_SUBSCRIPTIONS,
             CREATE_CONTEXT_ENTRIES,
+            CREATE_MEMORY_ENTRIES,
         ];
         for stmt in &tables {
             conn.execute_batch(stmt)
@@ -1323,6 +1349,185 @@ impl SqliteStore {
             "by_source": by_source,
         }))
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Memory CRUD
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Upsert a memory entry by `(device_id, name)`. Returns true if created, false if updated.
+    /// Any update resets `synced = 0` so the sync engine will re-push the row.
+    pub fn upsert_memory(&self, entry: &MemoryEntry) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let tags_json = serde_json::to_string(&entry.tags).unwrap_or_else(|_| "[]".into());
+
+        let existing_id: Option<String> = conn
+            .query_row(
+                "SELECT id FROM memory_entries WHERE device_id = ?1 AND name = ?2",
+                params![entry.device_id, entry.name],
+                |row| row.get(0),
+            )
+            .ok();
+
+        if existing_id.is_some() {
+            conn.execute(
+                "UPDATE memory_entries SET type = ?1, description = ?2, body = ?3, tags = ?4,
+                 updated_at = ?5, synced = 0
+                 WHERE device_id = ?6 AND name = ?7",
+                params![
+                    entry.memory_type.as_str(),
+                    entry.description,
+                    entry.body,
+                    tags_json,
+                    entry.updated_at.to_rfc3339(),
+                    entry.device_id,
+                    entry.name,
+                ],
+            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            Ok(false)
+        } else {
+            conn.execute(
+                "INSERT INTO memory_entries (id, type, name, description, body, tags, device_id, created_at, updated_at, synced)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)",
+                params![
+                    entry.id.0,
+                    entry.memory_type.as_str(),
+                    entry.name,
+                    entry.description,
+                    entry.body,
+                    tags_json,
+                    entry.device_id,
+                    entry.created_at.to_rfc3339(),
+                    entry.updated_at.to_rfc3339(),
+                ],
+            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            Ok(true)
+        }
+    }
+
+    pub fn get_memory(&self, id: &str) -> Result<Option<MemoryEntry>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, type, name, description, body, tags, device_id, created_at, updated_at, synced FROM memory_entries WHERE id = ?1",
+            [id],
+            row_to_memory_entry,
+        ).ok().map(Ok).transpose()
+    }
+
+    pub fn list_memories(&self, filter: &MemoryFilter) -> Result<Vec<MemoryEntry>> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut sql = String::from(
+            "SELECT id, type, name, description, body, tags, device_id, created_at, updated_at, synced FROM memory_entries WHERE 1=1"
+        );
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut idx = 1;
+
+        if let Some(ref ty) = filter.memory_type {
+            sql.push_str(&format!(" AND type = ?{}", idx));
+            params_vec.push(Box::new(ty.as_str().to_string()));
+            idx += 1;
+        }
+        if let Some(ref search) = filter.search {
+            sql.push_str(&format!(
+                " AND (name LIKE ?{0} OR description LIKE ?{0} OR body LIKE ?{0})",
+                idx
+            ));
+            params_vec.push(Box::new(format!("%{}%", search)));
+            idx += 1;
+        }
+
+        sql.push_str(" ORDER BY updated_at DESC");
+
+        if let Some(limit) = filter.limit {
+            sql.push_str(&format!(" LIMIT ?{}", idx));
+            params_vec.push(Box::new(limit as i64));
+        }
+
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let entries = stmt
+            .query_map(param_refs.as_slice(), row_to_memory_entry)
+            .map_err(|e| GctlError::Storage(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect::<Vec<_>>();
+
+        let entries = if let Some(ref tag) = filter.tag {
+            entries.into_iter().filter(|e| e.tags.contains(tag)).collect()
+        } else {
+            entries
+        };
+
+        Ok(entries)
+    }
+
+    pub fn remove_memory(&self, id: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let affected = conn
+            .execute("DELETE FROM memory_entries WHERE id = ?1", [id])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
+    pub fn get_memory_stats(&self) -> Result<MemoryStats> {
+        let conn = self.conn.lock().unwrap();
+
+        let total_entries: i64 = conn
+            .query_row("SELECT COUNT(*) FROM memory_entries", [], |row| row.get(0))
+            .unwrap_or(0);
+
+        let unsynced: i64 = conn
+            .query_row("SELECT COUNT(*) FROM memory_entries WHERE synced = 0", [], |row| row.get(0))
+            .unwrap_or(0);
+
+        let mut by_type = Vec::new();
+        {
+            let mut stmt = conn
+                .prepare("SELECT type, COUNT(*) FROM memory_entries GROUP BY type ORDER BY type")
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
+                let ty: String = row.get(0).unwrap_or_default();
+                let count: i64 = row.get(1).unwrap_or(0);
+                by_type.push((ty, count as u64));
+            }
+        }
+
+        Ok(MemoryStats {
+            total_entries: total_entries as u64,
+            by_type,
+            unsynced: unsynced as u64,
+        })
+    }
+
+    /// Fetch unsynced memory rows for the sync engine. Limited by `batch_size` to
+    /// keep D1 payloads bounded.
+    pub fn list_unsynced_memories(&self, batch_size: usize) -> Result<Vec<MemoryEntry>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, type, name, description, body, tags, device_id, created_at, updated_at, synced
+             FROM memory_entries WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([batch_size as i64], row_to_memory_entry)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Mark a set of memory rows as synced after a successful D1 push.
+    pub fn mark_memories_synced(&self, ids: &[String]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let conn = self.conn.lock().unwrap();
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let sql = format!("UPDATE memory_entries SET synced = 1 WHERE id IN ({placeholders})");
+        let params_vec: Vec<&dyn rusqlite::types::ToSql> =
+            ids.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        conn.execute(&sql, params_vec.as_slice())
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -1458,6 +1663,41 @@ fn row_to_context_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextEntr
         word_count: word_count as usize,
         content_hash,
         tags,
+        created_at,
+        updated_at,
+        synced,
+    })
+}
+
+fn row_to_memory_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemoryEntry> {
+    let id: String = row.get(0)?;
+    let type_str: String = row.get(1)?;
+    let name: String = row.get(2)?;
+    let description: String = row.get(3)?;
+    let body: String = row.get(4)?;
+    let tags_json: String = row.get(5)?;
+    let device_id: String = row.get(6)?;
+    let created_at: String = row.get(7)?;
+    let updated_at: String = row.get(8)?;
+    let synced: bool = row.get(9)?;
+
+    let memory_type = MemoryType::from_str(&type_str).unwrap_or(MemoryType::Reference);
+    let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+    let created_at = chrono::DateTime::parse_from_rfc3339(&created_at)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| chrono::Utc::now());
+    let updated_at = chrono::DateTime::parse_from_rfc3339(&updated_at)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| chrono::Utc::now());
+
+    Ok(MemoryEntry {
+        id: MemoryEntryId(id),
+        memory_type,
+        name,
+        description,
+        body,
+        tags,
+        device_id,
         created_at,
         updated_at,
         synced,
@@ -1743,5 +1983,121 @@ mod tests {
         let stats = store.get_context_stats().unwrap();
         assert_eq!(stats["total_entries"], 2);
         assert_eq!(stats["total_words"], 30);
+    }
+
+    fn make_memory(name: &str, ty: MemoryType, device: &str) -> MemoryEntry {
+        let now = Utc::now();
+        MemoryEntry {
+            id: MemoryEntryId(format!("mem-{device}-{name}")),
+            memory_type: ty,
+            name: name.into(),
+            description: format!("desc for {name}"),
+            body: format!("body for {name}"),
+            tags: vec!["t1".into()],
+            device_id: device.into(),
+            created_at: now,
+            updated_at: now,
+            synced: false,
+        }
+    }
+
+    #[test]
+    fn test_memory_crud() {
+        let store = test_store();
+        let entry = make_memory("no_bun", MemoryType::Feedback, "dev-a");
+
+        let created = store.upsert_memory(&entry).unwrap();
+        assert!(created);
+
+        let fetched = store.get_memory(&entry.id.0).unwrap().unwrap();
+        assert_eq!(fetched.name, "no_bun");
+        assert_eq!(fetched.memory_type, MemoryType::Feedback);
+        assert_eq!(fetched.tags, vec!["t1".to_string()]);
+        assert!(!fetched.synced);
+
+        // Upsert same (device_id, name) updates, preserves id.
+        let mut updated = entry.clone();
+        updated.body = "updated body".into();
+        updated.id = MemoryEntryId("mem-different".into()); // ignored; upsert finds by (device,name)
+        let was_new = store.upsert_memory(&updated).unwrap();
+        assert!(!was_new);
+        let fetched = store.get_memory(&entry.id.0).unwrap().unwrap();
+        assert_eq!(fetched.body, "updated body");
+
+        let removed = store.remove_memory(&entry.id.0).unwrap();
+        assert!(removed);
+        assert!(store.get_memory(&entry.id.0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_memory_list_and_filter() {
+        let store = test_store();
+        store.upsert_memory(&make_memory("m_user", MemoryType::User, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("m_fb", MemoryType::Feedback, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("m_ref", MemoryType::Reference, "dev-a")).unwrap();
+
+        let all = store.list_memories(&MemoryFilter::default()).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let fb_only = store.list_memories(&MemoryFilter {
+            memory_type: Some(MemoryType::Feedback),
+            ..Default::default()
+        }).unwrap();
+        assert_eq!(fb_only.len(), 1);
+        assert_eq!(fb_only[0].name, "m_fb");
+
+        let searched = store.list_memories(&MemoryFilter {
+            search: Some("user".into()),
+            ..Default::default()
+        }).unwrap();
+        assert_eq!(searched.len(), 1);
+        assert_eq!(searched[0].name, "m_user");
+    }
+
+    #[test]
+    fn test_memory_unique_per_device() {
+        let store = test_store();
+        store.upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-b")).unwrap();
+
+        let all = store.list_memories(&MemoryFilter::default()).unwrap();
+        assert_eq!(all.len(), 2, "same name on different devices must coexist");
+    }
+
+    #[test]
+    fn test_memory_sync_roundtrip() {
+        let store = test_store();
+        store.upsert_memory(&make_memory("a", MemoryType::User, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("b", MemoryType::User, "dev-a")).unwrap();
+
+        let pending = store.list_unsynced_memories(100).unwrap();
+        assert_eq!(pending.len(), 2);
+
+        let ids: Vec<String> = pending.iter().map(|m| m.id.0.clone()).collect();
+        store.mark_memories_synced(&ids).unwrap();
+
+        let pending = store.list_unsynced_memories(100).unwrap();
+        assert!(pending.is_empty());
+
+        // Update bumps synced back to 0.
+        let updated = make_memory("a", MemoryType::User, "dev-a");
+        store.upsert_memory(&updated).unwrap();
+        let pending = store.list_unsynced_memories(100).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].name, "a");
+    }
+
+    #[test]
+    fn test_memory_stats() {
+        let store = test_store();
+        store.upsert_memory(&make_memory("u1", MemoryType::User, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("u2", MemoryType::User, "dev-a")).unwrap();
+        store.upsert_memory(&make_memory("f1", MemoryType::Feedback, "dev-a")).unwrap();
+
+        let stats = store.get_memory_stats().unwrap();
+        assert_eq!(stats.total_entries, 3);
+        assert_eq!(stats.unsynced, 3);
+        let user_count = stats.by_type.iter().find(|(k, _)| k == "user").map(|(_, v)| *v);
+        assert_eq!(user_count, Some(2));
     }
 }

--- a/kernel/crates/gctl-sync/src/d1.rs
+++ b/kernel/crates/gctl-sync/src/d1.rs
@@ -260,9 +260,12 @@ pub fn validate_table_name(table: &str) -> Result<(), SyncError> {
     }
 }
 
-/// Tables synced via SQLite → D1 (board + tasks, OLTP workloads).
+/// Tables synced via SQLite → D1 (OLTP workloads: board, tasks, memory).
+///
+/// All tables here MUST carry the sync contract columns:
+/// `id TEXT PRIMARY KEY`, `device_id TEXT`, `updated_at TEXT`, `synced INTEGER`.
 pub const D1_SYNCABLE_TABLES: &[&str] =
-    &["projects", "issues", "comments", "issue_events", "tasks"];
+    &["projects", "issues", "comments", "issue_events", "tasks", "memory_entries"];
 
 #[cfg(test)]
 mod tests {
@@ -273,6 +276,7 @@ mod tests {
         assert!(validate_table_name("projects").is_ok());
         assert!(validate_table_name("issues").is_ok());
         assert!(validate_table_name("tasks").is_ok());
+        assert!(validate_table_name("memory_entries").is_ok());
     }
 
     #[test]

--- a/kernel/crates/gctl-sync/src/engine.rs
+++ b/kernel/crates/gctl-sync/src/engine.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use duckdb::Connection;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -16,6 +16,7 @@ use gctl_core::{
     SyncConfig, SyncManifest, SyncManifestEntry, SyncPendingRows, SyncResult, SyncStatus,
     SyncTableResult,
 };
+use gctl_storage::SqliteStore;
 
 use crate::d1::{D1Client, D1_SYNCABLE_TABLES};
 use crate::manifest;
@@ -45,6 +46,9 @@ pub struct R2SyncEngine {
     conn: Mutex<Connection>,
     r2: R2Client,
     d1: Option<D1Client>,
+    /// Optional SQLite store. Required to push OLTP tables (e.g. `memory_entries`)
+    /// that originate in SQLite rather than DuckDB. Without it, those tables skip sync.
+    sqlite: Option<Arc<SqliteStore>>,
     config: SyncConfig,
     sync_dir: PathBuf,
     workspace_id: String,
@@ -83,10 +87,17 @@ impl R2SyncEngine {
             conn: Mutex::new(conn),
             r2,
             d1,
+            sqlite: None,
             config,
             sync_dir,
             workspace_id,
         }
+    }
+
+    /// Attach a SQLite store so OLTP tables (e.g. `memory_entries`) can be pushed to D1.
+    pub fn with_sqlite(mut self, sqlite: Arc<SqliteStore>) -> Self {
+        self.sqlite = Some(sqlite);
+        self
     }
 
     /// Resolve which tables to sync: if `tables` is empty, use all syncable tables
@@ -112,9 +123,10 @@ impl R2SyncEngine {
 
     /// Push a single SQLite-backed table to D1.
     ///
-    /// For now queries the DuckDB connection for any rows with `synced = FALSE`
-    /// that belong to D1 tables (tasks). Board tables (projects, issues, etc.)
-    /// are written directly by the Worker; local sync is a future iteration.
+    /// Routing:
+    ///   - `memory_entries` → SQLite (via `self.sqlite`, the canonical path for OLTP rows)
+    ///   - `tasks`          → DuckDB (legacy interim store)
+    ///   - everything else  → no-op (board tables are written directly by the Worker)
     async fn push_table_to_d1(
         &self,
         table: &str,
@@ -125,9 +137,70 @@ impl R2SyncEngine {
             return Ok(0);
         };
 
-        // For tables that live only in D1 (board_* tables managed by the Worker),
-        // there are no local rows to push in this iteration — the Worker writes
-        // directly to D1. For `tasks` we query DuckDB as an interim store.
+        if table == "memory_entries" {
+            let Some(sqlite) = &self.sqlite else {
+                warn!(table, "memory_entries push skipped — SQLite store not attached");
+                return Ok(0);
+            };
+
+            // Batch size matches D1's practical statement limit.
+            let pending = sqlite
+                .list_unsynced_memories(100)
+                .map_err(|e| SyncError::Export(format!("list unsynced memories: {e}")))?;
+
+            if pending.is_empty() {
+                return Ok(0);
+            }
+
+            let rows: Vec<crate::d1::D1Row> = pending
+                .iter()
+                .map(|m| {
+                    let mut row = crate::d1::D1Row::new();
+                    row.insert("id".into(), serde_json::Value::String(m.id.0.clone()));
+                    row.insert(
+                        "type".into(),
+                        serde_json::Value::String(m.memory_type.as_str().to_string()),
+                    );
+                    row.insert("name".into(), serde_json::Value::String(m.name.clone()));
+                    row.insert(
+                        "description".into(),
+                        serde_json::Value::String(m.description.clone()),
+                    );
+                    row.insert("body".into(), serde_json::Value::String(m.body.clone()));
+                    row.insert(
+                        "tags".into(),
+                        serde_json::Value::String(
+                            serde_json::to_string(&m.tags).unwrap_or_else(|_| "[]".into()),
+                        ),
+                    );
+                    row.insert(
+                        "device_id".into(),
+                        serde_json::Value::String(m.device_id.clone()),
+                    );
+                    row.insert(
+                        "created_at".into(),
+                        serde_json::Value::String(m.created_at.to_rfc3339()),
+                    );
+                    row.insert(
+                        "updated_at".into(),
+                        serde_json::Value::String(m.updated_at.to_rfc3339()),
+                    );
+                    // D1 row goes in as synced=1 (it's now the canonical remote copy).
+                    row.insert("synced".into(), serde_json::Value::Number(1.into()));
+                    row
+                })
+                .collect();
+
+            let count = d1.batch_upsert(table, &rows).await?;
+
+            let ids: Vec<String> = pending.iter().map(|m| m.id.0.clone()).collect();
+            sqlite
+                .mark_memories_synced(&ids)
+                .map_err(|e| SyncError::Export(format!("mark memories synced: {e}")))?;
+
+            return Ok(count);
+        }
+
         if table == "tasks" {
             let rows = {
                 let conn = self.conn.lock().unwrap();
@@ -420,7 +493,7 @@ impl SyncEngine for R2SyncEngine {
         let device_id = &self.config.device_id;
 
         // DuckDB pending counts (OLAP tables).
-        let pending = {
+        let mut pending = {
             let conn = self.conn.lock().unwrap();
             SyncPendingRows {
                 sessions: parquet_export::pending_count(&conn, "sessions").unwrap_or(0),
@@ -428,8 +501,16 @@ impl SyncEngine for R2SyncEngine {
                 traffic: parquet_export::pending_count(&conn, "traffic").unwrap_or(0),
                 tasks: 0, // tasks now lives in SQLite→D1
                 context: 0,
+                memory: 0,
             }
         };
+
+        // SQLite pending counts (OLTP tables).
+        if let Some(sqlite) = &self.sqlite {
+            if let Ok(stats) = sqlite.get_memory_stats() {
+                pending.memory = stats.unsynced;
+            }
+        }
 
         let manifest = manifest::load_local(
             &self.sync_dir,
@@ -591,5 +672,51 @@ mod tests {
         assert_eq!(status.pending_rows.spans, 3);
         assert_eq!(status.pending_rows.traffic, 0);
         assert_eq!(status.pending_rows.tasks, 0); // tasks is now D1
+    }
+
+    #[tokio::test]
+    async fn status_counts_memory_pending_when_sqlite_attached() {
+        use gctl_core::{MemoryEntry, MemoryEntryId, MemoryType};
+        use gctl_storage::SqliteStore;
+        use std::sync::Arc;
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE spans (id VARCHAR, synced BOOLEAN DEFAULT FALSE);
+             CREATE TABLE traffic (id VARCHAR, synced BOOLEAN DEFAULT FALSE);",
+        )
+        .unwrap();
+
+        let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+        let now = chrono::Utc::now();
+        for i in 0..2 {
+            sqlite
+                .upsert_memory(&MemoryEntry {
+                    id: MemoryEntryId(format!("mem-t{i}")),
+                    memory_type: MemoryType::Feedback,
+                    name: format!("m{i}"),
+                    description: String::new(),
+                    body: String::new(),
+                    tags: vec![],
+                    device_id: "dev-x".into(),
+                    created_at: now,
+                    updated_at: now,
+                    synced: false,
+                })
+                .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = R2SyncEngine::new(
+            conn,
+            test_config(),
+            dir.path().to_path_buf(),
+            "ws1".into(),
+        )
+        .with_sqlite(sqlite);
+
+        let status = engine.status().await.unwrap();
+        assert_eq!(status.pending_rows.memory, 2);
     }
 }


### PR DESCRIPTION
## Summary
- Adds a kernel memory subsystem that mirrors the Claude auto-memory taxonomy (user / feedback / project / reference) so agents running under gctl can persist non-obvious context across sessions.
- Memory lives in SQLite (OLTP path, not DuckDB) so it rides on the existing SQLite→D1 sync contract introduced in #15. Every row carries `id`, `device_id`, `updated_at`, `synced` and participates in the same push/pull engine that already handles `tasks`.
- Exposed over HTTP (`/api/memory`, `/api/memory/{id}`, `/api/memory/stats`) so the shell and apps stay network-only callers of the kernel.

## What changed
- **`gctl-core`** — new `MemoryEntry` / `MemoryType` / `MemoryFilter` / `MemoryStats` domain types. `SyncPendingRows` gains a `memory` counter.
- **`gctl-storage`** — `memory_entries` table with `UNIQUE(device_id, name)` upsert semantics, plus `list_unsynced_memories` / `mark_memories_synced` hooks for the sync engine.
- **`gctl-otel`** — CRUD + stats routes behind the kernel HTTP API, with 400 validation on type / name / device_id.
- **`gctl-sync`** — `memory_entries` added to `D1_SYNCABLE_TABLES`; `R2SyncEngine::with_sqlite(store)` builder threads a SQLite store in; `push_table_to_d1` handles `memory_entries` via unsynced→batch_upsert→mark-synced; `status()` reports `pending_rows.memory` when sqlite is attached.

## Out of scope (intentional)
- No shell CLI commands yet — HTTP surface only.
- No embeddings / retrieval / decay — just structured storage + sync.
- No filesystem markdown mirror for memory (distinct from `context`).
- `gctl-context` is still DuckDB-backed; not migrated in this PR.

## Test plan
- [x] `cargo test --workspace` — all passing
- [x] `cargo test -p gctl-core -p gctl-storage -p gctl-otel -p gctl-sync` — 23 + 71 + (40 unit + 3 memory_routes + 2 pipeline) + 20
- [x] New integration tests: `memory_upsert_get_list_delete`, `memory_upsert_rejects_bad_input`, `memory_upsert_same_device_name_updates`
- [x] New engine test: `status_counts_memory_pending_when_sqlite_attached`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)