### PR TITLE
feat(specs): design drag-to-dispatch + seed TDD contracts

### DIFF
--- a/apps/gctrl-board/tests/acceptance/session-trigger.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/session-trigger.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Session Trigger — acceptance (TDD contract, currently pending).
+ *
+ * These tests encode the end-to-end drag-to-dispatch flow from
+ * [specs/architecture/session-trigger-from-board.md] and
+ * [specs/implementation/kernel/session-trigger.md §Tier 4].
+ *
+ * They are marked `test.fixme` until the implementation lands. The implementer:
+ *   1. Replace `test.fixme` with `test` one at a time (red → green).
+ *   2. Ensure the local kernel has Slice 1 wired up: promote-on-move,
+ *      orchestrator stub tick, `GET /api/sessions?issue_id=X` filter.
+ *   3. Run `pnpm exec playwright test session-trigger` — each un-fixme'd
+ *      test should first fail (RED), then pass once the backend is done.
+ */
+import { test, expect, dragIssueToColumn, selectProject } from "./fixtures/test"
+
+test.describe("Session Trigger from Board", () => {
+  test.fixme(
+    "dragging an Issue to in_progress creates a linked Session",
+    async ({ page, kernel, seedProject }) => {
+      const issue = await kernel.createIssue({
+        project_id: seedProject.id,
+        title: "Exercise drag-to-dispatch",
+        priority: "high",
+      })
+
+      await page.goto("/")
+      await selectProject(page, seedProject.key)
+
+      await dragIssueToColumn(page, issue.id, "in_progress")
+
+      // Card must land in the in_progress column
+      await expect(
+        page
+          .locator('[data-testid="column-in_progress"]')
+          .locator(`[data-testid="issue-card-${issue.id}"]`)
+      ).toBeVisible()
+
+      // Orchestrator stub should create a Session linked to this Issue
+      // within a couple of poll ticks (2s tick interval → 5s budget).
+      await expect
+        .poll(
+          async () => {
+            const sessions = await kernel.getSessions({ limit: 50 })
+            // TODO: once the `issue_id` query-param filter lands, call
+            //       kernel.getSessions({ issue_id: issue.id }) instead.
+            return sessions.filter(
+              (s: { issue_id?: string }) => s.issue_id === issue.id
+            ).length
+          },
+          { timeout: 5_000, intervals: [250, 500, 1_000] }
+        )
+        .toBeGreaterThanOrEqual(1)
+    }
+  )
+
+  test.fixme(
+    "re-dragging the same Issue does not create a second Task",
+    async ({ page, kernel, seedProject }) => {
+      const issue = await kernel.createIssue({
+        project_id: seedProject.id,
+        title: "Idempotent drag",
+      })
+
+      await page.goto("/")
+      await selectProject(page, seedProject.key)
+
+      await dragIssueToColumn(page, issue.id, "in_progress")
+      // Move back then forward again
+      await dragIssueToColumn(page, issue.id, "todo")
+      await dragIssueToColumn(page, issue.id, "in_progress")
+
+      // Reuse rule: while the Task is still non-terminal, re-promotion
+      // MUST reuse the existing row. Exactly one Task linked to the Issue.
+      // (Uses raw fetch until kernel test client exposes tasks listing.)
+      const tasks = await fetch(
+        `${process.env.PREVIEW_URL ?? "http://localhost:14318"}/api/tasks?issue_id=${issue.id}`
+      ).then((r) => r.json())
+      expect(Array.isArray(tasks) ? tasks.length : 0).toBe(1)
+    }
+  )
+
+  test.fixme(
+    "Issues in projects without WORKFLOW.md do not trigger dispatch",
+    async ({ page, kernel, seedProject }) => {
+      // seedProject has no WORKFLOW.md; dragging must NOT create a Task,
+      // but the Issue move itself must still succeed.
+      const issue = await kernel.createIssue({
+        project_id: seedProject.id,
+        title: "No agent config",
+      })
+
+      await page.goto("/")
+      await selectProject(page, seedProject.key)
+
+      await dragIssueToColumn(page, issue.id, "in_progress")
+
+      await expect(
+        page
+          .locator('[data-testid="column-in_progress"]')
+          .locator(`[data-testid="issue-card-${issue.id}"]`)
+      ).toBeVisible()
+
+      // No session should exist for this issue.
+      const sessions = await kernel.getSessions({ limit: 50 })
+      const linked = sessions.filter(
+        (s: { issue_id?: string }) => s.issue_id === issue.id
+      )
+      expect(linked.length).toBe(0)
+    }
+  )
+})

--- a/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
+++ b/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
@@ -1,0 +1,126 @@
+//! TDD contract tests for Issue → Task promotion on status move.
+//!
+//! These tests are **intentionally ignored** and compile against only the
+//! existing `SqliteStore` surface — they describe the contract from
+//! [specs/implementation/kernel/session-trigger.md §Tier 1] that a follow-up
+//! PR must satisfy.
+//!
+//! The implementer's job:
+//!   1. Remove the `#[ignore]` attribute on each test.
+//!   2. Implement `promote_issue_to_task` and `list_tasks_for_issue` on
+//!      `SqliteStore` per the spec.
+//!   3. Modify `update_board_issue_status` so that a transition to
+//!      `in_progress` promotes the Issue to a Task in the same transaction.
+//!   4. Replace each `unimplemented!()` below with the sketched assertions.
+//!
+//! Once the test panics turn into real assertions and those pass, commit.
+//! No new public API is added in this PR — the spec alone lands first.
+
+use chrono::Utc;
+use gctrl_core::{BoardIssue, BoardProject, IssueStatus};
+use gctrl_storage::SqliteStore;
+
+fn test_store() -> SqliteStore {
+    SqliteStore::open(":memory:").expect("open :memory: store")
+}
+
+fn seed_project_and_issue(store: &SqliteStore, key: &str, issue_id: &str) {
+    let project = BoardProject {
+        id: format!("{key}-project"),
+        name: key.into(),
+        key: key.into(),
+        counter: 1,
+        github_repo: None,
+    };
+    store.create_board_project(&project).expect("create project");
+
+    let now = Utc::now();
+    let issue = BoardIssue {
+        id: issue_id.into(),
+        project_id: project.id.clone(),
+        title: format!("Seed {issue_id}"),
+        description: None,
+        status: IssueStatus::Todo,
+        priority: "none".into(),
+        assignee_id: None,
+        assignee_name: None,
+        assignee_type: None,
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: Some(issue_id.into()),
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+    };
+    store.insert_board_issue(&issue).expect("insert issue");
+}
+
+#[test]
+#[ignore = "TDD pending — requires SqliteStore::promote_issue_to_task + list_tasks_for_issue (see specs/implementation/kernel/session-trigger.md §Tier 1, Red 1)"]
+fn promote_creates_single_task_for_unpromoted_issue() {
+    let store = test_store();
+    seed_project_and_issue(&store, "BACK", "BACK-1");
+
+    // let task = store.promote_issue_to_task("BACK-1", "claude-code").expect("promote");
+    // assert_eq!(task.issue_id.as_deref(), Some("BACK-1"));
+    // assert_eq!(task.agent_kind, "claude-code");
+    // assert_eq!(task.orchestrator_claim, "Unclaimed");
+    // assert_eq!(task.attempt, 0);
+
+    // let tasks = store.list_tasks_for_issue("BACK-1").expect("list");
+    // assert_eq!(tasks.len(), 1, "exactly one Task row should exist");
+
+    unimplemented!(
+        "Implement SqliteStore::promote_issue_to_task + list_tasks_for_issue, \
+         then replace this panic with the commented assertions above."
+    );
+}
+
+#[test]
+#[ignore = "TDD pending — promote-or-reuse rule: repeated promotion must not duplicate (spec §Tier 1, Red 2)"]
+fn promote_reuses_existing_nonterminal_task() {
+    let store = test_store();
+    seed_project_and_issue(&store, "BACK", "BACK-2");
+
+    // let first = store.promote_issue_to_task("BACK-2", "claude-code").expect("promote 1");
+    // let second = store.promote_issue_to_task("BACK-2", "claude-code").expect("promote 2");
+    // assert_eq!(first.id, second.id, "second promote must reuse the existing task");
+    //
+    // let tasks = store.list_tasks_for_issue("BACK-2").expect("list");
+    // assert_eq!(tasks.len(), 1);
+
+    unimplemented!(
+        "Assert second promote returns the same Task id when the first Task is still non-terminal."
+    );
+}
+
+#[test]
+#[ignore = "TDD pending — moving Issue to in_progress must promote in the same transaction (spec §Tier 1, Red 3)"]
+fn move_to_in_progress_promotes_linked_task() {
+    let store = test_store();
+    seed_project_and_issue(&store, "BACK", "BACK-3");
+
+    store
+        .update_board_issue_status("BACK-3", "in_progress", "actor-1", "Actor", "human")
+        .expect("move");
+
+    // let tasks = store.list_tasks_for_issue("BACK-3").expect("list");
+    // assert_eq!(tasks.len(), 1, "moving to in_progress must auto-promote the Issue");
+    // assert_eq!(tasks[0].orchestrator_claim, "Unclaimed");
+
+    unimplemented!(
+        "After implementation, uncomment the assertions — the move side-effect is \
+         the primary trigger for board drag-to-dispatch."
+    );
+}

--- a/specs/architecture/session-trigger-from-board.md
+++ b/specs/architecture/session-trigger-from-board.md
@@ -172,12 +172,16 @@ No new routes for Slice 1 — the existing `POST /api/board/issues/:id/move` rou
 ```json
 {
   "issue": { ... existing ... },
-  "task_id": "TASK-01HNABCDEFGH",
+  "task_id": "BACK-42.T1",
   "dispatched": true
 }
 ```
 
-`dispatched: false` returned when the Issue has no project-level agent config (i.e. WORKFLOW.md has no `agent:` section) — move still succeeds, just no session kicks off.
+Task IDs are project-keyed `<ISSUE_ID>.T<N>` (see [implementation/kernel/session-trigger.md §Task ID format](../implementation/kernel/session-trigger.md#task-id-format)).
+
+`dispatched: false` (with `task_id: null`) is returned when the Issue has no project-level agent config (i.e. WORKFLOW.md has no `agent:` section) — the move still succeeds, no Task row is created, and no session kicks off. This keeps the non-agentic flow a first-class path for human-only projects.
+
+Re-dragging an Issue whose latest Task is **`Released`** (terminal) creates a **new** Task with the next `.T<N>` ordinal. A drag while a non-terminal Task already exists reuses that Task, so rapid re-drags stay idempotent.
 
 ### Future routes (Slice 2+)
 

--- a/specs/architecture/session-trigger-from-board.md
+++ b/specs/architecture/session-trigger-from-board.md
@@ -1,0 +1,208 @@
+# Session Trigger from Board
+
+How dragging an Issue to `in_progress` on the gctrl-board web UI kicks off an agentic development session. Ties together existing primitives — it is **not** a new kernel subsystem.
+
+> Related specs:
+> - [kernel/orchestrator.md](kernel/orchestrator.md) — claim states, dispatch, retry (kernel primitive)
+> - [apps/gctl-board.md](apps/gctl-board.md) — what the board tracks (Issues vs. Tasks)
+> - [../gctrl/WORKFLOW.md](../gctrl/WORKFLOW.md) — issue lifecycle + agent dispatch CLI
+
+---
+
+## Problem
+
+Today, starting an agent session is a CLI act:
+
+```sh
+gctrl board assign BACK-42 --agent claude-code
+gctrl board move BACK-42 in_progress
+```
+
+The deployed gctrl-board is view-only for dispatch: a user can drag a card but nothing agentic happens. We want the drag gesture itself — on both local and deployed board — to be the trigger.
+
+---
+
+## Invariants (inherited, not redefined here)
+
+1. **Issues are app-level; the Orchestrator never sees them.** Board emits Issue-level events; kernel promotes them into Tasks; the Orchestrator dispatches Sessions against Tasks. See [kernel/orchestrator.md](kernel/orchestrator.md) §1.
+2. **Apps MUST NOT access storage or external services directly.** The board (both local and deployed) talks to the kernel HTTP API. See [os.md §Dependency Direction](os.md).
+3. **Orchestrator state machine is authoritative** for dispatch/claim/retry. The board does not implement its own scheduler.
+
+---
+
+## End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (browser)
+    participant B as gctrl-board (web/worker)
+    participant K as Kernel (HTTP :4318)
+    participant O as Orchestrator
+    participant R as AgentRuntime
+    participant C as ComputeBackend
+
+    U->>B: drag BACK-42 → in_progress
+    B->>K: POST /api/board/issues/BACK-42/move {status: "in_progress"}
+    K->>K: Issue state machine → promote-or-reuse Task
+    K-->>B: 200 {issue, task_id}
+    K->>O: storage event: task.dispatchable
+    O->>O: claim (Unclaimed → Claimed)
+    O->>R: render prompt + launch(task, workspace)
+    R->>C: start compute (local process | CF container)
+    C-->>R: agent runs, streams spans
+    R->>K: OTLP /v1/traces (session_id, span_id)
+    K-->>B: GET /api/sessions?issue_id=BACK-42 (polled or subscribed)
+```
+
+### Boundaries
+
+- The **board** is a dumb trigger. It sends `move` and renders state. It never decides which agent to run.
+- The **kernel** owns the Issue → Task promotion and feeds the Orchestrator.
+- The **Orchestrator** owns dispatch eligibility, claim, and retry. Unchanged from [kernel/orchestrator.md](kernel/orchestrator.md).
+- The **AgentRuntime** renders + launches the agent. It is a new abstraction that wraps today's `AgentAdapter` (see next section).
+- The **ComputeBackend** is where the runtime runs. It is a new abstraction.
+
+---
+
+## Compute × Runtime Split
+
+Today's [implementation/kernel/orchestrator.md](../implementation/kernel/orchestrator.md) defines `AgentAdapter::launch(prompt, workspace, attempt) -> AgentHandle{pid}`. That conflates two concerns:
+
+1. **Which agent is running?** (the *runtime*) — Claude Code, Claude Agent SDK, opencode, aider, custom.
+2. **Where is it running?** (the *compute*) — local process, Cloudflare Container, e2b, etc.
+
+We split the port:
+
+```text
+AgentRuntime × ComputeBackend  →  launched Session
+```
+
+### AgentRuntime
+
+```rust
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    fn kind(&self) -> &str;                           // "claude-code" | "claude-agent-sdk" | "opencode" | ...
+    fn render_invocation(&self, prompt: &str,
+                         workspace: &Path) -> Invocation;
+}
+
+/// Describes what to execute inside a ComputeBackend.
+pub struct Invocation {
+    pub command: Vec<String>,     // e.g. ["claude", "--print", "--prompt", ...]
+    pub env: BTreeMap<String, String>,
+    pub stdin: Option<String>,    // for runtimes that pass prompt via stdin
+    pub workspace_mount: PathBuf, // local path to mount/copy
+}
+```
+
+### ComputeBackend
+
+```rust
+#[async_trait]
+pub trait ComputeBackend: Send + Sync {
+    fn kind(&self) -> &str;  // "local-process" | "cf-containers" | ...
+    async fn launch(&self, invocation: Invocation) -> Result<ComputeHandle, ComputeError>;
+}
+
+pub struct ComputeHandle {
+    pub id: String,                               // pid for local, container_id for CF
+    pub kill: Box<dyn FnOnce() -> Result<(), ComputeError> + Send>,
+    pub wait: Box<dyn Future<Output = ComputeExit> + Send>,
+}
+```
+
+The existing `AgentAdapter` becomes a composite: `(runtime, compute) -> AgentHandle`. No changes to the Orchestrator state machine or claim logic.
+
+### Configuration
+
+`WORKFLOW.md` frontmatter gains a `compute` key (defaults to `local-process` for backward compatibility):
+
+```yaml
+agent:
+  runtime: claude-code
+  compute: local-process           # or: cf-containers
+  args: ["--print", "--dangerously-skip-permissions"]
+  # cf-containers-specific:
+  compute_config:
+    image: "gctrl/claude-code:latest"
+    cpu_ms: 30000
+    memory_mb: 2048
+```
+
+---
+
+## Deployment Phasing
+
+The deployed gctrl-board runs on Cloudflare Workers and has no local kernel to talk to. We reach the end goal in three slices, each shippable on its own.
+
+### Slice 1 — Local trigger (this PR)
+
+- Board drag works when run locally against a local kernel.
+- `ComputeBackend = local-process`, `AgentRuntime = claude-code`.
+- **No CF Containers yet, no deployed flow yet.** The deployed board still shows sessions read-only.
+- Acceptance: Playwright local — drag card → `GET /api/sessions?issue_id=X` returns a row.
+
+### Slice 2 — Remote compute, local orchestrator
+
+- Add `cf-containers` ComputeBackend. Same `claude-code` runtime.
+- Local kernel orchestrates; agent runs in a CF Container and streams OTLP back to the local kernel.
+- Still requires a local kernel daemon. Deployed board unchanged.
+- Acceptance: local kernel + CF Container — session completes, spans land in DuckDB.
+
+### Slice 3 — Cloud orchestrator (end goal)
+
+- Deploy an orchestrator slice on Cloudflare (Worker + Durable Object for claim state + D1 for session rows + Containers for compute + OTel forwarding to SigNoz / local via pull-sync).
+- Deployed board → deployed orchestrator. No local daemon needed.
+- The Rust `gctrl-orch` crate stays the source of truth for state-machine semantics; the Workers slice is a **Rust-compiled-to-Wasm** binding (candidate: `workers-rs`) wrapping the same `transition()` function. This keeps the Lean-verified semantics identical in both deployments.
+- Acceptance: `wrangler dev --remote` preview — drag card → session row in D1 via `GET /api/sessions`.
+
+Each slice is behind a feature flag; no slice breaks the prior one.
+
+---
+
+## HTTP Contract Changes
+
+No new routes for Slice 1 — the existing `POST /api/board/issues/:id/move` route gains side-effects when the target status is `in_progress`:
+
+- Kernel locates or creates the linked Task (by `issue_id` foreign key).
+- Kernel emits `task.dispatchable` event (storage row + tracing span).
+- Response shape extended:
+
+```json
+{
+  "issue": { ... existing ... },
+  "task_id": "TASK-01HNABCDEFGH",
+  "dispatched": true
+}
+```
+
+`dispatched: false` returned when the Issue has no project-level agent config (i.e. WORKFLOW.md has no `agent:` section) — move still succeeds, just no session kicks off.
+
+### Future routes (Slice 2+)
+
+- `POST /api/sessions` — explicit manual dispatch (bypasses the board flow).
+- `GET /api/sessions?issue_id=X` — already exists; re-used by the board to poll.
+- `POST /v1/traces` — OTLP receive endpoint, exists, used by CF-Container-hosted agent.
+
+---
+
+## Observability
+
+New events (appended to the existing orchestrator event table in [kernel/orchestrator.md](kernel/orchestrator.md) §Observability):
+
+| Event | Fields |
+|-------|--------|
+| `board.issue_moved` | `issue_id`, `from_status`, `to_status`, `actor_id`, `triggered_dispatch: bool` |
+| `task.promoted_from_issue` | `task_id`, `issue_id`, `project_key` |
+
+The existing `orchestrator.claim` / `orchestrator.dispatch` events fire downstream unchanged.
+
+---
+
+## Non-Goals
+
+- **No new state machine.** We reuse the existing claim-state machine.
+- **No write-path for Tasks from the board UI.** Tasks remain read-only from the human side per [apps/gctl-board.md](apps/gctl-board.md).
+- **No agent-of-the-month picker in the UI** (yet). Which runtime runs is configured via WORKFLOW.md; the drag just means "go".
+- **No per-slice rollback plan** — each slice sits behind a config flag; default stays on the previously shipped slice.

--- a/specs/implementation/kernel/session-trigger.md
+++ b/specs/implementation/kernel/session-trigger.md
@@ -54,16 +54,18 @@ Implementation plan for the Slice 1 subset of [architecture/session-trigger-from
 ```sql
 -- tasks (new)
 CREATE TABLE IF NOT EXISTS tasks (
-    id                  VARCHAR PRIMARY KEY,      -- TASK-01HN...
+    id                  VARCHAR PRIMARY KEY,      -- project-keyed: "<ISSUE_ID>.T<N>" e.g. "BACK-42.T1"
     issue_id            VARCHAR,                  -- FK to board_issues.id, nullable (Tasks can exist without Issues)
     project_key         VARCHAR NOT NULL,
+    attempt_ordinal     INTEGER NOT NULL,         -- monotonic per issue_id; drives the T<N> suffix
     agent_kind          VARCHAR NOT NULL,         -- from WORKFLOW.md agent.runtime
     orchestrator_claim  VARCHAR NOT NULL DEFAULT 'Unclaimed',
                                                    -- Unclaimed | Claimed | Running | RetryQueued | Released
     attempt             INTEGER NOT NULL DEFAULT 0,
     created_at          VARCHAR NOT NULL,
     updated_at          VARCHAR NOT NULL,
-    FOREIGN KEY (issue_id) REFERENCES board_issues(id) ON DELETE SET NULL
+    FOREIGN KEY (issue_id) REFERENCES board_issues(id) ON DELETE SET NULL,
+    UNIQUE (issue_id, attempt_ordinal)
 );
 
 -- sessions: link to task
@@ -71,7 +73,14 @@ ALTER TABLE sessions ADD COLUMN task_id VARCHAR;  -- nullable for backward compa
 CREATE INDEX IF NOT EXISTS sessions_task_id_idx ON sessions(task_id);
 ```
 
-Promote-or-reuse rule: if a non-terminal (`Unclaimed`/`Claimed`/`Running`/`RetryQueued`) Task already exists for the Issue, reuse it; else insert a new row. Prevents duplicate dispatch when a user drags the same card to `in_progress` twice.
+### Task ID format
+
+Project-keyed: `<ISSUE_ID>.T<N>` where `N = max(attempt_ordinal for issue_id) + 1`, starting at `1`. Examples: `BACK-42.T1`, `BACK-42.T2`. Readable in logs/URLs and aligns with the human-addressable issue IDs the board already uses. IDs are stable — never renumbered when earlier attempts are released.
+
+### Promote-or-reuse rule
+
+- If a **non-terminal** (`Unclaimed` / `Claimed` / `Running` / `RetryQueued`) Task already exists for the Issue, reuse it. Prevents duplicate dispatch when a user drags the same card twice in quick succession.
+- If the latest Task for the Issue is **`Released`** (terminal for the claim cycle), promotion inserts a **new** row with `attempt_ordinal + 1`. Rationale: `Released` means "that attempt is done"; a fresh drag is a fresh intent, and a new Task gives the orchestrator a clean slate for claim/retry bookkeeping while preserving audit history of prior attempts.
 
 ---
 
@@ -137,10 +146,8 @@ Soak tests wait until real compute is wired — no value running the stub under 
 
 ---
 
-## Open Questions for Slice 1 Review
+## Resolved Decisions (for Slice 1)
 
-1. **Task ID format** — `TASK-01HN...` (ULID) vs. project-keyed like `BACK-42.T1`? Prefer ULID for uniqueness; project-keyed for readability.
-2. **WORKFLOW.md resolution** — if no agent section, `dispatched: false` and no Task created, or Task created but never claimed? Proposal: no Task created, so `list tasks` stays clean.
-3. **Reuse window** — if a Task is `Released` (terminal for the claim cycle), dragging again creates a new Task or reuses? Proposal: always new, since `Released` means "this attempt is done".
-
-Resolve these in the PR description / review comments before implementation lands.
+1. **Task ID format** — **project-keyed `<ISSUE_ID>.T<N>`** (see [Task ID format](#task-id-format)). Readable in logs and URLs; aligns with existing human-addressable Issue IDs. Uniqueness is enforced by the `(issue_id, attempt_ordinal)` unique constraint.
+2. **No `agent:` section in WORKFLOW.md** — **move succeeds, no Task created, `dispatched: false`** in the move response. Keeps `list tasks` free of never-dispatchable rows and makes the non-agentic workflow a first-class path for human-only projects.
+3. **Released-state reuse** — **always create a new Task** when the latest Task for an Issue is `Released`. Preserves attempt history and gives the orchestrator a clean claim/retry slate for each fresh drag. Only non-terminal Tasks (`Unclaimed` / `Claimed` / `Running` / `RetryQueued`) are reused.

--- a/specs/implementation/kernel/session-trigger.md
+++ b/specs/implementation/kernel/session-trigger.md
@@ -1,0 +1,146 @@
+# Session Trigger — Implementation (Slice 1: Local)
+
+Implementation plan for the Slice 1 subset of [architecture/session-trigger-from-board.md](../../architecture/session-trigger-from-board.md): drag-to-`in_progress` on a locally-run gctrl-board → local kernel promotes Issue to Task → orchestrator dispatches `claude-code` via `local-process`. Slices 2 (CF Containers compute) and 3 (cloud orchestrator) are out of scope for this doc.
+
+> **Dependency note:** The `gctrl-orch` crate in [orchestrator.md](orchestrator.md) is marked `[deferred]`. Slice 1 lands the **trigger side** (promotion + intent recording) plus a **stub orchestrator** that owns just enough state for the acceptance test to observe a session. The full claim-state machine ships in a follow-up PR.
+
+---
+
+## Scope
+
+| In | Out |
+|----|-----|
+| HTTP side-effects on `POST /api/board/issues/:id/move` when `status == "in_progress"` | CF Containers compute |
+| Promote-or-reuse linked Task row + emit `task.promoted_from_issue` span | Deployed orchestrator on Workers |
+| Orchestrator stub that reads `task.dispatchable` and inserts a `sessions` row | Full claim-state machine from `kernel/orchestrator.md` |
+| AgentRuntime / ComputeBackend traits in `gctrl-core` (no adapter impls yet — just the abstractions) | Real Claude Code process launch (stub runtime for tests) |
+| `GET /api/sessions?issue_id=X` filter support | OTLP ingestion hookup for Containers |
+
+---
+
+## Crate / File Touch List
+
+### `kernel/crates/gctrl-core/`
+- `src/types.rs` — new structs: `Task`, `TaskDispatchability`, `AgentRuntimeKind`, `ComputeKind`.
+- `src/ports.rs` (new) — trait `AgentRuntime`, trait `ComputeBackend`, struct `Invocation`, struct `ComputeHandle`. No impls.
+
+### `kernel/crates/gctrl-storage/`
+- `src/schema.rs` — new table `tasks` (if not already present) + FK from `tasks` to `board_issues`. Migrate existing `sessions` to allow `task_id: VARCHAR NULL` column.
+- `src/sqlite_store.rs`:
+  - New: `promote_issue_to_task(issue_id: &str, agent_kind: &str) -> Result<Task>` — inserts or reuses.
+  - New: `list_dispatchable_tasks() -> Result<Vec<Task>>` — reads rows where `orchestrator_claim == 'Unclaimed'`.
+  - Modify: `update_board_issue_status` — when `new_status == "in_progress"`, also call `promote_issue_to_task` inside the same transaction and return the resulting `Task` via a new overload.
+
+### `kernel/crates/gctrl-otel/`
+- `src/receiver.rs`:
+  - `board_move_issue` — detect `in_progress` transition, call the overload that promotes; include `task_id` and `dispatched: bool` in response JSON.
+  - New: `GET /api/sessions?issue_id=X` filter param (extend existing handler).
+
+### `kernel/crates/gctrl-orch/` (new crate, minimal)
+- `Cargo.toml`
+- `src/lib.rs` — re-exports.
+- `src/stub.rs` — `Orchestrator::tick()` that does one poll: list dispatchable tasks, for each insert a `sessions` row with status `active`, emit `orchestrator.claim` tracing span. No actual agent launch yet — this is scaffolding so the acceptance test can observe a session appearing.
+- Wired into `gctrl-cli` daemon `serve` startup: tokio task calls `tick()` every 2s.
+
+### `apps/gctrl-board/`
+- `web/src/api/client.ts` — no change (existing `moveIssue` returns the extended body).
+- `web/src/hooks/useSessions.ts` (new or extend) — poll `GET /api/sessions?issue_id=X` every 3s while a card is in `in_progress`.
+- `web/src/components/IssueCard.tsx` — session-running indicator (spinner icon) when `issue.session_ids.length > 0`.
+
+---
+
+## Data Model Additions
+
+```sql
+-- tasks (new)
+CREATE TABLE IF NOT EXISTS tasks (
+    id                  VARCHAR PRIMARY KEY,      -- TASK-01HN...
+    issue_id            VARCHAR,                  -- FK to board_issues.id, nullable (Tasks can exist without Issues)
+    project_key         VARCHAR NOT NULL,
+    agent_kind          VARCHAR NOT NULL,         -- from WORKFLOW.md agent.runtime
+    orchestrator_claim  VARCHAR NOT NULL DEFAULT 'Unclaimed',
+                                                   -- Unclaimed | Claimed | Running | RetryQueued | Released
+    attempt             INTEGER NOT NULL DEFAULT 0,
+    created_at          VARCHAR NOT NULL,
+    updated_at          VARCHAR NOT NULL,
+    FOREIGN KEY (issue_id) REFERENCES board_issues(id) ON DELETE SET NULL
+);
+
+-- sessions: link to task
+ALTER TABLE sessions ADD COLUMN task_id VARCHAR;  -- nullable for backward compat
+CREATE INDEX IF NOT EXISTS sessions_task_id_idx ON sessions(task_id);
+```
+
+Promote-or-reuse rule: if a non-terminal (`Unclaimed`/`Claimed`/`Running`/`RetryQueued`) Task already exists for the Issue, reuse it; else insert a new row. Prevents duplicate dispatch when a user drags the same card to `in_progress` twice.
+
+---
+
+## Test Pyramid — TDD Order
+
+Red-green-refactor. Each step lands as its own commit on this branch.
+
+### Tier 1: Domain unit (`gctrl-storage`)
+
+**Red 1** — `tests/promote_issue_to_task.rs`:
+- Given: an issue exists (`backlog`), no Task linked.
+- When: `promote_issue_to_task("BACK-42", "claude-code")`.
+- Then: exactly one `tasks` row exists with `issue_id=BACK-42`, `orchestrator_claim=Unclaimed`.
+
+**Red 2** — same file:
+- Given: Issue + a `Running` Task linked.
+- When: `promote_issue_to_task` called again.
+- Then: row count unchanged; returned Task has the existing id.
+
+**Red 3** — `tests/update_board_issue_status_promotes.rs`:
+- Given: Issue with `status=todo`.
+- When: `update_board_issue_status(id, "in_progress", ...)`.
+- Then: Issue status updated AND a Task row created with matching `issue_id`.
+
+### Tier 2: HTTP integration (`gctrl-otel`)
+
+**Red 4** — `tests/board_move_triggers_task.rs` (uses `tower::ServiceExt::oneshot`):
+- POST `/api/board/issues/BACK-42/move` with `{status: "in_progress", ...}`.
+- Assert response contains `task_id` and `dispatched: true`.
+- Assert sqlite has the Task row.
+
+### Tier 3: Orchestrator stub (`gctrl-orch`)
+
+**Red 5** — `tests/tick_claims_dispatchable.rs`:
+- Given: one `Unclaimed` Task row.
+- When: `Orchestrator::tick()`.
+- Then: `sessions` row exists with `task_id` set; Task's `orchestrator_claim=Claimed`.
+
+### Tier 4: Acceptance (Playwright, `apps/gctrl-board/tests/acceptance/`)
+
+**Red 6** — `session-trigger.spec.ts`:
+- Seed: local kernel (`:memory:`) with one Issue `BACK-1` in `todo`, project with `WORKFLOW.md` specifying `agent.runtime: stub-runtime` (a no-op runtime so tests don't need Claude credentials).
+- Drag card `issue-card-BACK-1` → drop on `column-in_progress`.
+- Assert: within 5 s, `GET /api/sessions?issue_id=BACK-1` returns `length >= 1`.
+- Assert: card shows running indicator (`data-testid="session-running-BACK-1"`).
+
+The `stub-runtime` lives in a `#[cfg(test)]`-feature-gated adapter — used only by CI. Real `claude-code` runtime ships in a follow-up, behind a config flag.
+
+### Tier 5: Soak (deferred to Slice 2+)
+
+Soak tests wait until real compute is wired — no value running the stub under load.
+
+---
+
+## Acceptance Criteria (this slice only)
+
+- [ ] `cargo test -p gctrl-storage` green including new promote tests.
+- [ ] `cargo test -p gctrl-otel` green including HTTP integration test.
+- [ ] `cargo test -p gctrl-orch` green.
+- [ ] `pnpm --filter gctrl-board test` green.
+- [ ] `pnpm --filter gctrl-board exec playwright test session-trigger` green locally.
+- [ ] Manual: `gctrl serve` + open local board, drag an Issue to `in_progress`, see a session row in `gctl sessions list`.
+
+---
+
+## Open Questions for Slice 1 Review
+
+1. **Task ID format** — `TASK-01HN...` (ULID) vs. project-keyed like `BACK-42.T1`? Prefer ULID for uniqueness; project-keyed for readability.
+2. **WORKFLOW.md resolution** — if no agent section, `dispatched: false` and no Task created, or Task created but never claimed? Proposal: no Task created, so `list tasks` stays clean.
+3. **Reuse window** — if a Task is `Released` (terminal for the claim cycle), dragging again creates a new Task or reuses? Proposal: always new, since `Released` means "this attempt is done".
+
+Resolve these in the PR description / review comments before implementation lands.


### PR DESCRIPTION
## Summary

Design-only PR. Lays out how dragging an Issue to `in_progress` on the deployed gctrl-board kicks off an agentic dev session. No runtime behavior changes — adds two specs + skipped TDD seeds.

- `specs/architecture/session-trigger-from-board.md` — end-to-end flow; splits today's `AgentAdapter` into **AgentRuntime × ComputeBackend** (Claude Code / Agent SDK / opencode × local-process / CF Containers / …). Phases rollout: **Slice 1** local trigger → **Slice 2** CF Containers compute → **Slice 3** cloud orchestrator on Workers + DO + D1.
- `specs/implementation/kernel/session-trigger.md` — Slice 1 crate touch list, schema deltas (new `tasks` table + `task_id` on `sessions`), 4-tier TDD plan (6 red tests).

### TDD seeds (green in CI, ready to un-ignore)

- `kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs` — 3 `#[ignore]`'d tests. Bodies sketched in comments with `unimplemented!()` guards so removing the `#[ignore]` drives the next API addition.
- `apps/gctrl-board/tests/acceptance/session-trigger.spec.ts` — 3 Playwright `test.fixme`s covering happy path, idempotent re-drag, and no-op when WORKFLOW.md has no agent section.

### Resolved decisions (baked into specs)

The three open questions from the initial draft are now resolved in [`specs/implementation/kernel/session-trigger.md`](specs/implementation/kernel/session-trigger.md#resolved-decisions-for-slice-1):

1. **Task ID format** → **project-keyed `<ISSUE_ID>.T<N>`** (e.g. `BACK-42.T1`). Readable in logs/URLs, aligns with existing human-addressable Issue IDs. Uniqueness enforced by `UNIQUE (issue_id, attempt_ordinal)`.
2. **No `agent:` section in WORKFLOW.md** → **move succeeds**, no Task row is created, response returns `dispatched: false` with `task_id: null`. Keeps `list tasks` clean; makes the human-only flow first-class.
3. **Released-state re-drag** → **always create a new Task** with the next `.T<N>` ordinal. Only non-terminal Tasks (`Unclaimed` / `Claimed` / `Running` / `RetryQueued`) are reused. Preserves attempt history and gives the orchestrator a clean slate per drag.

## Test plan
- [x] `cargo build --workspace` green
- [x] `cargo test -p gctrl-storage --test promote_issue_to_task` — 3 ignored, 0 failed
- [x] `pnpm exec playwright test session-trigger --list` — 3 tests listed
- [ ] No Rust behavior changes — diff is specs + test seeds only
