### PR TITLE
feat(uebermensch): M1a — curator + strict renderer w/ citation verification

### DIFF
--- a/apps/uebermensch/src/adapters/FileSystemVault.ts
+++ b/apps/uebermensch/src/adapters/FileSystemVault.ts
@@ -70,6 +70,17 @@ export const FileSystemVaultLive = (vaultDir: string) =>
         catch: (e) =>
           new VaultError({ message: `recent scan failed: ${String(e)}`, path: vaultDir }),
       }),
+    listSlugs: () =>
+      Effect.tryPromise({
+        try: async () => {
+          const files = await walkMarkdown(vaultDir, ["wiki", "theses", "briefs"])
+          const slugs = new Set<string>()
+          for (const f of files) slugs.add(basename(f.abs, ".md"))
+          return slugs as ReadonlySet<string>
+        },
+        catch: (e) =>
+          new VaultError({ message: `list slugs failed: ${String(e)}`, path: vaultDir }),
+      }),
     writeBrief: (date, content) =>
       Effect.tryPromise({
         try: async () => {

--- a/apps/uebermensch/src/adapters/StrictRenderer.ts
+++ b/apps/uebermensch/src/adapters/StrictRenderer.ts
@@ -1,0 +1,111 @@
+import { Effect, Layer } from "effect"
+import { CitationError } from "../errors.js"
+import { citedSentences, claimSentences, extractLinks, isTypedPrefix } from "../lib/citations.js"
+import {
+  RendererService,
+  type CuratedItem,
+  type RenderInput,
+  type RenderResult,
+} from "../services/RendererService.js"
+
+const verifyItemCitations = (
+  item: CuratedItem,
+  idx: number,
+  vaultSlugs: ReadonlySet<string>,
+  candidateIds: ReadonlySet<string>,
+): CitationError | null => {
+  for (const src of item.source_candidate_ids) {
+    if (!candidateIds.has(src)) {
+      return new CitationError({
+        message: `item ${idx}: fabricated source candidate id: ${src}`,
+        kind: "fabricated_source",
+        link: src,
+        itemIndex: idx,
+      })
+    }
+  }
+  const links = extractLinks(item.summary_md)
+  for (const link of links) {
+    if (isTypedPrefix(link.target)) {
+      return new CitationError({
+        message: `item ${idx}: typed prefix forbidden in ${link.raw}`,
+        kind: "typed_prefix",
+        link: link.raw,
+        itemIndex: idx,
+      })
+    }
+    if (!vaultSlugs.has(link.target)) {
+      return new CitationError({
+        message: `item ${idx}: unresolved wikilink ${link.raw}`,
+        kind: "unresolved",
+        link: link.raw,
+        itemIndex: idx,
+      })
+    }
+  }
+  return null
+}
+
+const yamlList = (items: ReadonlyArray<string>): string =>
+  items.length === 0 ? "[]" : `[${items.join(", ")}]`
+
+const renderFrontmatter = (
+  input: RenderInput,
+  itemCount: number,
+  citedClaims: number,
+  totalClaims: number,
+): string =>
+  [
+    "---",
+    "page_type: brief",
+    `slug: brief-${input.date}`,
+    'kind: "daily"',
+    `generated_for: "${input.date}"`,
+    `generator: "${input.generator}"`,
+    `model: "${input.model}"`,
+    `prompt_hash: "${input.promptHash}"`,
+    `cost_usd: ${input.costUsd}`,
+    `item_count: ${itemCount}`,
+    `cited_claims: ${citedClaims}`,
+    `total_claims: ${totalClaims}`,
+    `topics: ${yamlList(input.topicsCovered)}`,
+    `theses: ${yamlList(input.thesesCovered)}`,
+    "---",
+  ].join("\n")
+
+const renderItem = (item: CuratedItem, idx: number): string => {
+  const lines: Array<string> = []
+  lines.push(`## ${idx + 1}. ${item.title}`)
+  lines.push("")
+  lines.push(item.summary_md.trim())
+  if (item.suggested_action) {
+    lines.push("")
+    lines.push(`**Suggested action:** ${item.suggested_action.trim()}`)
+  }
+  return lines.join("\n")
+}
+
+export const StrictRendererLive = Layer.succeed(RendererService, {
+  render: (input) =>
+    Effect.gen(function* () {
+      const candidateIds = new Set(input.candidates.map((c) => c.id))
+      let idx = 0
+      for (const item of input.items) {
+        const err = verifyItemCitations(item, idx, input.vaultSlugs, candidateIds)
+        if (err) return yield* Effect.fail(err)
+        idx += 1
+      }
+      const fullBody = input.items.map(renderItem).join("\n\n")
+      const totalClaims = claimSentences(fullBody)
+      const citedClaims = citedSentences(fullBody)
+      const frontmatter = renderFrontmatter(input, input.items.length, citedClaims, totalClaims)
+      const markdown = `${frontmatter}\n\n# Daily brief — ${input.date}\n\n${fullBody}\n`
+      const result: RenderResult = {
+        markdown,
+        itemCount: input.items.length,
+        citedClaims,
+        totalClaims,
+      }
+      return result
+    }),
+})

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -1,32 +1,70 @@
 import { Effect, Layer } from "effect"
+import { sha256 } from "../lib/hash.js"
 import { LlmService } from "../services/LlmService.js"
+import type { CuratedItem } from "../services/RendererService.js"
+
+const STUB_MODEL = "stub-llm@0.1"
+
+const renderPrompt = (
+  date: string,
+  profileName: string,
+  topics: ReadonlyArray<string>,
+  candidateIds: ReadonlyArray<string>,
+): string =>
+  [
+    "persona: uber-curator/stub",
+    `date: ${date}`,
+    `profile: ${profileName}`,
+    `topics: ${topics.join(",")}`,
+    `candidates: ${candidateIds.join(",")}`,
+  ].join("\n")
 
 export const StubLlmLive = Layer.succeed(LlmService, {
-  name: () => "stub-llm@0.1",
+  name: () => STUB_MODEL,
   generateBrief: (req) =>
     Effect.sync(() => {
-      const sorted = [...req.pages].sort((a, b) => b.mtime.getTime() - a.mtime.getTime())
-      const picked = sorted.slice(0, 5)
-      const items = picked.map((p, i) => {
-        const title = (p.frontmatter.title as string | undefined) ?? p.stem
+      const candidateIds = req.candidates.map((c) => c.id)
+      const prompt = renderPrompt(req.date, req.profileName, req.topics, candidateIds)
+      const promptHash = sha256(prompt)
+      const topCandidates = [...req.candidates]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, req.maxItems)
+      const items: Array<CuratedItem> = topCandidates.map((c) => {
+        const title =
+          (c.page.frontmatter.title as string | undefined) ?? c.page.stem
+        const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+        const topic = pageTopics[0] ?? null
         return {
-          heading: `${i + 1}. ${title}`,
-          body: `Stub brief note on ${title} — based on [[${p.stem}]].`,
-          citations: [p.stem],
+          kind: "news",
+          title,
+          summary_md: `Stub summary for [[${c.page.stem}]].`,
+          topic,
+          thesis: null,
+          source_candidate_ids: [c.id],
+          suggested_action: null,
         }
       })
       if (items.length === 0) {
         items.push({
-          heading: "1. No recent activity",
-          body: "Stub brief: no pages changed in window.",
-          citations: [],
+          kind: "news",
+          title: "No activity",
+          summary_md: "No candidate pages in window.",
+          topic: null,
+          thesis: null,
+          source_candidate_ids: [],
+          suggested_action: null,
         })
       }
-      const covered = new Set<string>()
-      for (const p of picked) {
-        const topics = p.frontmatter.topics as ReadonlyArray<string> | undefined
-        if (topics) for (const t of topics) covered.add(t)
+      const topicsCovered = Array.from(
+        new Set(items.map((i) => i.topic).filter((t): t is string => t !== null)),
+      )
+      return {
+        items,
+        topicsCovered,
+        thesesCovered: [],
+        promptHash,
+        costUsd: 0,
+        model: STUB_MODEL,
       }
-      return { items, topicsCovered: [...covered] }
     }),
 })

--- a/apps/uebermensch/src/commands/brief.ts
+++ b/apps/uebermensch/src/commands/brief.ts
@@ -1,16 +1,19 @@
 import { Command, Options } from "@effect/cli"
-import { Console, Effect } from "effect"
+import { Console, Effect, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
+import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
+import { selectCandidates } from "../lib/candidates.js"
 import { resolveVaultDir } from "../lib/env.js"
 import { LlmService } from "../services/LlmService.js"
 import { ProfileService } from "../services/ProfileService.js"
+import { RendererService } from "../services/RendererService.js"
 import { VaultService } from "../services/VaultService.js"
 
-const sinceHours = Options.integer("since-hours").pipe(
+const sinceHoursOpt = Options.integer("since-hours").pipe(
   Options.withDescription("Window of recently-changed pages to feed the LLM"),
-  Options.withDefault(24 * 7),
+  Options.withDefault(24),
 )
 
 const dateOpt = Options.text("date").pipe(
@@ -18,65 +21,109 @@ const dateOpt = Options.text("date").pipe(
   Options.optional,
 )
 
+const maxItemsOpt = Options.integer("max-items").pipe(
+  Options.withDescription("Maximum brief items (overrides profile brief format)"),
+  Options.optional,
+)
+
+const dryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Do not write the brief file; print to stdout only"),
+  Options.withDefault(false),
+)
+
 const today = () => new Date().toISOString().slice(0, 10)
 
-const renderBrief = (
-  date: string,
-  topicsCovered: ReadonlyArray<string>,
-  generator: string,
-  items: ReadonlyArray<{ heading: string; body: string; citations: ReadonlyArray<string> }>,
-) => {
-  const fm = [
-    "---",
-    "page_type: brief",
-    `slug: brief-${date}`,
-    `date: "${date}"`,
-    `generator: ${generator}`,
-    `topics_covered: [${topicsCovered.join(", ")}]`,
-    "---",
-    "",
-    `# Daily brief — ${date}`,
-    "",
-  ].join("\n")
-  const body = items
-    .map((it) => `### ${it.heading}\n\n${it.body.trim()}\n`)
-    .join("\n")
-  return `${fm}${body}`
+const itemsForFormat = (format: "long" | "short" | "digest"): number => {
+  switch (format) {
+    case "long":
+      return 12
+    case "short":
+      return 6
+    case "digest":
+      return 3
+  }
 }
 
 export const brief = Command.make(
   "brief",
-  { sinceHours, dateOpt },
-  ({ sinceHours: sinceHoursVal, dateOpt: dateOptVal }) =>
+  { sinceHoursOpt, dateOpt, maxItemsOpt, dryRunOpt },
+  ({ sinceHoursOpt: sinceHours, dateOpt: dateOptVal, maxItemsOpt: maxItemsOptVal, dryRunOpt: dryRun }) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
-      const date = dateOptVal._tag === "Some" ? dateOptVal.value : today()
+      const date = Option.getOrElse(dateOptVal, today)
       yield* Console.log(`generating brief for ${date} from ${vaultDir}`)
-      const profileLayer = FileSystemProfileLive(vaultDir)
-      const vaultLayer = FileSystemVaultLive(vaultDir)
       const program = Effect.gen(function* () {
         const profileSvc = yield* ProfileService
         const vaultSvc = yield* VaultService
         const llm = yield* LlmService
+        const renderer = yield* RendererService
         const profile = yield* profileSvc.load()
-        const pages = yield* vaultSvc.recentlyChanged(sinceHoursVal)
-        yield* Console.log(`  ${pages.length} page(s) changed in last ${sinceHoursVal}h`)
+
+        const pages = yield* vaultSvc.recentlyChanged(sinceHours)
+        yield* Console.log(`  ${pages.length} page(s) changed in last ${sinceHours}h`)
+
+        const topicWeights = profile.topics.topics.map((t) => ({
+          slug: t.slug,
+          weight: t.weight,
+        }))
+        const now = new Date()
+        const candidates = selectCandidates({
+          pages,
+          topics: topicWeights,
+          thesesSlugs: [],
+          now,
+          windowHours: sinceHours,
+          maxCandidates: 40,
+        })
+        yield* Console.log(`  ${candidates.length} candidate(s) after ranking`)
+
+        const maxItems = Option.getOrElse(maxItemsOptVal, () =>
+          itemsForFormat(profile.profile.delivery.brief.format),
+        )
+
         const response = yield* llm.generateBrief({
           date,
           profileName: profile.profile.identity.name,
-          pages,
-          topics: profile.topics.topics.map((t) => t.slug),
+          topics: topicWeights.map((t) => t.slug),
+          thesesSlugs: [],
+          candidates,
+          maxItems,
         })
-        const rendered = renderBrief(date, response.topicsCovered, llm.name(), response.items)
-        const written = yield* vaultSvc.writeBrief(date, rendered)
-        yield* Console.log(`✓ wrote ${written.relPath} (${written.contentHash})`)
+
+        const vaultSlugs = yield* vaultSvc.listSlugs()
+        const rendered = yield* renderer.render({
+          date,
+          generator: llm.name(),
+          model: response.model,
+          promptHash: response.promptHash,
+          costUsd: response.costUsd,
+          profileName: profile.profile.identity.name,
+          topicsCovered: response.topicsCovered,
+          thesesCovered: response.thesesCovered,
+          candidates,
+          items: response.items,
+          vaultSlugs,
+        })
+
+        if (dryRun) {
+          yield* Console.log("(dry-run — not writing)")
+          yield* Console.log("")
+          yield* Console.log(rendered.markdown)
+          return
+        }
+
+        const written = yield* vaultSvc.writeBrief(date, rendered.markdown)
+        yield* Console.log(
+          `✓ wrote ${written.relPath} (${written.contentHash}) — ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
+        )
         yield* Console.log("")
-        yield* Console.log(rendered)
+        yield* Console.log(rendered.markdown)
       })
       yield* program.pipe(
-        Effect.provide(profileLayer),
-        Effect.provide(vaultLayer),
+        Effect.provide(FileSystemProfileLive(vaultDir)),
+        Effect.provide(FileSystemVaultLive(vaultDir)),
         Effect.provide(StubLlmLive),
+        Effect.provide(StrictRendererLive),
       )
     }),
 ).pipe(Command.withDescription("Generate a daily brief from wiki pages + stub LLM"))

--- a/apps/uebermensch/src/errors.ts
+++ b/apps/uebermensch/src/errors.ts
@@ -12,4 +12,14 @@ export class ProfileError extends Schema.TaggedError<ProfileError>()("ProfileErr
 
 export class LlmError extends Schema.TaggedError<LlmError>()("LlmError", {
   message: Schema.String,
+  kind: Schema.optional(
+    Schema.Literal("unavailable", "rate_limited", "budget_exceeded", "invalid"),
+  ),
+}) {}
+
+export class CitationError extends Schema.TaggedError<CitationError>()("CitationError", {
+  message: Schema.String,
+  kind: Schema.Literal("typed_prefix", "unresolved", "fabricated_source"),
+  link: Schema.optional(Schema.String),
+  itemIndex: Schema.optional(Schema.Number),
 }) {}

--- a/apps/uebermensch/src/lib/candidates.ts
+++ b/apps/uebermensch/src/lib/candidates.ts
@@ -1,0 +1,109 @@
+import type { WikiPage } from "../services/VaultService.js"
+
+export type TopicWeight = { readonly slug: string; readonly weight: number }
+
+export type CandidateRef = {
+  readonly id: string
+  readonly page: WikiPage
+  readonly score: number
+}
+
+export type CandidateInput = {
+  readonly pages: ReadonlyArray<WikiPage>
+  readonly topics: ReadonlyArray<TopicWeight>
+  readonly thesesSlugs: ReadonlyArray<string>
+  readonly now: Date
+  readonly windowHours: number
+  readonly maxCandidates: number
+}
+
+const HALFLIFE_HOURS = 12
+const MAX_CANDIDATE_TYPES = new Set(["source", "synthesis", "question"])
+
+const recencyDecay = (page: WikiPage, now: Date): number => {
+  const ageHours = Math.max(0, (now.getTime() - page.mtime.getTime()) / 3_600_000)
+  return 2 ** (-ageHours / HALFLIFE_HOURS)
+}
+
+const topicWeightFor = (
+  page: WikiPage,
+  topics: ReadonlyArray<TopicWeight>,
+): number => {
+  const pageTopics = (page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+  if (pageTopics.length === 0) return 0.1
+  let best = 0
+  for (const t of pageTopics) {
+    const match = topics.find((w) => w.slug === t)
+    if (match && match.weight > best) best = match.weight
+  }
+  return best
+}
+
+const spamPenalty = (page: WikiPage): number => {
+  const q = page.frontmatter.quality as { spam_score?: number } | undefined
+  const score = q?.spam_score ?? 0
+  return Math.max(0, 1 - score)
+}
+
+const thesisBoost = (
+  page: WikiPage,
+  thesesSlugs: ReadonlyArray<string>,
+): number => {
+  const watched = (page.frontmatter.watched_by_thesis as ReadonlyArray<string> | undefined) ?? []
+  const linked = (page.frontmatter.linked_thesis as ReadonlyArray<string> | undefined) ?? []
+  const touched = [...watched, ...linked]
+  return touched.some((t) => thesesSlugs.includes(t)) ? 1.3 : 1.0
+}
+
+const pageType = (p: WikiPage): string =>
+  (p.frontmatter.page_type as string | undefined)?.toLowerCase() ?? "unknown"
+
+const spamScore = (p: WikiPage): number => {
+  const q = p.frontmatter.quality as { spam_score?: number } | undefined
+  return q?.spam_score ?? 0
+}
+
+const pageTopicSlugs = (p: WikiPage): ReadonlyArray<string> =>
+  (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+
+export const scorePrior = (
+  page: WikiPage,
+  topics: ReadonlyArray<TopicWeight>,
+  thesesSlugs: ReadonlyArray<string>,
+  now: Date,
+): number => {
+  const base = topicWeightFor(page, topics)
+  if (base === 0) return 0
+  return base * recencyDecay(page, now) * spamPenalty(page) * thesisBoost(page, thesesSlugs)
+}
+
+export const selectCandidates = (input: CandidateInput): ReadonlyArray<CandidateRef> => {
+  const { pages, topics, thesesSlugs, now, windowHours, maxCandidates } = input
+  const cutoff = now.getTime() - windowHours * 3_600_000
+  const topicSlugs = new Set(topics.map((t) => t.slug))
+
+  const filtered = pages.filter((p) => {
+    if (p.mtime.getTime() < cutoff) return false
+    if (!MAX_CANDIDATE_TYPES.has(pageType(p))) return false
+    if (spamScore(p) >= 0.6) return false
+    const pageTopics = pageTopicSlugs(p)
+    const topicHit = pageTopics.some((t) => topicSlugs.has(t))
+    const thesisHit = thesesSlugs.some((t) => {
+      const watched = (p.frontmatter.watched_by_thesis as ReadonlyArray<string> | undefined) ?? []
+      const linked = (p.frontmatter.linked_thesis as ReadonlyArray<string> | undefined) ?? []
+      return watched.includes(t) || linked.includes(t)
+    })
+    return topicHit || thesisHit
+  })
+
+  const scored = filtered
+    .map((page, i) => ({
+      id: `cand-${i.toString().padStart(4, "0")}`,
+      page,
+      score: scorePrior(page, topics, thesesSlugs, now),
+    }))
+    .filter((c) => c.score > 0)
+    .sort((a, b) => b.score - a.score)
+
+  return scored.slice(0, maxCandidates)
+}

--- a/apps/uebermensch/src/lib/citations.ts
+++ b/apps/uebermensch/src/lib/citations.ts
@@ -1,0 +1,40 @@
+export type WikiLink = {
+  readonly raw: string
+  readonly target: string
+  readonly display: string | null
+  readonly offset: number
+}
+
+const LINK_RE = /\[\[([^\]]+)\]\]/g
+
+export const extractLinks = (markdown: string): ReadonlyArray<WikiLink> => {
+  const out: Array<WikiLink> = []
+  for (const m of markdown.matchAll(LINK_RE)) {
+    const inner = m[1] ?? ""
+    const pipeIdx = inner.indexOf("|")
+    const target = (pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner).trim()
+    const display = pipeIdx >= 0 ? inner.slice(pipeIdx + 1).trim() : null
+    out.push({ raw: m[0], target, display, offset: m.index ?? 0 })
+  }
+  return out
+}
+
+export const isTypedPrefix = (target: string): boolean =>
+  target.includes(":") || target.includes("/") || target.includes("\\")
+
+const splitSentences = (markdown: string): ReadonlyArray<string> => {
+  const stripped = markdown
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]*`/g, "")
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n")
+  return stripped.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0)
+}
+
+const hasLink = (s: string): boolean => /\[\[[^\]]+\]\]/.test(s)
+
+export const claimSentences = (markdown: string): number => splitSentences(markdown).length
+
+export const citedSentences = (markdown: string): number =>
+  splitSentences(markdown).filter(hasLink).length

--- a/apps/uebermensch/src/lib/hash.ts
+++ b/apps/uebermensch/src/lib/hash.ts
@@ -1,0 +1,4 @@
+import { createHash } from "node:crypto"
+
+export const sha256 = (s: string): string =>
+  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -1,23 +1,24 @@
 import { Context, type Effect } from "effect"
 import type { LlmError } from "../errors.js"
-import type { WikiPage } from "./VaultService.js"
-
-export type BriefItem = {
-  readonly heading: string
-  readonly body: string
-  readonly citations: ReadonlyArray<string>
-}
+import type { CandidateRef } from "../lib/candidates.js"
+import type { CuratedItem } from "./RendererService.js"
 
 export type BriefRequest = {
   readonly date: string
   readonly profileName: string
-  readonly pages: ReadonlyArray<WikiPage>
   readonly topics: ReadonlyArray<string>
+  readonly thesesSlugs: ReadonlyArray<string>
+  readonly candidates: ReadonlyArray<CandidateRef>
+  readonly maxItems: number
 }
 
 export type BriefResponse = {
-  readonly items: ReadonlyArray<BriefItem>
+  readonly items: ReadonlyArray<CuratedItem>
   readonly topicsCovered: ReadonlyArray<string>
+  readonly thesesCovered: ReadonlyArray<string>
+  readonly promptHash: string
+  readonly costUsd: number
+  readonly model: string
 }
 
 export interface LlmServiceShape {

--- a/apps/uebermensch/src/services/RendererService.ts
+++ b/apps/uebermensch/src/services/RendererService.ts
@@ -1,0 +1,43 @@
+import { Context, type Effect } from "effect"
+import type { CitationError } from "../errors.js"
+import type { CandidateRef } from "../lib/candidates.ts"
+
+export type CuratedItem = {
+  readonly kind: "news" | "update" | "action" | "alert"
+  readonly title: string
+  readonly summary_md: string
+  readonly topic: string | null
+  readonly thesis: string | null
+  readonly source_candidate_ids: ReadonlyArray<string>
+  readonly suggested_action: string | null
+}
+
+export type RenderInput = {
+  readonly date: string
+  readonly generator: string
+  readonly model: string
+  readonly promptHash: string
+  readonly costUsd: number
+  readonly profileName: string
+  readonly topicsCovered: ReadonlyArray<string>
+  readonly thesesCovered: ReadonlyArray<string>
+  readonly candidates: ReadonlyArray<CandidateRef>
+  readonly items: ReadonlyArray<CuratedItem>
+  readonly vaultSlugs: ReadonlySet<string>
+}
+
+export type RenderResult = {
+  readonly markdown: string
+  readonly itemCount: number
+  readonly citedClaims: number
+  readonly totalClaims: number
+}
+
+export interface RendererServiceShape {
+  readonly render: (input: RenderInput) => Effect.Effect<RenderResult, CitationError>
+}
+
+export class RendererService extends Context.Tag("uebermensch/RendererService")<
+  RendererService,
+  RendererServiceShape
+>() {}

--- a/apps/uebermensch/src/services/VaultService.ts
+++ b/apps/uebermensch/src/services/VaultService.ts
@@ -21,6 +21,7 @@ export interface VaultServiceShape {
   readonly recentlyChanged: (
     sinceHours: number,
   ) => Effect.Effect<ReadonlyArray<WikiPage>, VaultError>
+  readonly listSlugs: () => Effect.Effect<ReadonlySet<string>, VaultError>
   readonly writeBrief: (
     date: string,
     content: string,

--- a/apps/uebermensch/tests/brief.test.ts
+++ b/apps/uebermensch/tests/brief.test.ts
@@ -2,10 +2,13 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect, Layer } from "effect"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import { StrictRendererLive } from "../src/adapters/StrictRenderer.js"
 import { StubLlmLive } from "../src/adapters/StubLlm.js"
+import { selectCandidates } from "../src/lib/candidates.js"
 import { LlmService } from "../src/services/LlmService.js"
+import { RendererService } from "../src/services/RendererService.js"
 import { VaultService } from "../src/services/VaultService.js"
 
 const seedPage = async (root: string, rel: string, frontmatter: string, body: string) => {
@@ -14,46 +17,69 @@ const seedPage = async (root: string, rel: string, frontmatter: string, body: st
   await writeFile(full, `---\n${frontmatter}---\n\n${body}\n`, "utf8")
 }
 
-describe("brief generation (vault + stub LLM)", () => {
+describe("brief generation (candidates + stub LLM + strict renderer)", () => {
   let vaultDir: string
 
   beforeEach(async () => {
     vaultDir = await mkdtemp(join(tmpdir(), "uber-vault-"))
     await seedPage(
       vaultDir,
-      "wiki/topics/foo.md",
-      "page_type: topic\nslug: foo\ntitle: Foo\n",
+      "wiki/sources/2026-04-18--foo.md",
+      "page_type: source\nslug: 2026-04-18--foo\ntitle: Foo Source\ntopics: [foo-topic]\n",
       "# Foo\n\nSome content.",
     )
     await seedPage(
       vaultDir,
-      "wiki/topics/bar.md",
-      "page_type: topic\nslug: bar\ntitle: Bar\n",
+      "wiki/sources/2026-04-18--bar.md",
+      "page_type: source\nslug: 2026-04-18--bar\ntitle: Bar Source\ntopics: [bar-topic]\n",
       "# Bar\n\nOther content.",
     )
   })
 
-  afterEach(async () => {
-    // temp dir — OS cleans up
-  })
-
-  it("writes a brief file to briefs/<date>.md with content hash", async () => {
+  it("writes a brief with frontmatter + resolved citations", async () => {
     const program = Effect.gen(function* () {
       const vault = yield* VaultService
       const llm = yield* LlmService
+      const renderer = yield* RendererService
       const pages = yield* vault.recentlyChanged(24)
+      const candidates = selectCandidates({
+        pages,
+        topics: [
+          { slug: "foo-topic", weight: 1 },
+          { slug: "bar-topic", weight: 1 },
+        ],
+        thesesSlugs: [],
+        now: new Date(),
+        windowHours: 24,
+        maxCandidates: 40,
+      })
       const response = yield* llm.generateBrief({
         date: "2026-04-19",
         profileName: "Test",
-        pages,
-        topics: ["foo", "bar"],
+        topics: ["foo-topic", "bar-topic"],
+        thesesSlugs: [],
+        candidates,
+        maxItems: 6,
       })
-      const rendered = `---\npage_type: brief\nslug: brief-2026-04-19\n---\n\n${response.items
-        .map((i) => `### ${i.heading}\n\n${i.body}\n`)
-        .join("\n")}`
-      return yield* vault.writeBrief("2026-04-19", rendered)
+      const vaultSlugs = yield* vault.listSlugs()
+      const rendered = yield* renderer.render({
+        date: "2026-04-19",
+        generator: llm.name(),
+        model: response.model,
+        promptHash: response.promptHash,
+        costUsd: response.costUsd,
+        profileName: "Test",
+        topicsCovered: response.topicsCovered,
+        thesesCovered: response.thesesCovered,
+        candidates,
+        items: response.items,
+        vaultSlugs,
+      })
+      return yield* vault.writeBrief("2026-04-19", rendered.markdown)
     }).pipe(
-      Effect.provide(Layer.merge(FileSystemVaultLive(vaultDir), StubLlmLive)),
+      Effect.provide(
+        Layer.mergeAll(FileSystemVaultLive(vaultDir), StubLlmLive, StrictRendererLive),
+      ),
     )
 
     const written = await Effect.runPromise(program)
@@ -61,6 +87,7 @@ describe("brief generation (vault + stub LLM)", () => {
     expect(written.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/)
     const onDisk = await readFile(join(vaultDir, written.relPath), "utf8")
     expect(onDisk).toContain("brief-2026-04-19")
-    expect(onDisk).toContain("[[foo]]")
+    expect(onDisk).toContain("prompt_hash:")
+    expect(onDisk).toContain("[[2026-04-18--foo]]")
   })
 })

--- a/apps/uebermensch/tests/candidates.test.ts
+++ b/apps/uebermensch/tests/candidates.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { scorePrior, selectCandidates } from "../src/lib/candidates.js"
+import type { WikiPage } from "../src/services/VaultService.js"
+
+const page = (
+  overrides: Partial<WikiPage> & { frontmatter?: Record<string, unknown> },
+): WikiPage => ({
+  relPath: "wiki/sources/stub.md",
+  stem: overrides.stem ?? "stub",
+  frontmatter: {
+    page_type: "source",
+    slug: overrides.stem ?? "stub",
+    topics: ["foo"],
+    ...overrides.frontmatter,
+  },
+  body: "",
+  mtime: overrides.mtime ?? new Date("2026-04-19T08:00:00Z"),
+})
+
+describe("selectCandidates", () => {
+  const now = new Date("2026-04-19T12:00:00Z")
+  const topics = [{ slug: "foo", weight: 1 }]
+
+  it("filters by page_type (only source/synthesis/question)", () => {
+    const pages = [
+      page({ stem: "src-a", frontmatter: { page_type: "source", topics: ["foo"] } }),
+      page({ stem: "ent-a", frontmatter: { page_type: "entity", topics: ["foo"] } }),
+      page({ stem: "syn-a", frontmatter: { page_type: "synthesis", topics: ["foo"] } }),
+      page({ stem: "top-a", frontmatter: { page_type: "topic", topics: ["foo"] } }),
+    ]
+    const got = selectCandidates({
+      pages,
+      topics,
+      thesesSlugs: [],
+      now,
+      windowHours: 24,
+      maxCandidates: 40,
+    })
+    expect(got.map((c) => c.page.stem).sort()).toEqual(["src-a", "syn-a"])
+  })
+
+  it("filters by window and topic intersection", () => {
+    const stale = new Date(now.getTime() - 48 * 3_600_000)
+    const pages = [
+      page({ stem: "recent-match", mtime: now, frontmatter: { page_type: "source", topics: ["foo"] } }),
+      page({ stem: "recent-miss", mtime: now, frontmatter: { page_type: "source", topics: ["bar"] } }),
+      page({ stem: "stale-match", mtime: stale, frontmatter: { page_type: "source", topics: ["foo"] } }),
+    ]
+    const got = selectCandidates({
+      pages,
+      topics,
+      thesesSlugs: [],
+      now,
+      windowHours: 24,
+      maxCandidates: 40,
+    })
+    expect(got.map((c) => c.page.stem)).toEqual(["recent-match"])
+  })
+
+  it("drops spammy pages (spam_score >= 0.6)", () => {
+    const pages = [
+      page({
+        stem: "spammy",
+        frontmatter: { page_type: "source", topics: ["foo"], quality: { spam_score: 0.8 } },
+      }),
+      page({ stem: "clean", frontmatter: { page_type: "source", topics: ["foo"] } }),
+    ]
+    const got = selectCandidates({
+      pages,
+      topics,
+      thesesSlugs: [],
+      now,
+      windowHours: 24,
+      maxCandidates: 40,
+    })
+    expect(got.map((c) => c.page.stem)).toEqual(["clean"])
+  })
+
+  it("ranks newer pages higher under recency decay", () => {
+    const older = new Date(now.getTime() - 10 * 3_600_000)
+    const newer = new Date(now.getTime() - 1 * 3_600_000)
+    const pA = page({ stem: "older", mtime: older })
+    const pB = page({ stem: "newer", mtime: newer })
+    const sA = scorePrior(pA, topics, [], now)
+    const sB = scorePrior(pB, topics, [], now)
+    expect(sB).toBeGreaterThan(sA)
+  })
+
+  it("applies thesis boost when page links a watched thesis", () => {
+    const pThesis = page({
+      stem: "with-thesis",
+      frontmatter: { page_type: "source", topics: ["foo"], linked_thesis: ["t1"] },
+    })
+    const pPlain = page({ stem: "plain", frontmatter: { page_type: "source", topics: ["foo"] } })
+    const sT = scorePrior(pThesis, topics, ["t1"], now)
+    const sP = scorePrior(pPlain, topics, ["t1"], now)
+    expect(sT).toBeGreaterThan(sP)
+  })
+})

--- a/apps/uebermensch/tests/citations.test.ts
+++ b/apps/uebermensch/tests/citations.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import {
+  citedSentences,
+  claimSentences,
+  extractLinks,
+  isTypedPrefix,
+} from "../src/lib/citations.js"
+
+describe("extractLinks", () => {
+  it("parses bare and display-text wikilinks", () => {
+    const md = "See [[alpha]] and [[beta|the Beta report]]."
+    const links = extractLinks(md)
+    expect(links).toHaveLength(2)
+    expect(links[0]!.target).toBe("alpha")
+    expect(links[0]!.display).toBeNull()
+    expect(links[1]!.target).toBe("beta")
+    expect(links[1]!.display).toBe("the Beta report")
+  })
+
+  it("ignores malformed link syntax", () => {
+    const md = "No [[ ]] here. Nor [link] here."
+    const links = extractLinks(md)
+    expect(links).toHaveLength(1)
+    expect(links[0]!.target).toBe("")
+  })
+})
+
+describe("isTypedPrefix", () => {
+  it.each([
+    ["thesis:foo", true],
+    ["foo/bar", true],
+    ["foo\\bar", true],
+    ["plain-slug", false],
+    ["2026-04-18--foo", false],
+  ])("%s -> %s", (target, expected) => {
+    expect(isTypedPrefix(target)).toBe(expected)
+  })
+})
+
+describe("claim/cited sentence counts", () => {
+  it("counts sentences containing a wikilink", () => {
+    const md = "Bare claim. Claim with [[alpha]] citation. And [[beta]] too!"
+    expect(claimSentences(md)).toBe(3)
+    expect(citedSentences(md)).toBe(2)
+  })
+
+  it("strips code fences", () => {
+    const md = "```\nSome.\nThing.\n```\nReal [[alpha]] here."
+    expect(claimSentences(md)).toBe(1)
+    expect(citedSentences(md)).toBe(1)
+  })
+})

--- a/apps/uebermensch/tests/renderer.test.ts
+++ b/apps/uebermensch/tests/renderer.test.ts
@@ -1,0 +1,154 @@
+import { Effect, Exit } from "effect"
+import { describe, expect, it } from "vitest"
+import { StrictRendererLive } from "../src/adapters/StrictRenderer.js"
+import type { CandidateRef } from "../src/lib/candidates.js"
+import {
+  RendererService,
+  type CuratedItem,
+  type RenderInput,
+} from "../src/services/RendererService.js"
+import type { WikiPage } from "../src/services/VaultService.js"
+
+const page = (stem: string): WikiPage => ({
+  relPath: `wiki/sources/${stem}.md`,
+  stem,
+  frontmatter: { page_type: "source", slug: stem, topics: ["foo"] },
+  body: "",
+  mtime: new Date("2026-04-19T00:00:00Z"),
+})
+
+const cand = (id: string, stem: string): CandidateRef => ({ id, page: page(stem), score: 1 })
+
+const baseInput = (
+  items: ReadonlyArray<CuratedItem>,
+  slugs: ReadonlyArray<string>,
+  cands: ReadonlyArray<CandidateRef>,
+): RenderInput => ({
+  date: "2026-04-19",
+  generator: "stub",
+  model: "stub-llm",
+  promptHash: "sha256:0".padEnd(71, "0"),
+  costUsd: 0,
+  profileName: "Test",
+  topicsCovered: ["foo"],
+  thesesCovered: [],
+  candidates: cands,
+  items,
+  vaultSlugs: new Set(slugs),
+})
+
+const run = (input: RenderInput) =>
+  Effect.gen(function* () {
+    const r = yield* RendererService
+    return yield* r.render(input)
+  }).pipe(Effect.provide(StrictRendererLive))
+
+describe("StrictRenderer", () => {
+  it("renders markdown with H2 items and cited-claims count", async () => {
+    const items: Array<CuratedItem> = [
+      {
+        kind: "news",
+        title: "Alpha",
+        summary_md: "Alpha update via [[alpha]]. Second sentence.",
+        topic: "foo",
+        thesis: null,
+        source_candidate_ids: ["cand-0000"],
+        suggested_action: null,
+      },
+    ]
+    const result = await Effect.runPromise(
+      run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
+    )
+    expect(result.markdown).toContain("## 1. Alpha")
+    expect(result.markdown).toContain("[[alpha]]")
+    expect(result.markdown).toContain("prompt_hash:")
+    expect(result.totalClaims).toBe(2)
+    expect(result.citedClaims).toBe(1)
+  })
+
+  it("rejects typed-prefix wikilinks", async () => {
+    const items: Array<CuratedItem> = [
+      {
+        kind: "news",
+        title: "Bad",
+        summary_md: "See [[thesis:alpha]] for details.",
+        topic: null,
+        thesis: null,
+        source_candidate_ids: ["cand-0000"],
+        suggested_action: null,
+      },
+    ]
+    const exit = await Effect.runPromiseExit(
+      run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failure = exit.cause
+      const msg = JSON.stringify(failure)
+      expect(msg).toMatch(/typed_prefix/)
+    }
+  })
+
+  it("rejects unresolved slugs", async () => {
+    const items: Array<CuratedItem> = [
+      {
+        kind: "news",
+        title: "Missing",
+        summary_md: "Link to [[ghost]] which does not exist.",
+        topic: null,
+        thesis: null,
+        source_candidate_ids: ["cand-0000"],
+        suggested_action: null,
+      },
+    ]
+    const exit = await Effect.runPromiseExit(
+      run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const msg = JSON.stringify(exit.cause)
+      expect(msg).toMatch(/unresolved/)
+    }
+  })
+
+  it("rejects fabricated source candidate ids", async () => {
+    const items: Array<CuratedItem> = [
+      {
+        kind: "news",
+        title: "Fake source",
+        summary_md: "Claim with [[alpha]].",
+        topic: null,
+        thesis: null,
+        source_candidate_ids: ["cand-9999"],
+        suggested_action: null,
+      },
+    ]
+    const exit = await Effect.runPromiseExit(
+      run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const msg = JSON.stringify(exit.cause)
+      expect(msg).toMatch(/fabricated_source/)
+    }
+  })
+
+  it("tolerates display-text wikilinks", async () => {
+    const items: Array<CuratedItem> = [
+      {
+        kind: "news",
+        title: "Pipe link",
+        summary_md: "See [[alpha|the Alpha report]].",
+        topic: null,
+        thesis: null,
+        source_candidate_ids: ["cand-0000"],
+        suggested_action: null,
+      },
+    ]
+    const result = await Effect.runPromise(
+      run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
+    )
+    expect(result.markdown).toContain("[[alpha|the Alpha report]]")
+  })
+})
+


### PR DESCRIPTION
## Summary
First slice of M1 from the uebermensch roadmap: wire the full brief pipeline behind the existing `LlmService` port. Still uses the stub LLM — the Anthropic adapter follows in a separate PR.

- **Candidate selection** (`src/lib/candidates.ts`) — ranks recent wiki pages via a cheap prior (topic weight × recency decay × spam penalty × thesis boost) per `specs/briefing-pipeline.md § 2.3`. Filters by `page_type ∈ {source, synthesis, question}`, window, spam_score, and topic/thesis intersection.
- **Strict renderer** (`src/adapters/StrictRenderer.ts`) — resolves every `[[slug]]` against the vault slug set and rejects typed prefixes, unresolved slugs, and fabricated `source_candidate_ids` per `specs/briefing-pipeline.md § 4` and `specs/knowledge-base.md § Wikilink Conventions`.
- **Frontmatter** now records `prompt_hash`, `model`, `cost_usd`, `item_count`, and `cited_claims`/`total_claims`.
- `VaultService.listSlugs()` spans `wiki/`, `theses/`, `briefs/` so thesis + same-brief citations resolve naturally.
- `StubLlm` now emits curator-shaped output with bare `[[slug]]` citations and a real `prompt_hash`, so downstream plumbing has something to validate against.

## Test plan
- [x] `pnpm test` — 22/22 passing (new: `candidates.test.ts` 5, `citations.test.ts` 9, `renderer.test.ts` 5)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` — tsup emits `dist/bin/uber.js`
- [ ] Manual: `uber brief --dry-run` against the fixture vault (do locally before merge)

## Out of scope (follow-up PRs)
- Anthropic LLM adapter (M1b)
- `gctrl uber ingest --url` (M1c)
- Daily budget guardrail (M1d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)