### PR TITLE
fix(sync): unblock D1 re-sync + rename GCTL_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ CLOUDFLARE_API_TOKEN=
 
 # --- Kernel ---
 # HTTP address the Rust kernel listens on. Shell and apps connect here.
-GCTL_KERNEL_URL=http://127.0.0.1:4318
+GCTRL_KERNEL_URL=http://127.0.0.1:4318

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,9 @@ jobs:
         working-directory: apps/gctrl-board
         env:
           CI: "true"
-          GCTL_KERNEL_PORT: "14318"
-          GCTL_VITE_PORT: "14200"
-          GCTL_KERNEL_BIN: ${{ github.workspace }}/target/debug/gctrld
+          GCTRL_KERNEL_PORT: "14318"
+          GCTRL_VITE_PORT: "14200"
+          GCTRL_KERNEL_BIN: ${{ github.workspace }}/target/debug/gctrld
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/apps/gctrl-board/playwright.config.ts
+++ b/apps/gctrl-board/playwright.config.ts
@@ -18,11 +18,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
  *    Tests run against PREVIEW_URL with a remote browser.
  *    Skips tests that require kernel-only endpoints (/v1/traces, filesystem).
  *
- * Set GCTL_KERNEL_PORT / GCTL_VITE_PORT to override local defaults.
+ * Set GCTRL_KERNEL_PORT / GCTRL_VITE_PORT to override local defaults.
  */
 
-const KERNEL_PORT = Number(process.env.GCTL_KERNEL_PORT ?? 14318)
-const VITE_PORT = Number(process.env.GCTL_VITE_PORT ?? 14200)
+const KERNEL_PORT = Number(process.env.GCTRL_KERNEL_PORT ?? 14318)
+const VITE_PORT = Number(process.env.GCTRL_VITE_PORT ?? 14200)
 
 // Remote mode: drive a (deployed) Worker at PREVIEW_URL. Browser is either
 // local Chromium (fallback) or Cloudflare Browser Rendering CDP (set
@@ -32,9 +32,9 @@ const isRemote = !!process.env.PREVIEW_URL
 const isRemoteCDP = isRemote && !!process.env.CDP_ENDPOINT
 
 // In CI, use the pre-built kernel binary to avoid needing cargo/Rust toolchain.
-// Set GCTL_KERNEL_BIN to the absolute path of the gctrl binary.
-const kernelCommand = process.env.GCTL_KERNEL_BIN
-  ? `${process.env.GCTL_KERNEL_BIN} --db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT}`
+// Set GCTRL_KERNEL_BIN to the absolute path of the gctrl binary.
+const kernelCommand = process.env.GCTRL_KERNEL_BIN
+  ? `${process.env.GCTRL_KERNEL_BIN} --db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT}`
   : `cargo run -p gctrl-cli -- --db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT}`
 
 export default defineConfig({
@@ -108,7 +108,7 @@ export default defineConfig({
             command: `pnpm exec vite --config web/vite.config.ts --port ${VITE_PORT}`,
             port: VITE_PORT,
             reuseExistingServer: !process.env.CI,
-            env: { GCTL_KERNEL_PORT: String(KERNEL_PORT) },
+            env: { GCTRL_KERNEL_PORT: String(KERNEL_PORT) },
           },
         ],
       }),

--- a/apps/gctrl-board/tests/acceptance/fixtures/kernel.ts
+++ b/apps/gctrl-board/tests/acceptance/fixtures/kernel.ts
@@ -10,7 +10,7 @@
  *  - Query analytics to validate telemetry pipeline
  */
 
-const DEFAULT_KERNEL_URL = `http://localhost:${process.env.GCTL_KERNEL_PORT ?? 14318}`
+const DEFAULT_KERNEL_URL = `http://localhost:${process.env.GCTRL_KERNEL_PORT ?? 14318}`
 
 // ── Response types ──
 

--- a/apps/gctrl-board/tests/acceptance/fixtures/test.ts
+++ b/apps/gctrl-board/tests/acceptance/fixtures/test.ts
@@ -109,7 +109,7 @@ export const test = base.extend<BoardFixtures>({
 
   kernel: async ({}, use) => {
     const previewUrl = process.env.PREVIEW_URL
-    const port = process.env.GCTL_KERNEL_PORT ?? "14318"
+    const port = process.env.GCTRL_KERNEL_PORT ?? "14318"
     const baseUrl = previewUrl ?? `http://localhost:${port}`
     const client = new KernelTestClient(baseUrl)
     if (previewUrl) {

--- a/apps/gctrl-board/web/vite.config.ts
+++ b/apps/gctrl-board/web/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 4200,
     proxy: {
       "/api": {
-        target: `http://localhost:${process.env.GCTL_KERNEL_PORT ?? "4318"}`,
+        target: `http://localhost:${process.env.GCTRL_KERNEL_PORT ?? "4318"}`,
         changeOrigin: true,
       },
     },

--- a/kernel/crates/gctrl-core/src/config.rs
+++ b/kernel/crates/gctrl-core/src/config.rs
@@ -90,8 +90,8 @@ pub struct SyncConfig {
     pub r2_secret_access_key: String,
 
     // D1 — SQLite sync target (board, tasks, app state)
-    // Credentials: CLI flags > env vars (GCTL_D1_DATABASE_ID, GCTL_D1_ACCOUNT_ID,
-    // GCTL_D1_API_TOKEN) > config file.
+    // Credentials: CLI flags > env vars (GCTRL_D1_DATABASE_ID, GCTRL_D1_ACCOUNT_ID,
+    // GCTRL_D1_API_TOKEN) > config file.
     #[serde(default)]
     pub d1_database_id: String,
     #[serde(default)]
@@ -126,21 +126,21 @@ impl SyncConfig {
             && !self.d1_api_token.is_empty()
     }
 
-    /// Populate D1 credentials from env vars (GCTL_D1_DATABASE_ID,
-    /// GCTL_D1_ACCOUNT_ID, GCTL_D1_API_TOKEN). Returns a config with
+    /// Populate D1 credentials from env vars (GCTRL_D1_DATABASE_ID,
+    /// GCTRL_D1_ACCOUNT_ID, GCTRL_D1_API_TOKEN). Returns a config with
     /// `enabled=true` iff all three are set.
     pub fn from_env() -> Self {
         let mut cfg = Self::default();
-        if let Ok(v) = std::env::var("GCTL_D1_DATABASE_ID") {
+        if let Ok(v) = std::env::var("GCTRL_D1_DATABASE_ID") {
             cfg.d1_database_id = v;
         }
-        if let Ok(v) = std::env::var("GCTL_D1_ACCOUNT_ID") {
+        if let Ok(v) = std::env::var("GCTRL_D1_ACCOUNT_ID") {
             cfg.d1_account_id = v;
         }
-        if let Ok(v) = std::env::var("GCTL_D1_API_TOKEN") {
+        if let Ok(v) = std::env::var("GCTRL_D1_API_TOKEN") {
             cfg.d1_api_token = v;
         }
-        if let Ok(v) = std::env::var("GCTL_DEVICE_ID") {
+        if let Ok(v) = std::env::var("GCTRL_DEVICE_ID") {
             cfg.device_id = v;
         }
         cfg.enabled = cfg.d1_enabled();

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -2227,7 +2227,7 @@ async fn inbox_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 
 #[derive(Deserialize, Default)]
 struct SyncPushBody {
-    /// Tables to push. Empty = all syncable tables.
+    /// Tables to push. Empty = all SQLite-backed (board) tables.
     #[serde(default)]
     tables: Vec<String>,
 }
@@ -2261,11 +2261,29 @@ async fn sync_push(
     )
     .with_sqlite(Arc::clone(&state.sqlite));
 
+    // Default empty body to the tables that route through `self.sqlite`
+    // inside `push_table_to_d1`. Passing `&[]` to the engine would expand to
+    // every syncable table (including DuckDB-backed `sessions`, `spans`,
+    // `tasks`) — but this handler gives the engine a throwaway in-memory
+    // DuckDB with no schema, so those branches error with "Table … does not
+    // exist". R2/DuckDB sync should land via a separate path once the real
+    // store connection is wired through.
+    const HANDLER_DEFAULT_TABLES: &[&str] = &[
+        "board_projects",
+        "board_issues",
+        "board_comments",
+        "board_events",
+        "memory_entries",
+    ];
     let requested = body.map(|Json(b)| b.tables).unwrap_or_default();
-    let table_refs: Vec<&str> = requested.iter().map(String::as_str).collect();
+    let defaulted: Vec<&str> = if requested.is_empty() {
+        HANDLER_DEFAULT_TABLES.to_vec()
+    } else {
+        requested.iter().map(String::as_str).collect()
+    };
 
     use gctrl_sync::SyncEngine;
-    match engine.push(&table_refs).await {
+    match engine.push(&defaulted).await {
         Ok(result) => Json(result).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -2364,6 +2382,46 @@ mod tests {
             ..SyncConfig::default()
         });
         create_router_dual_with_sync(store, sqlite, Some(sync_config))
+    }
+
+    #[tokio::test]
+    async fn test_sync_push_empty_body_defaults_to_sqlite_tables() {
+        // Regression: empty `{}` previously expanded to every syncable table
+        // including DuckDB ones (sessions/spans), which the throwaway in-memory
+        // DuckDB has no schema for — handler returned 500 "Catalog Error: Table
+        // with name sessions does not exist". Fix: default empty body to the
+        // SQLite-only table set.
+        let app = test_app_with_sync();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/sync/push")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["total_rows"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_sync_push_no_body_defaults_to_sqlite_tables() {
+        // Same regression, no body at all (not even `{}`). `Option<Json<...>>`
+        // resolves to None → handler uses the default SQLite-only set.
+        let app = test_app_with_sync();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/sync/push")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["total_rows"], 0);
     }
 
     #[tokio::test]

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -2239,7 +2239,7 @@ async fn sync_push(
     let Some(config) = state.sync_config.as_ref().filter(|c| c.d1_enabled()) else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
-            "D1 sync not configured — set GCTL_D1_DATABASE_ID, GCTL_D1_ACCOUNT_ID, GCTL_D1_API_TOKEN",
+            "D1 sync not configured — set GCTRL_D1_DATABASE_ID, GCTRL_D1_ACCOUNT_ID, GCTRL_D1_API_TOKEN",
         )
             .into_response();
     };

--- a/kernel/crates/gctrl-sync/src/d1.rs
+++ b/kernel/crates/gctrl-sync/src/d1.rs
@@ -148,10 +148,19 @@ impl D1Client {
         }
     }
 
-    /// Push rows into D1 using INSERT OR REPLACE.
+    /// Upsert rows into D1 using `INSERT ... ON CONFLICT(id) DO UPDATE SET ...`.
     ///
-    /// `rows` — each row is a map of column→value. All rows must have the same columns.
-    /// Rows are sent in batches of 100 to stay within D1 statement limits.
+    /// `rows` — each row is a map of column→value. All rows must have the
+    /// same columns and must include an `id` column (the conflict target).
+    /// Rows are sent one-by-one inside a chunking loop of 100 to stay within
+    /// D1 statement limits.
+    ///
+    /// This deliberately avoids `INSERT OR REPLACE`, which deletes the old
+    /// row before inserting the new one — that cascades through
+    /// `FOREIGN KEY` references and causes `SQLITE_CONSTRAINT_FOREIGNKEY`
+    /// when child rows exist (e.g. re-pushing a `projects` row while
+    /// `issues` still reference it). `DO UPDATE` mutates in place, leaving
+    /// child FKs intact.
     pub async fn batch_upsert(
         &self,
         table: &str,
@@ -164,11 +173,7 @@ impl D1Client {
         validate_table_name(table)?;
 
         let cols: Vec<String> = rows[0].keys().cloned().collect();
-        let placeholders = cols.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let col_list = cols.join(", ");
-        let sql = format!(
-            "INSERT OR REPLACE INTO {table} ({col_list}) VALUES ({placeholders})"
-        );
+        let sql = build_upsert_sql(table, &cols);
 
         let mut total_written = 0u64;
         for chunk in rows.chunks(100) {
@@ -249,6 +254,34 @@ impl D1Client {
     }
 }
 
+/// Build an `INSERT ... ON CONFLICT(id) DO UPDATE SET ...` statement.
+///
+/// We avoid `INSERT OR REPLACE`, which deletes the old row before inserting
+/// and cascades through FOREIGN KEY references (breaking re-pushes of parent
+/// rows while child rows exist). `DO UPDATE` mutates in place.
+///
+/// Degenerate case: if `id` is the only column, emit `DO NOTHING` since there
+/// is nothing else to update.
+fn build_upsert_sql(table: &str, cols: &[String]) -> String {
+    let col_list = cols.join(", ");
+    let placeholders = vec!["?"; cols.len()].join(", ");
+    let update_set = cols
+        .iter()
+        .filter(|c| c.as_str() != "id")
+        .map(|c| format!("{c} = excluded.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if update_set.is_empty() {
+        format!(
+            "INSERT INTO {table} ({col_list}) VALUES ({placeholders}) ON CONFLICT(id) DO NOTHING"
+        )
+    } else {
+        format!(
+            "INSERT INTO {table} ({col_list}) VALUES ({placeholders}) ON CONFLICT(id) DO UPDATE SET {update_set}"
+        )
+    }
+}
+
 /// Validate table name against the D1 syncable allowlist (SQL injection guard).
 pub fn validate_table_name(table: &str) -> Result<(), SyncError> {
     if D1_SYNCABLE_TABLES.contains(&table) {
@@ -319,6 +352,29 @@ mod tests {
         assert_eq!(
             client.query_url(),
             "https://api.cloudflare.com/client/v4/accounts/acct123/d1/database/db456/query"
+        );
+    }
+
+    #[test]
+    fn build_upsert_sql_uses_on_conflict_do_update() {
+        let sql = build_upsert_sql(
+            "projects",
+            &["id".into(), "name".into(), "key".into()],
+        );
+        assert!(sql.starts_with("INSERT INTO projects (id, name, key) VALUES (?, ?, ?)"));
+        assert!(sql.contains("ON CONFLICT(id) DO UPDATE SET"));
+        assert!(sql.contains("name = excluded.name"));
+        assert!(sql.contains("key = excluded.key"));
+        assert!(!sql.contains("id = excluded.id"));
+        assert!(!sql.contains("INSERT OR REPLACE"));
+    }
+
+    #[test]
+    fn build_upsert_sql_id_only_falls_back_to_do_nothing() {
+        let sql = build_upsert_sql("tasks", &["id".into()]);
+        assert_eq!(
+            sql,
+            "INSERT INTO tasks (id) VALUES (?) ON CONFLICT(id) DO NOTHING"
         );
     }
 }

--- a/shell/gctrl-shell/src/commands/net.ts
+++ b/shell/gctrl-shell/src/commands/net.ts
@@ -8,11 +8,11 @@ import { Command, Options, Args } from "@effect/cli"
 import { Console, Effect, Option } from "effect"
 import { execFilePromise } from "../lib/exec"
 
-const GCTL_BIN = "gctrl"
+const GCTRL_BIN = "gctrl"
 
 const runGctl = (args: string[]) =>
   Effect.gen(function* () {
-    const result = yield* execFilePromise(GCTL_BIN, args, process.cwd())
+    const result = yield* execFilePromise(GCTRL_BIN, args, process.cwd())
     if (!result.ok) {
       yield* Console.error(result.output || `gctrl ${args[0]} failed`)
       return yield* Effect.fail(new Error(`gctrl ${args[0]} failed`))

--- a/specs/architecture/kernel/sync.md
+++ b/specs/architecture/kernel/sync.md
@@ -236,7 +236,7 @@ pub struct SyncConfig {
 }
 ```
 
-Credentials priority: CLI flags > env vars (`GCTL_R2_ACCESS_KEY_ID`, `GCTL_R2_SECRET_ACCESS_KEY`, `GCTL_D1_DATABASE_ID`, `GCTL_D1_ACCOUNT_ID`, `GCTL_D1_API_TOKEN`) > config file.
+Credentials priority: CLI flags > env vars (`GCTRL_R2_ACCESS_KEY_ID`, `GCTRL_R2_SECRET_ACCESS_KEY`, `GCTRL_D1_DATABASE_ID`, `GCTRL_D1_ACCOUNT_ID`, `GCTRL_D1_API_TOKEN`) > config file.
 
 ## 9. CLI Commands
 

--- a/specs/implementation/apps/deployment.md
+++ b/specs/implementation/apps/deployment.md
@@ -213,7 +213,7 @@ Opportunities to move more CI work off Depot runners:
 cd apps/gctrl-board && pnpm dev
 
 # Vite proxies /api/* → http://localhost:4318 (kernel daemon)
-# Override kernel port: GCTL_KERNEL_PORT=5000 pnpm dev
+# Override kernel port: GCTRL_KERNEL_PORT=5000 pnpm dev
 ```
 
 For local D1 testing (without the Rust kernel):


### PR DESCRIPTION
## Summary

Three follow-ups from #25 (board SQLite → D1 sync) bundled together.

- **A — `/api/sync/push` empty body crashes** (`2991ef8`). An empty `{}` body expanded to *all* syncable tables via `resolve_tables`, including DuckDB-backed ones (`sessions`, `spans`, `tasks`). The handler feeds the engine a throwaway in-memory DuckDB with no schema, so those branches returned 500 `Catalog Error: Table with name sessions does not exist`. Fix: when the request's `tables` field is empty, the handler passes a hard-coded SQLite-only subset (`board_*` + `memory_entries`). Callers can still name DuckDB-backed tables explicitly; they'll fail the same way until the real DuckDB store is wired through (follow-up C: lift `R2SyncEngine` into `AppState`).

- **B — Re-push fails `FOREIGN KEY constraint failed`** (`ed31a12`). `batch_upsert` used `INSERT OR REPLACE`, which SQLite implements as delete-then-insert. Re-pushing a parent row (e.g. `projects`) cascaded through FKs and broke as soon as any child (e.g. `issues`) existed. Switched to `INSERT ... ON CONFLICT(id) DO UPDATE SET ...` so the row mutates in place and child FKs stay intact. SQL generation is lifted into a pure `build_upsert_sql` free function so it's unit-testable without the HTTP round-trip. Degenerate id-only case falls back to `DO NOTHING`.

- **E — `GCTL_*` → `GCTRL_*` env var rename** (`0132020`). Completes the `gctl → gctrl` brand rename from #22 / #23 — source identifiers and binary names were renamed, but env vars were left behind. 27 occurrences across 11 files: kernel config readers (`GCTRL_D1_*`, `GCTRL_DEVICE_ID`), CI workflow, Playwright config + fixtures, Vite proxy target, `.env.example`, sync architecture & deployment docs. The `GCTL_BIN` TS constant in `shell/net.ts` is renamed to `GCTRL_BIN` for symmetry (string value `"gctrl"` unchanged).

Breaking for E: any local `.env` or CI config setting `GCTL_*` must be updated. `.env.example` shows the new names.

## Test plan

- [x] `cargo test -p gctrl-sync` — 23 passing (includes new `build_upsert_sql_*` + empty-body regression tests)
- [x] `cargo test -p gctrl-otel` — sync handler regression tests green (`test_sync_push_empty_body_defaults_to_sqlite_tables`, `test_sync_push_no_body_defaults_to_sqlite_tables`)
- [x] `cargo build` on all affected crates
- [x] `grep -r GCTL_ .` returns zero matches
- [ ] CI green on this branch
- [ ] End-to-end re-push against prod D1 no longer raises FK error (follow-up verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)