### PR TITLE
ci: skip build/test jobs on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,37 @@ env:
 
 jobs:
   # ──────────────────────────────────────────────
+  # Path filter — skip build/test when only docs change
+  # ──────────────────────────────────────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - '!specs/**'
+              - '!**/*.md'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!LICENSE'
+
+  # ──────────────────────────────────────────────
   # Rust kernel — build & test
   # ──────────────────────────────────────────────
   rust:
     name: Rust (build + test)
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 30
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +82,8 @@ jobs:
     name: TypeScript (lint + test + build)
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -99,7 +126,8 @@ jobs:
     name: Playwright acceptance tests
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 20
-    needs: [rust, typescript]
+    needs: [changes, rust, typescript]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add a `changes` job using `dorny/paths-filter@v3` with `predicate-quantifier: every` — a file is "code" only if it matches none of `specs/**`, `**/*.md`, `.github/ISSUE_TEMPLATE/**`, `LICENSE`.
- Gate `rust`, `typescript`, and `playwright` on `needs.changes.outputs.code == 'true'`. Doc-only PRs skip those jobs (required-check-safe).

## Notes
- Mixed PRs (any non-doc file changed) still run the full suite.
- `deploy.yml` still triggers on `workflow_run` after CI. On a doc-only merge to `main`, the `typescript` job won't run and `board-web-dist` won't exist, so the production `deploy` job will fail at artifact download. Happy to follow up with a guard there if wanted.

## Test plan
- [ ] Open a docs-only PR; confirm `rust` / `typescript` / `playwright` show as skipped and CI concludes successfully.
- [ ] Open a code-only PR; confirm all three jobs run.
- [ ] Open a mixed PR; confirm all three jobs run.