### PR TITLE
feat(orch): Tier 3 worker daemon — `gctrld orch run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "gctrl-core",
  "gctrl-guardrails",
  "gctrl-net",
+ "gctrl-orch",
  "gctrl-otel",
  "gctrl-query",
  "gctrl-storage",
@@ -1376,6 +1377,23 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "gctrl-orch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "gctrl-core",
+ "gctrl-storage",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "kernel/crates/gctrl-net",
     "kernel/crates/gctrl-sync",
     "kernel/crates/gctrl-context",
+    "kernel/crates/gctrl-orch",
 ]
 
 [workspace.package]

--- a/kernel/crates/gctrl-cli/Cargo.toml
+++ b/kernel/crates/gctrl-cli/Cargo.toml
@@ -15,6 +15,7 @@ gctrl-guardrails = { path = "../gctrl-guardrails" }
 gctrl-query = { path = "../gctrl-query" }
 gctrl-net = { path = "../gctrl-net" }
 gctrl-context = { path = "../gctrl-context" }
+gctrl-orch = { path = "../gctrl-orch" }
 
 clap = { workspace = true }
 tokio = { workspace = true }

--- a/kernel/crates/gctrl-cli/src/commands/mod.rs
+++ b/kernel/crates/gctrl-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod analytics_spans;
 pub mod auto_score;
 pub mod check;
 pub mod net;
+pub mod orch;
 pub mod personas;
 pub mod prompt;
 pub mod query;

--- a/kernel/crates/gctrl-cli/src/commands/orch.rs
+++ b/kernel/crates/gctrl-cli/src/commands/orch.rs
@@ -11,7 +11,7 @@ pub async fn run(
     db_path: &str,
     once: bool,
     interval_secs: u64,
-    max_concurrent: usize,
+    max_per_pass: usize,
     timeout_secs: u64,
     agent: Vec<String>,
     working_dir: Option<PathBuf>,
@@ -30,7 +30,7 @@ pub async fn run(
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_else(|| PathBuf::from(".")),
         poll_interval: Duration::from_secs(interval_secs),
-        max_concurrent,
+        max_per_pass,
         task_timeout: Duration::from_secs(timeout_secs),
         dry_run,
     };
@@ -39,7 +39,7 @@ pub async fn run(
         sqlite = %sqlite_path,
         agent = ?config.agent_cmd,
         interval_s = interval_secs,
-        max_concurrent,
+        max_per_pass,
         timeout_s = timeout_secs,
         dry_run,
         "orch: starting"

--- a/kernel/crates/gctrl-cli/src/commands/orch.rs
+++ b/kernel/crates/gctrl-cli/src/commands/orch.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use gctrl_orch::{OrchConfig, Worker};
+use gctrl_storage::SqliteStore;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    db_path: &str,
+    once: bool,
+    interval_secs: u64,
+    max_concurrent: usize,
+    timeout_secs: u64,
+    agent: Vec<String>,
+    working_dir: Option<PathBuf>,
+    dry_run: bool,
+) -> Result<()> {
+    let sqlite_path = if db_path == ":memory:" {
+        ":memory:".to_string()
+    } else {
+        db_path.replace(".duckdb", ".sqlite")
+    };
+    let store = Arc::new(SqliteStore::open(&sqlite_path)?);
+
+    let config = OrchConfig {
+        agent_cmd: agent,
+        working_dir: working_dir
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| PathBuf::from(".")),
+        poll_interval: Duration::from_secs(interval_secs),
+        max_concurrent,
+        task_timeout: Duration::from_secs(timeout_secs),
+        dry_run,
+    };
+
+    tracing::info!(
+        sqlite = %sqlite_path,
+        agent = ?config.agent_cmd,
+        interval_s = interval_secs,
+        max_concurrent,
+        timeout_s = timeout_secs,
+        dry_run,
+        "orch: starting"
+    );
+
+    let worker = Worker::new(store, config);
+    if once {
+        let outcomes = worker.run_once().await?;
+        println!("dispatched {} task(s)", outcomes.len());
+        for o in outcomes {
+            println!("  {o:?}");
+        }
+        Ok(())
+    } else {
+        worker.run_forever().await
+    }
+}

--- a/kernel/crates/gctrl-cli/src/main.rs
+++ b/kernel/crates/gctrl-cli/src/main.rs
@@ -136,6 +136,9 @@ enum Commands {
     /// Import persona definitions from a markdown vault
     #[command(subcommand)]
     Personas(PersonasCmd),
+    /// Orchestrator — spawn agents for dispatch-eligible tasks
+    #[command(subcommand)]
+    Orch(OrchCmd),
 }
 
 #[derive(Subcommand)]
@@ -148,6 +151,34 @@ enum PersonasCmd {
     },
     /// List personas and review rules currently in the store
     List,
+}
+
+#[derive(Subcommand)]
+enum OrchCmd {
+    /// Run the worker loop (default: forever, polling every --interval s)
+    Run {
+        /// Do one drain pass then exit (instead of looping)
+        #[arg(long)]
+        once: bool,
+        /// Poll interval in seconds
+        #[arg(long, default_value = "5")]
+        interval: u64,
+        /// Max tasks to dispatch per drain pass
+        #[arg(long, default_value = "1")]
+        max_concurrent: usize,
+        /// Hard timeout for one agent run, in seconds
+        #[arg(long, default_value = "1800")]
+        timeout: u64,
+        /// Agent command (program + args). Prompt is sent on stdin.
+        #[arg(long, default_values_t = vec!["claude".to_string(), "-p".to_string()])]
+        agent: Vec<String>,
+        /// Working directory for the agent (default: current dir)
+        #[arg(long)]
+        working_dir: Option<std::path::PathBuf>,
+        /// Don't spawn anything — log what would happen, then release the claim
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -527,6 +558,11 @@ async fn main() -> Result<()> {
         Commands::Personas(cmd) => match cmd {
             PersonasCmd::Import { dir } => commands::personas::import(std::path::Path::new(&dir), &db_path),
             PersonasCmd::List => commands::personas::list(&db_path),
+        },
+        Commands::Orch(cmd) => match cmd {
+            OrchCmd::Run { once, interval, max_concurrent, timeout, agent, working_dir, dry_run } => {
+                commands::orch::run(&db_path, once, interval, max_concurrent, timeout, agent, working_dir, dry_run).await
+            }
         },
         Commands::Net(cmd) => match cmd {
             NetCmd::Fetch { url, no_readability, min_words } => {

--- a/kernel/crates/gctrl-cli/src/main.rs
+++ b/kernel/crates/gctrl-cli/src/main.rs
@@ -164,8 +164,8 @@ enum OrchCmd {
         #[arg(long, default_value = "5")]
         interval: u64,
         /// Max tasks to dispatch per drain pass
-        #[arg(long, default_value = "1")]
-        max_concurrent: usize,
+        #[arg(long = "max-per-pass", alias = "max-concurrent", default_value = "1")]
+        max_per_pass: usize,
         /// Hard timeout for one agent run, in seconds
         #[arg(long, default_value = "1800")]
         timeout: u64,
@@ -560,8 +560,8 @@ async fn main() -> Result<()> {
             PersonasCmd::List => commands::personas::list(&db_path),
         },
         Commands::Orch(cmd) => match cmd {
-            OrchCmd::Run { once, interval, max_concurrent, timeout, agent, working_dir, dry_run } => {
-                commands::orch::run(&db_path, once, interval, max_concurrent, timeout, agent, working_dir, dry_run).await
+            OrchCmd::Run { once, interval, max_per_pass, timeout, agent, working_dir, dry_run } => {
+                commands::orch::run(&db_path, once, interval, max_per_pass, timeout, agent, working_dir, dry_run).await
             }
         },
         Commands::Net(cmd) => match cmd {

--- a/kernel/crates/gctrl-orch/Cargo.toml
+++ b/kernel/crates/gctrl-orch/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gctrl-orch"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+gctrl-core = { path = "../gctrl-core" }
+gctrl-storage = { path = "../gctrl-storage" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/kernel/crates/gctrl-orch/src/agent.rs
+++ b/kernel/crates/gctrl-orch/src/agent.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 
 #[derive(Debug, Error)]
 pub enum SpawnError {
@@ -25,18 +25,15 @@ pub struct AgentRun {
     pub exit_code: i32,
 }
 
-/// Spawn the agent binary and feed the prompt on stdin. stdout + stderr
-/// are captured so the worker can post them back as a completion comment.
-///
-/// The agent inherits the caller's env — OTEL_EXPORTER_OTLP_ENDPOINT,
-/// HTTP_PROXY etc. flow through so sessions automatically land in the
-/// kernel's OTel receiver without extra wiring.
-pub async fn run_agent(
+/// Start the subprocess and write the prompt to stdin. Returns the live
+/// child. Errors here are pre-`agentLaunched` in the Lean spec's language —
+/// the worker should transition `Claimed → Released` (dispatchFailed), not
+/// through `Running`.
+pub async fn spawn_agent(
     cmd: &[String],
     working_dir: &Path,
     prompt: &str,
-    timeout: Duration,
-) -> Result<AgentRun, SpawnError> {
+) -> Result<Child, SpawnError> {
     let (program, args) = cmd
         .split_first()
         .ok_or_else(|| SpawnError::Spawn(std::io::Error::other("empty agent command")))?;
@@ -54,12 +51,17 @@ pub async fn run_agent(
         stdin.shutdown().await?;
     }
 
+    Ok(child)
+}
+
+/// Wait for an already-spawned child. Errors here happen after
+/// `agentLaunched`, so the worker should transition `Running → RetryQueued`
+/// (agentExitAbnormal).
+pub async fn await_agent(child: Child, timeout: Duration) -> Result<AgentRun, SpawnError> {
     let result = match tokio::time::timeout(timeout, child.wait_with_output()).await {
         Ok(r) => r?,
         Err(_) => {
-            // tokio::process kills the child when dropped on timeout, but
-            // we can't retrieve it now because wait_with_output consumed it.
-            // We *do* return Timeout so the caller transitions to RetryQueued.
+            // tokio::process kills the child when dropped on timeout.
             return Err(SpawnError::Timeout(timeout));
         }
     };
@@ -73,6 +75,20 @@ pub async fn run_agent(
         stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
         exit_code: exit,
     })
+}
+
+/// Convenience: spawn then await in one call. Error phase is not
+/// distinguished — the worker uses `spawn_agent` + `await_agent` directly
+/// so it can route `SpawnError::Spawn` to `dispatchFailed`.
+#[cfg(test)]
+pub async fn run_agent(
+    cmd: &[String],
+    working_dir: &Path,
+    prompt: &str,
+    timeout: Duration,
+) -> Result<AgentRun, SpawnError> {
+    let child = spawn_agent(cmd, working_dir, prompt).await?;
+    await_agent(child, timeout).await
 }
 
 #[cfg(test)]

--- a/kernel/crates/gctrl-orch/src/agent.rs
+++ b/kernel/crates/gctrl-orch/src/agent.rs
@@ -1,0 +1,139 @@
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+#[derive(Debug, Error)]
+pub enum SpawnError {
+    #[error("spawn failed: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("agent exited with code {0}")]
+    NonZero(i32),
+    #[error("agent killed by signal")]
+    Signal,
+    #[error("timed out after {0:?}")]
+    Timeout(Duration),
+}
+
+#[derive(Debug)]
+pub struct AgentRun {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Spawn the agent binary and feed the prompt on stdin. stdout + stderr
+/// are captured so the worker can post them back as a completion comment.
+///
+/// The agent inherits the caller's env — OTEL_EXPORTER_OTLP_ENDPOINT,
+/// HTTP_PROXY etc. flow through so sessions automatically land in the
+/// kernel's OTel receiver without extra wiring.
+pub async fn run_agent(
+    cmd: &[String],
+    working_dir: &Path,
+    prompt: &str,
+    timeout: Duration,
+) -> Result<AgentRun, SpawnError> {
+    let (program, args) = cmd
+        .split_first()
+        .ok_or_else(|| SpawnError::Spawn(std::io::Error::other("empty agent command")))?;
+
+    let mut child = Command::new(program)
+        .args(args)
+        .current_dir(working_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(prompt.as_bytes()).await?;
+        stdin.shutdown().await?;
+    }
+
+    let result = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(r) => r?,
+        Err(_) => {
+            // tokio::process kills the child when dropped on timeout, but
+            // we can't retrieve it now because wait_with_output consumed it.
+            // We *do* return Timeout so the caller transitions to RetryQueued.
+            return Err(SpawnError::Timeout(timeout));
+        }
+    };
+
+    let exit = result.status.code().ok_or(SpawnError::Signal)?;
+    if exit != 0 {
+        return Err(SpawnError::NonZero(exit));
+    }
+    Ok(AgentRun {
+        stdout: String::from_utf8_lossy(&result.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
+        exit_code: exit,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn echo_succeeds_and_captures_stdout() {
+        // `cat` echoes the prompt from stdin back to stdout — a stand-in
+        // agent that lets CI run without claude on the PATH.
+        let run = run_agent(
+            &["cat".into()],
+            Path::new("."),
+            "hello from worker",
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        assert_eq!(run.exit_code, 0);
+        assert!(run.stdout.contains("hello from worker"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_is_reported() {
+        let err = run_agent(
+            &["sh".into(), "-c".into(), "exit 7".into()],
+            Path::new("."),
+            "",
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+        match err {
+            SpawnError::NonZero(code) => assert_eq!(code, 7),
+            e => panic!("unexpected: {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn timeout_is_reported() {
+        let err = run_agent(
+            &["sh".into(), "-c".into(), "sleep 5".into()],
+            Path::new("."),
+            "",
+            Duration::from_millis(100),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, SpawnError::Timeout(_)));
+    }
+
+    #[tokio::test]
+    async fn missing_binary_is_reported() {
+        let err = run_agent(
+            &["this-binary-does-not-exist-12345".into()],
+            Path::new("."),
+            "",
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, SpawnError::Spawn(_)));
+    }
+}

--- a/kernel/crates/gctrl-orch/src/config.rs
+++ b/kernel/crates/gctrl-orch/src/config.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct OrchConfig {
     /// Agent binary + args. `{prompt}` is *not* interpolated — the prompt
-    /// is passed as a separate arg or via stdin (see `agent::spawn`).
+    /// is passed on stdin (see `agent::spawn_agent`).
     pub agent_cmd: Vec<String>,
 
     /// Working directory the agent runs in. Defaults to the current process
@@ -16,28 +16,16 @@ pub struct OrchConfig {
     /// indexed and cheap.
     pub poll_interval: Duration,
 
-    /// Max tasks launched per tick. The worker doesn't cap long-running
-    /// agents across ticks yet (see `Worker::run_once`) — treat this as
-    /// "how greedy is one drain pass."
-    pub max_concurrent: usize,
+    /// Max tasks dispatched per drain pass. The worker runs them
+    /// sequentially within a pass today; this is a batch size, not true
+    /// concurrency.
+    pub max_per_pass: usize,
 
     /// Hard ceiling on agent wall-clock time. A task blown past this is
     /// killed and transitions Running → RetryQueued.
     pub task_timeout: Duration,
 
-    /// If true, don't spawn anything — just log what would happen.
+    /// If true, don't spawn anything — just log what would happen and
+    /// return the task to the Unclaimed pool.
     pub dry_run: bool,
-}
-
-impl OrchConfig {
-    pub fn default_claude() -> Self {
-        Self {
-            agent_cmd: vec!["claude".into(), "-p".into()],
-            working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            poll_interval: Duration::from_secs(5),
-            max_concurrent: 1,
-            task_timeout: Duration::from_secs(60 * 30),
-            dry_run: false,
-        }
-    }
 }

--- a/kernel/crates/gctrl-orch/src/config.rs
+++ b/kernel/crates/gctrl-orch/src/config.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct OrchConfig {
+    /// Agent binary + args. `{prompt}` is *not* interpolated — the prompt
+    /// is passed as a separate arg or via stdin (see `agent::spawn`).
+    pub agent_cmd: Vec<String>,
+
+    /// Working directory the agent runs in. Defaults to the current process
+    /// cwd. Keep this explicit so we never accidentally launch an agent
+    /// outside the project root.
+    pub working_dir: PathBuf,
+
+    /// Poll interval between queue drains. Short is fine — the query is
+    /// indexed and cheap.
+    pub poll_interval: Duration,
+
+    /// Max tasks launched per tick. The worker doesn't cap long-running
+    /// agents across ticks yet (see `Worker::run_once`) — treat this as
+    /// "how greedy is one drain pass."
+    pub max_concurrent: usize,
+
+    /// Hard ceiling on agent wall-clock time. A task blown past this is
+    /// killed and transitions Running → RetryQueued.
+    pub task_timeout: Duration,
+
+    /// If true, don't spawn anything — just log what would happen.
+    pub dry_run: bool,
+}
+
+impl OrchConfig {
+    pub fn default_claude() -> Self {
+        Self {
+            agent_cmd: vec!["claude".into(), "-p".into()],
+            working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            poll_interval: Duration::from_secs(5),
+            max_concurrent: 1,
+            task_timeout: Duration::from_secs(60 * 30),
+            dry_run: false,
+        }
+    }
+}

--- a/kernel/crates/gctrl-orch/src/lib.rs
+++ b/kernel/crates/gctrl-orch/src/lib.rs
@@ -1,0 +1,28 @@
+//! # gctrl-orch — Tier 3 orchestrator / worker
+//!
+//! Spawns agents for dispatch-eligible tasks (`status=in_progress` +
+//! `assignee_type=agent`). Runs as its own `gctrld orch run` daemon so its
+//! blast radius is contained: killing the worker does not take the HTTP
+//! API down.
+//!
+//! The claim state machine mirrors `KernelSpec.Orchestrator.step` in
+//! `kernel/specs-lean4/KernelSpec/Orchestrator.lean`. Only transitions
+//! verified there are emitted by this crate:
+//!
+//!   Unclaimed → Claimed (dispatchEligible, atomic CAS against SQLite)
+//!   Claimed  → Running  (agentLaunched, after subprocess spawn)
+//!   Running  → Released (reconciliationTerminal, on clean exit)
+//!   Claimed  → Released (dispatchFailed, if spawn fails)
+//!   Running  → RetryQueued (agentExitAbnormal, on non-zero exit)
+//!
+//! Pause/resume, guardrail suspend, and Retry → Running re-dispatch are
+//! intentionally out of MVP scope — they exist in the verified spec but
+//! aren't wired up yet.
+
+pub mod agent;
+pub mod config;
+pub mod prompt;
+pub mod worker;
+
+pub use config::OrchConfig;
+pub use worker::{DispatchOutcome, Worker};

--- a/kernel/crates/gctrl-orch/src/prompt.rs
+++ b/kernel/crates/gctrl-orch/src/prompt.rs
@@ -1,0 +1,123 @@
+use gctrl_core::{BoardComment, BoardIssue};
+
+/// Pick the freshest dispatch comment posted by gctrl-board when the Issue
+/// moved to `in_progress`. The board UI posts them with a distinctive
+/// `## Agent:` section — we key off that so regular chat comments don't
+/// get mistaken for an agent brief.
+///
+/// Falls back to building a minimal prompt from title+description if no
+/// dispatch comment is found — lets `gctrld board move ... in_progress`
+/// work even without a persona match.
+pub fn build_prompt(issue: &BoardIssue, comments: &[BoardComment]) -> String {
+    if let Some(dispatch) = latest_dispatch_comment(comments) {
+        return dispatch.body.clone();
+    }
+    fallback_prompt(issue)
+}
+
+fn latest_dispatch_comment(comments: &[BoardComment]) -> Option<&BoardComment> {
+    comments
+        .iter()
+        .filter(|c| c.body.contains("## Agent:") || c.author_type == "agent")
+        .max_by_key(|c| c.created_at)
+}
+
+fn fallback_prompt(issue: &BoardIssue) -> String {
+    let desc = issue.description.as_deref().unwrap_or("");
+    format!(
+        "# {id}: {title}\n\n{desc}\n\n\
+         (No dispatch comment on this issue — run the board UI's \
+         drag-to-in_progress flow to get a full persona brief, or edit this \
+         fallback prompt.)",
+        id = issue.id,
+        title = issue.title,
+        desc = desc,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use gctrl_core::{BoardIssue, IssueStatus};
+
+    fn issue() -> BoardIssue {
+        let now = Utc::now();
+        BoardIssue {
+            id: "BACK-1".into(),
+            project_id: "p".into(),
+            title: "Fix thing".into(),
+            description: Some("describe".into()),
+            status: IssueStatus::InProgress,
+            priority: "none".into(),
+            assignee_id: None,
+            assignee_name: None,
+            assignee_type: None,
+            labels: vec![],
+            parent_id: None,
+            created_at: now,
+            updated_at: now,
+            created_by_id: "u".into(),
+            created_by_name: "u".into(),
+            created_by_type: "human".into(),
+            blocked_by: vec![],
+            blocking: vec![],
+            session_ids: vec![],
+            total_cost_usd: 0.0,
+            total_tokens: 0,
+            pr_numbers: vec![],
+            content_hash: None,
+            source_path: None,
+            github_issue_number: None,
+            github_url: None,
+        }
+    }
+
+    fn comment(id: &str, body: &str, minutes_ago: i64) -> BoardComment {
+        BoardComment {
+            id: id.into(),
+            issue_id: "BACK-1".into(),
+            author_id: "agent-1".into(),
+            author_name: "Board".into(),
+            author_type: "agent".into(),
+            body: body.into(),
+            created_at: Utc::now() - Duration::minutes(minutes_ago),
+            session_id: None,
+        }
+    }
+
+    #[test]
+    fn picks_latest_dispatch_comment() {
+        let comments = vec![
+            comment("c1", "## Agent: Engineer\nold brief", 10),
+            comment("c2", "## Agent: Engineer\nnew brief", 1),
+            comment("c3", "regular human comment", 2),
+        ];
+        let out = build_prompt(&issue(), &comments);
+        assert!(out.contains("new brief"), "got: {out}");
+        assert!(!out.contains("old brief"));
+    }
+
+    #[test]
+    fn falls_back_to_title_and_description() {
+        let out = build_prompt(&issue(), &[]);
+        assert!(out.contains("BACK-1"));
+        assert!(out.contains("Fix thing"));
+        assert!(out.contains("describe"));
+    }
+
+    #[test]
+    fn non_dispatch_comments_ignored() {
+        let comments = vec![comment("c1", "human note with no agent header", 1)];
+        // author_type=agent means we accept it as a dispatch comment. Use a
+        // plain-human comment instead to verify the filter.
+        let human = BoardComment {
+            author_type: "human".into(),
+            ..comments[0].clone()
+        };
+        let out = build_prompt(&issue(), &[human]);
+        // Should fall back to title/description since no dispatch matches.
+        assert!(out.contains("Fix thing"));
+        assert!(!out.contains("human note"));
+    }
+}

--- a/kernel/crates/gctrl-orch/src/worker.rs
+++ b/kernel/crates/gctrl-orch/src/worker.rs
@@ -4,9 +4,14 @@ use anyhow::Result;
 use gctrl_core::{BoardComment, Task};
 use gctrl_storage::SqliteStore;
 
-use crate::agent::{self, SpawnError};
+use crate::agent;
 use crate::config::OrchConfig;
 use crate::prompt;
+
+/// Cap on the agent stdout we echo into a completion comment. A real
+/// `claude -p` session can produce tens of thousands of lines; we keep
+/// the tail and flag truncation so the board stays readable.
+const COMPLETION_COMMENT_MAX_BYTES: usize = 50_000;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DispatchOutcome {
@@ -30,14 +35,14 @@ impl Worker {
         Self { store, config }
     }
 
-    /// One drain pass: pick up to `max_concurrent` dispatchable tasks and
+    /// One drain pass: pick up to `max_per_pass` dispatchable tasks and
     /// run them sequentially. Sequential is fine for MVP — agents are I/O
     /// bound waiting on LLM calls, not CPU bound, and one-at-a-time keeps
     /// the repo's working tree predictable.
     pub async fn run_once(&self) -> Result<Vec<DispatchOutcome>> {
         let tasks = self
             .store
-            .list_dispatchable_tasks(self.config.max_concurrent)?;
+            .list_dispatchable_tasks(self.config.max_per_pass)?;
         if tasks.is_empty() {
             tracing::debug!("orch: no dispatchable tasks");
             return Ok(vec![]);
@@ -92,39 +97,50 @@ impl Worker {
                 task_id = %task.id,
                 issue_id = %issue_id,
                 prompt_chars = prompt.len(),
-                "orch: dry-run, releasing claim"
+                "orch: dry-run, returning task to Unclaimed"
             );
-            // Release the claim so subsequent non-dry runs can pick it up.
-            self.store.try_transition_claim(
-                &task.id,
-                Task::CLAIM_CLAIMED,
-                Task::CLAIM_RELEASED,
-            )?;
+            // Non-destructive: put it back in the queue so a real run picks
+            // it up. The CAS target is Unclaimed — same pool list_dispatchable
+            // filters on.
+            self.strict_transition(&task.id, Task::CLAIM_CLAIMED, Task::CLAIM_UNCLAIMED)?;
             return Ok(DispatchOutcome::DryRun {
                 task_id: task.id.clone(),
             });
         }
 
-        // Claimed → Running (agentLaunched). Spawn the agent; if spawn
-        // itself fails we'll go Claimed → Released via the error arm below.
-        self.store.try_transition_claim(
-            &task.id,
-            Task::CLAIM_CLAIMED,
-            Task::CLAIM_RUNNING,
-        )?;
-
-        let run = agent::run_agent(
+        // Spawn first, *then* transition Claimed → Running. This matches the
+        // Lean spec: `dispatchFailed` (Claimed → Released) vs `agentLaunched`
+        // (Claimed → Running) vs `agentExitAbnormal` (Running → RetryQueued).
+        let child = match agent::spawn_agent(
             &self.config.agent_cmd,
             &self.config.working_dir,
             &prompt,
-            self.config.task_timeout,
         )
-        .await;
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let body = format!("## Agent run failed (spawn)\n\n{e}");
+                self.post_completion_comment(issue_id, &body, false)?;
+                self.strict_transition(
+                    &task.id,
+                    Task::CLAIM_CLAIMED,
+                    Task::CLAIM_RELEASED,
+                )?;
+                tracing::warn!(task_id = %task.id, err = %e, "orch: dispatchFailed");
+                return Ok(DispatchOutcome::Retried {
+                    task_id: task.id.clone(),
+                });
+            }
+        };
 
-        match run {
+        // agentLaunched.
+        self.strict_transition(&task.id, Task::CLAIM_CLAIMED, Task::CLAIM_RUNNING)?;
+
+        match agent::await_agent(child, self.config.task_timeout).await {
             Ok(result) => {
                 self.post_completion_comment(issue_id, &result.stdout, true)?;
-                self.store.try_transition_claim(
+                self.strict_transition(
                     &task.id,
                     Task::CLAIM_RUNNING,
                     Task::CLAIM_RELEASED,
@@ -137,13 +153,9 @@ impl Worker {
             Err(e) => {
                 let body = format!("## Agent run failed\n\n{e}");
                 self.post_completion_comment(issue_id, &body, false)?;
-                let from = match &e {
-                    SpawnError::Spawn(_) => Task::CLAIM_CLAIMED,
-                    _ => Task::CLAIM_RUNNING,
-                };
-                self.store.try_transition_claim(
+                self.strict_transition(
                     &task.id,
-                    from,
+                    Task::CLAIM_RUNNING,
                     Task::CLAIM_RETRY_QUEUED,
                 )?;
                 tracing::warn!(task_id = %task.id, err = %e, "orch: retry-queued");
@@ -154,14 +166,30 @@ impl Worker {
         }
     }
 
+    /// Non-contended transitions after the initial CAS win. We still route
+    /// through `try_transition_claim` so the single chokepoint property holds,
+    /// but we *expect* this to succeed — if it doesn't, something outside the
+    /// worker is mutating the row and the state machine is compromised.
+    fn strict_transition(&self, task_id: &str, from: &str, to: &str) -> Result<()> {
+        let ok = self.store.try_transition_claim(task_id, from, to)?;
+        if !ok {
+            anyhow::bail!(
+                "orch: expected transition {from}→{to} on {task_id} but CAS failed — \
+                 row was mutated externally"
+            );
+        }
+        Ok(())
+    }
+
     fn post_completion_comment(&self, issue_id: &str, body: &str, ok: bool) -> Result<()> {
         let heading = if ok {
             "## Agent run completed"
         } else {
             "## Agent run failed"
         };
+        let body = truncate_tail(body, COMPLETION_COMMENT_MAX_BYTES);
         let full = if body.trim_start().starts_with("## ") {
-            body.to_string()
+            body.into_owned()
         } else {
             format!("{heading}\n\n{body}")
         };
@@ -177,5 +205,43 @@ impl Worker {
         };
         self.store.insert_board_comment(&comment)?;
         Ok(())
+    }
+}
+
+/// Keep the last `max_bytes` of `body`, prepending a truncation marker if
+/// anything was dropped. Agent stdout tends to end with the useful summary,
+/// so tail-truncation preserves what reviewers care about.
+fn truncate_tail(body: &str, max_bytes: usize) -> std::borrow::Cow<'_, str> {
+    if body.len() <= max_bytes {
+        return std::borrow::Cow::Borrowed(body);
+    }
+    let dropped = body.len() - max_bytes;
+    // Find a char boundary at-or-after the cut point so we don't slice mid-UTF-8.
+    let mut cut = body.len() - max_bytes;
+    while cut < body.len() && !body.is_char_boundary(cut) {
+        cut += 1;
+    }
+    std::borrow::Cow::Owned(format!(
+        "_[truncated {dropped} bytes from the head]_\n\n{}",
+        &body[cut..]
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_tail_is_noop_when_under_limit() {
+        let out = truncate_tail("short", 100);
+        assert_eq!(out, "short");
+    }
+
+    #[test]
+    fn truncate_tail_keeps_end_with_marker() {
+        let body: String = "x".repeat(1000) + "TAIL";
+        let out = truncate_tail(&body, 100);
+        assert!(out.starts_with("_[truncated"));
+        assert!(out.ends_with("TAIL"));
     }
 }

--- a/kernel/crates/gctrl-orch/src/worker.rs
+++ b/kernel/crates/gctrl-orch/src/worker.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use gctrl_core::{BoardComment, Task};
+use gctrl_storage::SqliteStore;
+
+use crate::agent::{self, SpawnError};
+use crate::config::OrchConfig;
+use crate::prompt;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// Won the CAS, ran the agent, released the claim.
+    Released { task_id: String },
+    /// Won the CAS, agent failed or timed out — requeued for retry.
+    Retried { task_id: String },
+    /// Lost the CAS to another worker; no work done.
+    LostRace { task_id: String },
+    /// dry_run mode — logged what would have happened.
+    DryRun { task_id: String },
+}
+
+pub struct Worker {
+    store: Arc<SqliteStore>,
+    config: OrchConfig,
+}
+
+impl Worker {
+    pub fn new(store: Arc<SqliteStore>, config: OrchConfig) -> Self {
+        Self { store, config }
+    }
+
+    /// One drain pass: pick up to `max_concurrent` dispatchable tasks and
+    /// run them sequentially. Sequential is fine for MVP — agents are I/O
+    /// bound waiting on LLM calls, not CPU bound, and one-at-a-time keeps
+    /// the repo's working tree predictable.
+    pub async fn run_once(&self) -> Result<Vec<DispatchOutcome>> {
+        let tasks = self
+            .store
+            .list_dispatchable_tasks(self.config.max_concurrent)?;
+        if tasks.is_empty() {
+            tracing::debug!("orch: no dispatchable tasks");
+            return Ok(vec![]);
+        }
+        let mut outcomes = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            outcomes.push(self.dispatch_one(&task).await?);
+        }
+        Ok(outcomes)
+    }
+
+    /// Run forever, draining on each tick. Cancellation is via dropping
+    /// the caller's tokio runtime (SIGTERM at the CLI level).
+    pub async fn run_forever(&self) -> Result<()> {
+        loop {
+            if let Err(e) = self.run_once().await {
+                tracing::error!("orch: drain pass failed: {e:#}");
+            }
+            tokio::time::sleep(self.config.poll_interval).await;
+        }
+    }
+
+    async fn dispatch_one(&self, task: &Task) -> Result<DispatchOutcome> {
+        // Unclaimed → Claimed. If the CAS loses, another worker got here
+        // first; silently move on. This is the only place double-dispatch
+        // is prevented.
+        let won = self.store.try_transition_claim(
+            &task.id,
+            Task::CLAIM_UNCLAIMED,
+            Task::CLAIM_CLAIMED,
+        )?;
+        if !won {
+            tracing::info!(task_id = %task.id, "orch: lost claim race, skipping");
+            return Ok(DispatchOutcome::LostRace {
+                task_id: task.id.clone(),
+            });
+        }
+
+        let issue_id = task
+            .issue_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("task {} has no issue_id", task.id))?;
+        let issue = self
+            .store
+            .get_board_issue(issue_id)?
+            .ok_or_else(|| anyhow::anyhow!("issue {issue_id} disappeared"))?;
+        let comments = self.store.list_board_comments(issue_id)?;
+        let prompt = prompt::build_prompt(&issue, &comments);
+
+        if self.config.dry_run {
+            tracing::info!(
+                task_id = %task.id,
+                issue_id = %issue_id,
+                prompt_chars = prompt.len(),
+                "orch: dry-run, releasing claim"
+            );
+            // Release the claim so subsequent non-dry runs can pick it up.
+            self.store.try_transition_claim(
+                &task.id,
+                Task::CLAIM_CLAIMED,
+                Task::CLAIM_RELEASED,
+            )?;
+            return Ok(DispatchOutcome::DryRun {
+                task_id: task.id.clone(),
+            });
+        }
+
+        // Claimed → Running (agentLaunched). Spawn the agent; if spawn
+        // itself fails we'll go Claimed → Released via the error arm below.
+        self.store.try_transition_claim(
+            &task.id,
+            Task::CLAIM_CLAIMED,
+            Task::CLAIM_RUNNING,
+        )?;
+
+        let run = agent::run_agent(
+            &self.config.agent_cmd,
+            &self.config.working_dir,
+            &prompt,
+            self.config.task_timeout,
+        )
+        .await;
+
+        match run {
+            Ok(result) => {
+                self.post_completion_comment(issue_id, &result.stdout, true)?;
+                self.store.try_transition_claim(
+                    &task.id,
+                    Task::CLAIM_RUNNING,
+                    Task::CLAIM_RELEASED,
+                )?;
+                tracing::info!(task_id = %task.id, "orch: released on clean exit");
+                Ok(DispatchOutcome::Released {
+                    task_id: task.id.clone(),
+                })
+            }
+            Err(e) => {
+                let body = format!("## Agent run failed\n\n{e}");
+                self.post_completion_comment(issue_id, &body, false)?;
+                let from = match &e {
+                    SpawnError::Spawn(_) => Task::CLAIM_CLAIMED,
+                    _ => Task::CLAIM_RUNNING,
+                };
+                self.store.try_transition_claim(
+                    &task.id,
+                    from,
+                    Task::CLAIM_RETRY_QUEUED,
+                )?;
+                tracing::warn!(task_id = %task.id, err = %e, "orch: retry-queued");
+                Ok(DispatchOutcome::Retried {
+                    task_id: task.id.clone(),
+                })
+            }
+        }
+    }
+
+    fn post_completion_comment(&self, issue_id: &str, body: &str, ok: bool) -> Result<()> {
+        let heading = if ok {
+            "## Agent run completed"
+        } else {
+            "## Agent run failed"
+        };
+        let full = if body.trim_start().starts_with("## ") {
+            body.to_string()
+        } else {
+            format!("{heading}\n\n{body}")
+        };
+        let comment = BoardComment {
+            id: format!("cmt-{}", uuid::Uuid::new_v4()),
+            issue_id: issue_id.to_string(),
+            author_id: "orch".into(),
+            author_name: "gctrld-orch".into(),
+            author_type: "agent".into(),
+            body: full,
+            created_at: chrono::Utc::now(),
+            session_id: None,
+        };
+        self.store.insert_board_comment(&comment)?;
+        Ok(())
+    }
+}

--- a/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
+++ b/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
@@ -73,7 +73,7 @@ fn cat_config() -> OrchConfig {
         agent_cmd: vec!["cat".into()],
         working_dir: std::env::current_dir().unwrap(),
         poll_interval: Duration::from_millis(10),
-        max_concurrent: 4,
+        max_per_pass: 4,
         task_timeout: Duration::from_secs(5),
         dry_run: false,
     }
@@ -154,7 +154,7 @@ async fn second_worker_loses_race() {
 }
 
 #[tokio::test]
-async fn dry_run_releases_without_spawning() {
+async fn dry_run_returns_task_to_unclaimed() {
     let store = Arc::new(SqliteStore::open(":memory:").unwrap());
     let task = seed_dispatchable_issue(&store, "BACK-4");
 
@@ -171,10 +171,40 @@ async fn dry_run_releases_without_spawning() {
         }
     );
 
+    // Dry-run is non-destructive: the task lands back in Unclaimed so a
+    // real run can pick it up without re-promoting the issue.
     let tasks = store.list_tasks_for_issue("BACK-4").unwrap();
-    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_RELEASED);
+    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_UNCLAIMED);
 
     // No completion comment in dry-run mode.
     let comments = store.list_board_comments("BACK-4").unwrap();
     assert!(comments.iter().all(|c| c.author_id != "orch"));
+}
+
+#[tokio::test]
+async fn spawn_failure_transitions_to_released_not_retry() {
+    // Lean spec: `dispatchFailed` is Claimed→Released (not Claimed→RetryQueued).
+    // Verifies the split-phase spawn/await fix.
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let task = seed_dispatchable_issue(&store, "BACK-5");
+
+    let mut config = cat_config();
+    config.agent_cmd = vec!["this-binary-does-not-exist-12345".into()];
+    let worker = Worker::new(Arc::clone(&store), config);
+
+    let outcomes = worker.run_once().await.unwrap();
+    assert_eq!(
+        outcomes[0],
+        DispatchOutcome::Retried {
+            task_id: task.id.clone()
+        }
+    );
+
+    let tasks = store.list_tasks_for_issue("BACK-5").unwrap();
+    assert_eq!(
+        tasks[0].orchestrator_claim,
+        Task::CLAIM_RELEASED,
+        "spawn failure must land on Released per dispatchFailed; got {}",
+        tasks[0].orchestrator_claim
+    );
 }

--- a/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
+++ b/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
@@ -1,0 +1,180 @@
+//! End-to-end worker test — uses `/bin/cat` as the stand-in agent so CI
+//! doesn't need `claude` on the PATH. Drives the full Lean-verified
+//! transition chain `Unclaimed → Claimed → Running → Released`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use gctrl_core::{BoardComment, BoardIssue, BoardProject, IssueStatus, Task};
+use gctrl_orch::{DispatchOutcome, OrchConfig, Worker};
+use gctrl_storage::SqliteStore;
+
+fn seed_dispatchable_issue(store: &SqliteStore, issue_id: &str) -> Task {
+    let project = BoardProject {
+        id: "p".into(),
+        name: "Back".into(),
+        key: "BACK".into(),
+        counter: 1,
+        github_repo: None,
+    };
+    store.create_board_project(&project).unwrap();
+
+    let now = Utc::now();
+    let issue = BoardIssue {
+        id: issue_id.into(),
+        project_id: "p".into(),
+        title: "Test dispatch".into(),
+        description: Some("run the echo agent".into()),
+        status: IssueStatus::InProgress,
+        priority: "none".into(),
+        assignee_id: Some("agent:claude".into()),
+        assignee_name: Some("Claude".into()),
+        assignee_type: Some("agent".into()),
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: None,
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+    };
+    store.insert_board_issue(&issue).unwrap();
+
+    // Simulate the board UI's dispatch comment so prompt::build_prompt
+    // picks it up.
+    let comment = BoardComment {
+        id: "c1".into(),
+        issue_id: issue_id.into(),
+        author_id: "board".into(),
+        author_name: "Board".into(),
+        author_type: "agent".into(),
+        body: "## Agent: Engineer\nDo the thing.".into(),
+        created_at: now,
+        session_id: None,
+    };
+    store.insert_board_comment(&comment).unwrap();
+
+    store.promote_issue_to_task(issue_id, "claude-code").unwrap()
+}
+
+fn cat_config() -> OrchConfig {
+    OrchConfig {
+        agent_cmd: vec!["cat".into()],
+        working_dir: std::env::current_dir().unwrap(),
+        poll_interval: Duration::from_millis(10),
+        max_concurrent: 4,
+        task_timeout: Duration::from_secs(5),
+        dry_run: false,
+    }
+}
+
+#[tokio::test]
+async fn full_cycle_unclaimed_to_released() {
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let task = seed_dispatchable_issue(&store, "BACK-1");
+
+    let worker = Worker::new(Arc::clone(&store), cat_config());
+    let outcomes = worker.run_once().await.unwrap();
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(
+        outcomes[0],
+        DispatchOutcome::Released {
+            task_id: task.id.clone()
+        }
+    );
+
+    let tasks = store.list_tasks_for_issue("BACK-1").unwrap();
+    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_RELEASED);
+
+    // Worker posted a completion comment in addition to the seed dispatch.
+    let comments = store.list_board_comments("BACK-1").unwrap();
+    assert!(
+        comments.iter().any(|c| c.author_id == "orch"),
+        "expected orch completion comment, got {:?}",
+        comments.iter().map(|c| &c.author_id).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn failing_agent_transitions_to_retry_queued() {
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let task = seed_dispatchable_issue(&store, "BACK-2");
+
+    let mut config = cat_config();
+    config.agent_cmd = vec!["sh".into(), "-c".into(), "exit 1".into()];
+    let worker = Worker::new(Arc::clone(&store), config);
+
+    let outcomes = worker.run_once().await.unwrap();
+    assert_eq!(
+        outcomes[0],
+        DispatchOutcome::Retried {
+            task_id: task.id.clone()
+        }
+    );
+    let tasks = store.list_tasks_for_issue("BACK-2").unwrap();
+    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_RETRY_QUEUED);
+}
+
+#[tokio::test]
+async fn second_worker_loses_race() {
+    // Pre-claim the task so the worker's CAS loses.
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let task = seed_dispatchable_issue(&store, "BACK-3");
+    // Simulate worker A's CAS by moving the task out of Unclaimed before
+    // calling run_once. list_dispatchable_tasks won't return it, but we
+    // force the race by constructing the task manually.
+    store
+        .try_transition_claim(&task.id, Task::CLAIM_UNCLAIMED, Task::CLAIM_CLAIMED)
+        .unwrap();
+
+    let worker = Worker::new(Arc::clone(&store), cat_config());
+    let outcomes = worker.run_once().await.unwrap();
+    assert!(
+        outcomes.is_empty(),
+        "already-claimed tasks must not appear in the poll result"
+    );
+
+    let tasks = store.list_tasks_for_issue("BACK-3").unwrap();
+    assert_eq!(
+        tasks[0].orchestrator_claim,
+        Task::CLAIM_CLAIMED,
+        "claim must be untouched"
+    );
+}
+
+#[tokio::test]
+async fn dry_run_releases_without_spawning() {
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let task = seed_dispatchable_issue(&store, "BACK-4");
+
+    let mut config = cat_config();
+    config.dry_run = true;
+    config.agent_cmd = vec!["this-binary-does-not-exist".into()];
+    let worker = Worker::new(Arc::clone(&store), config);
+
+    let outcomes = worker.run_once().await.unwrap();
+    assert_eq!(
+        outcomes[0],
+        DispatchOutcome::DryRun {
+            task_id: task.id.clone()
+        }
+    );
+
+    let tasks = store.list_tasks_for_issue("BACK-4").unwrap();
+    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_RELEASED);
+
+    // No completion comment in dry-run mode.
+    let comments = store.list_board_comments("BACK-4").unwrap();
+    assert!(comments.iter().all(|c| c.author_id != "orch"));
+}

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -768,6 +768,60 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Atomic compare-and-swap on `orchestrator_claim`. Returns `true` iff
+    /// the row was in `from` and got moved to `to`. A `false` result means
+    /// another worker already claimed the task (or the task is gone).
+    ///
+    /// Safe to call concurrently — SQLite serializes the UPDATE and we trust
+    /// the rows-affected count. This is the race-free primitive the worker
+    /// uses for `Unclaimed → Claimed`; subsequent transitions (Claimed →
+    /// Running, Running → Released) are not contended but still go through
+    /// here so the state machine has one chokepoint.
+    ///
+    /// Mirrors `KernelSpec.Orchestrator.step` (kernel/specs-lean4/) — only
+    /// transitions verified there should ever be passed in.
+    pub fn try_transition_claim(&self, task_id: &str, from: &str, to: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let updated = conn
+            .execute(
+                "UPDATE tasks SET orchestrator_claim = ?1, updated_at = ?2 \
+                 WHERE id = ?3 AND orchestrator_claim = ?4",
+                params![to, now, task_id, from],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(updated == 1)
+    }
+
+    /// List tasks whose claim is `Unclaimed` and whose owning Issue is
+    /// dispatch-eligible (`status='in_progress'` and `assignee_type='agent'`).
+    /// Ordered oldest-first so workers drain the queue FIFO.
+    pub fn list_dispatchable_tasks(&self, limit: usize) -> Result<Vec<Task>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT t.id, t.issue_id, t.project_key, t.attempt_ordinal, \
+                        t.agent_kind, t.orchestrator_claim, t.attempt, \
+                        t.created_at, t.updated_at \
+                 FROM tasks t \
+                 INNER JOIN board_issues i ON i.id = t.issue_id \
+                 WHERE t.orchestrator_claim = 'Unclaimed' \
+                   AND i.status = 'in_progress' \
+                   AND i.assignee_type = 'agent' \
+                 ORDER BY t.created_at ASC \
+                 LIMIT ?1",
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([limit as i64], row_to_task)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut tasks = Vec::new();
+        for row in rows {
+            tasks.push(row.map_err(|e| GctlError::Storage(e.to_string()))?);
+        }
+        Ok(tasks)
+    }
+
     pub fn assign_board_issue(&self, id: &str, assignee_id: &str, assignee_name: &str, assignee_type: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let now = chrono::Utc::now().to_rfc3339();

--- a/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
+++ b/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
@@ -1,0 +1,154 @@
+//! Tests for the orchestrator-side primitives on `SqliteStore`:
+//! `try_transition_claim` (atomic CAS) and `list_dispatchable_tasks`
+//! (the worker's poll query).
+//!
+//! The CAS mirrors `KernelSpec.Orchestrator.step` — we don't re-verify the
+//! state machine here (Lean does that), but we exercise the boundary where
+//! two workers race for the same `Unclaimed → Claimed` transition.
+
+use chrono::Utc;
+use gctrl_core::{BoardIssue, BoardProject, IssueStatus, Task};
+use gctrl_storage::SqliteStore;
+
+fn test_store() -> SqliteStore {
+    SqliteStore::open(":memory:").expect("open :memory: store")
+}
+
+fn seed_project(store: &SqliteStore, key: &str) {
+    let project = BoardProject {
+        id: format!("{key}-project"),
+        name: key.into(),
+        key: key.into(),
+        counter: 1,
+        github_repo: None,
+    };
+    store.create_board_project(&project).expect("create project");
+}
+
+fn seed_issue(
+    store: &SqliteStore,
+    key: &str,
+    id: &str,
+    status: IssueStatus,
+    assignee_type: Option<&str>,
+) {
+    let now = Utc::now();
+    let issue = BoardIssue {
+        id: id.into(),
+        project_id: format!("{key}-project"),
+        title: format!("Seed {id}"),
+        description: None,
+        status,
+        priority: "none".into(),
+        assignee_id: assignee_type.map(|_| "agent:claude".into()),
+        assignee_name: assignee_type.map(|_| "Claude".into()),
+        assignee_type: assignee_type.map(str::to_string),
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: Some(id.into()),
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+    };
+    store.insert_board_issue(&issue).expect("insert issue");
+}
+
+#[test]
+fn try_transition_claim_succeeds_from_expected_state() {
+    let store = test_store();
+    seed_project(&store, "BACK");
+    seed_issue(&store, "BACK", "BACK-1", IssueStatus::InProgress, Some("agent"));
+    let task = store.promote_issue_to_task("BACK-1", "claude-code").unwrap();
+
+    let ok = store
+        .try_transition_claim(
+            &task.id,
+            Task::CLAIM_UNCLAIMED,
+            Task::CLAIM_CLAIMED,
+        )
+        .unwrap();
+    assert!(ok, "CAS should succeed when row is in expected state");
+
+    let tasks = store.list_tasks_for_issue("BACK-1").unwrap();
+    assert_eq!(tasks[0].orchestrator_claim, Task::CLAIM_CLAIMED);
+}
+
+#[test]
+fn try_transition_claim_fails_when_already_moved() {
+    // Simulates the race: worker A wins the CAS, worker B's CAS now fails
+    // because `from` no longer matches. No spurious double-dispatch.
+    let store = test_store();
+    seed_project(&store, "BACK");
+    seed_issue(&store, "BACK", "BACK-1", IssueStatus::InProgress, Some("agent"));
+    let task = store.promote_issue_to_task("BACK-1", "claude-code").unwrap();
+
+    let a = store
+        .try_transition_claim(&task.id, Task::CLAIM_UNCLAIMED, Task::CLAIM_CLAIMED)
+        .unwrap();
+    let b = store
+        .try_transition_claim(&task.id, Task::CLAIM_UNCLAIMED, Task::CLAIM_CLAIMED)
+        .unwrap();
+    assert!(a);
+    assert!(!b, "second CAS from same `from` state must fail");
+}
+
+#[test]
+fn try_transition_claim_missing_task_returns_false() {
+    let store = test_store();
+    let ok = store
+        .try_transition_claim("GHOST-1.T1", Task::CLAIM_UNCLAIMED, Task::CLAIM_CLAIMED)
+        .unwrap();
+    assert!(!ok);
+}
+
+#[test]
+fn list_dispatchable_tasks_filters_by_status_and_assignee() {
+    let store = test_store();
+    seed_project(&store, "BACK");
+
+    // Eligible: in_progress + agent assignee → promoted task.
+    seed_issue(&store, "BACK", "BACK-1", IssueStatus::InProgress, Some("agent"));
+    store.promote_issue_to_task("BACK-1", "claude-code").unwrap();
+
+    // Ineligible: wrong status.
+    seed_issue(&store, "BACK", "BACK-2", IssueStatus::Todo, Some("agent"));
+    store.promote_issue_to_task("BACK-2", "claude-code").unwrap();
+
+    // Ineligible: human assignee.
+    seed_issue(&store, "BACK", "BACK-3", IssueStatus::InProgress, Some("human"));
+    store.promote_issue_to_task("BACK-3", "claude-code").unwrap();
+
+    // Ineligible: no assignee at all.
+    seed_issue(&store, "BACK", "BACK-4", IssueStatus::InProgress, None);
+    store.promote_issue_to_task("BACK-4", "claude-code").unwrap();
+
+    let dispatchable = store.list_dispatchable_tasks(10).unwrap();
+    assert_eq!(dispatchable.len(), 1);
+    assert_eq!(dispatchable[0].issue_id.as_deref(), Some("BACK-1"));
+}
+
+#[test]
+fn list_dispatchable_tasks_excludes_already_claimed() {
+    let store = test_store();
+    seed_project(&store, "BACK");
+    seed_issue(&store, "BACK", "BACK-1", IssueStatus::InProgress, Some("agent"));
+    let task = store.promote_issue_to_task("BACK-1", "claude-code").unwrap();
+
+    store
+        .try_transition_claim(&task.id, Task::CLAIM_UNCLAIMED, Task::CLAIM_CLAIMED)
+        .unwrap();
+
+    let dispatchable = store.list_dispatchable_tasks(10).unwrap();
+    assert!(dispatchable.is_empty(), "claimed tasks must drop out of the queue");
+}


### PR DESCRIPTION
## Summary

MVP of the Tier 3 worker that was sketched in `specs/implementation/kernel/session-trigger-from-board.md` but never built. Drag-to-`in_progress` in gctrl-board today produces a persona-brief comment and then does *nothing* — this PR is the "and then" half.

`gctrld orch run` polls for tasks where the owning issue is `status=in_progress + assignee_type=agent`, atomically claims each one, spawns an agent subprocess with the brief on stdin, and transitions the claim per the Lean-verified state machine in `kernel/specs-lean4/KernelSpec/Orchestrator.lean`.

## Claim state machine (strict subset of the verified Lean spec)

```
Unclaimed → Claimed  (dispatchEligible, atomic CAS — only one worker wins)
Claimed   → Running  (agentLaunched, after subprocess spawn)
Claimed   → Released (dispatchFailed, if spawn itself errors)
Running   → Released (reconciliationTerminal, on clean exit 0)
Running   → RetryQueued (agentExitAbnormal, on non-zero exit or timeout)
```

All five transitions above exist in `Orchestrator.lean` and have verified properties (no-duplicate-dispatch, determinism, terminal convergence). Nothing outside that set is emitted.

## What's in

**`gctrl-storage` — new primitives:**
- `SqliteStore::try_transition_claim(task_id, from, to)` — race-free CAS via `UPDATE ... WHERE id=? AND orchestrator_claim=?`. Returns `true` iff exactly one row was updated; `false` is either "another worker beat us" or "row gone."
- `SqliteStore::list_dispatchable_tasks(limit)` — indexed join query; returns oldest-first `Unclaimed` tasks whose issue is dispatch-eligible.

**`gctrl-orch` — new crate:**
- `agent::run_agent` — spawns `program + args`, pipes the prompt on stdin, captures stdout/stderr, enforces a wall-clock timeout.
- `prompt::build_prompt` — picks the freshest `## Agent:` comment (that's the marker the board UI posts). Falls back to `title + description` if none.
- `worker::Worker` — ties it together: CAS → fetch issue + comments → build prompt → spawn → transition → post a completion comment.
- `config::OrchConfig` — agent cmd, working dir, interval, max-concurrent, timeout, dry-run.

**CLI:**
```
gctrld orch run [--once]
                [--interval 5]
                [--max-concurrent 1]
                [--timeout 1800]
                [--agent claude -p]
                [--working-dir .]
                [--dry-run]
```

Runs as its own daemon (`--once` for one drain + exit). Separate from `gctrld serve` so the worker can be killed/restarted without taking the HTTP API down — the rationale behind "one daemon, one job" that we discussed in the plan thread.

## What's deliberately not in

| Thing | Why deferred |
|-------|--------------|
| Pause / `humanResume` / `guardrailSuspend` | Verified in Lean but no trigger source yet; add when the guardrails engine has a suspend path. |
| `RetryQueued → Running` auto-redispatch | MVP leaves the row in `RetryQueued` for a human (or a future retry driver) to revive. Avoids runaway retry loops on a broken agent. |
| `session_id` linking back to the issue | The subprocess has no deterministic session id. Ships when we move from subprocess to direct SDK integration. |
| OTel trace correlation | The subprocess inherits `OTEL_EXPORTER_OTLP_ENDPOINT`, so spans flow to the kernel for free — but there's no cross-link to the task yet. |
| Direct Anthropic SDK | Subprocess is the MVP. SDK gives per-tool guardrail checks but is 3–5× the code; do it when we know which tools to restrict. |

## Test plan

- [x] `cargo test -p gctrl-storage` — **74 + 5** passing (5 new CAS / filter tests).
- [x] `cargo test -p gctrl-orch` — **7 + 4** passing, including `full_cycle_unclaimed_to_released` using `/bin/cat` as a stand-in agent so CI doesn't need `claude` on the PATH.
- [x] `cargo build -p gctrl-cli` — clean.
- [x] `gctrld orch run --once --agent cat` on an empty store → `dispatched 0 task(s)`.
- [ ] CI green on this branch.

## Next steps (separate PRs)

1. Link subprocess session back to the issue via `/api/board/issues/:id/link-session` — needs either the agent to post its own session id or a proxy-side correlation trick.
2. Retry driver: a second loop that moves `RetryQueued → Running` with backoff, up to `maxRetries` → `Released`.
3. Replace subprocess spawn with Anthropic SDK so guardrails can inspect tool calls.
