### PR TITLE
refactor: rename top-level board/ dir to gctrl/

### DIFF
--- a/apps/gctrl-board/WORKFLOW.md
+++ b/apps/gctrl-board/WORKFLOW.md
@@ -174,6 +174,26 @@ Migrations live in `migrations/` and are applied automatically by `wrangler depl
 wrangler d1 migrations create gctrl-board-db "<description>"
 ```
 
+## Markdown Directory Convention
+
+Issues can be authored as plain markdown files under the repo's top-level `gctrl/` directory. The kernel daemon (`gctrld serve`) auto-detects `./gctrl/` and runs a file watcher that imports new/modified `*.md` files into the local DuckDB `board_*` tables (content-hash deduped). Override the path with `gctrld serve --board-dir <path>`.
+
+```
+gctrl/                       # Configurable via --board-dir; default: ./gctrl/
+├── BOARD/                   # Subdirectory name = project key (uppercased)
+│   ├── BOARD-1.md           #   filename stem must match issue key
+│   └── BOARD-2.md
+└── INBOX/
+    └── INBOX-1.md
+```
+
+Rules:
+
+- Each subdirectory is a project key. The watcher auto-creates the `board_projects` row on first import if it doesn't exist.
+- Each `*.md` file is one issue. The filename stem (e.g. `BOARD-1`) must match the issue key in YAML frontmatter.
+- Imports are idempotent — `content_hash` (SHA-256 of file content) is stored on `board_issues`; unchanged files are skipped.
+- The watcher is **local-only**. Markdown files are not bidirectionally synced to D1 — they hydrate the daemon's local DuckDB, which the web UI/CLI then consumes via `/api/board/*`.
+
 ## Code Location
 
 | Component | Path |

--- a/specs/implementation/repo.md
+++ b/specs/implementation/repo.md
@@ -44,6 +44,13 @@ gctrl/
 │   ├── gctrl-board/            # App: kanban (schemas, services, adapters)
 │   └── ...                    # Future: observe-eval, capacity
 │
+├── gctrl/                     # Issue-tracker markdown (dogfooded)
+│   ├── BOARD/                 #   one subdirectory per project key
+│   │   ├── BOARD-1.md         #   filename = issue key (matches frontmatter)
+│   │   └── ...
+│   └── INBOX/                 #   project key INBOX (intake)
+│       └── ...
+│
 ├── specs/                     # Architecture, design, and formal specs
 │   ├── architecture/          # System structure (kernel/shell/apps layers)
 │   └── implementation/        # Coding patterns, testing, repo structure


### PR DESCRIPTION
## Summary

Renames the top-level issue-tracker directory `./board/` to `./gctrl/` to align with the brand migration.

- `git mv board gctrl` — 25 markdown files (BOARD/, INBOX/) moved
- Kernel auto-detect default in `gctrl-cli` flipped from `./board/` to `./gctrl/`
- `--board-dir` help text + `watch.rs` doc comments updated to use `gctrl/` in examples

## Out of scope (intentional)

- CLI flag `--board-dir` keeps its name — it describes the abstract role (the directory of board markdown), not the path
- Rust internal names (`board_dir`, `watch_board_dir`) keep their names for the same reason
- HTTP API prefix `/api/board/*` — separate concept (the API namespace, not a directory)
- Package `apps/gctrl-board/` — already brand-aligned

## Verification

- `cargo check --workspace` — clean
- `cargo test -p gctrl-cli` — passes

## Test plan

- [ ] CI green
- [ ] `gctrld serve` (no `--board-dir` flag) auto-detects `./gctrl/` and watches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)