### PR TITLE
feat(kernel): Tier 2 — POST /api/board/issues/:id/move envelope + task promotion

### DIFF
--- a/apps/gctrl-board/src/adapters/BoardServiceLive.ts
+++ b/apps/gctrl-board/src/adapters/BoardServiceLive.ts
@@ -133,7 +133,8 @@ export const BoardServiceLive = Layer.effect(
             actor_name: "gctrl-board",
             actor_type: "agent",
           })
-          return mapIssue(raw)
+          const envelope = raw as { issue: unknown }
+          return mapIssue(envelope.issue)
         }).pipe(
           Effect.catchTags({
             KernelError: (e): Effect.Effect<never, BoardError | IssueNotFoundError> =>

--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -239,7 +239,11 @@ const moveIssue: ApiHandler = (req, params) =>
     ])
 
     const row = yield* db.first("SELECT * FROM issues WHERE id = ?", params.id)
-    return jsonResponse(parseRow(row as Record<string, unknown>))
+    return jsonResponse({
+      issue: parseRow(row as Record<string, unknown>),
+      task_id: null,
+      dispatched: false,
+    })
   })
 
 const assignIssue: ApiHandler = (req, params) =>

--- a/apps/gctrl-board/test/board-service.test.ts
+++ b/apps/gctrl-board/test/board-service.test.ts
@@ -85,7 +85,7 @@ const createMockKernel = () => {
           if (!issue) return yield* fail404("not found")
           issue.status = b.status
           issue.updated_at = new Date().toISOString()
-          return issue
+          return { issue, task_id: null, dispatched: false }
         }
         const assignMatch = path.match(/\/api\/board\/issues\/([^/]+)\/assign/)
         if (assignMatch) {

--- a/apps/gctrl-board/tests/worker/issue-actions.test.ts
+++ b/apps/gctrl-board/tests/worker/issue-actions.test.ts
@@ -34,8 +34,14 @@ describe("Issue move (status transitions + events)", () => {
         )
         expect(moveRes.status).toBe(200)
 
-        const moved = (yield* moveRes.json) as Record<string, unknown>
-        expect(moved.status).toBe("in_progress")
+        const moved = (yield* moveRes.json) as {
+          issue: Record<string, unknown>
+          task_id: string | null
+          dispatched: boolean
+        }
+        expect(moved.issue.status).toBe("in_progress")
+        expect(moved.dispatched).toBe(false)
+        expect(moved.task_id).toBeNull()
 
         const eventsRes = yield* client.get(
           `${HOST}/api/board/issues/${issueId}/events`,

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -1,5 +1,6 @@
 import type {
   Issue,
+  MoveIssueResult,
   Project,
   Comment,
   IssueEvent,
@@ -73,7 +74,7 @@ export const api = {
       }),
 
     move: (id: string, status: string) =>
-      request<Issue>(`${BASE}/issues/${id}/move`, {
+      request<MoveIssueResult>(`${BASE}/issues/${id}/move`, {
         method: "POST",
         body: JSON.stringify({
           status,

--- a/apps/gctrl-board/web/src/components/KanbanBoard.tsx
+++ b/apps/gctrl-board/web/src/components/KanbanBoard.tsx
@@ -10,7 +10,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core"
-import type { Issue, IssueStatus } from "../types"
+import type { Issue, IssueStatus, MoveIssueResult } from "../types"
 import { STATUS_LABELS } from "../types"
 import { IssueCard } from "./IssueCard"
 
@@ -34,7 +34,7 @@ interface Props {
   issues: Issue[]
   loading: boolean
   hasProject: boolean
-  onMoveIssue: (issueId: string, newStatus: string) => Promise<Issue>
+  onMoveIssue: (issueId: string, newStatus: string) => Promise<MoveIssueResult>
   onSelectIssue: (issue: Issue) => void
 }
 

--- a/apps/gctrl-board/web/src/hooks/useBoard.ts
+++ b/apps/gctrl-board/web/src/hooks/useBoard.ts
@@ -65,9 +65,11 @@ export function useIssues(projectId: string | null) {
   const moveIssue = useCallback(
     async (issueId: string, newStatus: string) => {
       try {
-        const updated = await api.issues.move(issueId, newStatus)
-        setIssues((prev) => prev.map((i) => (i.id === issueId ? updated : i)))
-        return updated
+        const result = await api.issues.move(issueId, newStatus)
+        setIssues((prev) =>
+          prev.map((i) => (i.id === issueId ? result.issue : i))
+        )
+        return result
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Move failed"
         setError(msg)

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -52,6 +52,12 @@ export interface Project {
   github_repo?: string
 }
 
+export interface MoveIssueResult {
+  issue: Issue
+  task_id: string | null
+  dispatched: boolean
+}
+
 export interface IssueEvent {
   id: string
   issue_id: string

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -1034,17 +1034,46 @@ struct BoardMoveBody {
     actor_type: String,
 }
 
+/// Resolves the agent runtime kind for an Issue at dispatch time.
+///
+/// TODO(tier2.5): parse `agent.runtime` from `WORKFLOW.md` at the project
+/// filesystem root (see specs/architecture/session-trigger-from-board.md
+/// §"Agent resolution"). For now we hardcode the default runtime so the HTTP
+/// envelope contract is exercised end-to-end.
+fn resolve_agent_kind(_project_key: Option<&str>) -> String {
+    "claude-code".to_string()
+}
+
 async fn board_move_issue(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     Json(body): Json<BoardMoveBody>,
 ) -> impl IntoResponse {
-    match state.sqlite.update_board_issue_status(&id, &body.status, &body.actor_id, &body.actor_name, &body.actor_type) {
-        Ok(()) => {
-            match state.sqlite.get_board_issue(&id) {
-                Ok(Some(issue)) => Json(serde_json::to_value(&issue).unwrap()).into_response(),
-                _ => StatusCode::OK.into_response(),
-            }
+    let agent_kind = resolve_agent_kind(None);
+    let promoted = state.sqlite.update_board_issue_status_and_promote(
+        &id,
+        &body.status,
+        &agent_kind,
+        &body.actor_id,
+        &body.actor_name,
+        &body.actor_type,
+    );
+    match promoted {
+        Ok(task_opt) => {
+            let issue_val = match state.sqlite.get_board_issue(&id) {
+                Ok(Some(issue)) => serde_json::to_value(&issue).unwrap_or(serde_json::Value::Null),
+                _ => serde_json::Value::Null,
+            };
+            let (task_id, dispatched) = match task_opt {
+                Some(task) => (serde_json::Value::String(task.id), true),
+                None => (serde_json::Value::Null, false),
+            };
+            Json(serde_json::json!({
+                "issue": issue_val,
+                "task_id": task_id,
+                "dispatched": dispatched,
+            }))
+            .into_response()
         }
         Err(e) => {
             let msg = e.to_string();

--- a/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
+++ b/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
@@ -1,0 +1,155 @@
+//! Tier 2 integration tests: HTTP side-effects on `POST /api/board/issues/:id/move`.
+//!
+//! Response envelope contract (from
+//! specs/architecture/session-trigger-from-board.md §HTTP):
+//!
+//! ```json
+//! { "issue": { ... }, "task_id": "TASK-...", "dispatched": true }
+//! ```
+//!
+//! - Moving to `in_progress` auto-promotes the Issue to a Task in the same
+//!   transaction and returns `dispatched: true` + `task_id`.
+//! - Any other transition leaves `task_id: null` and `dispatched: false`.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use gctrl_core::{BoardIssue, BoardProject, IssueStatus};
+use gctrl_otel::create_router_dual;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn make_issue(project_id: &str, id: &str) -> BoardIssue {
+    let now = Utc::now();
+    BoardIssue {
+        id: id.into(),
+        project_id: project_id.into(),
+        title: format!("Test {id}"),
+        description: None,
+        status: IssueStatus::Todo,
+        priority: "none".into(),
+        assignee_id: None,
+        assignee_name: None,
+        assignee_type: None,
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: Some(id.into()),
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+    }
+}
+
+fn test_app() -> (axum::Router, Arc<SqliteStore>) {
+    let duck = Arc::new(DuckDbStore::open(":memory:").expect("duckdb"));
+    let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite"));
+
+    let project = BoardProject {
+        id: "BACK-project".into(),
+        name: "BACK".into(),
+        key: "BACK".into(),
+        counter: 1,
+        github_repo: None,
+    };
+    sqlite.create_board_project(&project).expect("create project");
+    sqlite
+        .insert_board_issue(&make_issue("BACK-project", "BACK-42"))
+        .expect("insert issue");
+
+    let router = create_router_dual(duck, Arc::clone(&sqlite));
+    (router, sqlite)
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: Value) -> (u16, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json_body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json_body)
+}
+
+#[tokio::test]
+async fn move_to_in_progress_returns_task_id_and_dispatched_true() {
+    let (app, sqlite) = test_app();
+
+    let (status, body) = post_json(
+        &app,
+        "/api/board/issues/BACK-42/move",
+        json!({
+            "status": "in_progress",
+            "actor_id": "u",
+            "actor_name": "User",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(
+        body["dispatched"],
+        Value::Bool(true),
+        "body missing `dispatched: true`: {body}"
+    );
+    let task_id = body["task_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("task_id missing: {body}"));
+    assert!(task_id.starts_with("TASK-"), "got: {task_id}");
+
+    assert_eq!(body["issue"]["id"], "BACK-42");
+    assert_eq!(body["issue"]["status"], "in_progress");
+
+    let tasks = sqlite.list_tasks_for_issue("BACK-42").unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].id, task_id);
+}
+
+#[tokio::test]
+async fn move_to_backlog_does_not_promote() {
+    let (app, sqlite) = test_app();
+
+    let (status, body) = post_json(
+        &app,
+        "/api/board/issues/BACK-42/move",
+        json!({
+            "status": "backlog",
+            "actor_id": "u",
+            "actor_name": "User",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["dispatched"], Value::Bool(false));
+    assert!(
+        body.get("task_id").map(|v| v.is_null()).unwrap_or(true),
+        "task_id should be null/absent: {body}"
+    );
+    assert_eq!(body["issue"]["status"], "backlog");
+
+    let tasks = sqlite.list_tasks_for_issue("BACK-42").unwrap();
+    assert!(tasks.is_empty());
+}

--- a/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
+++ b/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
@@ -4,7 +4,7 @@
 //! specs/architecture/session-trigger-from-board.md §HTTP):
 //!
 //! ```json
-//! { "issue": { ... }, "task_id": "TASK-...", "dispatched": true }
+//! { "issue": { ... }, "task_id": "<ISSUE_ID>.T<N>", "dispatched": true }
 //! ```
 //!
 //! - Moving to `in_progress` auto-promotes the Issue to a Task in the same
@@ -117,7 +117,7 @@ async fn move_to_in_progress_returns_task_id_and_dispatched_true() {
     let task_id = body["task_id"]
         .as_str()
         .unwrap_or_else(|| panic!("task_id missing: {body}"));
-    assert!(task_id.starts_with("TASK-"), "got: {task_id}");
+    assert_eq!(task_id, "BACK-42.T1", "task id must be <ISSUE_ID>.T<N>");
 
     assert_eq!(body["issue"]["id"], "BACK-42");
     assert_eq!(body["issue"]["status"], "in_progress");


### PR DESCRIPTION
## Summary

Tier 2 of the Session Trigger design (#28, builds on merged #29):
HTTP side of Issues → Tasks promotion on drag-to-`in_progress`.
**RED → GREEN → rebase-alignment** following the same TDD cadence
#28 seeded.

- **RED** (`2697631`): seeds the Tier 2 contract from
  specs/architecture/session-trigger-from-board.md §HTTP as two
  `#[tokio::test]` integration tests in `gctrl-otel`. Both hit the
  real axum router via `tower::ServiceExt::oneshot` and assert on
  the response envelope shape + sqlite side-effects.
- **GREEN** (`3e0256e`): rewires `board_move_issue` onto Tier 1's
  `update_board_issue_status_and_promote` overload. Response now
  matches the contract:

```json
{ "issue": { ... }, "task_id": "<ISSUE_ID>.T<N>" | null, "dispatched": bool }
```

`dispatched: true` + `task_id` set only on the `in_progress`
transition — every other status returns `dispatched: false`,
`task_id: null` with no row inserted into `tasks`.

- **Rebase alignment** (`ca87a78`): after #29 merged with the final
  `<ISSUE_ID>.T<N>` Task ID format, three things needed to follow:
  - updated the Tier 2 integration test to assert
    `task_id == "BACK-42.T1"` (was `starts_with("TASK-")`);
  - the Cloudflare Worker's own `/api/board/issues/:id/move` handler
    in `apps/gctrl-board/src/worker.ts` now returns the same
    envelope (`task_id: null, dispatched: false` — the Worker has
    no `tasks` table yet). This fixes the 3 preview-Worker
    drag-and-drop acceptance failures from the pre-rebase run.
  - `BoardServiceLive` unwraps `.issue` from the envelope before
    calling `mapIssue`, and the Worker + BoardService test mocks
    return the envelope shape.

### Agent resolution — deferred to Tier 2.5

A new `resolve_agent_kind()` helper holds the seam for WORKFLOW.md
lookup and currently returns a hardcoded `"claude-code"`:

```rust
/// TODO(tier2.5): parse `agent.runtime` from `WORKFLOW.md` at the
/// project filesystem root.
fn resolve_agent_kind(_project_key: Option<&str>) -> String {
    "claude-code".to_string()
}
```

Tier 2.5 replaces the body with filesystem-backed parsing without
touching the handler.

### Frontend (GREEN commit)

Minimal envelope plumbing so the Kanban board keeps compiling and
existing `handleDragEnd` logic is untouched:

- `types.ts`: new `MoveIssueResult { issue, task_id, dispatched }`
- `api/client.ts`: `issues.move` return type → `MoveIssueResult`
- `hooks/useBoard.ts`: `moveIssue` unwraps `.issue` into the list,
  returns the full envelope to the caller
- `components/KanbanBoard.tsx`: `onMoveIssue` prop retyped

No UI changes yet — consumers (toast "dispatched to `<ISSUE_ID>.T<N>`…",
orchestrator hand-off) come in later tiers.

### Stack

```
main  ← #29 merged (Tier 1 storage)
 └── feat/session-trigger-tier2-http (← this PR)
```

Base: `main` (re-targeted after #29 merged).

## Test plan

- [x] `cargo test -p gctrl-otel --test board_move_triggers_task`
      — 2 passed, 0 failed.
- [x] `cargo test --workspace --no-fail-fast` — no regressions.
- [x] `pnpm --filter gctrl-board test` — 24 passed, 29 skipped
      (unrelated `sync-d1` + `deploy-smoke` always skipped locally).
- [x] `pnpm --filter gctrl-board exec tsc --noEmit` — clean.
- [ ] Tier 2.5 — parse `agent.runtime` from WORKFLOW.md.
- [ ] Tier 3 — `gctrl-orch` stub claiming dispatchable Tasks.
- [ ] Tier 4 — Playwright acceptance (un-`fixme` the 3
      `session-trigger.spec.ts` tests) once Tier 3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
