### PR TITLE
refactor(infra): rename Cloudflare Worker + D1 to gctrl-*

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # D1 DB name stays `gctl-*` — infra rename deferred to separate PR
-        run: pnpm exec wrangler d1 migrations apply gctl-board-preview-db --env preview --remote
+        run: pnpm exec wrangler d1 migrations apply gctrl-board-preview-db --env preview --remote
 
       - name: Deploy preview to Cloudflare Workers
         id: deploy
@@ -141,7 +140,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          pnpm exec wrangler d1 execute gctl-board-preview-db --env preview --remote \
+          pnpm exec wrangler d1 execute gctrl-board-preview-db --env preview --remote \
             --command "DELETE FROM issue_events; DELETE FROM comments; DELETE FROM issues; DELETE FROM projects;"
 
       # Installed as a fallback: the fixture prefers CF Browser Rendering

--- a/apps/gctrl-board/wrangler.toml
+++ b/apps/gctrl-board/wrangler.toml
@@ -1,8 +1,4 @@
-# NOTE: Worker name and D1 database_name intentionally kept as `gctl-*` —
-# these identify deployed infrastructure. Renaming to `gctrl-*` requires a
-# separate PR with deploy coordination (new Worker route, D1 migration or
-# rename, updated DNS). Code/docs elsewhere use the new `gctrl` brand.
-name = "gctl-board"
+name = "gctrl-board"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 main = "src/worker.ts"
@@ -20,16 +16,16 @@ not_found_handling = "single-page-application"
 # D1 database for board state (projects, issues, comments, events)
 [[d1_databases]]
 binding = "DB"
-database_name = "gctl-board-db"
-database_id = "2173a9e0-f901-4d76-9f26-71f532b0eda7"
+database_name = "gctrl-board-db"
+database_id = "4b40671f-5e06-43b0-ad68-23434aeaca1e"
 migrations_dir = "migrations"
 
 # ── Preview environment (PR deploys) ──
 [env.preview]
-name = "gctl-board-preview"
+name = "gctrl-board-preview"
 
 [[env.preview.d1_databases]]
 binding = "DB"
-database_name = "gctl-board-preview-db"
-database_id = "9b255c9a-738e-4d17-b371-ad6f01511104"
+database_name = "gctrl-board-preview-db"
+database_id = "90820d6b-e1c8-4f7d-a80d-536e9ce748bd"
 migrations_dir = "migrations"


### PR DESCRIPTION
## Summary

Completes the brand migration from #22 for the deferred infra identifiers.

- Worker: `gctl-board` → `gctrl-board`, `gctl-board-preview` → `gctrl-board-preview`
- D1 prod: `gctl-board-db` → `gctrl-board-db` (new DB `4b40671f-5e06-43b0-ad68-23434aeaca1e`)
- D1 preview: `gctl-board-preview-db` → `gctrl-board-preview-db` (new DB `90820d6b-e1c8-4f7d-a80d-536e9ce748bd`)
- `.github/workflows/deploy.yml`: D1 migration + cleanup commands retargeted

## Why safe now

Old D1 state before cut:
- `gctl-board-db` (prod): **0 projects, 0 issues** — empty
- `gctl-board-preview-db`: 30 projects, 38 issues — test data only, acceptable to leave behind

No data migration needed.

## What happens on deploy

- **Preview (this PR)**: new Worker `gctrl-board-preview` is created by `wrangler deploy --env preview`, bound to the new D1 `gctrl-board-preview-db`. Migrations apply fresh. Acceptance suite runs against the new preview URL.
- **Production (on merge)**: new Worker `gctrl-board` is created, bound to new D1 `gctrl-board-db`. Old Worker URL (`gctl-board.<subdomain>.workers.dev`) stops receiving new deploys but continues serving stale content until deleted.

## Validation

- `wrangler deploy --dry-run` — both envs validate, bindings resolve to new D1 DBs
- New D1 DBs provisioned via `wrangler d1 create` (IDs above)

## Post-merge cleanup (manual)

```sh
# Delete old Workers
wrangler delete --name gctl-board
wrangler delete --name gctl-board-preview

# Delete old D1 DBs
wrangler d1 delete gctl-board-db            # empty, safe
wrangler d1 delete gctl-board-preview-db    # test data only
```

## Test plan

- [ ] CI green
- [ ] Preview deploy publishes to new `gctrl-board-preview` Worker
- [ ] Preview D1 migrations apply on first deploy
- [ ] Acceptance tests pass against new preview URL
- [ ] Post-merge: prod deploy creates `gctrl-board` Worker bound to new D1
- [ ] Post-merge manual cleanup of old resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)