### PR TITLE
feat(uebermensch): M1d — daily budget guardrail on briefs

### DIFF
--- a/apps/uebermensch/src/adapters/FileBudgetLedger.ts
+++ b/apps/uebermensch/src/adapters/FileBudgetLedger.ts
@@ -1,0 +1,119 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { Effect, Layer } from "effect"
+import { LlmError, VaultError } from "../errors.js"
+import { BudgetService } from "../services/BudgetService.js"
+
+type LedgerEntry = {
+  readonly date: string
+  readonly cost_usd: number
+  readonly prompt_hash: string
+  readonly model: string
+  readonly ts: string
+}
+
+const readLedger = async (path: string): Promise<ReadonlyArray<LedgerEntry>> => {
+  try {
+    const raw = await readFile(path, "utf8")
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0)
+    const entries: Array<LedgerEntry> = []
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as LedgerEntry
+        if (parsed && typeof parsed.date === "string" && typeof parsed.cost_usd === "number") {
+          entries.push(parsed)
+        }
+      } catch {
+        // skip corrupt line
+      }
+    }
+    return entries
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw e
+  }
+}
+
+const sumSpent = (entries: ReadonlyArray<LedgerEntry>, date: string): number =>
+  entries.filter((e) => e.date === date).reduce((acc, e) => acc + e.cost_usd, 0)
+
+export const FileBudgetLedgerLive = (vaultDir: string) => {
+  const ledgerPath = join(vaultDir, ".uber", "spend.jsonl")
+
+  const loadSpent = (date: string) =>
+    Effect.tryPromise({
+      try: async () => sumSpent(await readLedger(ledgerPath), date),
+      catch: (e) =>
+        new VaultError({
+          message: `read spend ledger failed: ${String(e)}`,
+          path: ledgerPath,
+        }),
+    })
+
+  return Layer.succeed(BudgetService, {
+    snapshot: (date, limits) =>
+      Effect.gen(function* () {
+        const spent = yield* loadSpent(date)
+        const remaining = Math.max(0, limits.dailyUsd - spent)
+        return {
+          date,
+          dailyUsd: limits.dailyUsd,
+          spentTodayUsd: spent,
+          remainingTodayUsd: remaining,
+          perBriefUsd: limits.perBriefUsd,
+        }
+      }),
+    checkBefore: (date, limits) =>
+      Effect.gen(function* () {
+        const snap = yield* loadSpent(date).pipe(
+          Effect.map((spent) => ({
+            date,
+            dailyUsd: limits.dailyUsd,
+            spentTodayUsd: spent,
+            remainingTodayUsd: Math.max(0, limits.dailyUsd - spent),
+            perBriefUsd: limits.perBriefUsd,
+          })),
+        )
+        if (snap.remainingTodayUsd <= 0) {
+          return yield* Effect.fail(
+            new LlmError({
+              message: `daily budget exhausted for ${date}: spent $${snap.spentTodayUsd.toFixed(
+                4,
+              )} / $${limits.dailyUsd.toFixed(2)}`,
+              kind: "budget_exceeded",
+            }),
+          )
+        }
+        if (snap.remainingTodayUsd < limits.perBriefUsd) {
+          return yield* Effect.fail(
+            new LlmError({
+              message: `remaining $${snap.remainingTodayUsd.toFixed(
+                4,
+              )} less than per_brief_usd $${limits.perBriefUsd.toFixed(2)}`,
+              kind: "budget_exceeded",
+            }),
+          )
+        }
+        return snap
+      }),
+    record: (entry) =>
+      Effect.tryPromise({
+        try: async () => {
+          await mkdir(dirname(ledgerPath), { recursive: true })
+          const line: LedgerEntry = {
+            date: entry.date,
+            cost_usd: entry.costUsd,
+            prompt_hash: entry.promptHash,
+            model: entry.model,
+            ts: new Date().toISOString(),
+          }
+          await appendFile(ledgerPath, `${JSON.stringify(line)}\n`, "utf8")
+        },
+        catch: (e) =>
+          new VaultError({
+            message: `append spend ledger failed: ${String(e)}`,
+            path: ledgerPath,
+          }),
+      }),
+  })
+}

--- a/apps/uebermensch/src/commands/brief.ts
+++ b/apps/uebermensch/src/commands/brief.ts
@@ -1,11 +1,13 @@
 import { Command, Options } from "@effect/cli"
 import { Console, Effect, Option } from "effect"
+import { FileBudgetLedgerLive } from "../adapters/FileBudgetLedger.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
 import { selectCandidates } from "../lib/candidates.js"
 import { resolveVaultDir } from "../lib/env.js"
+import { BudgetService } from "../services/BudgetService.js"
 import { LlmService } from "../services/LlmService.js"
 import { ProfileService } from "../services/ProfileService.js"
 import { RendererService } from "../services/RendererService.js"
@@ -57,7 +59,17 @@ export const brief = Command.make(
         const vaultSvc = yield* VaultService
         const llm = yield* LlmService
         const renderer = yield* RendererService
+        const budget = yield* BudgetService
         const profile = yield* profileSvc.load()
+
+        const limits = {
+          dailyUsd: profile.profile.budgets.daily_usd,
+          perBriefUsd: profile.profile.budgets.per_brief_usd,
+        }
+        const snap = yield* budget.checkBefore(date, limits)
+        yield* Console.log(
+          `  budget: spent $${snap.spentTodayUsd.toFixed(4)} / $${limits.dailyUsd.toFixed(2)} today; per_brief cap $${limits.perBriefUsd.toFixed(2)}`,
+        )
 
         const pages = yield* vaultSvc.recentlyChanged(sinceHours)
         yield* Console.log(`  ${pages.length} page(s) changed in last ${sinceHours}h`)
@@ -88,6 +100,20 @@ export const brief = Command.make(
           thesesSlugs: [],
           candidates,
           maxItems,
+        })
+
+        if (response.costUsd > limits.perBriefUsd) {
+          yield* Console.error(
+            `✗ brief cost $${response.costUsd.toFixed(4)} exceeded per_brief_usd cap $${limits.perBriefUsd.toFixed(2)}; not writing`,
+          )
+          return
+        }
+
+        yield* budget.record({
+          date,
+          costUsd: response.costUsd,
+          promptHash: response.promptHash,
+          model: response.model,
         })
 
         const vaultSlugs = yield* vaultSvc.listSlugs()
@@ -122,6 +148,7 @@ export const brief = Command.make(
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(FileSystemVaultLive(vaultDir)),
+        Effect.provide(FileBudgetLedgerLive(vaultDir)),
         Effect.provide(StubLlmLive),
         Effect.provide(StrictRendererLive),
       )

--- a/apps/uebermensch/src/services/BudgetService.ts
+++ b/apps/uebermensch/src/services/BudgetService.ts
@@ -1,0 +1,39 @@
+import { Context, type Effect } from "effect"
+import type { LlmError, VaultError } from "../errors.js"
+
+export type BudgetSnapshot = {
+  readonly date: string
+  readonly dailyUsd: number
+  readonly spentTodayUsd: number
+  readonly remainingTodayUsd: number
+  readonly perBriefUsd: number
+}
+
+export type BudgetLimits = {
+  readonly dailyUsd: number
+  readonly perBriefUsd: number
+}
+
+export interface BudgetServiceShape {
+  readonly snapshot: (
+    date: string,
+    limits: BudgetLimits,
+  ) => Effect.Effect<BudgetSnapshot, VaultError>
+  readonly checkBefore: (
+    date: string,
+    limits: BudgetLimits,
+  ) => Effect.Effect<BudgetSnapshot, LlmError | VaultError>
+  readonly record: (
+    entry: {
+      readonly date: string
+      readonly costUsd: number
+      readonly promptHash: string
+      readonly model: string
+    },
+  ) => Effect.Effect<void, VaultError>
+}
+
+export class BudgetService extends Context.Tag("uebermensch/BudgetService")<
+  BudgetService,
+  BudgetServiceShape
+>() {}

--- a/apps/uebermensch/tests/budget.test.ts
+++ b/apps/uebermensch/tests/budget.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp, readFile, writeFile, mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Exit } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileBudgetLedgerLive } from "../src/adapters/FileBudgetLedger.js"
+import { BudgetService } from "../src/services/BudgetService.js"
+
+const LIMITS = { dailyUsd: 1.0, perBriefUsd: 0.25 }
+
+const run = <A, E>(vaultDir: string, eff: (svc: typeof BudgetService.Service) => Effect.Effect<A, E>) =>
+  Effect.runPromiseExit(
+    Effect.gen(function* () {
+      const svc = yield* BudgetService
+      return yield* eff(svc)
+    }).pipe(Effect.provide(FileBudgetLedgerLive(vaultDir))),
+  )
+
+describe("FileBudgetLedger", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-budget-"))
+  })
+
+  it("returns zero spend + full remaining when no ledger exists", async () => {
+    const exit = await run(vaultDir, (svc) => svc.snapshot("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Success")
+    if (exit._tag !== "Success") return
+    expect(exit.value.spentTodayUsd).toBe(0)
+    expect(exit.value.remainingTodayUsd).toBe(1.0)
+  })
+
+  it("sums only entries matching the requested date", async () => {
+    await mkdir(join(vaultDir, ".uber"), { recursive: true })
+    const lines = [
+      '{"date":"2026-04-19","cost_usd":0.3,"prompt_hash":"x","model":"m","ts":"t"}',
+      '{"date":"2026-04-20","cost_usd":0.15,"prompt_hash":"y","model":"m","ts":"t"}',
+      '{"date":"2026-04-20","cost_usd":0.10,"prompt_hash":"z","model":"m","ts":"t"}',
+    ]
+    await writeFile(join(vaultDir, ".uber", "spend.jsonl"), `${lines.join("\n")}\n`)
+
+    const exit = await run(vaultDir, (svc) => svc.snapshot("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Success")
+    if (exit._tag !== "Success") return
+    expect(exit.value.spentTodayUsd).toBeCloseTo(0.25, 6)
+    expect(exit.value.remainingTodayUsd).toBeCloseTo(0.75, 6)
+  })
+
+  it("checkBefore fails with kind=budget_exceeded when daily is exhausted", async () => {
+    await mkdir(join(vaultDir, ".uber"), { recursive: true })
+    await writeFile(
+      join(vaultDir, ".uber", "spend.jsonl"),
+      '{"date":"2026-04-20","cost_usd":1.5,"prompt_hash":"x","model":"m","ts":"t"}\n',
+    )
+    const exit = await run(vaultDir, (svc) => svc.checkBefore("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      const cause = JSON.stringify(exit.cause)
+      expect(cause).toContain("budget_exceeded")
+      expect(cause).toContain("daily budget exhausted")
+    }
+  })
+
+  it("checkBefore fails when remaining < per_brief_usd", async () => {
+    await mkdir(join(vaultDir, ".uber"), { recursive: true })
+    // daily=$1, per_brief=$0.25, spent $0.85 → remaining $0.15 < $0.25
+    await writeFile(
+      join(vaultDir, ".uber", "spend.jsonl"),
+      '{"date":"2026-04-20","cost_usd":0.85,"prompt_hash":"x","model":"m","ts":"t"}\n',
+    )
+    const exit = await run(vaultDir, (svc) => svc.checkBefore("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      const cause = JSON.stringify(exit.cause)
+      expect(cause).toContain("budget_exceeded")
+      expect(cause).toContain("less than per_brief_usd")
+    }
+  })
+
+  it("checkBefore passes when remaining >= per_brief_usd", async () => {
+    const exit = await run(vaultDir, (svc) => svc.checkBefore("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Success")
+  })
+
+  it("record appends JSONL line to <vault>/.uber/spend.jsonl", async () => {
+    const exit = await run(vaultDir, (svc) =>
+      svc.record({
+        date: "2026-04-20",
+        costUsd: 0.123456,
+        promptHash: "sha256:abc",
+        model: "claude-sonnet-4-6",
+      }),
+    )
+    expect(exit._tag).toBe("Success")
+    const raw = await readFile(join(vaultDir, ".uber", "spend.jsonl"), "utf8")
+    const lines = raw.trim().split("\n")
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0]!)
+    expect(parsed.date).toBe("2026-04-20")
+    expect(parsed.cost_usd).toBeCloseTo(0.123456, 6)
+    expect(parsed.prompt_hash).toBe("sha256:abc")
+    expect(parsed.model).toBe("claude-sonnet-4-6")
+    expect(typeof parsed.ts).toBe("string")
+  })
+
+  it("record then snapshot sees the appended cost", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* BudgetService
+        yield* svc.record({
+          date: "2026-04-20",
+          costUsd: 0.4,
+          promptHash: "h1",
+          model: "m",
+        })
+        yield* svc.record({
+          date: "2026-04-20",
+          costUsd: 0.3,
+          promptHash: "h2",
+          model: "m",
+        })
+      }).pipe(Effect.provide(FileBudgetLedgerLive(vaultDir))),
+    )
+    const exit = await run(vaultDir, (svc) => svc.snapshot("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Success")
+    if (exit._tag !== "Success") return
+    expect(exit.value.spentTodayUsd).toBeCloseTo(0.7, 6)
+    expect(exit.value.remainingTodayUsd).toBeCloseTo(0.3, 6)
+  })
+
+  it("tolerates corrupt ledger lines", async () => {
+    await mkdir(join(vaultDir, ".uber"), { recursive: true })
+    const lines = [
+      '{"date":"2026-04-20","cost_usd":0.1,"prompt_hash":"x","model":"m","ts":"t"}',
+      "not-json-at-all",
+      '{"date":"2026-04-20","cost_usd":0.2,"prompt_hash":"y","model":"m","ts":"t"}',
+    ]
+    await writeFile(join(vaultDir, ".uber", "spend.jsonl"), `${lines.join("\n")}\n`)
+    const exit = await run(vaultDir, (svc) => svc.snapshot("2026-04-20", LIMITS))
+    expect(exit._tag).toBe("Success")
+    if (exit._tag === "Success") expect(exit.value.spentTodayUsd).toBeCloseTo(0.3, 6)
+  })
+})


### PR DESCRIPTION
## Summary

Stacked on #43 — lands **M1d** of the uebermensch M1 roadmap: a daily cost guardrail on `uber brief`.

- `BudgetService` port with `snapshot` / `checkBefore` / `record`
- `FileBudgetLedger` adapter writes JSONL at `<vaultDir>/.uber/spend.jsonl` (hidden from Obsidian); append-only, tolerant of corrupt lines on read
- `uber brief`:
  - `checkBefore(date, limits)` fails fast with `LlmError{kind:"budget_exceeded"}` when daily is exhausted **or** `remaining < per_brief_usd`
  - After the LLM returns, refuses to write if `response.costUsd > per_brief_usd`
  - Otherwise `record({date, costUsd, promptHash, model})` and continue
- Limits come from the profile `budgets` block (`daily_usd`, `per_brief_usd`)

## Note on `cost_usd` values

The brief still runs on `StubLlm`, so `response.costUsd` is 0 today. Once the kernel `driver-llm` lands (`POST /api/llm/generate`), the app's new `KernelLlm` adapter will surface real cost from the driver response and the guardrail logic here is what enforces it. Budget ledger + guardrail is usable in its own right for any future LLM caller (re-summariser, classifier, etc.).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 40 tests across 7 files (8 new budget tests)
- [x] `pnpm lint` clean
- [ ] End-to-end smoke: once `driver-llm` exists, run two `uber brief` calls that together exceed `daily_usd` — second should abort with `budget_exceeded` and leave the ledger intact
- [ ] End-to-end smoke: run one brief whose measured cost exceeds `per_brief_usd` — expect `✗` message, no write, no ledger entry

Merge #43 first; this will rebase onto main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
