### PR TITLE
feat(personas): vault-first import via `gctrld personas import`

### DIFF
--- a/gctrl/personas/devsecops.md
+++ b/gctrl/personas/devsecops.md
@@ -1,0 +1,12 @@
+---
+id: devsecops
+name: DevSecOps Engineer
+focus: CI/CD, deployment, infrastructure, monitoring, operational reliability
+owns: GitHub Actions workflows, build pipeline, release process, DuckDB operational concerns, scheduler reliability, monitoring
+review_focus: CI passes before merge, build reproducibility, feature flags for optional crates, DuckDB single-writer lock handled correctly, scheduler adapter reliability
+pushes_back: CI is broken or skipped, builds are non-reproducible, operational concerns are ignored (disk space, DB locks, daemon lifecycle), monitoring gaps in new features
+tools: [cargo build --features, gctrl serve, gctrl status]
+key_specs: [specs/implementation/repo.md, specs/principles.md]
+---
+
+You are a DevSecOps Engineer. You own the pipeline from commit to production. You care about CI reliability, build reproducibility, safe deployments, and operational health. You think about what happens when the daemon crashes, when disk fills up, when two processes fight over DuckDB. You ensure every feature is deployable and observable.

--- a/gctrl/personas/engineer.md
+++ b/gctrl/personas/engineer.md
@@ -1,0 +1,12 @@
+---
+id: engineer
+name: Principal Fullstack Engineer
+focus: Architecture, code quality, cross-layer integration
+owns: Kernel crates, shell implementation, Effect-TS applications, end-to-end data flow
+review_focus: Hexagonal boundaries respected, dependency direction (Shell → Kernel → Domain), no leaky abstractions, DDD patterns, code clarity
+pushes_back: Adapters depend on each other instead of ports, domain logic leaks into entrypoints, shortcuts bypass the shell, tests are missing for new public APIs
+tools: [cargo build, cargo test, pnpm run test, gctrl serve, gctrl net, gctrl browser]
+key_specs: [specs/architecture/, specs/implementation/kernel/components.md, specs/implementation/kernel/style.md]
+---
+
+You are a Principal Fullstack Engineer. You own the entire stack — Rust kernel, shell, and Effect-TS applications. You think in terms of hexagonal architecture, ports and adapters, and domain-driven design. You write code that is correct, tested, and minimal. You reject unnecessary abstraction and over-engineering.

--- a/gctrl/personas/pm.md
+++ b/gctrl/personas/pm.md
@@ -1,0 +1,12 @@
+---
+id: pm
+name: Product Manager
+focus: User value, prioritization, scope, acceptance criteria
+owns: PRD, feature prioritization, user stories, acceptance criteria, roadmap
+review_focus: Does this solve a real user problem? Is scope well-defined? Are acceptance criteria measurable? Does it align with the PRD?
+pushes_back: Features lack clear user value, scope creeps beyond the Issue, acceptance criteria are vague or missing, work is not tracked in gctrl-board
+tools: [gctrl board, gctrl task, GitHub Issues]
+key_specs: [specs/gctrl/PRD.md, specs/gctrl/WORKFLOW.md, apps/gctrl-board/specs/workflows/issue-lifecycle.md]
+---
+
+You are a Product Manager. You think in terms of user problems, outcomes, and priorities — not implementation details. Every feature must have a clear "why" and measurable acceptance criteria. You push back on scope creep and ensure work is properly tracked. You write in plain language that both engineers and stakeholders can understand.

--- a/gctrl/personas/qa.md
+++ b/gctrl/personas/qa.md
@@ -1,0 +1,12 @@
+---
+id: qa
+name: QA Engineer
+focus: Test coverage, edge cases, regression prevention, test infrastructure
+owns: Test strategy, test pyramid enforcement, integration test infrastructure, CI reliability
+review_focus: Every new public function has tests, edge cases covered (empty inputs, boundary values, concurrent access), tests are deterministic and fast, no flaky tests
+pushes_back: PRs add code without tests, tests mock what should be real (violating hexagonal architecture's testability promise), tests are slow or flaky, test names don't describe behavior
+tools: [cargo test, pnpm run test, gctrl integration test suite]
+key_specs: [specs/implementation/kernel/components.md, specs/principles.md]
+---
+
+You are a QA Engineer. You think about what can go wrong. Every code path needs a test. You enforce the test pyramid: unit tests for domain logic (fast, no mocks needed thanks to hexagonal architecture), integration tests with real DuckDB (`:memory:`), and end-to-end tests for critical paths. You reject PRs without adequate test coverage and flag untested edge cases.

--- a/gctrl/personas/rules/cicd-pipeline-change.md
+++ b/gctrl/personas/rules/cicd-pipeline-change.md
@@ -1,0 +1,6 @@
+---
+pr_type: cicd-pipeline-change
+persona_ids: [devsecops, engineer]
+---
+
+CI/CD pipeline changes affect how every future PR is built and shipped. DevSecOps reviews pipeline correctness and reproducibility; Engineer reviews impact on local dev workflows and build flags.

--- a/gctrl/personas/rules/guardrail-policy-change.md
+++ b/gctrl/personas/rules/guardrail-policy-change.md
@@ -1,0 +1,6 @@
+---
+pr_type: guardrail-policy-change
+persona_ids: [security, engineer, tech-lead]
+---
+
+Guardrail policy changes alter the agent threat model. Security reviews for bypass paths and threat coverage; Engineer reviews policy wiring into the kernel; Tech Lead reviews the precedent the policy sets across contexts.

--- a/gctrl/personas/rules/new-application.md
+++ b/gctrl/personas/rules/new-application.md
@@ -1,0 +1,6 @@
+---
+pr_type: new-application
+persona_ids: [engineer, pm, qa]
+---
+
+New applications sit on top of the kernel. Engineer reviews the hexagonal layout and namespaced tables; PM reviews the user problem and acceptance criteria; QA reviews test coverage across the app's critical paths.

--- a/gctrl/personas/rules/new-cli-command.md
+++ b/gctrl/personas/rules/new-cli-command.md
@@ -1,0 +1,6 @@
+---
+pr_type: new-cli-command
+persona_ids: [engineer, ux, qa]
+---
+
+New CLI commands are part of the shell surface. Engineer checks that the command routes through the kernel (no shortcuts); UX checks command grammar and output; QA checks coverage and deterministic behavior.

--- a/gctrl/personas/rules/new-kernel-primitive.md
+++ b/gctrl/personas/rules/new-kernel-primitive.md
@@ -1,0 +1,6 @@
+---
+pr_type: new-kernel-primitive
+persona_ids: [engineer, security, tech-lead]
+---
+
+New kernel primitives touch the stable foundation every app depends on. Engineer reviews hexagonal boundaries; Security reviews threat model and guardrail implications; Tech Lead reviews fit with the Unix layered model.

--- a/gctrl/personas/rules/spec-doc-change.md
+++ b/gctrl/personas/rules/spec-doc-change.md
@@ -1,0 +1,6 @@
+---
+pr_type: spec-doc-change
+persona_ids: [pm, tech-lead]
+---
+
+Spec/doc changes shape how the team and future agents reason about the system. PM reviews whether intent and acceptance criteria stay clear; Tech Lead reviews consistency with existing architecture and principles.

--- a/gctrl/personas/security.md
+++ b/gctrl/personas/security.md
@@ -1,0 +1,12 @@
+---
+id: security
+name: Security Expert
+focus: Threat modeling, input validation, guardrail policies, supply chain security
+owns: Guardrails engine policies, MITM proxy security, agent sandboxing, input validation at system boundaries, dependency audit
+review_focus: OWASP top 10 in HTTP API, command injection via CLI inputs, SQL injection in query engine, guardrail bypass paths, CA cert handling in proxy, secrets in logs
+pushes_back: User input reaches DuckDB without validation, new HTTP endpoints lack auth considerations, guardrail policies can be bypassed, dependencies have known CVEs, error messages leak internal state
+tools: [cargo audit, gctrl guardrails, code review for injection vectors]
+key_specs: [specs/architecture/README.md, specs/principles.md, specs/implementation/kernel/components.md]
+---
+
+You are a Security Expert. You assume every input is hostile. You review for injection (SQL, command, XSS), authentication gaps, guardrail bypass paths, and information leakage. You think about the agent threat model: agents have broad access and must be constrained by guardrails. You audit dependencies and flag CVEs. You never approve "we'll add security later."

--- a/gctrl/personas/tech-lead.md
+++ b/gctrl/personas/tech-lead.md
@@ -1,0 +1,12 @@
+---
+id: tech-lead
+name: Tech Lead
+focus: Technical direction, trade-off decisions, cross-cutting concerns, team coordination
+owns: Architectural decisions (ADRs), cross-persona conflict resolution, technical debt prioritization, specs consistency
+review_focus: Alignment with Unix layered model (Kernel/Shell/Apps), consistency across specs, pragmatic trade-offs (simplicity over perfection), documentation quality
+pushes_back: Architecture deviates from established patterns without an ADR, specs contradict each other, over-engineering or premature abstraction, work is not decomposed into reviewable chunks
+tools: [all persona tools — the Tech Lead can assume any specialist hat temporarily]
+key_specs: [specs/architecture/, specs/principles.md, AGENTS.md]
+---
+
+You are a Tech Lead. You hold the architectural vision — the Unix layered model, hexagonal architecture, and the principle that the kernel stays stable while applications evolve fast. You resolve conflicts between personas by finding pragmatic trade-offs. You write ADRs for significant decisions. You keep the team focused on what matters: shipping correct, simple, well-tested software. You are the tiebreaker, not the bottleneck.

--- a/gctrl/personas/ux.md
+++ b/gctrl/personas/ux.md
@@ -1,0 +1,12 @@
+---
+id: ux
+name: UX Specialist
+focus: CLI ergonomics, output formatting, developer experience, error messages
+owns: CLI command naming, flag conventions, output formatting (table/json/markdown), error messages, help text, progressive disclosure
+review_focus: Consistent CLI grammar (gctrl <noun> <verb>), helpful error messages with actionable suggestions, sensible defaults, output that pipes well (Unix composability)
+pushes_back: Error messages are cryptic or missing context, CLI flags are inconsistent across subcommands, output formats break Unix pipes, new commands don't follow existing naming patterns
+tools: [gctrl --help, gctrl <command> --help, manual CLI walkthroughs]
+key_specs: [specs/gctrl/PRD.md, specs/principles.md]
+---
+
+You are a UX Specialist focused on CLI and developer experience. The terminal is your canvas. You care about consistent command grammar, helpful error messages, sensible defaults, and output that composes well with Unix pipes. Every interaction should feel predictable and discoverable. You advocate for the developer who is using gctrl for the first time.

--- a/kernel/crates/gctrl-cli/src/commands/mod.rs
+++ b/kernel/crates/gctrl-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod analytics_spans;
 pub mod auto_score;
 pub mod check;
 pub mod net;
+pub mod personas;
 pub mod prompt;
 pub mod query;
 pub mod score;

--- a/kernel/crates/gctrl-cli/src/commands/personas.rs
+++ b/kernel/crates/gctrl-cli/src/commands/personas.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+
+use anyhow::Result;
+use gctrl_storage::{import_persona_dir, SqliteStore};
+
+pub fn import(dir: &Path, db_path: &str) -> Result<()> {
+    let sqlite_path = if db_path == ":memory:" {
+        ":memory:".to_string()
+    } else {
+        db_path.replace(".duckdb", ".sqlite")
+    };
+    let store = SqliteStore::open(&sqlite_path)?;
+
+    let imported = import_persona_dir(dir)?;
+
+    let mut created = 0;
+    let mut updated = 0;
+    for p in &imported.personas {
+        if store.upsert_persona(p)? {
+            created += 1;
+        } else {
+            updated += 1;
+        }
+    }
+
+    let mut rule_created = 0;
+    let mut rule_updated = 0;
+    for r in &imported.review_rules {
+        if store.upsert_review_rule(r)? {
+            rule_created += 1;
+        } else {
+            rule_updated += 1;
+        }
+    }
+
+    println!(
+        "personas: {} created, {} updated ({} total)",
+        created,
+        updated,
+        imported.personas.len()
+    );
+    println!(
+        "review rules: {} created, {} updated ({} total)",
+        rule_created,
+        rule_updated,
+        imported.review_rules.len()
+    );
+    println!("sqlite: {sqlite_path}");
+    Ok(())
+}
+
+pub fn list(db_path: &str) -> Result<()> {
+    let sqlite_path = if db_path == ":memory:" {
+        ":memory:".to_string()
+    } else {
+        db_path.replace(".duckdb", ".sqlite")
+    };
+    let store = SqliteStore::open(&sqlite_path)?;
+
+    let personas = store.list_personas()?;
+    let rules = store.list_review_rules()?;
+
+    println!("Personas ({}):", personas.len());
+    for p in &personas {
+        println!("  {:12} {}", p.id, p.name);
+    }
+    println!();
+    println!("Review rules ({}):", rules.len());
+    for r in &rules {
+        println!("  {:30} → {:?}", r.pr_type, r.persona_ids);
+    }
+    Ok(())
+}

--- a/kernel/crates/gctrl-cli/src/main.rs
+++ b/kernel/crates/gctrl-cli/src/main.rs
@@ -133,6 +133,21 @@ enum Commands {
     /// Project management and kanban
     #[command(subcommand)]
     Board(BoardCmd),
+    /// Import persona definitions from a markdown vault
+    #[command(subcommand)]
+    Personas(PersonasCmd),
+}
+
+#[derive(Subcommand)]
+enum PersonasCmd {
+    /// Import personas and review rules from a vault directory
+    Import {
+        /// Vault directory (default: gctrl/personas)
+        #[arg(long, default_value = "gctrl/personas")]
+        dir: String,
+    },
+    /// List personas and review rules currently in the store
+    List,
 }
 
 #[derive(Subcommand)]
@@ -508,6 +523,10 @@ async fn main() -> Result<()> {
                 commands::board::assign_issue(&id, &name, &r#type, &db_path)
             }
             BoardCmd::Comment { id, body, by } => commands::board::comment(&id, &body, &by, &db_path),
+        },
+        Commands::Personas(cmd) => match cmd {
+            PersonasCmd::Import { dir } => commands::personas::import(std::path::Path::new(&dir), &db_path),
+            PersonasCmd::List => commands::personas::list(&db_path),
         },
         Commands::Net(cmd) => match cmd {
             NetCmd::Fetch { url, no_readability, min_words } => {

--- a/kernel/crates/gctrl-storage/src/board_markdown.rs
+++ b/kernel/crates/gctrl-storage/src/board_markdown.rs
@@ -263,7 +263,7 @@ pub fn export_markdown_dir(
 
 // ── Internal helpers ──
 
-fn split_frontmatter(content: &str) -> Result<(String, String)> {
+pub(crate) fn split_frontmatter(content: &str) -> Result<(String, String)> {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
         return Ok((String::new(), content.to_string()));
@@ -279,7 +279,7 @@ fn split_frontmatter(content: &str) -> Result<(String, String)> {
     Ok((frontmatter, body))
 }
 
-fn parse_yaml_frontmatter(yaml_str: &str) -> Result<HashMap<String, serde_json::Value>> {
+pub(crate) fn parse_yaml_frontmatter(yaml_str: &str) -> Result<HashMap<String, serde_json::Value>> {
     if yaml_str.is_empty() {
         return Ok(HashMap::new());
     }

--- a/kernel/crates/gctrl-storage/src/lib.rs
+++ b/kernel/crates/gctrl-storage/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod board_markdown;
 pub mod duckdb_store;
+pub mod persona_markdown;
 pub mod schema;
 pub mod sqlite_store;
 
 pub use board_markdown::{export_markdown_dir, import_markdown_dir};
 pub use duckdb_store::DuckDbStore;
+pub use persona_markdown::{
+    import_persona_dir, parse_persona_markdown, parse_review_rule_markdown, PersonaImport,
+};
 pub use sqlite_store::SqliteStore;

--- a/kernel/crates/gctrl-storage/src/persona_markdown.rs
+++ b/kernel/crates/gctrl-storage/src/persona_markdown.rs
@@ -1,0 +1,266 @@
+//! Markdown ↔ Persona import.
+//!
+//! Vault layout (mirrors how `board_markdown` handles board issues):
+//!
+//!   gctrl/personas/
+//!     <id>.md            ← one PersonaDefinition per file
+//!     rules/
+//!       <pr-type>.md     ← one PersonaReviewRule per file
+//!
+//! Each file's YAML frontmatter holds the structured fields; the body is a
+//! free-form note for human readers (the body of a persona file is also used
+//! as the `prompt_prefix` if the frontmatter does not provide one).
+//!
+//! Format kept deliberately flat to match the hand-rolled YAML parser shared
+//! with `board_markdown` (no nested lists of objects).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use gctrl_core::{GctlError, PersonaDefinition, PersonaReviewRule, Result};
+
+use crate::board_markdown::{parse_yaml_frontmatter, split_frontmatter};
+
+/// Result of importing a persona vault directory.
+#[derive(Debug, Default)]
+pub struct PersonaImport {
+    pub personas: Vec<PersonaDefinition>,
+    pub review_rules: Vec<PersonaReviewRule>,
+}
+
+/// Parse a single persona markdown file (frontmatter + body → PersonaDefinition).
+pub fn parse_persona_markdown(content: &str) -> Result<PersonaDefinition> {
+    let (fm_str, body) = split_frontmatter(content)?;
+    if fm_str.is_empty() {
+        return Err(GctlError::InvalidInput(
+            "persona markdown missing YAML frontmatter".into(),
+        ));
+    }
+    let fm = parse_yaml_frontmatter(&fm_str)?;
+
+    let id = require_string(&fm, "id")?;
+    let name = require_string(&fm, "name")?;
+    let focus = require_string(&fm, "focus")?;
+    let owns = require_string(&fm, "owns")?;
+    let review_focus = require_string(&fm, "review_focus")?;
+    let pushes_back = require_string(&fm, "pushes_back")?;
+
+    let tools = optional_string_array(&fm, "tools");
+    let key_specs = optional_string_array(&fm, "key_specs");
+
+    let prompt_prefix = optional_string(&fm, "prompt_prefix")
+        .unwrap_or_else(|| body.trim().to_string());
+    if prompt_prefix.is_empty() {
+        return Err(GctlError::InvalidInput(format!(
+            "persona '{id}' has no prompt_prefix (frontmatter or body)"
+        )));
+    }
+
+    Ok(PersonaDefinition {
+        id,
+        name,
+        focus,
+        prompt_prefix,
+        owns,
+        review_focus,
+        pushes_back,
+        tools,
+        key_specs,
+        source_hash: None,
+    })
+}
+
+/// Parse a review-rule markdown file. The frontmatter must contain
+/// `pr_type` and `persona_ids: [...]`. Rule `id` is derived from `pr_type`
+/// so re-imports update in place.
+pub fn parse_review_rule_markdown(content: &str) -> Result<PersonaReviewRule> {
+    let (fm_str, _body) = split_frontmatter(content)?;
+    if fm_str.is_empty() {
+        return Err(GctlError::InvalidInput(
+            "review-rule markdown missing YAML frontmatter".into(),
+        ));
+    }
+    let fm = parse_yaml_frontmatter(&fm_str)?;
+
+    let pr_type = require_string(&fm, "pr_type")?;
+    let persona_ids = optional_string_array(&fm, "persona_ids");
+    if persona_ids.is_empty() {
+        return Err(GctlError::InvalidInput(format!(
+            "review rule '{pr_type}' has empty persona_ids"
+        )));
+    }
+
+    Ok(PersonaReviewRule {
+        id: format!("rule:{pr_type}"),
+        pr_type,
+        persona_ids,
+    })
+}
+
+/// Walk `dir` for persona files (`*.md` at the top level) and review-rule
+/// files (`rules/*.md`). Returns a `PersonaImport` with parsed entries.
+///
+/// Files starting with `_` and the `rules/` directory itself are skipped at
+/// the top level; the `rules/` subdir is read separately.
+pub fn import_persona_dir(dir: &Path) -> Result<PersonaImport> {
+    if !dir.is_dir() {
+        return Err(GctlError::InvalidInput(format!(
+            "persona dir not found: {}",
+            dir.display()
+        )));
+    }
+
+    let mut out = PersonaImport::default();
+
+    for entry in std::fs::read_dir(dir).map_err(io_err)? {
+        let entry = entry.map_err(io_err)?;
+        let path = entry.path();
+        if path.is_file() && is_md(&path) && !is_hidden(&path) {
+            let content = std::fs::read_to_string(&path).map_err(io_err)?;
+            let persona = parse_persona_markdown(&content).map_err(|e| {
+                GctlError::InvalidInput(format!("{}: {e}", path.display()))
+            })?;
+            out.personas.push(persona);
+        }
+    }
+
+    let rules_dir = dir.join("rules");
+    if rules_dir.is_dir() {
+        for entry in std::fs::read_dir(&rules_dir).map_err(io_err)? {
+            let entry = entry.map_err(io_err)?;
+            let path = entry.path();
+            if path.is_file() && is_md(&path) && !is_hidden(&path) {
+                let content = std::fs::read_to_string(&path).map_err(io_err)?;
+                let rule = parse_review_rule_markdown(&content).map_err(|e| {
+                    GctlError::InvalidInput(format!("{}: {e}", path.display()))
+                })?;
+                out.review_rules.push(rule);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+// --- helpers ---
+
+fn is_md(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("md")
+}
+
+fn is_hidden(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with('_') || n.starts_with('.'))
+}
+
+fn io_err(e: std::io::Error) -> GctlError {
+    GctlError::InvalidInput(e.to_string())
+}
+
+fn require_string(fm: &HashMap<String, serde_json::Value>, key: &str) -> Result<String> {
+    optional_string(fm, key).ok_or_else(|| {
+        GctlError::InvalidInput(format!("persona frontmatter missing required field '{key}'"))
+    })
+}
+
+fn optional_string(fm: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+    fm.get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn optional_string_array(fm: &HashMap<String, serde_json::Value>, key: &str) -> Vec<String> {
+    fm.get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const ENGINEER_MD: &str = r#"---
+id: engineer
+name: Principal Fullstack Engineer
+focus: Architecture, code quality, cross-layer integration
+owns: kernel crates, shell, Effect-TS apps
+review_focus: Hexagonal boundaries respected, no leaky abstractions
+pushes_back: Adapters depend on each other instead of ports
+tools: [cargo build, cargo test, pnpm run test]
+key_specs: [specs/architecture/, specs/principles.md]
+---
+
+You are a Principal Fullstack Engineer. You own the entire stack.
+"#;
+
+    const RULE_MD: &str = r#"---
+pr_type: new-kernel-primitive
+persona_ids: [engineer, security, tech-lead]
+---
+
+Requires engineer ownership and security sign-off.
+"#;
+
+    #[test]
+    fn parses_persona_with_body_as_prompt() {
+        let p = parse_persona_markdown(ENGINEER_MD).unwrap();
+        assert_eq!(p.id, "engineer");
+        assert_eq!(p.name, "Principal Fullstack Engineer");
+        assert!(p.prompt_prefix.starts_with("You are a Principal"));
+        assert_eq!(p.tools.len(), 3);
+        assert_eq!(p.key_specs.len(), 2);
+    }
+
+    #[test]
+    fn rejects_persona_without_frontmatter() {
+        let err = parse_persona_markdown("just body, no fm").unwrap_err();
+        assert!(err.to_string().contains("missing YAML frontmatter"));
+    }
+
+    #[test]
+    fn rejects_persona_missing_required_field() {
+        let md = "---\nid: x\n---\nbody";
+        let err = parse_persona_markdown(md).unwrap_err();
+        assert!(err.to_string().contains("missing required field"));
+    }
+
+    #[test]
+    fn parses_review_rule() {
+        let r = parse_review_rule_markdown(RULE_MD).unwrap();
+        assert_eq!(r.pr_type, "new-kernel-primitive");
+        assert_eq!(r.id, "rule:new-kernel-primitive");
+        assert_eq!(r.persona_ids, vec!["engineer", "security", "tech-lead"]);
+    }
+
+    #[test]
+    fn rejects_review_rule_with_empty_persona_ids() {
+        let md = "---\npr_type: foo\npersona_ids: []\n---";
+        let err = parse_review_rule_markdown(md).unwrap_err();
+        assert!(err.to_string().contains("empty persona_ids"));
+    }
+
+    #[test]
+    fn imports_full_dir_with_personas_and_rules() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("engineer.md"), ENGINEER_MD).unwrap();
+        std::fs::write(dir.path().join("_skipped.md"), "---\nid: x\n---\n").unwrap();
+        let rules_dir = dir.path().join("rules");
+        std::fs::create_dir(&rules_dir).unwrap();
+        std::fs::write(rules_dir.join("new-kernel-primitive.md"), RULE_MD).unwrap();
+
+        let imported = import_persona_dir(dir.path()).unwrap();
+        assert_eq!(imported.personas.len(), 1, "underscore prefix should be skipped");
+        assert_eq!(imported.review_rules.len(), 1);
+        assert_eq!(imported.personas[0].id, "engineer");
+        assert_eq!(imported.review_rules[0].pr_type, "new-kernel-primitive");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the earlier JSON seed + shell script approach (rejected: duplicates `specs/team/personas.md` and bypasses the kernel) with a vault-first, kernel-native path that mirrors how `gctrl/BOARD/` and `gctrl/INBOX/` already work.

- `gctrl/personas/<id>.md` (7 files) — one persona per file, frontmatter carries structured fields, body is the prompt prefix.
- `gctrl/personas/rules/<pr-type>.md` (6 files) — Multi-Persona Review matrix from the spec, one rule per file.
- `gctrl-storage::persona_markdown` — new module, reuses the hand-rolled YAML helpers from `board_markdown` (now `pub(crate)`). No new deps.
- `gctrld personas import [--dir gctrl/personas]` — writes straight to `SqliteStore` via the existing `upsert_persona` / `upsert_review_rule` (same primitives `/api/personas/seed` calls).
- `gctrld personas list` — sanity check.

## Why

On a fresh kernel, `POST /api/team/recommend` returns an empty array and the gctrl-board drag-to-`in_progress` auto-dispatch flow (`apps/gctrl-board/web/src/App.tsx`) skips the `rec.personas.length > 0` branch — no assignee, no persona prompts. Seeding lights up the existing UI flow end-to-end.

Doing it this way (markdown vault + kernel importer) instead of a JSON seed file:

- **No duplication.** The persona text lives in one place (`gctrl/personas/`). `specs/team/personas.md` stays as the human-readable spec.
- **Dogfoods vault-first.** Same pattern the board and inbox already use — frontmatter + body, SHA-hashable, Obsidian-editable.
- **No script layer.** `gctrld` owns the parse + store path; nothing Python-shaped in the repo.

## What this does **not** do

- Does **not** spawn or execute any agent — `assignee` is metadata, dispatch comment is a hand-off artifact.
- Does **not** auto-import on daemon startup. Import is explicit (`gctrld personas import`) and idempotent.

## Test plan

- [x] `cargo test -p gctrl-storage` — 80 passing (6 new in `persona_markdown::tests`)
- [x] `cargo build -p gctrl-cli` — clean
- [x] `gctrld personas import` → `personas: 7 created, 0 updated; review rules: 6 created, 0 updated`
- [x] `gctrld personas list` — 7 personas + 6 rules rendered correctly
- [x] Re-running is idempotent (`0 created, 7 updated`)
- [ ] CI green on this branch
