### PR TITLE
chore(kernel): rename Rust binary to gctld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gctl-kernel
-          path: target/debug/gctl
+          path: target/debug/gctld
           retention-days: 1
 
   # ──────────────────────────────────────────────
@@ -109,7 +109,7 @@ jobs:
           path: target/debug/
 
       - name: Make kernel binary executable
-        run: chmod +x target/debug/gctl
+        run: chmod +x target/debug/gctld
 
       - name: Run Playwright tests
         run: pnpm exec playwright test
@@ -118,7 +118,7 @@ jobs:
           CI: "true"
           GCTL_KERNEL_PORT: "14318"
           GCTL_VITE_PORT: "14200"
-          GCTL_KERNEL_BIN: ${{ github.workspace }}/target/debug/gctl
+          GCTL_KERNEL_BIN: ${{ github.workspace }}/target/debug/gctld
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/kernel/crates/gctl-cli/Cargo.toml
+++ b/kernel/crates/gctl-cli/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [[bin]]
-name = "gctl"
+name = "gctld"
 path = "src/main.rs"
 
 [dependencies]

--- a/kernel/crates/gctl-cli/src/main.rs
+++ b/kernel/crates/gctl-cli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 mod commands;
 
 #[derive(Parser)]
-#[command(name = "gctl", version, about = "GroundCtrl — local-first OS for human+agent teams")]
+#[command(name = "gctld", version, about = "GroundCtrl kernel daemon — local-first OS for human+agent teams")]
 struct Cli {
     /// Path to DuckDB database file (default: ~/.local/share/gctl/gctl.duckdb)
     #[arg(long, global = true)]


### PR DESCRIPTION
## Summary
- Renames the Rust kernel binary from `gctl` → `gctld` so the Effect-TS shell can own the user-facing `gctl` name on PATH (per the dogfood rule: everything goes through the shell, which speaks to the daemon over HTTP).
- Aligns with the Unix daemon convention (`sshd`, `cupsd`, `systemd`) and removes the PATH collision that blocked `pnpm link --global` from the shell package.

## What changed
- `kernel/crates/gctl-cli/Cargo.toml` — `[[bin]] name = "gctl"` → `gctld`
- `kernel/crates/gctl-cli/src/main.rs` — clap `name` / `about` updated (`"GroundCtrl kernel daemon"`)
- `.github/workflows/ci.yml` — artifact upload/download paths, `chmod +x`, and `GCTL_KERNEL_BIN` all point at `target/debug/gctld`

## Follow-ups (not in this PR)
- `pnpm link --global` from `shell/gctl-shell/` already done locally; doc that install step somewhere once we settle on the install story.
- Remaining spec references to `target/debug/gctl` in `apps/gctl-board/playwright.config.ts`, `specs/**`, etc. — the config file already reads `GCTL_KERNEL_BIN`, so no runtime change needed, but spec text will drift from reality until updated. Can sweep in a follow-up.

## Test plan
- [x] `cargo build --bin gctld` — produces `target/debug/gctld`
- [x] `cargo check --workspace` clean
- [x] `./target/debug/gctld --help` shows `gctld` in usage / description
- [ ] CI green — Playwright job pulls the renamed artifact and launches it via `GCTL_KERNEL_BIN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)