### PR TITLE
fix(orch): swallow BrokenPipe on stdin write to agent

### DIFF
--- a/kernel/crates/gctrl-orch/src/agent.rs
+++ b/kernel/crates/gctrl-orch/src/agent.rs
@@ -47,8 +47,21 @@ pub async fn spawn_agent(
         .spawn()?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(prompt.as_bytes()).await?;
-        stdin.shutdown().await?;
+        // A child that exits before reading its input (e.g. `sh -c "exit 1"`)
+        // closes the pipe out from under us. That's not a spawn failure —
+        // the process is already launched and its exit code should drive the
+        // retry decision. Swallow BrokenPipe here so `await_agent` sees the
+        // real exit status instead of us reporting dispatchFailed.
+        if let Err(e) = stdin.write_all(prompt.as_bytes()).await {
+            if e.kind() != std::io::ErrorKind::BrokenPipe {
+                return Err(SpawnError::Spawn(e));
+            }
+        }
+        if let Err(e) = stdin.shutdown().await {
+            if e.kind() != std::io::ErrorKind::BrokenPipe {
+                return Err(SpawnError::Spawn(e));
+            }
+        }
     }
 
     Ok(child)
@@ -138,6 +151,27 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, SpawnError::Timeout(_)));
+    }
+
+    #[tokio::test]
+    async fn child_that_exits_before_reading_stdin_reports_nonzero_not_spawn() {
+        // Regression: a child that closes stdin before we finish writing
+        // (sh -c "exit 1" on a fast Linux runner) used to bubble up as
+        // SpawnError::Spawn(BrokenPipe), which the Worker routes to
+        // dispatchFailed → Released instead of Running → RetryQueued.
+        let prompt: String = "x".repeat(256 * 1024);
+        let err = run_agent(
+            &["sh".into(), "-c".into(), "exit 1".into()],
+            Path::new("."),
+            &prompt,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, SpawnError::NonZero(1)),
+            "expected NonZero(1), got {err:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the flaky `failing_agent_transitions_to_retry_queued` test that was failing CI on PR #43 (and previously on PR #41's merge to main).

`spawn_agent` wrote the prompt to the child's stdin via `write_all` and propagated any `io::Error` as `SpawnError::Spawn`. On fast Linux runners a child that exits before reading its input (`sh -c "exit 1"`) closes the pipe, so the write races — sometimes it completes cleanly, sometimes it returns `BrokenPipe`.

A `BrokenPipe` there got routed through `Worker::dispatch_one` as `dispatchFailed` (Claimed → Released) instead of letting `await_agent` observe the real non-zero exit code and route through `agentExitAbnormal` (Running → RetryQueued). Hence the flake — it never reproduced locally on macOS.

## Fix

`BrokenPipe` on the stdin write/shutdown is not a spawn failure — the process is launched, just uninterested in its input. Swallow it and let the exit code drive the retry decision. Other `io::Error` kinds still surface as `SpawnError::Spawn` (so a genuine "program not found" still lands on Released per the Lean spec).

Added a regression test that forces the race with a 256 KiB prompt against `sh -c "exit 1"` and asserts `SpawnError::NonZero(1)`.

## Test plan

- [x] `cargo test -p gctrl-orch` — all 10 unit tests + 5 worker_dispatch integration tests pass
- [x] New `child_that_exits_before_reading_stdin_reports_nonzero_not_spawn` test covers the race deterministically
- [ ] CI on Linux passes (the real validation — previous failures were Linux-only)