### PR TITLE
ci: cache cargo builds and collapse compile/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build workspace
-        run: cargo build --workspace
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kernel
+
+      - name: Compile workspace + tests
+        run: cargo test --workspace --locked --no-run
 
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --no-fail-fast
+
+      - name: Build kernel binary
+        run: cargo build --bin gctrld --locked
 
       # Upload the built kernel binary for the Playwright job
       - name: Upload kernel binary


### PR DESCRIPTION
## Summary

Current CI bottleneck is the Rust job at ~23m. Two changes:

- **`Swatinem/rust-cache@v2`** — persists `~/.cargo` + `target/` across runs. Biggest single saving: `libduckdb-sys` (bundled C++ compile) no longer rebuilds every PR.
- **Collapsed `cargo build` + `cargo test`** → `cargo test --no-run` (compile) + `cargo test --no-fail-fast` (run) + `cargo build --bin gctrld` (artifact). Old flow compiled non-test and test configs back-to-back, duplicating most codegen.

Added `--locked` so lockfile drift fails fast.

Expected: ~23m → ~5–8m on warm cache. Cold cache (first run, or after `Cargo.lock` changes) unchanged.

## Test plan
- [ ] First run (cold cache) completes successfully within the 30m timeout
- [ ] Second run on same branch shows substantial time reduction in the Rust job
- [ ] `target/debug/gctrld` artifact still uploads and Playwright job passes
