### PR TITLE
feat(uebermensch): research reports + RSS ingest + R2/Pages hosting + paywall quality pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ UBER_VAULT_DIR=~/uebermensch-vault
 # `target_ref: dc:webhook:env:DISCORD_FEED_URL`. The kernel driver
 # validates the URL host before forwarding.
 # DISCORD_FEED_URL=
+
+# --- LLM driver (kernel-side) ---
+# Read by the kernel's driver-llm handler (`/api/llm/messages`). The
+# uebermensch `uber brief` command POSTs prompts to the kernel; apps never
+# read this key directly.
+# ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,19 @@
 CLOUDFLARE_ACCOUNT_ID=
 CLOUDFLARE_API_TOKEN=
 
+# --- Cloudflare AI Gateway (kernel driver-llm) ---
+# The kernel's `/api/llm/messages` driver forwards Anthropic-shape requests
+# through your AI Gateway for observability, caching, and (optionally)
+# managed provider credentials. Create a gateway in the CF dashboard:
+#   https://dash.cloudflare.com/?to=/:account/ai/ai-gateway
+# Then put its slug below.
+# CLOUDFLARE_AI_GATEWAY_ID=
+#
+# Optional — required if "Authenticated Gateway" is enabled on the gateway.
+# Generate under gateway settings → Authentication. With managed keys you
+# can omit ANTHROPIC_API_KEY entirely (CF injects it server-side).
+# CLOUDFLARE_AI_GATEWAY_TOKEN=
+
 # --- GitHub ---
 # `gctrl gh` delegates to local `gh` CLI auth by default; this override is only
 # needed when running without a `gh auth login` session (e.g. CI).
@@ -41,8 +54,8 @@ UBER_VAULT_DIR=~/uebermensch-vault
 # validates the URL host before forwarding.
 # DISCORD_FEED_URL=
 
-# --- LLM driver (kernel-side) ---
-# Read by the kernel's driver-llm handler (`/api/llm/messages`). The
-# uebermensch `uber brief` command POSTs prompts to the kernel; apps never
-# read this key directly.
+# --- LLM provider keys (kernel-side, BYOK through AI Gateway) ---
+# When CLOUDFLARE_AI_GATEWAY_TOKEN is NOT set, the kernel forwards this key
+# to Anthropic via AI Gateway (`x-api-key` header). If your gateway uses
+# managed credentials, you can leave this unset.
 # ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,19 @@ GCTRL_KERNEL_URL=http://127.0.0.1:4318
 # --- Uebermensch ---
 # Path to the Obsidian-mountable markdown vault (profile + wiki + briefs).
 UBER_VAULT_DIR=~/uebermensch-vault
+
+# --- Messaging drivers (kernel-side) ---
+# Read by the kernel's driver-telegram handler (`/api/telegram/send`). The
+# uebermensch `uber send` command POSTs to the kernel; it never reads the bot
+# token directly.
+# TELEGRAM_BOT_TOKEN=
+
+# Chat id referenced from profile.md via `target_ref: tg:chat:env:TELEGRAM_PRIMARY_CHAT_ID`.
+# Resolved inside uebermensch before the kernel call (target ids are
+# per-channel app-level config; secrets stay kernel-side).
+# TELEGRAM_PRIMARY_CHAT_ID=
+
+# Discord webhook URL referenced from profile.md via
+# `target_ref: dc:webhook:env:DISCORD_FEED_URL`. The kernel driver
+# validates the URL host before forwarding.
+# DISCORD_FEED_URL=

--- a/apps/gctrl-board/src/adapters/BoardServiceLive.ts
+++ b/apps/gctrl-board/src/adapters/BoardServiceLive.ts
@@ -5,12 +5,7 @@
  */
 import { Effect, Layer } from "effect"
 import { BoardService } from "../services/BoardService.js"
-import {
-  BoardError,
-  IssueNotFoundError,
-  KernelError,
-  KernelUnavailableError,
-} from "../services/errors.js"
+import { BoardError, IssueNotFoundError } from "../services/errors.js"
 import { KernelClient } from "./KernelClient.js"
 import type { Issue, IssueId, IssueStatus, IssueFilter, CreateIssueInput, Assignee, Project } from "../schema/index.js"
 

--- a/apps/gctrl-board/src/adapters/KernelClient.ts
+++ b/apps/gctrl-board/src/adapters/KernelClient.ts
@@ -7,7 +7,7 @@
  * Uses @effect/platform HttpClient with typed TaggedErrors and Effect.catchTags.
  */
 import { Context, Effect, Layer } from "effect"
-import { HttpClient, HttpClientResponse, HttpBody } from "@effect/platform"
+import { HttpBody, HttpClient } from "@effect/platform"
 import { KernelError, KernelUnavailableError } from "../services/errors.js"
 
 export class KernelClient extends Context.Tag("KernelClient")<

--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -72,10 +72,10 @@ interface Route {
 const defineRoute = (method: string, path: string, handler: ApiHandler): Route => {
   const paramNames: string[] = []
   const pattern = new RegExp(
-    "^" + path.replace(/:([^/]+)/g, (_, name) => {
+    `^${path.replace(/:([^/]+)/g, (_, name) => {
       paramNames.push(name)
       return "([^/]+)"
-    }) + "$"
+    })}$`,
   )
   return { method, pattern, paramNames, handler }
 }

--- a/apps/uebermensch-pages/package.json
+++ b/apps/uebermensch-pages/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "uebermensch-pages",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "hono": "^4.6.0",
+    "marked": "^14.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240925.0",
+    "typescript": "^5.7",
+    "vitest": "^3.0.0",
+    "wrangler": "^4.84.0"
+  }
+}

--- a/apps/uebermensch-pages/src/index.ts
+++ b/apps/uebermensch-pages/src/index.ts
@@ -1,0 +1,121 @@
+import { Hono, type Context } from "hono"
+import { escapeHtml, renderMarkdown, renderMetaFooter, renderShell } from "./markdown.ts"
+
+export type Bindings = {
+  readonly VAULT: R2Bucket
+}
+
+type AppContext = Context<{ Bindings: Bindings }>
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+const SAFE_KEY_RE = /^[a-z0-9._-]+$/i
+
+const notFound = (c: AppContext, path: string) =>
+  c.html(
+    renderShell(
+      `<h1>Not found</h1><p>No page at <code>${escapeHtml(path)}</code>.</p>`,
+      "Not found",
+    ),
+    404,
+  )
+
+// Generic prefix listing: returns { key, uploaded } for .md objects under prefix/.
+const listUnder = async (
+  bucket: R2Bucket,
+  prefix: string,
+): Promise<ReadonlyArray<{ key: string; uploaded: Date | null }>> => {
+  const out: Array<{ key: string; uploaded: Date | null }> = []
+  let cursor: string | undefined
+  for (let i = 0; i < 20; i += 1) {
+    const page = await bucket.list({ prefix, cursor, limit: 500 })
+    for (const obj of page.objects) {
+      if (!obj.key.endsWith(".md")) continue
+      out.push({ key: obj.key, uploaded: obj.uploaded ?? null })
+    }
+    if (!page.truncated) break
+    cursor = page.cursor
+  }
+  // Sort newest first by uploaded, fallback to key desc.
+  out.sort((a, b) => {
+    const at = a.uploaded ? a.uploaded.getTime() : 0
+    const bt = b.uploaded ? b.uploaded.getTime() : 0
+    if (bt !== at) return bt - at
+    return b.key.localeCompare(a.key)
+  })
+  return out
+}
+
+const stem = (key: string): string => {
+  const slash = key.lastIndexOf("/")
+  const base = slash >= 0 ? key.slice(slash + 1) : key
+  return base.replace(/\.md$/, "")
+}
+
+const renderIndex = (
+  title: string,
+  linkBase: string,
+  items: ReadonlyArray<{ key: string; uploaded: Date | null }>,
+): string => {
+  if (items.length === 0) {
+    return `<h1>${escapeHtml(title)}</h1><p>No entries yet. Run <code>uber sync r2</code> after generating a report.</p>`
+  }
+  const rows = items
+    .map((it) => {
+      const s = stem(it.key)
+      const when = it.uploaded
+        ? it.uploaded.toISOString().slice(0, 10)
+        : ""
+      return `<li><time>${escapeHtml(when)}</time><a href="${linkBase}${encodeURIComponent(s)}">${escapeHtml(s)}</a></li>`
+    })
+    .join("")
+  return `<h1>${escapeHtml(title)}</h1><ul class="index">${rows}</ul>`
+}
+
+app.get("/", async (c) => {
+  const [reports, briefs] = await Promise.all([
+    listUnder(c.env.VAULT, "reports/"),
+    listUnder(c.env.VAULT, "briefs/"),
+  ])
+  const inner = [
+    `<h1>uebermensch</h1>`,
+    `<p>Local-first chief-of-staff vault, synced here from R2. <span class="muted">(noindex; link-only)</span></p>`,
+    renderIndex("Reports", "/reports/", reports.slice(0, 20)),
+    renderIndex("Briefs", "/briefs/", briefs.slice(0, 20)),
+  ].join("\n")
+  return c.html(renderShell(inner, "uebermensch"))
+})
+
+app.get("/reports/", async (c) => {
+  const items = await listUnder(c.env.VAULT, "reports/")
+  return c.html(renderShell(renderIndex("Reports", "/reports/", items), "Reports"))
+})
+
+app.get("/briefs/", async (c) => {
+  const items = await listUnder(c.env.VAULT, "briefs/")
+  return c.html(renderShell(renderIndex("Briefs", "/briefs/", items), "Briefs"))
+})
+
+const renderKey = async (c: AppContext, prefix: string, slug: string) => {
+  if (!SAFE_KEY_RE.test(slug)) return notFound(c, `${prefix}${slug}`)
+  const key = `${prefix}${slug}.md`
+  const obj = await c.env.VAULT.get(key)
+  if (!obj) return notFound(c, `${prefix}${slug}`)
+  const raw = await obj.text()
+  const rendered = renderMarkdown(raw)
+  const heading = rendered.title ?? slug
+  const inner = `${rendered.html}${renderMetaFooter(rendered.frontmatter)}`
+  return c.html(renderShell(inner, heading))
+}
+
+app.get("/reports/:slug", (c) => renderKey(c, "reports/", c.req.param("slug")))
+app.get("/briefs/:slug", (c) => renderKey(c, "briefs/", c.req.param("slug")))
+app.get("/wiki/:slug", (c) => renderKey(c, "wiki/sources/", c.req.param("slug")))
+
+app.get("/robots.txt", (c) =>
+  c.text("User-agent: *\nDisallow: /\n", 200, { "content-type": "text/plain" }),
+)
+
+app.notFound((c) => notFound(c, c.req.path))
+
+export default app

--- a/apps/uebermensch-pages/src/markdown.ts
+++ b/apps/uebermensch-pages/src/markdown.ts
@@ -1,0 +1,132 @@
+import matter from "gray-matter"
+import { marked } from "marked"
+
+export type RenderedPage = {
+  readonly html: string
+  readonly frontmatter: Record<string, unknown>
+  readonly title: string | null
+}
+
+// Safe-ish: only allow kebab/slug characters in the stem; anything else
+// (spaces, punctuation) falls back to the raw text.
+const STEM_RE = /^[a-z0-9][a-z0-9._-]*$/i
+
+const escapeHtml = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+
+// Rewrite [[stem]] and [[stem|label]] before handing off to marked.
+// Runs on raw markdown (not HTML) so we don't fight marked's AST.
+// Protect fenced code + inline code so wikilinks inside snippets stay literal.
+export const rewriteWikilinks = (md: string): string => {
+  const fenceSplit = md.split(/(^```[\s\S]*?^```\s*$)/m)
+  return fenceSplit
+    .map((chunk, idx) => {
+      if (idx % 2 === 1) return chunk // fenced block
+      const inlineSplit = chunk.split(/(`[^`\n]+`)/g)
+      return inlineSplit
+        .map((piece, j) => {
+          if (j % 2 === 1) return piece // inline code
+          return piece.replace(/\[\[([^\]|\n]+)(?:\|([^\]]+))?\]\]/g, (raw, rawStem, rawLabel) => {
+            const stem = String(rawStem).trim()
+            const label = rawLabel ? String(rawLabel).trim() : stem
+            if (!STEM_RE.test(stem)) return raw
+            return `[${label}](/wiki/${encodeURIComponent(stem)})`
+          })
+        })
+        .join("")
+    })
+    .join("")
+}
+
+marked.setOptions({ gfm: true, breaks: false })
+
+export const renderMarkdown = (raw: string): RenderedPage => {
+  const parsed = matter(raw)
+  const rewritten = rewriteWikilinks(parsed.content)
+  const html = marked.parse(rewritten, { async: false }) as string
+  const fm = (parsed.data ?? {}) as Record<string, unknown>
+  const title =
+    (typeof fm.title === "string" && fm.title) ||
+    (typeof fm.slug === "string" && fm.slug) ||
+    null
+  return { html, frontmatter: fm, title }
+}
+
+export const renderShell = (inner: string, title: string): string => {
+  const safeTitle = escapeHtml(title)
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>${safeTitle}</title>
+<style>
+  :root { color-scheme: light dark; --fg:#1a1a1a; --bg:#fafafa; --muted:#666; --rule:#e5e5e5; --accent:#2563eb; --code-bg:#f0f0f0; }
+  @media (prefers-color-scheme: dark) { :root { --fg:#eaeaea; --bg:#111; --muted:#999; --rule:#2a2a2a; --accent:#60a5fa; --code-bg:#1e1e1e; } }
+  html,body { margin:0; padding:0; background:var(--bg); color:var(--fg); }
+  body { font:16px/1.6 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
+  main { max-width: 760px; margin: 0 auto; padding: 2rem 1.2rem 4rem; }
+  header nav { font-size: .9rem; color: var(--muted); margin-bottom: 2rem; }
+  header nav a { color: var(--muted); margin-right: 1rem; text-decoration: none; }
+  header nav a:hover { color: var(--accent); }
+  h1 { font-size: 1.9rem; margin: 0 0 .8rem; line-height: 1.2; }
+  h2 { font-size: 1.35rem; margin: 2rem 0 .6rem; padding-bottom: .3rem; border-bottom: 1px solid var(--rule); }
+  h3 { font-size: 1.05rem; margin: 1.4rem 0 .4rem; }
+  a { color: var(--accent); }
+  blockquote { margin: .8rem 0; padding: .2rem .9rem; border-left: 3px solid var(--rule); color: var(--muted); font-style: italic; }
+  pre,code { font-family: ui-monospace,SFMono-Regular,Menlo,monospace; }
+  code { background: var(--code-bg); padding: .1rem .35rem; border-radius: 3px; font-size: .92em; }
+  pre { background: var(--code-bg); padding: .8rem 1rem; border-radius: 6px; overflow-x: auto; }
+  pre code { background: transparent; padding: 0; }
+  ul.index { list-style: none; padding: 0; margin: 0; }
+  ul.index li { margin: .2rem 0; display: flex; gap: 1rem; border-bottom: 1px dotted var(--rule); padding: .5rem 0; }
+  ul.index li time { color: var(--muted); font-variant-numeric: tabular-nums; flex: 0 0 6rem; }
+  footer.meta { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); font-size: .82rem; color: var(--muted); }
+  footer.meta dl { display: grid; grid-template-columns: max-content 1fr; gap: .2rem .8rem; margin: 0; }
+  footer.meta dt { color: var(--muted); }
+  footer.meta dd { margin: 0; font-family: ui-monospace,Menlo,monospace; word-break: break-all; }
+</style>
+</head>
+<body>
+<main>
+<header><nav><a href="/">home</a><a href="/reports/">reports</a><a href="/briefs/">briefs</a></nav></header>
+${inner}
+</main>
+</body>
+</html>`
+}
+
+export const renderMetaFooter = (fm: Record<string, unknown>): string => {
+  const keys = [
+    "period_label",
+    "generated_for",
+    "kind",
+    "generator",
+    "model",
+    "cost_usd",
+    "section_count",
+    "item_count",
+    "cited_claims",
+    "total_claims",
+    "interests",
+    "topics",
+    "prompt_hash",
+  ]
+  const rows: Array<string> = []
+  for (const k of keys) {
+    const v = fm[k]
+    if (v === undefined || v === null || v === "") continue
+    const str = Array.isArray(v) ? (v as ReadonlyArray<unknown>).join(", ") : String(v)
+    rows.push(`<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(str)}</dd>`)
+  }
+  if (rows.length === 0) return ""
+  return `<footer class="meta"><dl>${rows.join("")}</dl></footer>`
+}
+
+export { escapeHtml }

--- a/apps/uebermensch-pages/tests/markdown.test.ts
+++ b/apps/uebermensch-pages/tests/markdown.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { renderMarkdown, renderMetaFooter, rewriteWikilinks } from "../src/markdown.ts"
+
+describe("rewriteWikilinks", () => {
+  it("rewrites bare stems to /wiki/ links", () => {
+    const out = rewriteWikilinks("See [[2026-04-22--wikipedia-boj]].")
+    expect(out).toContain("[2026-04-22--wikipedia-boj](/wiki/2026-04-22--wikipedia-boj)")
+  })
+  it("uses the label when provided", () => {
+    const out = rewriteWikilinks("See [[my-note|the note]].")
+    expect(out).toContain("[the note](/wiki/my-note)")
+  })
+  it("leaves unsafe stems alone", () => {
+    const out = rewriteWikilinks("See [[/etc/passwd]].")
+    expect(out).toBe("See [[/etc/passwd]].")
+  })
+  it("does not rewrite inside inline code", () => {
+    const out = rewriteWikilinks("Call `[[stem]]` in prose")
+    expect(out).toBe("Call `[[stem]]` in prose")
+  })
+  it("does not rewrite inside fenced code", () => {
+    const md = "before\n```\n[[stem]]\n```\nafter [[stem]]"
+    const out = rewriteWikilinks(md)
+    expect(out).toContain("```\n[[stem]]\n```")
+    expect(out).toContain("after [stem](/wiki/stem)")
+  })
+})
+
+describe("renderMarkdown", () => {
+  it("renders frontmatter + wikilinks + body", () => {
+    const raw = `---
+page_type: report
+slug: report-2026-W17
+title: Weekly report — 2026-W17
+cost_usd: 0.40
+---
+
+# Heading
+
+Body with [[2026-04-22--boj]] inside.
+`
+    const { html, frontmatter, title } = renderMarkdown(raw)
+    expect(title).toBe("Weekly report — 2026-W17")
+    expect(frontmatter.slug).toBe("report-2026-W17")
+    expect(html).toContain("<h1>")
+    expect(html).toContain('href="/wiki/2026-04-22--boj"')
+  })
+})
+
+describe("renderMetaFooter", () => {
+  it("renders known keys only", () => {
+    const html = renderMetaFooter({ model: "claude-opus-4-7", cost_usd: 0.4, nope: "x" })
+    expect(html).toContain("model")
+    expect(html).toContain("claude-opus-4-7")
+    expect(html).toContain("0.4")
+    expect(html).not.toContain("nope")
+  })
+  it("returns empty string when nothing to render", () => {
+    expect(renderMetaFooter({})).toBe("")
+  })
+})

--- a/apps/uebermensch-pages/tests/routes.test.ts
+++ b/apps/uebermensch-pages/tests/routes.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest"
+import app from "../src/index.ts"
+
+// Minimal R2Bucket stub covering the surface the app uses.
+const makeR2 = (files: Record<string, { body: string; uploaded?: Date }>): R2Bucket => {
+  const bucket: R2Bucket = {
+    async get(key: string) {
+      const hit = files[key]
+      if (!hit) return null
+      return {
+        key,
+        uploaded: hit.uploaded ?? new Date(),
+        async text() {
+          return hit.body
+        },
+      } as unknown as R2ObjectBody
+    },
+    async head() {
+      return null
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const objects = Object.entries(files)
+        .filter(([k]) => k.startsWith(prefix))
+        .map(([k, v]) => ({
+          key: k,
+          size: v.body.length,
+          uploaded: v.uploaded ?? new Date(),
+          etag: "",
+          httpEtag: "",
+          checksums: {},
+        }))
+      return {
+        objects,
+        truncated: false,
+        delimitedPrefixes: [],
+      } as unknown as R2Objects
+    },
+    async put() {
+      throw new Error("not implemented in stub")
+    },
+    async delete() {},
+    async createMultipartUpload() {
+      throw new Error("not implemented in stub")
+    },
+    async resumeMultipartUpload() {
+      throw new Error("not implemented in stub")
+    },
+  } as unknown as R2Bucket
+  return bucket
+}
+
+const env = (files: Record<string, { body: string; uploaded?: Date }>) => ({
+  VAULT: makeR2(files),
+})
+
+const sampleReport = `---
+page_type: report
+slug: report-2026-W17
+kind: "weekly"
+title: Weekly report 2026-W17
+cost_usd: 0.4
+model: claude-opus-4-7
+---
+
+# Weekly research report
+
+Cites [[2026-04-22--wikipedia-boj]] and [[2026-04-22--wikipedia-2026-senate]].
+`
+
+const sampleWiki = `---
+page_type: source
+slug: 2026-04-22--wikipedia-boj
+title: Bank of Japan
+---
+
+# Bank of Japan
+
+The BoJ set its policy rate at 0.75%.
+`
+
+describe("pages routes", () => {
+  it("GET / lists reports and briefs", async () => {
+    const files = {
+      "reports/2026-W17.md": { body: sampleReport, uploaded: new Date("2026-04-22T10:00Z") },
+      "reports/2026-W16.md": { body: sampleReport, uploaded: new Date("2026-04-15T10:00Z") },
+      "briefs/2026-04-22.md": { body: sampleReport, uploaded: new Date("2026-04-22T07:00Z") },
+      "wiki/sources/2026-04-22--wikipedia-boj.md": { body: sampleWiki },
+    }
+    const res = await app.fetch(new Request("http://x/"), env(files))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("2026-W17")
+    expect(html).toContain("2026-W16")
+    expect(html).toContain("2026-04-22")
+    // newest first
+    expect(html.indexOf("2026-W17")).toBeLessThan(html.indexOf("2026-W16"))
+  })
+
+  it("GET /reports/:slug renders markdown + wikilinks", async () => {
+    const files = {
+      "reports/2026-W17.md": { body: sampleReport },
+      "wiki/sources/2026-04-22--wikipedia-boj.md": { body: sampleWiki },
+    }
+    const res = await app.fetch(new Request("http://x/reports/2026-W17"), env(files))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("<h1>Weekly research report</h1>")
+    expect(html).toContain('href="/wiki/2026-04-22--wikipedia-boj"')
+    expect(html).toContain("claude-opus-4-7")
+  })
+
+  it("GET /reports/:missing returns 404", async () => {
+    const res = await app.fetch(new Request("http://x/reports/nope"), env({}))
+    expect(res.status).toBe(404)
+  })
+
+  it("GET /wiki/:stem returns the source page", async () => {
+    const files = {
+      "wiki/sources/2026-04-22--wikipedia-boj.md": { body: sampleWiki },
+    }
+    const res = await app.fetch(
+      new Request("http://x/wiki/2026-04-22--wikipedia-boj"),
+      env(files),
+    )
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("Bank of Japan")
+    expect(html).toContain("0.75%")
+  })
+
+  it("rejects unsafe slugs with 404", async () => {
+    const res = await app.fetch(new Request("http://x/wiki/..%2Fetc%2Fpasswd"), env({}))
+    expect(res.status).toBe(404)
+  })
+
+  it("serves robots.txt disallowing all", async () => {
+    const res = await app.fetch(new Request("http://x/robots.txt"), env({}))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("Disallow: /")
+  })
+})

--- a/apps/uebermensch-pages/tsconfig.json
+++ b/apps/uebermensch-pages/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/apps/uebermensch-pages/wrangler.toml
+++ b/apps/uebermensch-pages/wrangler.toml
@@ -1,0 +1,8 @@
+name = "uebermensch-pages"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[r2_buckets]]
+binding = "VAULT"
+bucket_name = "gctrl-vault"

--- a/apps/uebermensch/package.json
+++ b/apps/uebermensch/package.json
@@ -22,6 +22,7 @@
     "@effect/platform-node": "^0.68.0",
     "@effect/schema": "^0.75.0",
     "effect": "^3.14.0",
+    "fast-xml-parser": "^5.7.1",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {

--- a/apps/uebermensch/src/adapters/FileSystemVault.ts
+++ b/apps/uebermensch/src/adapters/FileSystemVault.ts
@@ -1,10 +1,15 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
 import { basename, extname, join, relative } from "node:path"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import matter from "gray-matter"
 import { VaultError } from "../errors.js"
-import { VaultService, type WikiPage } from "../services/VaultService.js"
+import { ResearchInterestFrontmatter } from "../schemas.js"
+import {
+  VaultService,
+  type ResearchInterest,
+  type WikiPage,
+} from "../services/VaultService.js"
 
 const hashContent = (s: string) =>
   `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
@@ -73,7 +78,12 @@ export const FileSystemVaultLive = (vaultDir: string) =>
     listSlugs: () =>
       Effect.tryPromise({
         try: async () => {
-          const files = await walkMarkdown(vaultDir, ["wiki", "theses", "briefs"])
+          const files = await walkMarkdown(vaultDir, [
+            "wiki",
+            "theses",
+            "briefs",
+            "reports",
+          ])
           const slugs = new Set<string>()
           for (const f of files) slugs.add(basename(f.abs, ".md"))
           return slugs as ReadonlySet<string>
@@ -94,6 +104,72 @@ export const FileSystemVaultLive = (vaultDir: string) =>
         },
         catch: (e) =>
           new VaultError({ message: `write brief failed: ${String(e)}`, path: vaultDir }),
+      }),
+    listResearchInterests: () =>
+      Effect.gen(function* () {
+        const files = yield* Effect.tryPromise({
+          try: () => walkMarkdown(vaultDir, ["research"]),
+          catch: (e) =>
+            new VaultError({
+              message: `list research failed: ${String(e)}`,
+              path: vaultDir,
+              kind: "io_failure",
+            }),
+        })
+        const out: Array<ResearchInterest> = []
+        for (const f of files) {
+          const raw = yield* Effect.tryPromise({
+            try: () => readFile(f.abs, "utf8"),
+            catch: (e) =>
+              new VaultError({
+                message: `read research file failed: ${String(e)}`,
+                path: f.abs,
+                kind: "io_failure",
+              }),
+          })
+          const parsed = matter(raw)
+          const data = (parsed.data ?? {}) as Record<string, unknown>
+          const decoded = yield* Schema.decodeUnknown(ResearchInterestFrontmatter)(data).pipe(
+            Effect.mapError(
+              (e) =>
+                new VaultError({
+                  message: `research interest ${f.rel} invalid: ${String(e)}`,
+                  path: f.abs,
+                  kind: "parse_failure",
+                }),
+            ),
+          )
+          out.push({
+            slug: decoded.slug,
+            title: decoded.title,
+            question: decoded.question ?? null,
+            topics: decoded.topics,
+            sources: decoded.sources ?? [],
+            horizon: decoded.horizon ?? null,
+            weight: decoded.weight ?? null,
+            notes: parsed.content.trim(),
+            relPath: f.rel,
+          })
+        }
+        return out
+      }),
+    writeReport: (slug, content) =>
+      Effect.tryPromise({
+        try: async () => {
+          const relPath = `reports/${slug}.md`
+          const absPath = join(vaultDir, relPath)
+          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
+          await mkdir(join(vaultDir, "reports"), { recursive: true })
+          await writeFile(tmpPath, content, "utf8")
+          await rename(tmpPath, absPath)
+          return { absPath, relPath, contentHash: hashContent(content) }
+        },
+        catch: (e) =>
+          new VaultError({
+            message: `write report failed: ${String(e)}`,
+            path: vaultDir,
+            kind: "io_failure",
+          }),
       }),
     writeSource: (slug, content, options) =>
       Effect.gen(function* () {

--- a/apps/uebermensch/src/adapters/HttpDeliverer.ts
+++ b/apps/uebermensch/src/adapters/HttpDeliverer.ts
@@ -1,0 +1,199 @@
+import { Effect, Layer } from "effect"
+import { DeliveryError } from "../errors.js"
+import {
+  DelivererService,
+  type DeliverInput,
+  type DeliveryResult,
+} from "../services/DelivererService.js"
+
+const TG_MAX = 3800
+const DC_MAX = 1900
+
+const splitChunks = (content: string, max: number): ReadonlyArray<string> => {
+  if (content.length <= max) return [content]
+  const chunks: Array<string> = []
+  const lines = content.split("\n")
+  let buf = ""
+  for (const line of lines) {
+    const next = buf.length === 0 ? line : `${buf}\n${line}`
+    if (next.length > max && buf.length > 0) {
+      chunks.push(buf)
+      buf = line
+    } else if (next.length > max) {
+      for (let i = 0; i < line.length; i += max) chunks.push(line.slice(i, i + max))
+      buf = ""
+    } else {
+      buf = next
+    }
+  }
+  if (buf.length > 0) chunks.push(buf)
+  return chunks
+}
+
+const stripFrontmatter = (md: string): string => {
+  if (!md.startsWith("---\n")) return md
+  const end = md.indexOf("\n---\n", 4)
+  if (end === -1) return md
+  return md.slice(end + 5).replace(/^\n+/, "")
+}
+
+const resolveEnvRef = (targetRef: string, prefix: string): string | null => {
+  if (!targetRef.startsWith(prefix)) return null
+  const rest = targetRef.slice(prefix.length)
+  if (rest.startsWith("env:")) return process.env[rest.slice(4)] ?? null
+  return rest
+}
+
+const classifyKernelStatus = (
+  status: number,
+): "config" | "unreachable" | "rate_limited" | "invalid" | "io_failure" => {
+  if (status === 503) return "config"
+  if (status === 429) return "rate_limited"
+  if (status === 502 || status === 504) return "unreachable"
+  if (status >= 500) return "unreachable"
+  if (status === 400 || status === 401 || status === 403 || status === 404) return "invalid"
+  return "io_failure"
+}
+
+const kernelBase = () =>
+  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
+
+const postToKernel = (
+  path: string,
+  body: unknown,
+  channel: string,
+  driver: string,
+): Effect.Effect<unknown, DeliveryError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const res = await fetch(`${kernelBase()}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        const err: DeliveryError = new DeliveryError({
+          message: `kernel ${path} HTTP ${res.status}: ${text.slice(0, 500)}`,
+          channel,
+          driver,
+          kind: classifyKernelStatus(res.status),
+          status: res.status,
+        })
+        throw err
+      }
+      return text.length > 0 ? JSON.parse(text) : {}
+    },
+    catch: (e) =>
+      e instanceof DeliveryError
+        ? e
+        : new DeliveryError({
+            message: `kernel ${path} fetch failed: ${String(e)}`,
+            channel,
+            driver,
+            kind: "unreachable",
+          }),
+  })
+
+const sendTelegram = (input: DeliverInput): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.gen(function* () {
+    const chatId = resolveEnvRef(input.targetRef, "tg:chat:")
+    if (!chatId) {
+      return yield* Effect.fail(
+        new DeliveryError({
+          message: `unresolved target_ref for telegram: ${input.targetRef}`,
+          channel: input.channel,
+          driver: input.driver,
+          kind: "config",
+        }),
+      )
+    }
+    const body = stripFrontmatter(input.content)
+    const chunks = splitChunks(body, TG_MAX)
+    const externalIds: Array<string> = []
+    for (let i = 0; i < chunks.length; i++) {
+      const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length})\n` : ""
+      const json = (yield* postToKernel(
+        "/api/telegram/send",
+        {
+          chat_id: chatId,
+          text: `${prefix}${chunks[i]}`,
+          disable_notification: input.silent,
+        },
+        input.channel,
+        input.driver,
+      )) as { message_id?: number | null }
+      if (typeof json.message_id === "number") externalIds.push(String(json.message_id))
+    }
+    return {
+      channel: input.channel,
+      driver: input.driver,
+      externalIds,
+      parts: chunks.length,
+    }
+  })
+
+const sendDiscord = (input: DeliverInput): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.gen(function* () {
+    const webhook = resolveEnvRef(input.targetRef, "dc:webhook:")
+    if (!webhook) {
+      return yield* Effect.fail(
+        new DeliveryError({
+          message: `unresolved target_ref for discord: ${input.targetRef}`,
+          channel: input.channel,
+          driver: input.driver,
+          kind: "config",
+        }),
+      )
+    }
+    const body = stripFrontmatter(input.content)
+    const chunks = splitChunks(body, DC_MAX)
+    for (let i = 0; i < chunks.length; i++) {
+      const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length})\n` : ""
+      const content = input.silent ? `@silent ${prefix}${chunks[i]}` : `${prefix}${chunks[i]}`
+      yield* postToKernel(
+        "/api/discord/send",
+        { webhook_url: webhook, content },
+        input.channel,
+        input.driver,
+      )
+    }
+    return {
+      channel: input.channel,
+      driver: input.driver,
+      externalIds: [],
+      parts: chunks.length,
+    }
+  })
+
+const sendApp = (input: DeliverInput): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.succeed({
+    channel: input.channel,
+    driver: input.driver,
+    externalIds: [],
+    parts: 1,
+  })
+
+export const HttpDelivererLive = Layer.succeed(DelivererService, {
+  send: (input) => {
+    switch (input.driver) {
+      case "telegram":
+        return sendTelegram(input)
+      case "discord":
+        return sendDiscord(input)
+      case "app":
+        return sendApp(input)
+      default:
+        return Effect.fail(
+          new DeliveryError({
+            message: `unknown driver: ${input.driver}`,
+            channel: input.channel,
+            driver: input.driver,
+            kind: "config",
+          }),
+        )
+    }
+  },
+})
+
+export const _internal = { splitChunks, stripFrontmatter, resolveEnvRef, kernelBase }

--- a/apps/uebermensch/src/adapters/HttpDeliverer.ts
+++ b/apps/uebermensch/src/adapters/HttpDeliverer.ts
@@ -37,6 +37,24 @@ const stripFrontmatter = (md: string): string => {
   return md.slice(end + 5).replace(/^\n+/, "")
 }
 
+const ITEM_HEADING = /^## \d+\. /m
+
+const splitBrief = (content: string, max: number): ReadonlyArray<string> => {
+  const body = stripFrontmatter(content)
+  if (!ITEM_HEADING.test(body)) return splitChunks(body, max)
+  const withoutH1 = body.replace(/^#\s+[^\n]*\n+/, "")
+  const parts = withoutH1
+    .split(/(?=^## \d+\. )/m)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  const out: Array<string> = []
+  for (const p of parts) {
+    if (p.length <= max) out.push(p)
+    else for (const c of splitChunks(p, max)) out.push(c)
+  }
+  return out
+}
+
 const resolveEnvRef = (targetRef: string, prefix: string): string | null => {
   if (!targetRef.startsWith(prefix)) return null
   const rest = targetRef.slice(prefix.length)
@@ -108,8 +126,7 @@ const sendTelegram = (input: DeliverInput): Effect.Effect<DeliveryResult, Delive
         }),
       )
     }
-    const body = stripFrontmatter(input.content)
-    const chunks = splitChunks(body, TG_MAX)
+    const chunks = splitBrief(input.content, TG_MAX)
     const externalIds: Array<string> = []
     for (let i = 0; i < chunks.length; i++) {
       const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length})\n` : ""
@@ -146,8 +163,7 @@ const sendDiscord = (input: DeliverInput): Effect.Effect<DeliveryResult, Deliver
         }),
       )
     }
-    const body = stripFrontmatter(input.content)
-    const chunks = splitChunks(body, DC_MAX)
+    const chunks = splitBrief(input.content, DC_MAX)
     for (let i = 0; i < chunks.length; i++) {
       const prefix = chunks.length > 1 ? `(${i + 1}/${chunks.length})\n` : ""
       const content = input.silent ? `@silent ${prefix}${chunks[i]}` : `${prefix}${chunks[i]}`
@@ -196,4 +212,4 @@ export const HttpDelivererLive = Layer.succeed(DelivererService, {
   },
 })
 
-export const _internal = { splitChunks, stripFrontmatter, resolveEnvRef, kernelBase }
+export const _internal = { splitChunks, splitBrief, stripFrontmatter, resolveEnvRef, kernelBase }

--- a/apps/uebermensch/src/adapters/HttpFeed.ts
+++ b/apps/uebermensch/src/adapters/HttpFeed.ts
@@ -1,0 +1,66 @@
+import { Context, Effect, Layer } from "effect"
+import { IngestError } from "../errors.js"
+import { parseFeed } from "../lib/rss.js"
+import { FeedService } from "../services/FeedService.js"
+
+export type HttpFeedConfig = {
+  readonly fetch?: typeof fetch
+  readonly userAgent?: string
+}
+
+export class HttpFeedConfigTag extends Context.Tag("uebermensch/HttpFeedConfig")<
+  HttpFeedConfigTag,
+  HttpFeedConfig
+>() {}
+
+// Some feeds (criticalthreats, a few Bloomberg mirrors) 403 on default UAs.
+// Use a browser-like UA so we match what `uber ingest url` already does.
+const DEFAULT_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) uebermensch-feed/0.1"
+
+const ingestErr = (kind: IngestError["kind"], url: string, message: string): IngestError =>
+  new IngestError({ kind, url, message })
+
+export const HttpFeedLive = Layer.effect(
+  FeedService,
+  Effect.gen(function* () {
+    const config = yield* HttpFeedConfigTag
+    const doFetch = config.fetch ?? fetch
+    const userAgent = config.userAgent ?? DEFAULT_UA
+
+    return {
+      fetchFeed: (url) =>
+        Effect.gen(function* () {
+          const response = yield* Effect.tryPromise({
+            try: () =>
+              doFetch(url, {
+                headers: {
+                  "user-agent": userAgent,
+                  accept:
+                    "application/rss+xml, application/atom+xml, application/xml;q=0.9, text/xml;q=0.9, */*;q=0.1",
+                },
+              }),
+            catch: (e) => ingestErr("fetch_failed", url, `fetch failed: ${String(e)}`),
+          }).pipe(
+            Effect.filterOrFail(
+              (r) => r.ok,
+              (r) => ingestErr("fetch_failed", url, `fetch returned ${r.status}`),
+            ),
+          )
+          const xml = yield* Effect.tryPromise({
+            try: () => response.text(),
+            catch: (e) => ingestErr("fetch_failed", url, `read body failed: ${String(e)}`),
+          })
+          const parsed = parseFeed(xml)
+          return {
+            url,
+            format: parsed.format,
+            title: parsed.title,
+            items: parsed.items,
+          }
+        }),
+    }
+  }),
+)
+
+export const HttpFeedDefaultConfig = Layer.succeed(HttpFeedConfigTag, {})

--- a/apps/uebermensch/src/adapters/HttpIngest.ts
+++ b/apps/uebermensch/src/adapters/HttpIngest.ts
@@ -15,8 +15,39 @@ export class HttpIngestConfigTag extends Context.Tag("uebermensch/HttpIngestConf
   HttpIngestConfig
 >() {}
 
-const DEFAULT_UA = "uebermensch-ingest/0.1 (+https://github.com/OpenHackersClub/gctrl)"
+// Browser-like UA — bare `uebermensch-ingest` gets 403'd by FT, Bloomberg, SCMP, BoJ.
+const DEFAULT_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
 const MAX_BODY_CHARS = 8000
+
+// Patterns that indicate a paywalled / metered article. If any match the extracted
+// body we consider the fetched content unusable and fall back to the RSS description
+// (when available). Ordered by how strongly they signal paywall.
+const PAYWALL_PATTERNS: ReadonlyArray<RegExp> = [
+  /subscribe to (?:unlock|continue|read)/i,
+  /sign in to (?:read|continue|access)/i,
+  /try unlimited access/i,
+  /only\s+\S+\s*\$?1\s+for\s+\d+\s+weeks?/i,
+  /keep reading for/i,
+  /already have an account\??\s*(?:log ?in|sign ?in)/i,
+  /create (?:a |an )?free account to (?:read|continue)/i,
+  /complete digital access/i,
+  /your subscription (?:gives|grants|provides)/i,
+  /register (?:for free|to continue)/i,
+]
+
+export type PaywallCheck = {
+  readonly paywalled: boolean
+  readonly matched: string | null
+}
+
+export const detectPaywall = (body: string): PaywallCheck => {
+  for (const re of PAYWALL_PATTERNS) {
+    const hit = body.match(re)
+    if (hit) return { paywalled: true, matched: hit[0] }
+  }
+  return { paywalled: false, matched: null }
+}
 
 const ingestErr = (kind: IngestError["kind"], url: string, message: string): IngestError =>
   new IngestError({ kind, url, message })
@@ -24,15 +55,35 @@ const ingestErr = (kind: IngestError["kind"], url: string, message: string): Ing
 const vaultToIngest = (url: string) => (e: VaultError): IngestError =>
   ingestErr(e.kind === "collision" ? "collision" : "io_failure", url, e.message)
 
-const classifyTopics = (
+// A slug "japan-macro" as plain text rarely appears in articles — but its watchlist
+// terms (boj, yen, jgb, ueda…) do. classifyTopics matches against BOTH:
+//   (a) the slug rendered as a phrase (kebab → space), and
+//   (b) each watchlist term (with word-boundary regex to avoid substring collisions
+//       like "us" matching "usual").
+export const classifyTopics = (
   text: string,
   topicSlugs: ReadonlyArray<string>,
+  watchlists: Readonly<Record<string, ReadonlyArray<string>>> = {},
 ): ReadonlyArray<string> => {
   const haystack = text.toLowerCase()
   const hits: Array<string> = []
   for (const slug of topicSlugs) {
-    const needle = slug.toLowerCase().replace(/-/g, " ")
-    if (haystack.includes(needle)) hits.push(slug)
+    const phrase = slug.toLowerCase().replace(/-/g, " ")
+    let matched = haystack.includes(phrase)
+    if (!matched) {
+      for (const term of watchlists[slug] ?? []) {
+        const t = term.toLowerCase()
+        if (!t) continue
+        // Word-boundary match on kebab/space/punct so "us" doesn't match "usual".
+        const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[ \\-/]")
+        const re = new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`, "i")
+        if (re.test(haystack)) {
+          matched = true
+          break
+        }
+      }
+    }
+    if (matched) hits.push(slug)
   }
   return hits
 }
@@ -63,10 +114,33 @@ const renderFrontmatter = (fields: Record<string, unknown>): string => {
   return lines.join("\n")
 }
 
-const renderSourceBody = (title: string, url: string, text: string): string => {
+const renderSourceBody = (title: string, url: string, text: string, paywalled: boolean, bodySource: "extracted" | "rss_description"): string => {
   const truncated =
     text.length > MAX_BODY_CHARS ? `${text.slice(0, MAX_BODY_CHARS)}\n\n…(truncated)` : text
-  return [`# ${title}`, "", `Source: <${url}>`, "", truncated, ""].join("\n")
+  const note =
+    bodySource === "rss_description"
+      ? "_Body below is the RSS publisher-supplied description; the linked article is paywalled._"
+      : paywalled
+        ? "_Extracted content may be truncated by a paywall._"
+        : ""
+  const parts = [`# ${title}`, "", `Source: <${url}>`, ""]
+  if (note) parts.push(note, "")
+  parts.push(truncated, "")
+  return parts.join("\n")
+}
+
+const MIN_FEED_DESCRIPTION_CHARS = 80
+
+const narrowTopics = (
+  classified: ReadonlyArray<string>,
+  forceTopics: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> => {
+  if (!forceTopics || forceTopics.length === 0) {
+    return Array.from(new Set(classified))
+  }
+  const ceiling = new Set(forceTopics)
+  const narrowed = classified.filter((t) => ceiling.has(t))
+  return Array.from(new Set(narrowed))
 }
 
 export const HttpIngestLive = Layer.effect(
@@ -83,7 +157,15 @@ export const HttpIngestLive = Layer.effect(
           const fetchedAt = new Date().toISOString()
 
           const response = yield* Effect.tryPromise({
-            try: () => doFetch(req.url, { headers: { "user-agent": userAgent } }),
+            try: () =>
+              doFetch(req.url, {
+                headers: {
+                  "user-agent": userAgent,
+                  accept:
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                  "accept-language": "en-US,en;q=0.9",
+                },
+              }),
             catch: (e) => ingestErr("fetch_failed", req.url, `fetch failed: ${String(e)}`),
           }).pipe(
             Effect.filterOrFail(
@@ -100,27 +182,42 @@ export const HttpIngestLive = Layer.effect(
           const extracted = yield* Effect.try({
             try: () => extractFromHtml(html),
             catch: (e) => ingestErr("extract_failed", req.url, `extract failed: ${String(e)}`),
-          }).pipe(
-            Effect.filterOrFail(
-              (x) => x.wordCount >= req.minWordCount,
-              (x) =>
-                ingestErr(
-                  "low_quality",
-                  req.url,
-                  `word_count ${x.wordCount} < min ${req.minWordCount}`,
-                ),
-            ),
-          )
+          })
+
+          // Decide which body to use. Paywall detection runs on the extracted text;
+          // if it hits, we fall back to the RSS description (when long enough).
+          const paywall = detectPaywall(extracted.text)
+          const feedDesc = (req.descriptionFromFeed ?? "").trim()
+          const useFeedDesc = paywall.paywalled && feedDesc.length >= MIN_FEED_DESCRIPTION_CHARS
+          const bodySource: "extracted" | "rss_description" = useFeedDesc ? "rss_description" : "extracted"
+          const bodyText = useFeedDesc ? feedDesc : extracted.text
+          const effectiveWordCount = bodyText.split(/\s+/).filter(Boolean).length
+
+          // Quality gate: if still below minWordCount after the description fallback,
+          // reject. Title-only pages are not useful to the curator.
+          if (effectiveWordCount < req.minWordCount) {
+            return yield* Effect.fail(
+              ingestErr(
+                "low_quality",
+                req.url,
+                `effective word_count ${effectiveWordCount} < min ${req.minWordCount} (paywalled=${paywall.paywalled}, feedDesc=${feedDesc.length})`,
+              ),
+            )
+          }
 
           const slug = slugForSource(req.url, req.date)
           const domain = domainKebab(req.url).replace(/-/g, ".")
-          const topicsMatched = classifyTopics(
-            `${extracted.title}\n${extracted.text.slice(0, 2000)}`,
-            req.topicSlugs,
-          )
-          const contentHash = sha256(extracted.text)
 
-          const body = renderSourceBody(extracted.title, req.url, extracted.text)
+          const classifyText = `${extracted.title}\n${bodyText.slice(0, 2000)}\n${feedDesc.slice(0, 1000)}`
+          const classified = classifyTopics(
+            classifyText,
+            req.topicSlugs,
+            req.topicWatchlists ?? {},
+          )
+          const topicsMatched = narrowTopics(classified, req.forceTopics)
+          const contentHash = sha256(bodyText)
+
+          const body = renderSourceBody(extracted.title, req.url, bodyText, paywall.paywalled, bodySource)
           const frontmatter = renderFrontmatter({
             page_type: "source",
             slug,
@@ -133,9 +230,11 @@ export const HttpIngestLive = Layer.effect(
             entities: [],
             content_hash: contentHash,
             quality: {
-              word_count: extracted.wordCount,
+              word_count: effectiveWordCount,
               readability_used: false,
               spam_score: 0,
+              paywalled: paywall.paywalled,
+              body_source: bodySource,
             },
           })
           const full = `${frontmatter}\n\n${body}`
@@ -150,9 +249,11 @@ export const HttpIngestLive = Layer.effect(
             absPath: written.absPath,
             title: extracted.title,
             domain,
-            wordCount: extracted.wordCount,
+            wordCount: effectiveWordCount,
             topicsMatched,
             contentHash: written.contentHash,
+            paywalled: paywall.paywalled,
+            bodySource,
           }
         }),
     }

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,0 +1,221 @@
+import { Effect, Layer, Schema } from "effect"
+import { LlmError } from "../errors.js"
+import type { CandidateRef } from "../lib/candidates.js"
+import { sha256 } from "../lib/hash.js"
+import { LlmService, type BriefRequest } from "../services/LlmService.js"
+import type { CuratedItem } from "../services/RendererService.js"
+
+const MODEL = "claude-opus-4-7"
+const INPUT_COST_PER_MTOK = 5.0
+const OUTPUT_COST_PER_MTOK = 25.0
+const MAX_CANDIDATE_EXCERPT = 2000
+const DEFAULT_MAX_TOKENS = 16000
+
+const kernelBase = (): string =>
+  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
+
+const excerptOf = (body: string, max: number): string => {
+  const trimmed = body.trim()
+  if (trimmed.length <= max) return trimmed
+  return `${trimmed.slice(0, max)}…`
+}
+
+const candidateBlock = (c: CandidateRef): string => {
+  const fm = c.page.frontmatter
+  const title = (fm.title as string | undefined) ?? c.page.stem
+  const topics = ((fm.topics as ReadonlyArray<string> | undefined) ?? []).join(", ")
+  const url = (fm.url as string | undefined) ?? ""
+  const lines: Array<string> = [
+    `- id: ${c.id}`,
+    `  stem: ${c.page.stem}`,
+    `  title: ${title}`,
+    `  topics: [${topics}]`,
+  ]
+  if (url) lines.push(`  url: ${url}`)
+  lines.push(`  score: ${c.score.toFixed(3)}`)
+  lines.push(`  excerpt: |`)
+  const excerptBody = excerptOf(c.page.body, MAX_CANDIDATE_EXCERPT)
+  for (const line of excerptBody.split("\n")) lines.push(`    ${line}`)
+  return lines.join("\n")
+}
+
+const SYSTEM_PROMPT = `You are uebermensch-curator, a chief-of-staff curator that produces a daily brief from a set of wiki pages.
+
+OUTPUT CONTRACT:
+- Output MUST be a single JSON object wrapped in a triple-backtick json fenced block. No prose outside the fence.
+- Shape: { "items": CuratedItem[], "topicsCovered": string[], "thesesCovered": string[] }
+- CuratedItem: {
+    "kind": "news" | "update" | "action" | "alert",
+    "title": string,
+    "summary_md": string,
+    "topic": string | null,
+    "thesis": string | null,
+    "source_candidate_ids": string[],
+    "suggested_action": string | null
+  }
+
+CITATION RULES (strict — brief generation will FAIL if violated):
+- Every \`[[link]]\` in \`summary_md\` MUST match a candidate's \`stem\` field exactly.
+- Do NOT use typed-prefix links like \`[[source:x]]\` or \`[[thesis:x]]\` — bare stems only.
+- \`source_candidate_ids\` MUST be a subset of the provided candidate \`id\` values (e.g. "cand-0000"). Never fabricate.
+
+CURATION RULES:
+- \`summary_md\` is 2–5 sentences of substantive, concrete content derived from the candidate excerpts. No hedging.
+- Each item must cite at least one source via a \`[[stem]]\` link AND list the corresponding id in \`source_candidate_ids\`.
+- Merge near-duplicate candidates into one item referencing multiple sources.
+- \`topic\` is the single most relevant topic slug from the profile, or null.
+- Produce at most \`maxItems\` items; prefer high-scored, topic-aligned candidates.
+- If there are no usable candidates, return \`{ "items": [], "topicsCovered": [], "thesesCovered": [] }\`.`
+
+const buildUserPrompt = (req: BriefRequest): string => {
+  const lines: Array<string> = []
+  lines.push(`date: ${req.date}`)
+  lines.push(`profile: ${req.profileName}`)
+  lines.push(`maxItems: ${req.maxItems}`)
+  lines.push(`topics: [${req.topics.join(", ")}]`)
+  lines.push(`theses: [${req.thesesSlugs.join(", ")}]`)
+  lines.push("")
+  lines.push("candidates:")
+  for (const c of req.candidates) lines.push(candidateBlock(c))
+  lines.push("")
+  lines.push("Return ONLY a fenced ```json block with the schema above.")
+  return lines.join("\n")
+}
+
+const ItemSchema = Schema.Struct({
+  kind: Schema.Literal("news", "update", "action", "alert"),
+  title: Schema.String,
+  summary_md: Schema.String,
+  topic: Schema.NullOr(Schema.String),
+  thesis: Schema.NullOr(Schema.String),
+  source_candidate_ids: Schema.Array(Schema.String),
+  suggested_action: Schema.NullOr(Schema.String),
+})
+
+const LlmOutputSchema = Schema.Struct({
+  items: Schema.Array(ItemSchema),
+  topicsCovered: Schema.Array(Schema.String),
+  thesesCovered: Schema.Array(Schema.String),
+})
+
+type AnthropicResponse = {
+  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>
+  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number }
+  readonly model?: string
+}
+
+const extractJson = (text: string): string | null => {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/)
+  if (fenced) return fenced[1].trim()
+  const start = text.indexOf("{")
+  const end = text.lastIndexOf("}")
+  if (start === -1 || end === -1 || end < start) return null
+  return text.slice(start, end + 1)
+}
+
+const llmErr = (kind: LlmError["kind"], message: string): LlmError =>
+  new LlmError({ kind, message })
+
+const classifyKernelStatus = (status: number): LlmError["kind"] => {
+  if (status === 503) return "unavailable"
+  if (status === 429) return "rate_limited"
+  if (status === 400 || status === 401 || status === 403) return "invalid"
+  if (status >= 500) return "unavailable"
+  return "invalid"
+}
+
+const postMessages = (body: unknown): Effect.Effect<AnthropicResponse, LlmError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const res = await fetch(`${kernelBase()}/api/llm/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      const text = await res.text()
+      if (!res.ok) {
+        throw llmErr(
+          classifyKernelStatus(res.status),
+          `kernel /api/llm/messages HTTP ${res.status}: ${text.slice(0, 500)}`,
+        )
+      }
+      return text.length > 0 ? (JSON.parse(text) as AnthropicResponse) : ({} as AnthropicResponse)
+    },
+    catch: (e) =>
+      e instanceof LlmError
+        ? e
+        : llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`),
+  })
+
+export const KernelLlmLive = Layer.succeed(LlmService, {
+  name: () => `kernel-llm@${MODEL}`,
+  generateBrief: (req) =>
+    Effect.gen(function* () {
+      const userPrompt = buildUserPrompt(req)
+      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const body = {
+        model: MODEL,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        thinking: { type: "adaptive" },
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userPrompt }],
+      }
+      const res = yield* postMessages(body)
+      const textBlock = (res.content ?? []).find(
+        (b): b is { type: string; text: string } =>
+          b.type === "text" && typeof b.text === "string",
+      )
+      if (!textBlock) {
+        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"))
+      }
+      const raw = extractJson(textBlock.text)
+      if (raw === null) {
+        return yield* Effect.fail(
+          llmErr("invalid", "kernel response text did not contain a JSON object"),
+        )
+      }
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch (e) {
+        return yield* Effect.fail(
+          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
+        )
+      }
+      const decoded = yield* Schema.decodeUnknown(LlmOutputSchema)(parsed).pipe(
+        Effect.mapError((e) =>
+          llmErr("invalid", `kernel response schema mismatch: ${String(e)}`),
+        ),
+      )
+      const costUsd =
+        ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
+          (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
+        1_000_000
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
+      }))
+      return {
+        items,
+        topicsCovered: decoded.topicsCovered,
+        thesesCovered: decoded.thesesCovered,
+        promptHash,
+        costUsd,
+        model: res.model ?? MODEL,
+      }
+    }),
+})
+
+export const _internal = {
+  buildUserPrompt,
+  extractJson,
+  kernelBase,
+  LlmOutputSchema,
+  SYSTEM_PROMPT,
+  MODEL,
+}

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -2,7 +2,12 @@ import { Effect, Layer, Schema } from "effect"
 import { LlmError } from "../errors.js"
 import type { CandidateRef } from "../lib/candidates.js"
 import { sha256 } from "../lib/hash.js"
-import { LlmService, type BriefRequest } from "../services/LlmService.js"
+import {
+  LlmService,
+  type BriefRequest,
+  type ReportRequest,
+  type ReportSection,
+} from "../services/LlmService.js"
 import type { CuratedItem } from "../services/RendererService.js"
 
 const MODEL = "claude-opus-4-7"
@@ -147,6 +152,93 @@ const postMessages = (body: unknown): Effect.Effect<AnthropicResponse, LlmError>
         : llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`),
   })
 
+const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst that produces a weekly research report grouped by research interest.
+
+OUTPUT CONTRACT:
+- Output MUST be a single JSON object wrapped in a triple-backtick json fenced block. No prose outside the fence.
+- Shape: { "sections": ReportSection[] }
+- ReportSection: {
+    "interestSlug": string,  // MUST match one of the provided interest slugs
+    "summary_md": string,    // 3–6 sentence overview of the week for this interest; may cite candidates via [[stem]]
+    "items": CuratedItem[]   // up to maxItemsPerInterest per section
+  }
+- CuratedItem: {
+    "kind": "news" | "update" | "action" | "alert",
+    "title": string,
+    "summary_md": string,
+    "topic": string | null,
+    "thesis": string | null,
+    "source_candidate_ids": string[],
+    "suggested_action": string | null
+  }
+
+CITATION RULES (strict — report generation will FAIL if violated):
+- Every \`[[link]]\` in any \`summary_md\` MUST match a candidate's \`stem\` field exactly.
+- Do NOT use typed-prefix links like \`[[source:x]]\` or \`[[thesis:x]]\` — bare stems only.
+- \`source_candidate_ids\` MUST be a subset of the provided candidate \`id\` values for THAT interest section. Never fabricate.
+CURATION RULES:
+- Produce one section per provided interest, in the order given. Use the exact interestSlug.
+- For each section, use ONLY the candidates listed under that interest.
+- summary_md in each item: 2–4 sentences, substantive and concrete, derived from candidate excerpts. No hedging.
+- Merge near-duplicate candidates into one item referencing multiple sources.
+- topic: the single most relevant topic slug for that interest, or null.
+- Produce at most maxItemsPerInterest items per section; prefer high-scored candidates aligned with the interest's question.
+
+INSIGHT-ONLY RULES (strict — enforced by reviewer):
+- Write substantive insight only. NEVER describe what is absent, thin, missing, or quiet in the candidate pool.
+- BANNED phrases and patterns: "No direct X...", "No fresh X...", "appeared in the candidate set", "This week was quiet for...", "Candidate pool was thin...", "Most items were only indirectly relevant...", "Reference pages were also indexed but carry no new information", "Treat this week as a quiet one for...".
+- If a section has no candidates OR no substantive signal, return {"interestSlug": slug, "summary_md": "", "items": []} — the renderer will drop empty sections. Do NOT apologize or meta-commentate.
+- If the candidate pool contains only adjacent signal (no direct hit on the interest's question), lead with the adjacent signal as a concrete claim. Example: "BHP–China iron ore deal resets seaborne pricing relevant to Japanese steelmaker input costs." Do NOT frame it as "No direct X but adjacent Y...".
+- No "Suggested action" lines about expanding ingestion, adding feeds, or describing the system itself. Actions must target the substantive domain (markets, policy, company behavior).`
+
+const reportCandidateBlock = (c: CandidateRef): string => candidateBlock(c)
+
+const buildReportUserPrompt = (req: ReportRequest): string => {
+  const lines: Array<string> = []
+  lines.push(`period: ${req.periodLabel}`)
+  lines.push(`periodStart: ${req.periodStart}`)
+  lines.push(`periodEnd: ${req.periodEnd}`)
+  lines.push(`profile: ${req.profileName}`)
+  lines.push(`maxItemsPerInterest: ${req.maxItemsPerInterest}`)
+  lines.push("")
+  lines.push("interests:")
+  for (const it of req.interests) {
+    lines.push(`- slug: ${it.slug}`)
+    lines.push(`  title: ${it.title}`)
+    if (it.question) lines.push(`  question: ${it.question}`)
+    lines.push(`  topics: [${it.topics.join(", ")}]`)
+    if (it.notes) {
+      lines.push(`  notes: |`)
+      for (const line of it.notes.split("\n")) lines.push(`    ${line}`)
+    }
+    lines.push(`  candidates:`)
+    if (it.candidates.length === 0) {
+      lines.push(`    (none)`)
+    } else {
+      for (const c of it.candidates) {
+        const block = reportCandidateBlock(c)
+          .split("\n")
+          .map((l) => `  ${l}`)
+          .join("\n")
+        lines.push(block)
+      }
+    }
+  }
+  lines.push("")
+  lines.push("Return ONLY a fenced ```json block with the schema above.")
+  return lines.join("\n")
+}
+
+const ReportSectionSchema = Schema.Struct({
+  interestSlug: Schema.String,
+  summary_md: Schema.String,
+  items: Schema.Array(ItemSchema),
+})
+
+const ReportOutputSchema = Schema.Struct({
+  sections: Schema.Array(ReportSectionSchema),
+})
+
 export const KernelLlmLive = Layer.succeed(LlmService, {
   name: () => `kernel-llm@${MODEL}`,
   generateBrief: (req) =>
@@ -209,13 +301,80 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         model: res.model ?? MODEL,
       }
     }),
+  generateReport: (req) =>
+    Effect.gen(function* () {
+      const userPrompt = buildReportUserPrompt(req)
+      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const body = {
+        model: MODEL,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        thinking: { type: "adaptive" },
+        system: REPORT_SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userPrompt }],
+      }
+      const res = yield* postMessages(body)
+      const textBlock = (res.content ?? []).find(
+        (b): b is { type: string; text: string } =>
+          b.type === "text" && typeof b.text === "string",
+      )
+      if (!textBlock) {
+        return yield* Effect.fail(
+          llmErr("invalid", "kernel response missing text content block"),
+        )
+      }
+      const raw = extractJson(textBlock.text)
+      if (raw === null) {
+        return yield* Effect.fail(
+          llmErr("invalid", "kernel response text did not contain a JSON object"),
+        )
+      }
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch (e) {
+        return yield* Effect.fail(
+          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
+        )
+      }
+      const decoded = yield* Schema.decodeUnknown(ReportOutputSchema)(parsed).pipe(
+        Effect.mapError((e) =>
+          llmErr("invalid", `kernel response schema mismatch: ${String(e)}`),
+        ),
+      )
+      const costUsd =
+        ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
+          (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
+        1_000_000
+      const sections: ReadonlyArray<ReportSection> = decoded.sections.map((s) => ({
+        interestSlug: s.interestSlug,
+        summary_md: s.summary_md,
+        items: s.items.map((i) => ({
+          kind: i.kind,
+          title: i.title,
+          summary_md: i.summary_md,
+          topic: i.topic,
+          thesis: i.thesis,
+          source_candidate_ids: i.source_candidate_ids,
+          suggested_action: i.suggested_action,
+        })),
+      }))
+      return {
+        sections,
+        promptHash,
+        costUsd,
+        model: res.model ?? MODEL,
+      }
+    }),
 })
 
 export const _internal = {
   buildUserPrompt,
+  buildReportUserPrompt,
   extractJson,
   kernelBase,
   LlmOutputSchema,
+  ReportOutputSchema,
   SYSTEM_PROMPT,
+  REPORT_SYSTEM_PROMPT,
   MODEL,
 }

--- a/apps/uebermensch/src/adapters/R2Sync.ts
+++ b/apps/uebermensch/src/adapters/R2Sync.ts
@@ -1,0 +1,249 @@
+import { spawn } from "node:child_process"
+import { createHash } from "node:crypto"
+import { readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
+import { join, relative } from "node:path"
+import { Context, Effect, Layer } from "effect"
+import {
+  SyncError,
+  SyncService,
+  type SyncInput,
+  type SyncPlanEntry,
+  type SyncResult,
+} from "../services/SyncService.js"
+
+const MANIFEST_FILENAME = ".uber-sync-state.json"
+
+type ManifestEntry = { readonly sha256: string; readonly uploadedAt: string }
+type Manifest = { readonly version: 1; readonly entries: Record<string, ManifestEntry> }
+
+const emptyManifest = (): Manifest => ({ version: 1, entries: {} })
+
+const loadManifest = async (vaultDir: string): Promise<Manifest> => {
+  try {
+    const raw = await readFile(join(vaultDir, MANIFEST_FILENAME), "utf8")
+    const parsed = JSON.parse(raw) as Partial<Manifest>
+    if (parsed.version !== 1 || typeof parsed.entries !== "object" || parsed.entries === null) {
+      return emptyManifest()
+    }
+    return { version: 1, entries: parsed.entries as Record<string, ManifestEntry> }
+  } catch {
+    return emptyManifest()
+  }
+}
+
+const saveManifest = async (vaultDir: string, m: Manifest): Promise<void> => {
+  const abs = join(vaultDir, MANIFEST_FILENAME)
+  const tmp = `${abs}.tmp-${process.pid}-${Date.now()}`
+  await writeFile(tmp, `${JSON.stringify(m, null, 2)}\n`, "utf8")
+  await rename(tmp, abs)
+}
+
+export type R2SyncConfig = {
+  readonly bucket: string
+  // Command + args to invoke wrangler. Default: `pnpm dlx wrangler@latest`.
+  readonly wranglerCmd?: ReadonlyArray<string>
+  readonly concurrency?: number
+}
+
+export class R2SyncConfigTag extends Context.Tag("uebermensch/R2SyncConfig")<
+  R2SyncConfigTag,
+  R2SyncConfig
+>() {}
+
+const DEFAULT_CMD: ReadonlyArray<string> = ["pnpm", "dlx", "wrangler@latest"]
+
+const sha256Of = (buf: Buffer): string =>
+  createHash("sha256").update(buf).digest("hex")
+
+const walkMd = async (root: string, prefixes: ReadonlyArray<string>) => {
+  const out: Array<{ abs: string; key: string; size: number }> = []
+  for (const sub of prefixes) {
+    const start = join(root, sub)
+    try {
+      const entries = await readdir(start, { recursive: true, withFileTypes: true })
+      for (const e of entries) {
+        if (!e.isFile()) continue
+        if (!e.name.endsWith(".md")) continue
+        const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? start
+        const abs = join(parent, e.name)
+        const st = await stat(abs)
+        const key = relative(root, abs).split("/").join("/")
+        out.push({ abs, key, size: st.size })
+      }
+    } catch {
+      // prefix missing — skip
+    }
+  }
+  return out
+}
+
+type RunResult = { code: number; stdout: string; stderr: string }
+
+const runCmd = (cmd: string, args: ReadonlyArray<string>, opts: { input?: Buffer } = {}): Promise<RunResult> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, [...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    })
+    const outChunks: Array<Buffer> = []
+    const errChunks: Array<Buffer> = []
+    child.stdout.on("data", (d: Buffer) => outChunks.push(d))
+    child.stderr.on("data", (d: Buffer) => errChunks.push(d))
+    child.on("error", reject)
+    child.on("close", (code) =>
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(outChunks).toString("utf8"),
+        stderr: Buffer.concat(errChunks).toString("utf8"),
+      }),
+    )
+    if (opts.input) {
+      child.stdin.end(opts.input)
+    } else {
+      child.stdin.end()
+    }
+  })
+
+const putObject = async (
+  wrangler: ReadonlyArray<string>,
+  bucket: string,
+  key: string,
+  body: Buffer,
+): Promise<void> => {
+  const [cmd, ...base] = wrangler
+  if (!cmd) throw new Error("empty wrangler command")
+  const args = [
+    ...base,
+    "r2",
+    "object",
+    "put",
+    `${bucket}/${key}`,
+    "--pipe",
+    "--remote",
+    "--content-type",
+    "text/markdown; charset=utf-8",
+  ]
+  const res = await runCmd(cmd, args, { input: body })
+  if (res.code !== 0) {
+    throw new Error(
+      `wrangler r2 object put exited ${res.code}: ${res.stderr.trim() || res.stdout.trim()}`,
+    )
+  }
+}
+
+const syncErr = (
+  kind: SyncError["kind"],
+  message: string,
+  key?: string,
+): SyncError => new SyncError({ kind, message, key })
+
+const runSync = async (
+  cfg: R2SyncConfig,
+  input: SyncInput,
+  onProgress: (entry: SyncPlanEntry) => void,
+): Promise<SyncResult> => {
+  const wrangler = cfg.wranglerCmd ?? DEFAULT_CMD
+  const files = await walkMd(input.vaultDir, input.prefixes)
+  const manifest = input.force ? emptyManifest() : await loadManifest(input.vaultDir)
+  const nextManifest: Manifest = { version: 1, entries: { ...manifest.entries } }
+
+  const entries: Array<SyncPlanEntry> = []
+  let uploaded = 0
+  let skipped = 0
+  let failed = 0
+
+  const concurrency = cfg.concurrency ?? 3
+  let next = 0
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (true) {
+      const i = next
+      next += 1
+      if (i >= files.length) return
+      const f = files[i]
+      try {
+        const buf = await readFile(f.abs)
+        const sha = sha256Of(buf)
+        const prior = manifest.entries[f.key]
+        const unchanged = prior !== undefined && prior.sha256 === sha
+
+        if (unchanged && !input.force) {
+          const entry: SyncPlanEntry = {
+            absPath: f.abs,
+            key: f.key,
+            sizeBytes: f.size,
+            sha256: sha,
+            action: "skip",
+            remoteSha256: prior.sha256,
+          }
+          entries.push(entry)
+          onProgress(entry)
+          skipped += 1
+          continue
+        }
+
+        if (!input.dryRun) {
+          await putObject(wrangler, cfg.bucket, f.key, buf)
+          nextManifest.entries[f.key] = { sha256: sha, uploadedAt: new Date().toISOString() }
+        }
+        const entry: SyncPlanEntry = {
+          absPath: f.abs,
+          key: f.key,
+          sizeBytes: f.size,
+          sha256: sha,
+          action: "upload",
+          remoteSha256: prior?.sha256 ?? null,
+        }
+        entries.push(entry)
+        onProgress(entry)
+        uploaded += 1
+      } catch {
+        failed += 1
+      }
+    }
+  })
+  await Promise.all(workers)
+
+  if (!input.dryRun && (uploaded > 0 || Object.keys(manifest.entries).length === 0)) {
+    await saveManifest(input.vaultDir, nextManifest)
+  }
+  return { uploaded, skipped, failed, entries }
+}
+
+export const R2SyncLive = Layer.effect(
+  SyncService,
+  Effect.gen(function* () {
+    const cfg = yield* R2SyncConfigTag
+    return {
+      run: (input) =>
+        Effect.async<SyncResult, SyncError>((resume) => {
+          const log = (entry: SyncPlanEntry) => {
+            // Skipped files are silent by default — summary line shows the count.
+            // Show them in dry-run so the plan is auditable.
+            if (entry.action === "skip" && !input.dryRun) return
+            const tag = input.dryRun ? `[dry-run] ${entry.action}` : entry.action === "upload" ? "✓ upload" : "- skip"
+            // eslint-disable-next-line no-console
+            console.log(
+              `  ${tag} ${entry.key} (${entry.sizeBytes}B sha=${entry.sha256.slice(0, 12)}…)`,
+            )
+          }
+          runSync(cfg, input, log).then(
+            (r) => resume(Effect.succeed(r)),
+            (e) => resume(Effect.fail(syncErr("unreachable", `r2 sync failed: ${String(e)}`))),
+          )
+        }),
+    }
+  }),
+)
+
+export const R2SyncConfigFromEnv = Layer.effect(
+  R2SyncConfigTag,
+  Effect.gen(function* () {
+    const bucket = process.env.R2_BUCKET ?? "gctrl-vault"
+    const concurrency = Number(process.env.R2_SYNC_CONCURRENCY ?? "3")
+    const cfg: R2SyncConfig = {
+      bucket,
+      concurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 3,
+    }
+    return cfg
+  }),
+)

--- a/apps/uebermensch/src/adapters/R2Sync.ts
+++ b/apps/uebermensch/src/adapters/R2Sync.ts
@@ -235,15 +235,13 @@ export const R2SyncLive = Layer.effect(
   }),
 )
 
-export const R2SyncConfigFromEnv = Layer.effect(
-  R2SyncConfigTag,
-  Effect.gen(function* () {
-    const bucket = process.env.R2_BUCKET ?? "gctrl-vault"
-    const concurrency = Number(process.env.R2_SYNC_CONCURRENCY ?? "3")
-    const cfg: R2SyncConfig = {
-      bucket,
-      concurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 3,
-    }
-    return cfg
-  }),
-)
+const configFromEnv = (): R2SyncConfig => {
+  const bucket = process.env.R2_BUCKET ?? "gctrl-vault"
+  const concurrency = Number(process.env.R2_SYNC_CONCURRENCY ?? "3")
+  return {
+    bucket,
+    concurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : 3,
+  }
+}
+
+export const R2SyncConfigFromEnv = Layer.sync(R2SyncConfigTag, configFromEnv)

--- a/apps/uebermensch/src/adapters/StrictRenderer.ts
+++ b/apps/uebermensch/src/adapters/StrictRenderer.ts
@@ -6,6 +6,9 @@ import {
   type CuratedItem,
   type RenderInput,
   type RenderResult,
+  type ReportRenderInput,
+  type ReportRenderResult,
+  type ReportSectionInput,
 } from "../services/RendererService.js"
 
 const verifyItemCitations = (
@@ -85,6 +88,85 @@ const renderItem = (item: CuratedItem, idx: number): string => {
   return lines.join("\n")
 }
 
+const verifySectionCitations = (
+  section: ReportSectionInput,
+  sectionIdx: number,
+  vaultSlugs: ReadonlySet<string>,
+): CitationError | null => {
+  const links = extractLinks(section.summary_md)
+  for (const link of links) {
+    if (isTypedPrefix(link.target)) {
+      return new CitationError({
+        message: `section ${sectionIdx} (${section.interestSlug}): typed prefix forbidden in ${link.raw}`,
+        kind: "typed_prefix",
+        link: link.raw,
+        itemIndex: sectionIdx,
+      })
+    }
+    if (!vaultSlugs.has(link.target)) {
+      return new CitationError({
+        message: `section ${sectionIdx} (${section.interestSlug}): unresolved wikilink ${link.raw}`,
+        kind: "unresolved",
+        link: link.raw,
+        itemIndex: sectionIdx,
+      })
+    }
+  }
+  return null
+}
+
+const renderReportFrontmatter = (
+  input: ReportRenderInput,
+  sectionCount: number,
+  itemCount: number,
+  citedClaims: number,
+  totalClaims: number,
+): string =>
+  [
+    "---",
+    "page_type: report",
+    `slug: report-${input.periodLabel}`,
+    'kind: "weekly"',
+    `period_label: "${input.periodLabel}"`,
+    `period_start: "${input.periodStart}"`,
+    `period_end: "${input.periodEnd}"`,
+    `generator: "${input.generator}"`,
+    `model: "${input.model}"`,
+    `prompt_hash: "${input.promptHash}"`,
+    `cost_usd: ${input.costUsd}`,
+    `section_count: ${sectionCount}`,
+    `item_count: ${itemCount}`,
+    `cited_claims: ${citedClaims}`,
+    `total_claims: ${totalClaims}`,
+    `interests: ${yamlList(input.sections.map((s) => s.interestSlug))}`,
+    "---",
+  ].join("\n")
+
+const renderReportSection = (section: ReportSectionInput): string => {
+  const lines: Array<string> = []
+  lines.push(`## ${section.interestTitle}`)
+  lines.push("")
+  if (section.interestQuestion) {
+    lines.push(`> ${section.interestQuestion}`)
+    lines.push("")
+  }
+  lines.push(section.summary_md.trim())
+  if (section.items.length > 0) {
+    lines.push("")
+    section.items.forEach((item, idx) => {
+      lines.push(`### ${idx + 1}. ${item.title}`)
+      lines.push("")
+      lines.push(item.summary_md.trim())
+      if (item.suggested_action) {
+        lines.push("")
+        lines.push(`**Suggested action:** ${item.suggested_action.trim()}`)
+      }
+      lines.push("")
+    })
+  }
+  return lines.join("\n").trimEnd()
+}
+
 export const StrictRendererLive = Layer.succeed(RendererService, {
   render: (input) =>
     Effect.gen(function* () {
@@ -103,6 +185,42 @@ export const StrictRendererLive = Layer.succeed(RendererService, {
       const result: RenderResult = {
         markdown,
         itemCount: input.items.length,
+        citedClaims,
+        totalClaims,
+      }
+      return result
+    }),
+  renderReport: (input) =>
+    Effect.gen(function* () {
+      let sIdx = 0
+      for (const section of input.sections) {
+        const sErr = verifySectionCitations(section, sIdx, input.vaultSlugs)
+        if (sErr) return yield* Effect.fail(sErr)
+        const candidateIds = new Set(section.candidates.map((c) => c.id))
+        let iIdx = 0
+        for (const item of section.items) {
+          const err = verifyItemCitations(item, iIdx, input.vaultSlugs, candidateIds)
+          if (err) return yield* Effect.fail(err)
+          iIdx += 1
+        }
+        sIdx += 1
+      }
+      const body = input.sections.map(renderReportSection).join("\n\n")
+      const totalClaims = claimSentences(body)
+      const citedClaims = citedSentences(body)
+      const itemCount = input.sections.reduce((n, s) => n + s.items.length, 0)
+      const frontmatter = renderReportFrontmatter(
+        input,
+        input.sections.length,
+        itemCount,
+        citedClaims,
+        totalClaims,
+      )
+      const markdown = `${frontmatter}\n\n# Weekly research report — ${input.periodLabel}\n\n_Period ${input.periodStart} → ${input.periodEnd}_\n\n${body}\n`
+      const result: ReportRenderResult = {
+        markdown,
+        sectionCount: input.sections.length,
+        itemCount,
         citedClaims,
         totalClaims,
       }

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect"
 import { sha256 } from "../lib/hash.js"
-import { LlmService } from "../services/LlmService.js"
+import { LlmService, type ReportSection } from "../services/LlmService.js"
 import type { CuratedItem } from "../services/RendererService.js"
 
 const STUB_MODEL = "stub-llm@0.1"
@@ -62,6 +62,50 @@ export const StubLlmLive = Layer.succeed(LlmService, {
         items,
         topicsCovered,
         thesesCovered: [],
+        promptHash,
+        costUsd: 0,
+        model: STUB_MODEL,
+      }
+    }),
+  generateReport: (req) =>
+    Effect.sync(() => {
+      const candidateIds = req.interests.flatMap((it) => it.candidates.map((c) => c.id))
+      const prompt = [
+        "persona: uber-researcher/stub",
+        `period: ${req.periodLabel}`,
+        `profile: ${req.profileName}`,
+        `interests: ${req.interests.map((i) => i.slug).join(",")}`,
+        `candidates: ${candidateIds.join(",")}`,
+      ].join("\n")
+      const promptHash = sha256(prompt)
+      const sections: Array<ReportSection> = req.interests.map((it) => {
+        const top = [...it.candidates]
+          .sort((a, b) => b.score - a.score)
+          .slice(0, req.maxItemsPerInterest)
+        const items: Array<CuratedItem> = top.map((c) => {
+          const title =
+            (c.page.frontmatter.title as string | undefined) ?? c.page.stem
+          const pageTopics =
+            (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+          const topic = pageTopics[0] ?? null
+          return {
+            kind: "news",
+            title,
+            summary_md: `Stub summary for [[${c.page.stem}]].`,
+            topic,
+            thesis: null,
+            source_candidate_ids: [c.id],
+            suggested_action: null,
+          }
+        })
+        const summary_md =
+          items.length === 0
+            ? `No new candidates this week for ${it.title}.`
+            : `Stub weekly overview for ${it.title} covering ${items.length} item(s).`
+        return { interestSlug: it.slug, summary_md, items }
+      })
+      return {
+        sections,
         promptHash,
         costUsd: 0,
         model: STUB_MODEL,

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -4,10 +4,11 @@ import { Effect } from "effect"
 import { brief } from "../commands/brief.js"
 import { ingest } from "../commands/ingest.js"
 import { profile } from "../commands/profile-validate.js"
+import { send } from "../commands/send.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest]),
+  Command.withSubcommands([vault, profile, brief, ingest, send]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -4,11 +4,13 @@ import { Effect } from "effect"
 import { brief } from "../commands/brief.js"
 import { ingest } from "../commands/ingest.js"
 import { profile } from "../commands/profile-validate.js"
+import { report } from "../commands/report.js"
 import { send } from "../commands/send.js"
+import { sync } from "../commands/sync.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest, send]),
+  Command.withSubcommands([vault, profile, brief, ingest, send, report, sync]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/commands/brief.ts
+++ b/apps/uebermensch/src/commands/brief.ts
@@ -2,6 +2,7 @@ import { Command, Options } from "@effect/cli"
 import { Console, Effect, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
+import { KernelLlmLive } from "../adapters/KernelLlm.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
 import { selectCandidates } from "../lib/candidates.js"
@@ -31,6 +32,13 @@ const dryRunOpt = Options.boolean("dry-run").pipe(
   Options.withDefault(false),
 )
 
+const llmOpt = Options.choice("llm", ["kernel", "stub"]).pipe(
+  Options.withDescription(
+    "LLM backend: 'kernel' (real Claude via kernel /api/llm/messages) or 'stub'",
+  ),
+  Options.withDefault("kernel" as const),
+)
+
 const today = () => new Date().toISOString().slice(0, 10)
 
 const itemsForFormat = (format: "long" | "short" | "digest"): number => {
@@ -46,12 +54,18 @@ const itemsForFormat = (format: "long" | "short" | "digest"): number => {
 
 export const brief = Command.make(
   "brief",
-  { sinceHoursOpt, dateOpt, maxItemsOpt, dryRunOpt },
-  ({ sinceHoursOpt: sinceHours, dateOpt: dateOptVal, maxItemsOpt: maxItemsOptVal, dryRunOpt: dryRun }) =>
+  { sinceHoursOpt, dateOpt, maxItemsOpt, dryRunOpt, llmOpt },
+  ({
+    sinceHoursOpt: sinceHours,
+    dateOpt: dateOptVal,
+    maxItemsOpt: maxItemsOptVal,
+    dryRunOpt: dryRun,
+    llmOpt: llmKind,
+  }) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
       const date = Option.getOrElse(dateOptVal, today)
-      yield* Console.log(`generating brief for ${date} from ${vaultDir}`)
+      yield* Console.log(`generating brief for ${date} from ${vaultDir} (llm=${llmKind})`)
       const program = Effect.gen(function* () {
         const profileSvc = yield* ProfileService
         const vaultSvc = yield* VaultService
@@ -119,10 +133,11 @@ export const brief = Command.make(
         yield* Console.log("")
         yield* Console.log(rendered.markdown)
       })
+      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(FileSystemVaultLive(vaultDir)),
-        Effect.provide(StubLlmLive),
+        Effect.provide(llmLayer),
         Effect.provide(StrictRendererLive),
       )
     }),

--- a/apps/uebermensch/src/commands/ingest.ts
+++ b/apps/uebermensch/src/commands/ingest.ts
@@ -1,9 +1,11 @@
 import { Command, Options } from "@effect/cli"
-import { Console, Effect, Layer, Option } from "effect"
+import { Console, Effect, Either, Layer, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
+import { HttpFeedDefaultConfig, HttpFeedLive } from "../adapters/HttpFeed.js"
 import { HttpIngestDefaultConfig, HttpIngestLive } from "../adapters/HttpIngest.js"
 import { resolveVaultDir } from "../lib/env.js"
+import { FeedService } from "../services/FeedService.js"
 import { IngestService } from "../services/IngestService.js"
 import { ProfileService } from "../services/ProfileService.js"
 
@@ -70,7 +72,197 @@ const url = Command.make(
     }),
 ).pipe(Command.withDescription("Fetch a URL and write wiki/sources/<date>--<domain>.md"))
 
+const driverOpt = Options.text("driver").pipe(
+  Options.withDescription("Only ingest sources with this driver (default: rss)"),
+  Options.withDefault("rss"),
+)
+
+const sinceHoursOpt = Options.integer("since-hours").pipe(
+  Options.withDescription("Only ingest feed items published within the last N hours"),
+  Options.withDefault(168), // 7 days
+)
+
+const sourceSlugOpt = Options.text("source").pipe(
+  Options.withDescription("Restrict to a single source slug from sources.md"),
+  Options.optional,
+)
+
+const perFeedLimitOpt = Options.integer("limit").pipe(
+  Options.withDescription("Max items to ingest per feed"),
+  Options.withDefault(10),
+)
+
+const sourcesMinWordsOpt = Options.integer("min-words").pipe(
+  Options.withDescription("Reject ingested pages with fewer words (default 50)"),
+  Options.withDefault(50),
+)
+
+const sourcesOverwriteOpt = Options.boolean("overwrite").pipe(
+  Options.withDescription("Overwrite existing pages (default: skip on collision)"),
+  Options.withDefault(false),
+)
+
+const sourcesDryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Show what would be ingested without writing"),
+  Options.withDefault(false),
+)
+
+const sources = Command.make(
+  "sources",
+  {
+    driverOpt,
+    sinceHoursOpt,
+    sourceSlugOpt,
+    perFeedLimitOpt,
+    sourcesMinWordsOpt,
+    sourcesOverwriteOpt,
+    sourcesDryRunOpt,
+  },
+  ({
+    driverOpt: driver,
+    sinceHoursOpt: sinceHours,
+    sourceSlugOpt: onlySlugVal,
+    perFeedLimitOpt: limit,
+    sourcesMinWordsOpt: minWords,
+    sourcesOverwriteOpt: overwrite,
+    sourcesDryRunOpt: dryRun,
+  }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const onlySlug = Option.getOrNull(onlySlugVal)
+      const now = new Date()
+      const cutoff = new Date(now.getTime() - sinceHours * 3_600_000)
+      const date = now.toISOString().slice(0, 10)
+
+      yield* Console.log(
+        `ingesting sources from ${vaultDir} (driver=${driver}, since ${cutoff.toISOString()})`,
+      )
+
+      const program = Effect.gen(function* () {
+        const profileSvc = yield* ProfileService
+        const feedSvc = yield* FeedService
+        const ingestSvc = yield* IngestService
+        const profile = yield* profileSvc.load()
+
+        const allTopicSlugs = profile.topics.topics.map((t) => t.slug)
+        const topicWatchlists: Record<string, ReadonlyArray<string>> = {}
+        for (const t of profile.topics.topics) {
+          topicWatchlists[t.slug] = t.watchlist ?? []
+        }
+        const selected = profile.sources.sources.filter((s) => {
+          if (onlySlug !== null) return s.slug === onlySlug
+          return s.driver === driver
+        })
+        if (selected.length === 0) {
+          yield* Console.log(
+            onlySlug !== null
+              ? `  no source with slug "${onlySlug}"`
+              : `  no sources with driver=${driver}`,
+          )
+          return
+        }
+        yield* Console.log(`  ${selected.length} source(s) selected`)
+
+        let totalFetched = 0
+        let totalIngested = 0
+        let totalSkipped = 0
+        let totalFailed = 0
+
+        for (const src of selected) {
+          if (!src.url) {
+            yield* Console.log(`  - ${src.slug}: no url (driver=${src.driver}), skipping`)
+            continue
+          }
+          const fetched = yield* feedSvc.fetchFeed(src.url).pipe(
+            Effect.tap((f) =>
+              Console.log(`  - ${src.slug}: ${f.format} "${f.title}" — ${f.items.length} item(s)`),
+            ),
+            Effect.tapError((e) =>
+              Console.log(`  - ${src.slug}: feed fetch failed — ${e.kind}: ${e.message}`),
+            ),
+            Effect.either,
+          )
+          const feed = Either.getOrNull(fetched)
+          if (feed === null) {
+            totalFailed += 1
+            continue
+          }
+          const windowItems = feed.items.filter((it) => {
+            if (!it.link) return false
+            if (!it.publishedAt) return true // include undated items
+            return it.publishedAt >= cutoff
+          })
+          const batch = windowItems.slice(0, limit)
+          totalFetched += batch.length
+          yield* Console.log(
+            `    ${batch.length}/${windowItems.length} within window (limit=${limit})`,
+          )
+          for (const item of batch) {
+            if (dryRun) {
+              yield* Console.log(`    [dry-run] ${item.link}`)
+              continue
+            }
+            const result = yield* ingestSvc
+              .ingestUrl({
+                url: item.link,
+                date,
+                topicSlugs: allTopicSlugs,
+                minWordCount: minWords,
+                overwrite,
+                forceTopics: src.topics,
+                topicWatchlists,
+                descriptionFromFeed: item.description ?? undefined,
+              })
+              .pipe(
+                Effect.tap((r) =>
+                  Console.log(
+                    `    ✓ ${r.relPath} (${r.wordCount}w${r.paywalled ? ", paywalled" : ""}${r.bodySource === "rss_description" ? ", rss-desc" : ""}, topics=[${r.topicsMatched.join(", ")}])`,
+                  ),
+                ),
+                Effect.tapError((e) =>
+                  Console.log(`    ✗ ${item.link} — ${e.kind}: ${e.message}`),
+                ),
+                Effect.either,
+              )
+            Either.match(result, {
+              onLeft: (e) => {
+                if (e.kind === "collision") totalSkipped += 1
+                else totalFailed += 1
+              },
+              onRight: () => {
+                totalIngested += 1
+              },
+            })
+          }
+        }
+        yield* Console.log(
+          `\ntotals: fetched=${totalFetched} ingested=${totalIngested} skipped=${totalSkipped} failed=${totalFailed}`,
+        )
+      })
+
+      const vaultLayer = FileSystemVaultLive(vaultDir)
+      const ingestLayer = HttpIngestLive.pipe(
+        Layer.provide(Layer.mergeAll(vaultLayer, HttpIngestDefaultConfig)),
+      )
+      const feedLayer = HttpFeedLive.pipe(Layer.provide(HttpFeedDefaultConfig))
+      yield* program.pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            FileSystemProfileLive(vaultDir),
+            vaultLayer,
+            ingestLayer,
+            feedLayer,
+          ),
+        ),
+      )
+    }),
+).pipe(
+  Command.withDescription(
+    "Walk sources.md, fetch each feed, and ingest recent items through the source pipeline",
+  ),
+)
+
 export const ingest = Command.make("ingest").pipe(
-  Command.withSubcommands([url]),
+  Command.withSubcommands([url, sources]),
   Command.withDescription("Ingest external sources into the vault"),
 )

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -1,0 +1,362 @@
+import { Command, Options } from "@effect/cli"
+import { Console, Effect, Layer, Option } from "effect"
+import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
+import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
+import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
+import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
+import { StrictRendererLive } from "../adapters/StrictRenderer.js"
+import { StubLlmLive } from "../adapters/StubLlm.js"
+import { selectCandidates, type CandidateRef } from "../lib/candidates.js"
+import { resolveChannels } from "../lib/channels.js"
+import { publicReportUrl, resolveVaultDir } from "../lib/env.js"
+import { DelivererService } from "../services/DelivererService.js"
+import {
+  LlmService,
+  type ReportInterestInput,
+  type ReportSection,
+} from "../services/LlmService.js"
+import { ProfileService } from "../services/ProfileService.js"
+import {
+  RendererService,
+  type ReportSectionInput,
+} from "../services/RendererService.js"
+import { SyncService } from "../services/SyncService.js"
+import {
+  VaultService,
+  type ResearchInterest,
+  type WikiPage,
+} from "../services/VaultService.js"
+
+const sinceDaysOpt = Options.integer("since-days").pipe(
+  Options.withDescription("Lookback window in days (default 7)"),
+  Options.withDefault(7),
+)
+
+const dateOpt = Options.text("date").pipe(
+  Options.withDescription(
+    "Anchor date (YYYY-MM-DD) used to derive the ISO week label; defaults to today",
+  ),
+  Options.optional,
+)
+
+const maxItemsOpt = Options.integer("max-items-per-interest").pipe(
+  Options.withDescription("Cap items per research interest section"),
+  Options.withDefault(5),
+)
+
+const dryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Do not write the report file or send; print to stdout"),
+  Options.withDefault(false),
+)
+
+const sendOpt = Options.boolean("send").pipe(
+  Options.withDescription("After generating, deliver to enabled telegram/discord channels"),
+  Options.withDefault(false),
+)
+
+const syncOpt = Options.boolean("sync").pipe(
+  Options.withDescription(
+    "After writing, upload report + briefs + wiki/sources to R2 (auto-on when --send and UBER_PUBLIC_BASE_URL are set)",
+  ),
+  Options.withDefault(false),
+)
+
+const llmOpt = Options.choice("llm", ["kernel", "stub"]).pipe(
+  Options.withDescription(
+    "LLM backend: 'kernel' (real Claude via kernel /api/llm/messages) or 'stub'",
+  ),
+  Options.withDefault("kernel" as const),
+)
+
+const today = () => new Date().toISOString().slice(0, 10)
+
+const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`)
+
+const addDays = (d: Date, n: number): Date => {
+  const x = new Date(d)
+  x.setUTCDate(x.getUTCDate() + n)
+  return x
+}
+
+const toYmd = (d: Date): string =>
+  `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`
+
+// ISO 8601 week-numbering year + week
+const isoWeekLabel = (d: Date): { year: number; week: number; label: string } => {
+  const target = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  )
+  const day = target.getUTCDay() || 7
+  target.setUTCDate(target.getUTCDate() + 4 - day)
+  const yearStart = new Date(Date.UTC(target.getUTCFullYear(), 0, 1))
+  const week = Math.ceil(((target.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+  return {
+    year: target.getUTCFullYear(),
+    week,
+    label: `${target.getUTCFullYear()}-W${pad2(week)}`,
+  }
+}
+
+const filterPagesForInterest = (
+  pages: ReadonlyArray<WikiPage>,
+  interest: ResearchInterest,
+): ReadonlyArray<WikiPage> => {
+  const topicSet = new Set(interest.topics)
+  return pages.filter((p) => {
+    const pageTopics = (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+    return pageTopics.some((t) => topicSet.has(t))
+  })
+}
+
+const weightedTopicsFor = (
+  interest: ResearchInterest,
+  profileTopics: ReadonlyArray<{ slug: string; weight: number }>,
+): ReadonlyArray<{ slug: string; weight: number }> => {
+  const interestSet = new Set(interest.topics)
+  const boost = interest.weight ?? 1.0
+  return profileTopics
+    .filter((t) => interestSet.has(t.slug))
+    .map((t) => ({ slug: t.slug, weight: t.weight * boost }))
+}
+
+export const report = Command.make(
+  "report",
+  { sinceDaysOpt, dateOpt, maxItemsOpt, dryRunOpt, sendOpt, syncOpt, llmOpt },
+  ({
+    sinceDaysOpt: sinceDays,
+    dateOpt: dateOptVal,
+    maxItemsOpt: maxItems,
+    dryRunOpt: dryRun,
+    sendOpt: doSend,
+    syncOpt: doSyncOpt,
+    llmOpt: llmKind,
+  }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const anchor = Option.getOrElse(dateOptVal, today)
+      const anchorDate = new Date(`${anchor}T00:00:00Z`)
+      const { label: periodLabel } = isoWeekLabel(anchorDate)
+      const periodEnd = anchor
+      const periodStart = toYmd(addDays(anchorDate, -sinceDays))
+      yield* Console.log(
+        `generating weekly report ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind})`,
+      )
+
+      const program = Effect.gen(function* () {
+        const profileSvc = yield* ProfileService
+        const vaultSvc = yield* VaultService
+        const llm = yield* LlmService
+        const renderer = yield* RendererService
+        const profile = yield* profileSvc.load()
+
+        const interests = yield* vaultSvc.listResearchInterests()
+        if (interests.length === 0) {
+          yield* Console.log("  no research interests in research/ — nothing to report")
+          return
+        }
+        yield* Console.log(`  ${interests.length} research interest(s) loaded`)
+
+        // Cross-check interest topic/source slugs against profile (warn only).
+        const topicSlugs = new Set(profile.topics.topics.map((t) => t.slug))
+        const sourceSlugs = new Set(profile.sources.sources.map((s) => s.slug))
+        for (const it of interests) {
+          for (const t of it.topics) {
+            if (!topicSlugs.has(t)) {
+              yield* Console.log(
+                `  ! research/${it.slug}: references unknown topic '${t}' (not in topics.md)`,
+              )
+            }
+          }
+          for (const s of it.sources) {
+            if (!sourceSlugs.has(s)) {
+              yield* Console.log(
+                `  ! research/${it.slug}: references unknown source '${s}' (not in sources.md)`,
+              )
+            }
+          }
+        }
+
+        const windowHours = sinceDays * 24
+        const pages = yield* vaultSvc.recentlyChanged(windowHours)
+        const profileTopicWeights = profile.topics.topics.map((t) => ({
+          slug: t.slug,
+          weight: t.weight,
+        }))
+        const now = new Date()
+
+        const interestInputs: Array<
+          ReportInterestInput & { readonly candidates: ReadonlyArray<CandidateRef> }
+        > = interests.map((it) => {
+          const scoped = filterPagesForInterest(pages, it)
+          const weighted = weightedTopicsFor(it, profileTopicWeights)
+          const cands = selectCandidates({
+            pages: scoped,
+            topics: weighted,
+            thesesSlugs: [],
+            now,
+            windowHours,
+            maxCandidates: 20,
+          })
+          return {
+            slug: it.slug,
+            title: it.title,
+            question: it.question,
+            topics: it.topics,
+            notes: it.notes,
+            candidates: cands,
+          }
+        })
+
+        for (const ii of interestInputs) {
+          yield* Console.log(
+            `    ${ii.slug}: ${ii.candidates.length} candidate(s)`,
+          )
+        }
+
+        const response = yield* llm.generateReport({
+          periodLabel,
+          periodStart,
+          periodEnd,
+          profileName: profile.profile.identity.name,
+          interests: interestInputs,
+          maxItemsPerInterest: maxItems,
+        })
+
+        // Merge by slug so renderer has access to candidates per section.
+        const sectionBySlug = new Map<string, ReportSection>()
+        for (const s of response.sections) sectionBySlug.set(s.interestSlug, s)
+
+        const rendererSections: Array<ReportSectionInput> = interestInputs
+          .map((ii) => {
+            const s = sectionBySlug.get(ii.slug)
+            return {
+              interestSlug: ii.slug,
+              interestTitle: ii.title,
+              interestQuestion: ii.question,
+              summary_md: s?.summary_md?.trim() ?? "",
+              items: s?.items ?? [],
+              candidates: ii.candidates,
+            }
+          })
+          // Insight-only: drop sections the LLM chose to leave empty.
+          .filter((s) => s.summary_md.length > 0 || s.items.length > 0)
+
+        const vaultSlugs = yield* vaultSvc.listSlugs()
+        const rendered = yield* renderer.renderReport({
+          periodLabel,
+          periodStart,
+          periodEnd,
+          generator: llm.name(),
+          model: response.model,
+          promptHash: response.promptHash,
+          costUsd: response.costUsd,
+          profileName: profile.profile.identity.name,
+          sections: rendererSections,
+          vaultSlugs,
+        })
+
+        if (dryRun) {
+          yield* Console.log("(dry-run — not writing)")
+          yield* Console.log("")
+          yield* Console.log(rendered.markdown)
+          return
+        }
+
+        const written = yield* vaultSvc.writeReport(periodLabel, rendered.markdown)
+        yield* Console.log(
+          `✓ wrote ${written.relPath} (${written.contentHash}) — ${rendered.sectionCount} section(s), ${rendered.itemCount} item(s), ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
+        )
+
+        const reportUrl = publicReportUrl(periodLabel)
+        // Auto-sync when sending, so the URL in the delivered message resolves.
+        const doSync = doSyncOpt || (doSend && reportUrl !== null)
+        if (doSync) {
+          yield* Console.log(`syncing vault → R2 ...`)
+          const syncResult = yield* Effect.serviceOption(SyncService).pipe(
+            Effect.flatMap((maybe) =>
+              Option.match(maybe, {
+                onNone: () => Effect.succeed(null),
+                onSome: (sync) =>
+                  sync
+                    .run({
+                      vaultDir,
+                      prefixes: ["reports", "briefs", "wiki/sources"],
+                      dryRun: false,
+                      force: false,
+                    })
+                    .pipe(
+                      Effect.map((r) => r),
+                      Effect.catchTag("SyncError", (e) =>
+                        Console.log(`  ✗ sync failed (${e.kind}): ${e.message}`).pipe(
+                          Effect.as(null),
+                        ),
+                      ),
+                    ),
+              }),
+            ),
+          )
+          if (syncResult) {
+            yield* Console.log(
+              `  uploaded=${syncResult.uploaded} skipped=${syncResult.skipped} failed=${syncResult.failed}`,
+            )
+          }
+        }
+
+        if (!doSend) {
+          yield* Console.log("")
+          yield* Console.log(rendered.markdown)
+          return
+        }
+
+        const deliveryContent = reportUrl
+          ? `🌐 ${reportUrl}\n\n${rendered.markdown}`
+          : rendered.markdown
+
+        const deliverer = yield* DelivererService
+        const channels = yield* resolveChannels(
+          profile.profile.delivery.channels as Record<string, unknown>,
+          null,
+        )
+        yield* Console.log(`  ${channels.length} channel(s) to deliver`)
+        for (const ch of channels) {
+          const result = yield* deliverer
+            .send({
+              channel: ch.name,
+              driver: ch.driver,
+              targetRef: ch.targetRef,
+              silent: ch.silent,
+              content: deliveryContent,
+              briefDate: periodLabel,
+            })
+            .pipe(
+              Effect.tap((r) =>
+                Console.log(
+                  `  ✓ ${r.channel} (${r.driver}) — ${r.parts} part(s)${r.externalIds.length > 0 ? ` ids=${r.externalIds.join(",")}` : ""}`,
+                ),
+              ),
+              Effect.tapError((e) =>
+                Console.log(`  ✗ ${ch.name} (${ch.driver}) — ${e.kind}: ${e.message}`),
+              ),
+              Effect.either,
+            )
+          void result
+        }
+      })
+
+      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
+      const syncLayer = R2SyncLive.pipe(Layer.provide(R2SyncConfigFromEnv))
+      yield* program.pipe(
+        Effect.provide(FileSystemProfileLive(vaultDir)),
+        Effect.provide(FileSystemVaultLive(vaultDir)),
+        Effect.provide(llmLayer),
+        Effect.provide(StrictRendererLive),
+        Effect.provide(HttpDelivererLive),
+        Effect.provide(syncLayer),
+      )
+    }),
+).pipe(
+  Command.withDescription(
+    "Generate a weekly research report from research/ interests (optionally --send to channels)",
+  ),
+)

--- a/apps/uebermensch/src/commands/send.ts
+++ b/apps/uebermensch/src/commands/send.ts
@@ -1,12 +1,12 @@
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { Command, Options } from "@effect/cli"
-import { Console, Effect, Option, Schema } from "effect"
+import { Console, Effect, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
-import { DeliveryError, VaultError } from "../errors.js"
-import { resolveVaultDir } from "../lib/env.js"
-import { Channel } from "../schemas.js"
+import { VaultError } from "../errors.js"
+import { resolveChannels } from "../lib/channels.js"
+import { publicBriefUrl, resolveVaultDir } from "../lib/env.js"
 import { DelivererService } from "../services/DelivererService.js"
 import { ProfileService } from "../services/ProfileService.js"
 
@@ -26,51 +26,6 @@ const dryRunOpt = Options.boolean("dry-run").pipe(
 )
 
 const today = () => new Date().toISOString().slice(0, 10)
-
-type ResolvedChannel = {
-  readonly name: string
-  readonly driver: string
-  readonly targetRef: string
-  readonly silent: boolean
-}
-
-const resolveChannels = (
-  channelsRaw: Record<string, unknown>,
-  only: string | null,
-): Effect.Effect<ReadonlyArray<ResolvedChannel>, DeliveryError> =>
-  Effect.gen(function* () {
-    const resolved: Array<ResolvedChannel> = []
-    for (const [name, raw] of Object.entries(channelsRaw)) {
-      if (only !== null && name !== only) continue
-      const decoded = yield* Schema.decodeUnknown(Channel)(raw).pipe(
-        Effect.mapError(
-          (e) =>
-            new DeliveryError({
-              message: `channel ${name} invalid: ${String(e)}`,
-              channel: name,
-              kind: "config",
-            }),
-        ),
-      )
-      if (!decoded.enabled && only === null) continue
-      resolved.push({
-        name,
-        driver: decoded.driver,
-        targetRef: decoded.target_ref,
-        silent: decoded.silent ?? false,
-      })
-    }
-    if (only !== null && resolved.length === 0) {
-      return yield* Effect.fail(
-        new DeliveryError({
-          message: `no channel named "${only}" in profile.md`,
-          channel: only,
-          kind: "config",
-        }),
-      )
-    }
-    return resolved
-  })
 
 export const send = Command.make(
   "send",
@@ -113,6 +68,8 @@ export const send = Command.make(
           return
         }
 
+        const briefUrl = publicBriefUrl(date)
+        const deliveryContent = briefUrl ? `🌐 ${briefUrl}\n\n${content}` : content
         for (const ch of channels) {
           const result = yield* deliverer
             .send({
@@ -120,7 +77,7 @@ export const send = Command.make(
               driver: ch.driver,
               targetRef: ch.targetRef,
               silent: ch.silent,
-              content,
+              content: deliveryContent,
               briefDate: date,
             })
             .pipe(

--- a/apps/uebermensch/src/commands/send.ts
+++ b/apps/uebermensch/src/commands/send.ts
@@ -1,0 +1,148 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { Command, Options } from "@effect/cli"
+import { Console, Effect, Option, Schema } from "effect"
+import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
+import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
+import { DeliveryError, VaultError } from "../errors.js"
+import { resolveVaultDir } from "../lib/env.js"
+import { Channel } from "../schemas.js"
+import { DelivererService } from "../services/DelivererService.js"
+import { ProfileService } from "../services/ProfileService.js"
+
+const dateOpt = Options.text("date").pipe(
+  Options.withDescription("Brief date (YYYY-MM-DD); defaults to today"),
+  Options.optional,
+)
+
+const channelOpt = Options.text("channel").pipe(
+  Options.withDescription("Send to a specific channel name (bypasses enabled flag)"),
+  Options.optional,
+)
+
+const dryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Resolve channels + preview payload; skip HTTP"),
+  Options.withDefault(false),
+)
+
+const today = () => new Date().toISOString().slice(0, 10)
+
+type ResolvedChannel = {
+  readonly name: string
+  readonly driver: string
+  readonly targetRef: string
+  readonly silent: boolean
+}
+
+const resolveChannels = (
+  channelsRaw: Record<string, unknown>,
+  only: string | null,
+): Effect.Effect<ReadonlyArray<ResolvedChannel>, DeliveryError> =>
+  Effect.gen(function* () {
+    const resolved: Array<ResolvedChannel> = []
+    for (const [name, raw] of Object.entries(channelsRaw)) {
+      if (only !== null && name !== only) continue
+      const decoded = yield* Schema.decodeUnknown(Channel)(raw).pipe(
+        Effect.mapError(
+          (e) =>
+            new DeliveryError({
+              message: `channel ${name} invalid: ${String(e)}`,
+              channel: name,
+              kind: "config",
+            }),
+        ),
+      )
+      if (!decoded.enabled && only === null) continue
+      resolved.push({
+        name,
+        driver: decoded.driver,
+        targetRef: decoded.target_ref,
+        silent: decoded.silent ?? false,
+      })
+    }
+    if (only !== null && resolved.length === 0) {
+      return yield* Effect.fail(
+        new DeliveryError({
+          message: `no channel named "${only}" in profile.md`,
+          channel: only,
+          kind: "config",
+        }),
+      )
+    }
+    return resolved
+  })
+
+export const send = Command.make(
+  "send",
+  { dateOpt, channelOpt, dryRunOpt },
+  ({ dateOpt: dateOptVal, channelOpt: channelOptVal, dryRunOpt: dryRun }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const date = Option.getOrElse(dateOptVal, today)
+      const only = Option.getOrNull(channelOptVal)
+      const briefRel = `briefs/${date}.md`
+      const briefAbs = join(vaultDir, briefRel)
+      const content = yield* Effect.tryPromise({
+        try: () => readFile(briefAbs, "utf8"),
+        catch: () =>
+          new VaultError({
+            message: `brief not found: ${briefRel} (run \`uber brief --date ${date}\` first)`,
+            path: briefAbs,
+            kind: "not_found",
+          }),
+      })
+
+      yield* Console.log(`sending ${briefRel} from ${vaultDir}`)
+
+      const program = Effect.gen(function* () {
+        const profileSvc = yield* ProfileService
+        const deliverer = yield* DelivererService
+        const loaded = yield* profileSvc.load()
+        const channels = yield* resolveChannels(
+          loaded.profile.delivery.channels as Record<string, unknown>,
+          only,
+        )
+        yield* Console.log(`  ${channels.length} channel(s) to deliver`)
+
+        if (dryRun) {
+          for (const ch of channels) {
+            yield* Console.log(
+              `  [dry-run] ${ch.name} (driver=${ch.driver}, target=${ch.targetRef}, silent=${ch.silent})`,
+            )
+          }
+          return
+        }
+
+        for (const ch of channels) {
+          const result = yield* deliverer
+            .send({
+              channel: ch.name,
+              driver: ch.driver,
+              targetRef: ch.targetRef,
+              silent: ch.silent,
+              content,
+              briefDate: date,
+            })
+            .pipe(
+              Effect.tap((r) =>
+                Console.log(
+                  `  ✓ ${r.channel} (${r.driver}) — ${r.parts} part(s)${r.externalIds.length > 0 ? ` ids=${r.externalIds.join(",")}` : ""}`,
+                ),
+              ),
+              Effect.tapError((e) =>
+                Console.log(`  ✗ ${ch.name} (${ch.driver}) — ${e.kind}: ${e.message}`),
+              ),
+              Effect.either,
+            )
+          void result
+        }
+      })
+
+      yield* program.pipe(
+        Effect.provide(FileSystemProfileLive(vaultDir)),
+        Effect.provide(HttpDelivererLive),
+      )
+    }),
+).pipe(
+  Command.withDescription("Send a generated brief to configured channels (telegram, discord, app)"),
+)

--- a/apps/uebermensch/src/commands/sync.ts
+++ b/apps/uebermensch/src/commands/sync.ts
@@ -1,0 +1,54 @@
+import { Command, Options } from "@effect/cli"
+import { Console, Effect } from "effect"
+import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
+import { resolveVaultDir } from "../lib/env.js"
+import { SyncService } from "../services/SyncService.js"
+
+const dryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Show what would be uploaded without pushing"),
+  Options.withDefault(false),
+)
+
+const forceOpt = Options.boolean("force").pipe(
+  Options.withDescription("Ignore local sync manifest and re-upload everything"),
+  Options.withDefault(false),
+)
+
+const prefixesOpt = Options.text("prefixes").pipe(
+  Options.withDescription("Comma-separated vault subdirs to sync (default: reports,briefs,wiki/sources)"),
+  Options.withDefault("reports,briefs,wiki/sources"),
+)
+
+const r2 = Command.make(
+  "r2",
+  { dryRunOpt, forceOpt, prefixesOpt },
+  ({ dryRunOpt: dryRun, forceOpt: force, prefixesOpt: prefixesStr }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const prefixes = prefixesStr.split(",").map((s) => s.trim()).filter(Boolean)
+      yield* Console.log(
+        `syncing ${prefixes.join(", ")} from ${vaultDir} to R2 (dry-run=${dryRun})`,
+      )
+      const program = Effect.gen(function* () {
+        const sync = yield* SyncService
+        const result = yield* sync.run({ vaultDir, prefixes, dryRun, force })
+        // Progress is logged inside the adapter; just print the summary line.
+        yield* Console.log(
+          `\ntotals: uploaded=${result.uploaded} skipped=${result.skipped} failed=${result.failed}`,
+        )
+      })
+      yield* program.pipe(
+        Effect.provide(R2SyncLive),
+        Effect.provide(R2SyncConfigFromEnv),
+      )
+    }),
+).pipe(
+  Command.withDescription(
+    "Push reports/, briefs/, and wiki/sources/ to the R2 bucket (S3-compat; dedup via sha256 metadata)",
+  ),
+)
+
+export const sync = Command.make("sync").pipe(
+  Command.withSubcommands([r2]),
+  Command.withDescription("Sync vault content to external storage"),
+)

--- a/apps/uebermensch/src/errors.ts
+++ b/apps/uebermensch/src/errors.ts
@@ -32,3 +32,11 @@ export class IngestError extends Schema.TaggedError<IngestError>()("IngestError"
   kind: Schema.Literal("fetch_failed", "extract_failed", "low_quality", "collision", "io_failure"),
   url: Schema.optional(Schema.String),
 }) {}
+
+export class DeliveryError extends Schema.TaggedError<DeliveryError>()("DeliveryError", {
+  message: Schema.String,
+  channel: Schema.optional(Schema.String),
+  driver: Schema.optional(Schema.String),
+  kind: Schema.Literal("config", "unreachable", "rate_limited", "invalid", "io_failure"),
+  status: Schema.optional(Schema.Number),
+}) {}

--- a/apps/uebermensch/src/lib/candidates.ts
+++ b/apps/uebermensch/src/lib/candidates.ts
@@ -45,6 +45,11 @@ const spamPenalty = (page: WikiPage): number => {
   return Math.max(0, 1 - score)
 }
 
+const paywallPenalty = (page: WikiPage): number => {
+  const q = page.frontmatter.quality as { paywalled?: boolean } | undefined
+  return q?.paywalled === true ? 0.5 : 1.0
+}
+
 const thesisBoost = (
   page: WikiPage,
   thesesSlugs: ReadonlyArray<string>,
@@ -74,7 +79,13 @@ export const scorePrior = (
 ): number => {
   const base = topicWeightFor(page, topics)
   if (base === 0) return 0
-  return base * recencyDecay(page, now) * spamPenalty(page) * thesisBoost(page, thesesSlugs)
+  return (
+    base *
+    recencyDecay(page, now) *
+    spamPenalty(page) *
+    paywallPenalty(page) *
+    thesisBoost(page, thesesSlugs)
+  )
 }
 
 export const selectCandidates = (input: CandidateInput): ReadonlyArray<CandidateRef> => {

--- a/apps/uebermensch/src/lib/channels.ts
+++ b/apps/uebermensch/src/lib/channels.ts
@@ -1,0 +1,48 @@
+import { Effect, Schema } from "effect"
+import { DeliveryError } from "../errors.js"
+import { Channel } from "../schemas.js"
+
+export type ResolvedChannel = {
+  readonly name: string
+  readonly driver: string
+  readonly targetRef: string
+  readonly silent: boolean
+}
+
+export const resolveChannels = (
+  channelsRaw: Record<string, unknown>,
+  only: string | null,
+): Effect.Effect<ReadonlyArray<ResolvedChannel>, DeliveryError> =>
+  Effect.gen(function* () {
+    const resolved: Array<ResolvedChannel> = []
+    for (const [name, raw] of Object.entries(channelsRaw)) {
+      if (only !== null && name !== only) continue
+      const decoded = yield* Schema.decodeUnknown(Channel)(raw).pipe(
+        Effect.mapError(
+          (e) =>
+            new DeliveryError({
+              message: `channel ${name} invalid: ${String(e)}`,
+              channel: name,
+              kind: "config",
+            }),
+        ),
+      )
+      if (!decoded.enabled && only === null) continue
+      resolved.push({
+        name,
+        driver: decoded.driver,
+        targetRef: decoded.target_ref,
+        silent: decoded.silent ?? false,
+      })
+    }
+    if (only !== null && resolved.length === 0) {
+      return yield* Effect.fail(
+        new DeliveryError({
+          message: `no channel named "${only}" in profile.md`,
+          channel: only,
+          kind: "config",
+        }),
+      )
+    }
+    return resolved
+  })

--- a/apps/uebermensch/src/lib/env.ts
+++ b/apps/uebermensch/src/lib/env.ts
@@ -3,6 +3,23 @@ import { resolve } from "node:path"
 import { Effect } from "effect"
 import { VaultError } from "../errors.js"
 
+export const publicBaseUrl = (): string | null => {
+  const raw = process.env.UBER_PUBLIC_BASE_URL
+  if (!raw) return null
+  const trimmed = raw.trim().replace(/\/+$/, "")
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export const publicReportUrl = (slug: string): string | null => {
+  const base = publicBaseUrl()
+  return base ? `${base}/reports/${encodeURIComponent(slug)}` : null
+}
+
+export const publicBriefUrl = (date: string): string | null => {
+  const base = publicBaseUrl()
+  return base ? `${base}/briefs/${encodeURIComponent(date)}` : null
+}
+
 export const resolveVaultDir = () =>
   Effect.gen(function* () {
     const env = process.env.UBER_VAULT_DIR

--- a/apps/uebermensch/src/lib/html-extract.ts
+++ b/apps/uebermensch/src/lib/html-extract.ts
@@ -76,4 +76,27 @@ export const domainKebab = (url: string): string => {
   return host.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
 }
 
-export const slugForSource = (url: string, date: string): string => `${date}--${domainKebab(url)}`
+const kebab = (s: string): string =>
+  s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
+
+// Short, stable, deterministic 8-char hash of the URL for disambiguation.
+const urlHashShort = (url: string): string => {
+  let h = 2166136261 >>> 0 // FNV-1a 32-bit
+  for (let i = 0; i < url.length; i += 1) {
+    h ^= url.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h.toString(16).padStart(8, "0")
+}
+
+export const pathStem = (url: string): string => {
+  const u = new URL(url)
+  const parts = u.pathname.split("/").filter(Boolean)
+  const last = parts[parts.length - 1] ?? ""
+  const noExt = last.replace(/\.[a-z0-9]{1,6}$/i, "")
+  const stem = kebab(noExt).slice(0, 40)
+  return stem || urlHashShort(url)
+}
+
+export const slugForSource = (url: string, date: string): string =>
+  `${date}--${domainKebab(url)}--${pathStem(url)}`

--- a/apps/uebermensch/src/lib/rss.ts
+++ b/apps/uebermensch/src/lib/rss.ts
@@ -1,0 +1,147 @@
+import { XMLParser } from "fast-xml-parser"
+
+export type FeedItem = {
+  readonly title: string
+  readonly link: string
+  readonly publishedAt: Date | null
+  readonly guid: string | null
+  readonly description: string | null
+}
+
+export type FeedFormat = "rss2" | "atom" | "unknown"
+
+export type ParsedFeed = {
+  readonly format: FeedFormat
+  readonly title: string
+  readonly items: ReadonlyArray<FeedItem>
+}
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  parseAttributeValue: false,
+  trimValues: true,
+  cdataPropName: "#cdata",
+  textNodeName: "#text",
+})
+
+const asArray = <T>(v: T | ReadonlyArray<T> | undefined | null): ReadonlyArray<T> => {
+  if (v === undefined || v === null) return []
+  return Array.isArray(v) ? (v as ReadonlyArray<T>) : [v as T]
+}
+
+const textOf = (v: unknown): string => {
+  if (v === null || v === undefined) return ""
+  if (typeof v === "string") return v.trim()
+  if (typeof v === "number" || typeof v === "boolean") return String(v)
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>
+    if (typeof o["#cdata"] === "string") return (o["#cdata"] as string).trim()
+    if (typeof o["#text"] === "string") return (o["#text"] as string).trim()
+    // Atom <title type="html">…</title> often nests differently.
+    for (const key of Object.keys(o)) {
+      if (key.startsWith("@_")) continue
+      const t = textOf(o[key])
+      if (t) return t
+    }
+  }
+  return ""
+}
+
+const parseDate = (s: string | null | undefined): Date | null => {
+  if (!s) return null
+  const t = s.trim()
+  if (!t) return null
+  const d = new Date(t)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+const atomLink = (links: unknown): string => {
+  for (const l of asArray<unknown>(links as ReadonlyArray<unknown>)) {
+    if (typeof l === "string") return l.trim()
+    if (typeof l === "object" && l !== null) {
+      const o = l as Record<string, unknown>
+      const rel = (o["@_rel"] as string | undefined) ?? "alternate"
+      const href = (o["@_href"] as string | undefined) ?? textOf(l)
+      if (rel === "alternate" && href) return href.trim()
+    }
+  }
+  // Fallback: first link's href regardless of rel.
+  for (const l of asArray<unknown>(links as ReadonlyArray<unknown>)) {
+    if (typeof l === "object" && l !== null) {
+      const href = (l as Record<string, unknown>)["@_href"] as string | undefined
+      if (href) return href.trim()
+    }
+  }
+  return ""
+}
+
+const parseRss2 = (root: Record<string, unknown>): ParsedFeed => {
+  const channel = (root.channel as Record<string, unknown> | undefined) ?? {}
+  const items = asArray<Record<string, unknown>>(
+    channel.item as Record<string, unknown> | ReadonlyArray<Record<string, unknown>> | undefined,
+  ).map<FeedItem>((item) => {
+    const linkRaw = item.link
+    const link =
+      typeof linkRaw === "string"
+        ? linkRaw.trim()
+        : textOf(linkRaw) ||
+          (typeof linkRaw === "object" && linkRaw !== null
+            ? ((linkRaw as Record<string, unknown>)["@_href"] as string | undefined) ?? ""
+            : "")
+    const guidRaw = item.guid
+    const guid =
+      typeof guidRaw === "string"
+        ? guidRaw.trim()
+        : typeof guidRaw === "object" && guidRaw !== null
+          ? textOf(guidRaw)
+          : null
+    return {
+      title: textOf(item.title),
+      link,
+      publishedAt: parseDate(
+        textOf(item.pubDate) || textOf((item as Record<string, unknown>)["dc:date"]),
+      ),
+      guid: guid || null,
+      description: textOf(item.description) || null,
+    }
+  })
+  return {
+    format: "rss2",
+    title: textOf(channel.title),
+    items,
+  }
+}
+
+const parseAtom = (feed: Record<string, unknown>): ParsedFeed => {
+  const items = asArray<Record<string, unknown>>(
+    feed.entry as Record<string, unknown> | ReadonlyArray<Record<string, unknown>> | undefined,
+  ).map<FeedItem>((entry) => ({
+    title: textOf(entry.title),
+    link: atomLink(entry.link),
+    publishedAt: parseDate(textOf(entry.updated) || textOf(entry.published)),
+    guid: textOf(entry.id) || null,
+    description: textOf(entry.summary) || textOf(entry.content) || null,
+  }))
+  return {
+    format: "atom",
+    title: textOf(feed.title),
+    items,
+  }
+}
+
+export const parseFeed = (xml: string): ParsedFeed => {
+  let doc: Record<string, unknown>
+  try {
+    doc = parser.parse(xml) as Record<string, unknown>
+  } catch {
+    return { format: "unknown", title: "", items: [] }
+  }
+  const rss = doc.rss as Record<string, unknown> | undefined
+  if (rss) return parseRss2(rss)
+  const rdf = doc["rdf:RDF"] as Record<string, unknown> | undefined
+  if (rdf) return parseRss2(rdf) // RSS 1.0 items at top level — same shape
+  const feed = doc.feed as Record<string, unknown> | undefined
+  if (feed) return parseAtom(feed)
+  return { format: "unknown", title: "", items: [] }
+}

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -79,3 +79,13 @@ export const SourceEntry = Schema.Struct({
 export const SourcesConfig = Schema.Struct({
   sources: Schema.Array(SourceEntry).pipe(Schema.minItems(1)),
 })
+
+export const ResearchInterestFrontmatter = Schema.Struct({
+  slug: Slug,
+  title: Schema.String,
+  question: Schema.optional(Schema.String),
+  topics: Schema.Array(Slug).pipe(Schema.minItems(1)),
+  sources: Schema.optional(Schema.Array(Slug)),
+  horizon: Schema.optional(Schema.Literal("short", "long", "both")),
+  weight: Schema.optional(Schema.Number),
+})

--- a/apps/uebermensch/src/services/DelivererService.ts
+++ b/apps/uebermensch/src/services/DelivererService.ts
@@ -1,0 +1,27 @@
+import { Context, type Effect } from "effect"
+import type { DeliveryError } from "../errors.js"
+
+export type DeliveryResult = {
+  readonly channel: string
+  readonly driver: string
+  readonly externalIds: ReadonlyArray<string>
+  readonly parts: number
+}
+
+export type DeliverInput = {
+  readonly channel: string
+  readonly driver: string
+  readonly targetRef: string
+  readonly silent: boolean
+  readonly content: string
+  readonly briefDate: string
+}
+
+export interface DelivererServiceShape {
+  readonly send: (input: DeliverInput) => Effect.Effect<DeliveryResult, DeliveryError>
+}
+
+export class DelivererService extends Context.Tag("uebermensch/DelivererService")<
+  DelivererService,
+  DelivererServiceShape
+>() {}

--- a/apps/uebermensch/src/services/FeedService.ts
+++ b/apps/uebermensch/src/services/FeedService.ts
@@ -1,0 +1,19 @@
+import { Context, type Effect } from "effect"
+import type { IngestError } from "../errors.js"
+import type { FeedItem } from "../lib/rss.js"
+
+export type FetchedFeed = {
+  readonly url: string
+  readonly format: "rss2" | "atom" | "unknown"
+  readonly title: string
+  readonly items: ReadonlyArray<FeedItem>
+}
+
+export interface FeedServiceShape {
+  readonly fetchFeed: (url: string) => Effect.Effect<FetchedFeed, IngestError>
+}
+
+export class FeedService extends Context.Tag("uebermensch/FeedService")<
+  FeedService,
+  FeedServiceShape
+>() {}

--- a/apps/uebermensch/src/services/IngestService.ts
+++ b/apps/uebermensch/src/services/IngestService.ts
@@ -7,6 +7,16 @@ export type IngestUrlRequest = {
   readonly topicSlugs: ReadonlyArray<string>
   readonly minWordCount: number
   readonly overwrite: boolean
+  // Topics this source CAN cover (from sources.md). Used as a ceiling — the final
+  // set is (forceTopics ∩ classified). Pass undefined to skip the intersection and
+  // use classifier results alone (e.g. from manual `uber ingest url`).
+  readonly forceTopics?: ReadonlyArray<string>
+  // Per-topic watchlist terms from topics.md. Expanded during classification so
+  // a page matches `japan-macro` when its text mentions "boj", "yen", "jgb" etc.
+  readonly topicWatchlists?: Readonly<Record<string, ReadonlyArray<string>>>
+  // Free description/summary from the feed item (RSS <description> / Atom <summary>).
+  // Used as body when the fetched article turns out to be paywalled.
+  readonly descriptionFromFeed?: string
 }
 
 export type IngestedSource = {
@@ -18,6 +28,8 @@ export type IngestedSource = {
   readonly wordCount: number
   readonly topicsMatched: ReadonlyArray<string>
   readonly contentHash: string
+  readonly paywalled: boolean
+  readonly bodySource: "extracted" | "rss_description"
 }
 
 export interface IngestServiceShape {

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -21,9 +21,41 @@ export type BriefResponse = {
   readonly model: string
 }
 
+export type ReportInterestInput = {
+  readonly slug: string
+  readonly title: string
+  readonly question: string | null
+  readonly topics: ReadonlyArray<string>
+  readonly notes: string
+  readonly candidates: ReadonlyArray<CandidateRef>
+}
+
+export type ReportRequest = {
+  readonly periodLabel: string
+  readonly periodStart: string
+  readonly periodEnd: string
+  readonly profileName: string
+  readonly interests: ReadonlyArray<ReportInterestInput>
+  readonly maxItemsPerInterest: number
+}
+
+export type ReportSection = {
+  readonly interestSlug: string
+  readonly summary_md: string
+  readonly items: ReadonlyArray<CuratedItem>
+}
+
+export type ReportResponse = {
+  readonly sections: ReadonlyArray<ReportSection>
+  readonly promptHash: string
+  readonly costUsd: number
+  readonly model: string
+}
+
 export interface LlmServiceShape {
   readonly name: () => string
   readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>
+  readonly generateReport: (req: ReportRequest) => Effect.Effect<ReportResponse, LlmError>
 }
 
 export class LlmService extends Context.Tag("uebermensch/LlmService")<

--- a/apps/uebermensch/src/services/RendererService.ts
+++ b/apps/uebermensch/src/services/RendererService.ts
@@ -33,8 +33,41 @@ export type RenderResult = {
   readonly totalClaims: number
 }
 
+export type ReportSectionInput = {
+  readonly interestSlug: string
+  readonly interestTitle: string
+  readonly interestQuestion: string | null
+  readonly summary_md: string
+  readonly items: ReadonlyArray<CuratedItem>
+  readonly candidates: ReadonlyArray<CandidateRef>
+}
+
+export type ReportRenderInput = {
+  readonly periodLabel: string
+  readonly periodStart: string
+  readonly periodEnd: string
+  readonly generator: string
+  readonly model: string
+  readonly promptHash: string
+  readonly costUsd: number
+  readonly profileName: string
+  readonly sections: ReadonlyArray<ReportSectionInput>
+  readonly vaultSlugs: ReadonlySet<string>
+}
+
+export type ReportRenderResult = {
+  readonly markdown: string
+  readonly sectionCount: number
+  readonly itemCount: number
+  readonly citedClaims: number
+  readonly totalClaims: number
+}
+
 export interface RendererServiceShape {
   readonly render: (input: RenderInput) => Effect.Effect<RenderResult, CitationError>
+  readonly renderReport: (
+    input: ReportRenderInput,
+  ) => Effect.Effect<ReportRenderResult, CitationError>
 }
 
 export class RendererService extends Context.Tag("uebermensch/RendererService")<

--- a/apps/uebermensch/src/services/SyncService.ts
+++ b/apps/uebermensch/src/services/SyncService.ts
@@ -1,0 +1,41 @@
+import { Context, type Effect } from "effect"
+import { Schema } from "effect"
+
+export class SyncError extends Schema.TaggedError<SyncError>()("SyncError", {
+  message: Schema.String,
+  kind: Schema.Literal("config", "unreachable", "io_failure", "invalid"),
+  key: Schema.optional(Schema.String),
+}) {}
+
+export type SyncPlanEntry = {
+  readonly absPath: string
+  readonly key: string
+  readonly sizeBytes: number
+  readonly sha256: string
+  readonly action: "upload" | "skip"
+  readonly remoteSha256: string | null
+}
+
+export type SyncResult = {
+  readonly uploaded: number
+  readonly skipped: number
+  readonly failed: number
+  readonly entries: ReadonlyArray<SyncPlanEntry>
+}
+
+export type SyncInput = {
+  readonly vaultDir: string
+  readonly prefixes: ReadonlyArray<string>
+  readonly dryRun: boolean
+  // When true, bypass the local sha256 manifest and re-upload every file.
+  readonly force?: boolean
+}
+
+export interface SyncServiceShape {
+  readonly run: (input: SyncInput) => Effect.Effect<SyncResult, SyncError>
+}
+
+export class SyncService extends Context.Tag("uebermensch/SyncService")<
+  SyncService,
+  SyncServiceShape
+>() {}

--- a/apps/uebermensch/src/services/VaultService.ts
+++ b/apps/uebermensch/src/services/VaultService.ts
@@ -22,6 +22,24 @@ export type WrittenSource = {
   readonly existed: boolean
 }
 
+export type WrittenReport = {
+  readonly absPath: string
+  readonly relPath: string
+  readonly contentHash: string
+}
+
+export type ResearchInterest = {
+  readonly slug: string
+  readonly title: string
+  readonly question: string | null
+  readonly topics: ReadonlyArray<string>
+  readonly sources: ReadonlyArray<string>
+  readonly horizon: "short" | "long" | "both" | null
+  readonly weight: number | null
+  readonly notes: string
+  readonly relPath: string
+}
+
 export interface VaultServiceShape {
   readonly root: () => string
   readonly listWikiPages: () => Effect.Effect<ReadonlyArray<WikiPage>, VaultError>
@@ -29,6 +47,10 @@ export interface VaultServiceShape {
     sinceHours: number,
   ) => Effect.Effect<ReadonlyArray<WikiPage>, VaultError>
   readonly listSlugs: () => Effect.Effect<ReadonlySet<string>, VaultError>
+  readonly listResearchInterests: () => Effect.Effect<
+    ReadonlyArray<ResearchInterest>,
+    VaultError
+  >
   readonly writeBrief: (
     date: string,
     content: string,
@@ -38,6 +60,10 @@ export interface VaultServiceShape {
     content: string,
     options?: { readonly overwrite?: boolean },
   ) => Effect.Effect<WrittenSource, VaultError>
+  readonly writeReport: (
+    slug: string,
+    content: string,
+  ) => Effect.Effect<WrittenReport, VaultError>
 }
 
 export class VaultService extends Context.Tag("uebermensch/VaultService")<

--- a/apps/uebermensch/tests/fixtures/vault/research/example-interest.md
+++ b/apps/uebermensch/tests/fixtures/vault/research/example-interest.md
@@ -1,0 +1,15 @@
+---
+slug: example-interest
+title: Example research interest — edit me
+question: What should this interest track this week?
+topics:
+  - example-topic
+sources: []
+horizon: both
+weight: 1.0
+---
+
+# Example research interest
+
+Describe *why* you care and what signals to surface. References `topics[]` and
+`sources[]` by slug — do not redefine them here. Delete this file or rename it.

--- a/apps/uebermensch/tests/ingest.test.ts
+++ b/apps/uebermensch/tests/ingest.test.ts
@@ -59,10 +59,19 @@ describe("slug + domain helpers", () => {
     expect(domainKebab("https://www.Anthropic.COM/news/claude")).toBe("anthropic-com")
     expect(domainKebab("https://blog.example.co.uk/post")).toBe("blog-example-co-uk")
   })
-  it("slugForSource combines date + domain", () => {
-    expect(slugForSource("https://www.anthropic.com/news/x", "2026-04-20")).toBe(
-      "2026-04-20--anthropic-com",
+  it("slugForSource combines date + domain + path stem", () => {
+    expect(slugForSource("https://www.anthropic.com/news/claude-4-7", "2026-04-20")).toBe(
+      "2026-04-20--anthropic-com--claude-4-7",
     )
+  })
+  it("slugForSource disambiguates two paths on the same domain + date", () => {
+    const a = slugForSource("https://en.wikipedia.org/wiki/Bank_of_Japan", "2026-04-22")
+    const b = slugForSource("https://en.wikipedia.org/wiki/Aging_of_Japan", "2026-04-22")
+    expect(a).not.toBe(b)
+  })
+  it("slugForSource falls back to URL hash when path is empty", () => {
+    const s = slugForSource("https://example.com/", "2026-04-20")
+    expect(s).toMatch(/^2026-04-20--example-com--[0-9a-f]{8}$/)
   })
 })
 
@@ -113,8 +122,8 @@ describe("HttpIngest adapter", () => {
     expect(Exit.isSuccess(exit)).toBe(true)
     if (!Exit.isSuccess(exit)) return
     const res = exit.value
-    expect(res.slug).toBe("2026-04-20--example-com")
-    expect(res.relPath).toBe("wiki/sources/2026-04-20--example-com.md")
+    expect(res.slug).toBe("2026-04-20--example-com--big-story")
+    expect(res.relPath).toBe("wiki/sources/2026-04-20--example-com--big-story.md")
     expect(res.title).toBe("Big Story About AI")
     expect(res.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/)
     expect([...res.topicsMatched].sort()).toEqual(["ai", "markets"])
@@ -122,7 +131,7 @@ describe("HttpIngest adapter", () => {
     const onDisk = await readFile(join(dir, res.relPath), "utf8")
     const parsed = matter(onDisk)
     expect(parsed.data.page_type).toBe("source")
-    expect(parsed.data.slug).toBe("2026-04-20--example-com")
+    expect(parsed.data.slug).toBe("2026-04-20--example-com--big-story")
     expect(parsed.data.url).toBe(seedReq.url)
     expect(parsed.data.domain).toBe("example.com")
     expect((parsed.data.quality as { word_count: number }).word_count).toBeGreaterThan(10)

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -1,0 +1,189 @@
+import { Effect, Exit } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { KernelLlmLive, _internal } from "../src/adapters/KernelLlm.js"
+import type { CandidateRef } from "../src/lib/candidates.js"
+import { LlmService } from "../src/services/LlmService.js"
+import type { WikiPage } from "../src/services/VaultService.js"
+
+const { extractJson, buildUserPrompt, kernelBase, MODEL } = _internal
+
+const page = (stem: string, body: string, topics: ReadonlyArray<string> = []): WikiPage => ({
+  relPath: `wiki/sources/${stem}.md`,
+  stem,
+  frontmatter: { page_type: "source", slug: stem, topics },
+  body,
+  mtime: new Date("2026-04-20T12:00:00Z"),
+})
+
+const candidate = (id: string, stem: string, body: string, topics: ReadonlyArray<string> = []): CandidateRef => ({
+  id,
+  page: page(stem, body, topics),
+  score: 0.9,
+})
+
+const anthropicJson = (jsonBlock: unknown, usage = { input_tokens: 100, output_tokens: 200 }) => ({
+  model: MODEL,
+  usage,
+  content: [
+    {
+      type: "text",
+      text: `Some preamble.\n\n\`\`\`json\n${JSON.stringify(jsonBlock)}\n\`\`\`\n\nTrailing prose.`,
+    },
+  ],
+})
+
+describe("KernelLlm pure helpers", () => {
+  it("extracts fenced JSON from text", () => {
+    const out = extractJson('```json\n{"x": 1}\n```')
+    expect(out).toBe('{"x": 1}')
+  })
+
+  it("falls back to curly-brace slice when no fence", () => {
+    expect(extractJson('prose {"x": 1} more prose')).toBe('{"x": 1}')
+  })
+
+  it("returns null when no JSON at all", () => {
+    expect(extractJson("just prose, nothing else")).toBe(null)
+  })
+
+  it("prompt includes candidates with stems, ids, and topics", () => {
+    const prompt = buildUserPrompt({
+      date: "2026-04-22",
+      profileName: "Test",
+      topics: ["alpha", "beta"],
+      thesesSlugs: [],
+      candidates: [
+        candidate("cand-0000", "2026-04-18--foo", "Foo body text.", ["alpha"]),
+        candidate("cand-0001", "2026-04-18--bar", "Bar body text.", ["beta"]),
+      ],
+      maxItems: 5,
+    })
+    expect(prompt).toContain("cand-0000")
+    expect(prompt).toContain("2026-04-18--foo")
+    expect(prompt).toContain("cand-0001")
+    expect(prompt).toContain("topics: [alpha, beta]")
+    expect(prompt).toContain("maxItems: 5")
+    expect(prompt).toContain("Foo body text")
+  })
+})
+
+describe("KernelLlm generateBrief (kernel-routed)", () => {
+  const originalFetch = globalThis.fetch
+  const prevKernel = process.env.GCTRL_KERNEL_URL
+
+  beforeEach(() => {
+    process.env.GCTRL_KERNEL_URL = "http://kernel.test"
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.env.GCTRL_KERNEL_URL = prevKernel
+  })
+
+  it("POSTs to kernel /api/llm/messages and decodes items", async () => {
+    const payload = anthropicJson({
+      items: [
+        {
+          kind: "news",
+          title: "Foo happened",
+          summary_md: "Important thing in [[2026-04-18--foo]].",
+          topic: "alpha",
+          thesis: null,
+          source_candidate_ids: ["cand-0000"],
+          suggested_action: null,
+        },
+      ],
+      topicsCovered: ["alpha"],
+      thesesCovered: [],
+    })
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const res = await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.generateBrief({
+          date: "2026-04-22",
+          profileName: "Test",
+          topics: ["alpha"],
+          thesesSlugs: [],
+          candidates: [candidate("cand-0000", "2026-04-18--foo", "Foo body text.", ["alpha"])],
+          maxItems: 3,
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+
+    expect(res.items).toHaveLength(1)
+    expect(res.items[0].title).toBe("Foo happened")
+    expect(res.items[0].source_candidate_ids).toEqual(["cand-0000"])
+    expect(res.topicsCovered).toEqual(["alpha"])
+    expect(res.model).toBe(MODEL)
+    // 100 * $5/M input + 200 * $25/M output = $0.0005 + $0.005 = $0.0055
+    expect(res.costUsd).toBeCloseTo(0.0055, 6)
+    expect(res.promptHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(`${kernelBase()}/api/llm/messages`)
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.model).toBe(MODEL)
+    expect(body.thinking).toEqual({ type: "adaptive" })
+    expect(body.system).toContain("uebermensch-curator")
+    expect(body.messages[0].role).toBe("user")
+    expect(body.messages[0].content).toContain("cand-0000")
+  })
+
+  it("fails with unavailable when kernel returns 503", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "ANTHROPIC_API_KEY not configured",
+    }) as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.generateBrief({
+          date: "2026-04-22",
+          profileName: "Test",
+          topics: [],
+          thesesSlugs: [],
+          candidates: [],
+          maxItems: 3,
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("fails with invalid when response text has no JSON", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          model: MODEL,
+          content: [{ type: "text", text: "just prose, no object here" }],
+        }),
+    }) as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.generateBrief({
+          date: "2026-04-22",
+          profileName: "Test",
+          topics: [],
+          thesesSlugs: [],
+          candidates: [],
+          maxItems: 3,
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+})

--- a/apps/uebermensch/tests/paywall.test.ts
+++ b/apps/uebermensch/tests/paywall.test.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Exit, Layer } from "effect"
+import matter from "gray-matter"
+import { describe, expect, it } from "vitest"
+import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import {
+  classifyTopics,
+  detectPaywall,
+  HttpIngestConfigTag,
+  HttpIngestLive,
+} from "../src/adapters/HttpIngest.js"
+import { IngestService } from "../src/services/IngestService.js"
+
+const mkFetch = (body: string, status = 200): typeof fetch =>
+  (async () =>
+    new Response(body, { status, headers: { "content-type": "text/html" } })) as unknown as typeof fetch
+
+describe("detectPaywall", () => {
+  it("flags FT-style teaser boilerplate", () => {
+    const body = `Prudential extends Japan pause.
+
+Subscribe to unlock this article
+
+Try unlimited access
+Only S$1 for 4 weeks`
+    const r = detectPaywall(body)
+    expect(r.paywalled).toBe(true)
+  })
+  it("flags Bloomberg-style sign-in wall", () => {
+    const body = "Lede paragraph...\n\nSign in to read the rest."
+    expect(detectPaywall(body).paywalled).toBe(true)
+  })
+  it("does not flag clean article body", () => {
+    const body =
+      "The Bank of Japan raised its policy rate to 0.75% today, Governor Ueda announced. Markets reacted with a sharp move in the yen."
+    expect(detectPaywall(body).paywalled).toBe(false)
+  })
+})
+
+describe("classifyTopics with watchlist expansion", () => {
+  const watchlists = {
+    "japan-macro": ["boj", "ueda", "yen", "usd-jpy", "jgb"],
+    "japan-aging-healthcare": ["mhlw", "pmda", "dementia-care"],
+    "us-midterms-2026": ["midterms-2026", "nrcc", "dccc", "redistricting"],
+  }
+  const topicSlugs = Object.keys(watchlists)
+
+  it("matches japan-macro via watchlist term 'boj'", () => {
+    const hits = classifyTopics("The BoJ held rates steady.", topicSlugs, watchlists)
+    expect(hits).toContain("japan-macro")
+    expect(hits).not.toContain("japan-aging-healthcare")
+  })
+  it("matches multi-word watchlist terms like 'usd-jpy'", () => {
+    const hits = classifyTopics("USD/JPY touched 155 overnight.", topicSlugs, watchlists)
+    expect(hits).toContain("japan-macro")
+  })
+  it("uses word-boundary — 'us' inside 'usual' does not match", () => {
+    const wl = { "us-politics": ["us"] }
+    const hits = classifyTopics("Usual market volatility persists.", ["us-politics"], wl)
+    expect(hits).not.toContain("us-politics")
+  })
+  it("falls back to slug-as-phrase when no watchlist", () => {
+    const hits = classifyTopics("A semiconductors story", ["semiconductors"], {})
+    expect(hits).toContain("semiconductors")
+  })
+  it("returns empty when nothing matches", () => {
+    expect(classifyTopics("Weather is nice.", topicSlugs, watchlists)).toEqual([])
+  })
+})
+
+describe("HttpIngest paywall → RSS description fallback", () => {
+  it("uses RSS description when extracted body is paywalled", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-paywall-"))
+    const paywalledHtml = `
+<html><head><title>Prudential extends Japan sales pause</title></head>
+<body><article>
+<p>Prudential extends Japan sales pause after mis-selling scandal.</p>
+<p>Subscribe to unlock this article</p>
+<p>Try unlimited access</p>
+<p>Only S$1 for 4 weeks. Then S$99 per month. Complete digital access.</p>
+</article></body></html>`
+    const description =
+      "Prudential Financial has extended its sales suspension in Japan following a mis-selling scandal, deepening the distribution disruption for its life insurance and annuity products with Japanese retail savers. The FSA is expected to require broader conduct remediation."
+
+    const program = Effect.gen(function* () {
+      const svc = yield* IngestService
+      return yield* svc.ingestUrl({
+        url: "https://www.ft.com/content/prudential-japan",
+        date: "2026-04-22",
+        topicSlugs: ["japan-aging-healthcare"],
+        minWordCount: 20,
+        overwrite: false,
+        descriptionFromFeed: description,
+        topicWatchlists: { "japan-aging-healthcare": ["prudential", "mis-selling", "life insurance"] },
+      })
+    }).pipe(
+      Effect.provide(
+        HttpIngestLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              FileSystemVaultLive(dir),
+              Layer.succeed(HttpIngestConfigTag, { fetch: mkFetch(paywalledHtml) }),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    const exit = await Effect.runPromiseExit(program)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (!Exit.isSuccess(exit)) return
+    const res = exit.value
+    expect(res.paywalled).toBe(true)
+    expect(res.bodySource).toBe("rss_description")
+    expect(res.topicsMatched).toEqual(["japan-aging-healthcare"])
+
+    const onDisk = await readFile(join(dir, res.relPath), "utf8")
+    const parsed = matter(onDisk)
+    const quality = parsed.data.quality as { paywalled?: boolean; body_source?: string }
+    expect(quality.paywalled).toBe(true)
+    expect(quality.body_source).toBe("rss_description")
+    // Body should contain the description, NOT the paywall boilerplate.
+    expect(parsed.content).toContain("Prudential Financial has extended")
+    expect(parsed.content).not.toContain("Only S$1 for 4 weeks")
+  })
+
+  it("keeps extracted body when not paywalled", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-nopaywall-"))
+    const html = `
+<html><head><title>BoJ holds rates</title></head>
+<body><article>
+<p>The Bank of Japan held its policy rate at 0.75% today. Governor Ueda cited persistent inflation. Traders priced in a later hike. Yen weakened to 156.</p>
+</article></body></html>`
+    const program = Effect.gen(function* () {
+      const svc = yield* IngestService
+      return yield* svc.ingestUrl({
+        url: "https://example.com/news/boj",
+        date: "2026-04-22",
+        topicSlugs: ["japan-macro"],
+        minWordCount: 10,
+        overwrite: false,
+        descriptionFromFeed: "ignored short teaser",
+        topicWatchlists: { "japan-macro": ["boj", "ueda", "yen"] },
+      })
+    }).pipe(
+      Effect.provide(
+        HttpIngestLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              FileSystemVaultLive(dir),
+              Layer.succeed(HttpIngestConfigTag, { fetch: mkFetch(html) }),
+            ),
+          ),
+        ),
+      ),
+    )
+    const exit = await Effect.runPromiseExit(program)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (!Exit.isSuccess(exit)) return
+    expect(exit.value.paywalled).toBe(false)
+    expect(exit.value.bodySource).toBe("extracted")
+    expect(exit.value.topicsMatched).toEqual(["japan-macro"])
+  })
+
+  it("rejects with low_quality when paywalled AND no useful description", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-paywall-lowq-"))
+    const paywalledHtml = `
+<html><head><title>Some FT article</title></head>
+<body><article>
+<p>Lede.</p>
+<p>Subscribe to unlock this article</p>
+<p>Try unlimited access</p>
+</article></body></html>`
+    const program = Effect.gen(function* () {
+      const svc = yield* IngestService
+      return yield* svc.ingestUrl({
+        url: "https://www.ft.com/content/x",
+        date: "2026-04-22",
+        topicSlugs: ["japan-macro"],
+        minWordCount: 100,
+        overwrite: false,
+        descriptionFromFeed: "too short",
+      })
+    }).pipe(
+      Effect.provide(
+        HttpIngestLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              FileSystemVaultLive(dir),
+              Layer.succeed(HttpIngestConfigTag, { fetch: mkFetch(paywalledHtml) }),
+            ),
+          ),
+        ),
+      ),
+    )
+    const exit = await Effect.runPromiseExit(program)
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("narrows topics to forceTopics ∩ classified", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-narrow-"))
+    // Article about yen only; feed covers [japan-macro, us-politics, sg-property] — only japan-macro should survive.
+    const html = `
+<html><head><title>Yen moves</title></head>
+<body><article>
+<p>The yen weakened to 156 as the BoJ held rates. Ueda's press conference gave no new guidance.</p>
+<p>Traders now price a later move. JGB yields flat.</p>
+</article></body></html>`
+    const program = Effect.gen(function* () {
+      const svc = yield* IngestService
+      return yield* svc.ingestUrl({
+        url: "https://news.example.com/yen",
+        date: "2026-04-22",
+        topicSlugs: ["japan-macro", "us-politics", "sg-property"],
+        minWordCount: 10,
+        overwrite: false,
+        forceTopics: ["japan-macro", "us-politics", "sg-property"],
+        topicWatchlists: {
+          "japan-macro": ["boj", "yen", "ueda", "jgb"],
+          "us-politics": ["trump", "congress", "fomc"],
+          "sg-property": ["hdb", "mas", "cooling-measures-sg"],
+        },
+      })
+    }).pipe(
+      Effect.provide(
+        HttpIngestLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              FileSystemVaultLive(dir),
+              Layer.succeed(HttpIngestConfigTag, { fetch: mkFetch(html) }),
+            ),
+          ),
+        ),
+      ),
+    )
+    const exit = await Effect.runPromiseExit(program)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (!Exit.isSuccess(exit)) return
+    expect(exit.value.topicsMatched).toEqual(["japan-macro"])
+  })
+})

--- a/apps/uebermensch/tests/report.test.ts
+++ b/apps/uebermensch/tests/report.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Layer } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import { StrictRendererLive } from "../src/adapters/StrictRenderer.js"
+import { StubLlmLive } from "../src/adapters/StubLlm.js"
+import { selectCandidates } from "../src/lib/candidates.js"
+import { LlmService } from "../src/services/LlmService.js"
+import {
+  RendererService,
+  type ReportSectionInput,
+} from "../src/services/RendererService.js"
+import { VaultService } from "../src/services/VaultService.js"
+
+const seedPage = async (root: string, rel: string, frontmatter: string, body: string) => {
+  const full = join(root, rel)
+  await mkdir(join(full, ".."), { recursive: true })
+  await writeFile(full, `---\n${frontmatter}---\n\n${body}\n`, "utf8")
+}
+
+describe("weekly report (research interests + stub LLM + strict renderer)", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-vault-"))
+    await seedPage(
+      vaultDir,
+      "research/japan-macro.md",
+      'slug: japan-macro\ntitle: Japan macro\nquestion: "What is moving BoJ?"\ntopics: [japan-macro]\n',
+      "# Japan macro interest",
+    )
+    await seedPage(
+      vaultDir,
+      "research/us-midterms-2026.md",
+      'slug: us-midterms-2026\ntitle: US 2026 midterms\nquestion: "Which races are shifting?"\ntopics: [us-midterms-2026]\n',
+      "# US midterms interest",
+    )
+    await seedPage(
+      vaultDir,
+      "wiki/sources/2026-04-22--wikipedia-boj.md",
+      "page_type: source\nslug: 2026-04-22--wikipedia-boj\ntitle: Bank of Japan\ntopics: [japan-macro]\n",
+      "# BoJ\n\nThe BoJ held its policy rate steady.",
+    )
+    await seedPage(
+      vaultDir,
+      "wiki/sources/2026-04-22--wikipedia-2026-senate.md",
+      "page_type: source\nslug: 2026-04-22--wikipedia-2026-senate\ntitle: 2026 Senate\ntopics: [us-midterms-2026]\n",
+      "# 2026 Senate\n\n33 Class 2 seats plus 2 specials are on the 2026 ballot.",
+    )
+  })
+
+  it("lists interests, scopes candidates per interest, and renders a report", async () => {
+    const program = Effect.gen(function* () {
+      const vault = yield* VaultService
+      const llm = yield* LlmService
+      const renderer = yield* RendererService
+      const interests = yield* vault.listResearchInterests()
+      expect(interests.map((i) => i.slug).sort()).toEqual([
+        "japan-macro",
+        "us-midterms-2026",
+      ])
+      const pages = yield* vault.recentlyChanged(24)
+      const now = new Date()
+
+      const inputs = interests.map((it) => {
+        const topicSet = new Set(it.topics)
+        const scoped = pages.filter((p) => {
+          const pt =
+            (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+          return pt.some((t) => topicSet.has(t))
+        })
+        const cands = selectCandidates({
+          pages: scoped,
+          topics: it.topics.map((t) => ({ slug: t, weight: 1 })),
+          thesesSlugs: [],
+          now,
+          windowHours: 24,
+          maxCandidates: 10,
+        })
+        return {
+          slug: it.slug,
+          title: it.title,
+          question: it.question,
+          topics: it.topics,
+          notes: it.notes,
+          candidates: cands,
+        }
+      })
+      // Each interest sees only its own candidate.
+      for (const ii of inputs) expect(ii.candidates).toHaveLength(1)
+
+      const response = yield* llm.generateReport({
+        periodLabel: "2026-W17",
+        periodStart: "2026-04-15",
+        periodEnd: "2026-04-22",
+        profileName: "Test",
+        interests: inputs,
+        maxItemsPerInterest: 3,
+      })
+      expect(response.sections).toHaveLength(2)
+
+      const bySlug = new Map(response.sections.map((s) => [s.interestSlug, s]))
+      const sections: Array<ReportSectionInput> = inputs.map((ii) => {
+        const s = bySlug.get(ii.slug)!
+        return {
+          interestSlug: ii.slug,
+          interestTitle: ii.title,
+          interestQuestion: ii.question,
+          summary_md: s.summary_md,
+          items: s.items,
+          candidates: ii.candidates,
+        }
+      })
+
+      const vaultSlugs = yield* vault.listSlugs()
+      const rendered = yield* renderer.renderReport({
+        periodLabel: "2026-W17",
+        periodStart: "2026-04-15",
+        periodEnd: "2026-04-22",
+        generator: llm.name(),
+        model: response.model,
+        promptHash: response.promptHash,
+        costUsd: response.costUsd,
+        profileName: "Test",
+        sections,
+        vaultSlugs,
+      })
+      return yield* vault.writeReport("2026-W17", rendered.markdown)
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(FileSystemVaultLive(vaultDir), StubLlmLive, StrictRendererLive),
+      ),
+    )
+
+    const written = await Effect.runPromise(program)
+    expect(written.relPath).toBe("reports/2026-W17.md")
+    const onDisk = await readFile(join(vaultDir, written.relPath), "utf8")
+    expect(onDisk).toContain("page_type: report")
+    expect(onDisk).toContain("slug: report-2026-W17")
+    expect(onDisk).toContain("[[2026-04-22--wikipedia-boj]]")
+    expect(onDisk).toContain("[[2026-04-22--wikipedia-2026-senate]]")
+    expect(onDisk).toContain("## Japan macro")
+    expect(onDisk).toContain("## US 2026 midterms")
+  })
+})

--- a/apps/uebermensch/tests/rss.test.ts
+++ b/apps/uebermensch/tests/rss.test.ts
@@ -1,0 +1,308 @@
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Context, Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { FileSystemProfileLive } from "../src/adapters/FileSystemProfile.js"
+import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import { HttpFeedConfigTag, HttpFeedLive } from "../src/adapters/HttpFeed.js"
+import { HttpIngestConfigTag, HttpIngestLive } from "../src/adapters/HttpIngest.js"
+import { parseFeed } from "../src/lib/rss.js"
+import { FeedService } from "../src/services/FeedService.js"
+import { IngestService } from "../src/services/IngestService.js"
+
+const rss2Fixture = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>Test Feed</title>
+  <link>https://news.example.com/</link>
+  <description>Sample</description>
+  <item>
+    <title><![CDATA[BoJ holds rates at 0.75%]]></title>
+    <link>https://news.example.com/2026/04/22/boj-holds</link>
+    <guid isPermaLink="true">https://news.example.com/2026/04/22/boj-holds</guid>
+    <pubDate>Wed, 22 Apr 2026 07:00:00 GMT</pubDate>
+    <description>The Bank of Japan held its policy rate.</description>
+  </item>
+  <item>
+    <title>Senate recruiting heats up in Michigan</title>
+    <link>https://news.example.com/2026/04/21/mi-senate</link>
+    <pubDate>Tue, 21 Apr 2026 12:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Ancient news</title>
+    <link>https://news.example.com/2024/01/01/ancient</link>
+    <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+  </item>
+</channel></rss>`
+
+const atomFixture = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>MHLW releases LTCI premium update</title>
+    <link rel="alternate" href="https://mhlw.example.jp/press/1" />
+    <id>tag:mhlw.example.jp,2026:press/1</id>
+    <updated>2026-04-22T08:00:00Z</updated>
+    <summary>Ministry updates long-term care insurance premiums.</summary>
+  </entry>
+  <entry>
+    <title>Another entry</title>
+    <link rel="alternate" href="https://mhlw.example.jp/press/2" />
+    <updated>2026-04-19T00:00:00Z</updated>
+  </entry>
+</feed>`
+
+describe("parseFeed", () => {
+  it("parses RSS 2.0 with CDATA titles and dated items", () => {
+    const parsed = parseFeed(rss2Fixture)
+    expect(parsed.format).toBe("rss2")
+    expect(parsed.title).toBe("Test Feed")
+    expect(parsed.items).toHaveLength(3)
+    expect(parsed.items[0].title).toBe("BoJ holds rates at 0.75%")
+    expect(parsed.items[0].link).toBe("https://news.example.com/2026/04/22/boj-holds")
+    expect(parsed.items[0].publishedAt?.toISOString()).toBe("2026-04-22T07:00:00.000Z")
+    expect(parsed.items[2].publishedAt?.getUTCFullYear()).toBe(2024)
+  })
+  it("parses Atom with rel=alternate links", () => {
+    const parsed = parseFeed(atomFixture)
+    expect(parsed.format).toBe("atom")
+    expect(parsed.title).toBe("Atom Feed")
+    expect(parsed.items).toHaveLength(2)
+    expect(parsed.items[0].link).toBe("https://mhlw.example.jp/press/1")
+    expect(parsed.items[0].publishedAt?.toISOString()).toBe("2026-04-22T08:00:00.000Z")
+  })
+  it("returns unknown format for garbage", () => {
+    expect(parseFeed("not xml").format).toBe("unknown")
+  })
+})
+
+type MockFetchMap = Record<string, { body: string; status?: number; headers?: Record<string, string> }>
+
+const makeFetch = (map: MockFetchMap): typeof fetch =>
+  (async (input: unknown) => {
+    const url = typeof input === "string" ? input : (input as URL).toString()
+    const hit = map[url]
+    if (!hit) return new Response("not found", { status: 404 })
+    return new Response(hit.body, {
+      status: hit.status ?? 200,
+      headers: hit.headers ?? { "content-type": "application/xml" },
+    })
+  }) as unknown as typeof fetch
+
+const htmlFor = (title: string, body: string) => `
+<!doctype html><html><head><title>${title}</title></head>
+<body><article><h1>${title}</h1>${body
+  .split("\n")
+  .map((p) => `<p>${p}</p>`)
+  .join("")}</article></body></html>`
+
+const mkVault = async () => {
+  const dir = await mkdtemp(join(tmpdir(), "uber-rss-"))
+  await mkdir(join(dir, "wiki"), { recursive: true })
+  await mkdir(join(dir, "theses"), { recursive: true })
+  await writeFile(
+    join(dir, "profile.md"),
+    `---
+schema_version: 1
+identity: { name: "T", slug: "t", tz: "UTC", lang: "en" }
+budgets: { daily_usd: 1, per_brief_usd: 0.5 }
+delivery:
+  brief: { cron: "0 0 * * *", format: "short" }
+  channels: {}
+---
+`,
+    "utf8",
+  )
+  await writeFile(
+    join(dir, "topics.md"),
+    `---
+topics:
+  - slug: japan-macro
+    title: Japan macro
+    horizon: both
+    weight: 1.0
+  - slug: us-midterms-2026
+    title: US midterms
+    horizon: both
+    weight: 1.0
+---
+`,
+    "utf8",
+  )
+  await writeFile(
+    join(dir, "sources.md"),
+    `---
+sources:
+  - slug: test-rss
+    driver: rss
+    url: https://feeds.example.com/combined.xml
+    cadence: "0 */30 * * * *"
+    topics: [japan-macro, us-midterms-2026]
+  - slug: manual-only
+    driver: manual
+    cadence: "@never"
+    topics: [japan-macro]
+---
+`,
+    "utf8",
+  )
+  return dir
+}
+
+// Thin helper to count ingested files under wiki/sources/
+const countSources = async (dir: string): Promise<number> => {
+  try {
+    const entries = await readdir(join(dir, "wiki", "sources"))
+    return entries.filter((e) => e.endsWith(".md")).length
+  } catch {
+    return 0
+  }
+}
+
+describe("feed → ingest acceptance", () => {
+  it("fetches a feed, filters by window, forces topics, and writes pages", async () => {
+    const dir = await mkVault()
+    const cutoff = new Date("2026-04-20T00:00:00Z") // items before this get filtered
+    const mockFetch = makeFetch({
+      "https://feeds.example.com/combined.xml": { body: rss2Fixture },
+      "https://news.example.com/2026/04/22/boj-holds": {
+        body: htmlFor("BoJ holds rates", "BoJ held the policy rate steady.\nYen reacted modestly."),
+      },
+      "https://news.example.com/2026/04/21/mi-senate": {
+        body: htmlFor("Senate MI", "Michigan Senate race competitive.\nGOP recruit announced."),
+      },
+      "https://news.example.com/2024/01/01/ancient": {
+        body: htmlFor("Old", "ancient content.\npadding for word count."),
+      },
+    })
+
+    const program = Effect.gen(function* () {
+      const feedSvc = yield* FeedService
+      const ingestSvc = yield* IngestService
+      const feed = yield* feedSvc.fetchFeed("https://feeds.example.com/combined.xml")
+      expect(feed.items).toHaveLength(3)
+      const recent = feed.items.filter(
+        (it) => it.publishedAt && it.publishedAt >= cutoff,
+      )
+      expect(recent).toHaveLength(2)
+      const out: Array<string> = []
+      for (const item of recent) {
+        const r = yield* ingestSvc.ingestUrl({
+          url: item.link,
+          date: "2026-04-22",
+          topicSlugs: ["japan-macro", "us-midterms-2026"],
+          minWordCount: 5,
+          overwrite: false,
+          forceTopics: ["japan-macro", "us-midterms-2026"],
+        })
+        out.push(r.slug)
+      }
+      return out
+    })
+    const layer = Layer.mergeAll(
+      FileSystemProfileLive(dir),
+      FileSystemVaultLive(dir),
+      HttpFeedLive.pipe(
+        Layer.provide(Layer.succeed(HttpFeedConfigTag, { fetch: mockFetch })),
+      ),
+      HttpIngestLive.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            FileSystemVaultLive(dir),
+            Layer.succeed(HttpIngestConfigTag, { fetch: mockFetch }),
+          ),
+        ),
+      ),
+    )
+    const slugs = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(slugs).toHaveLength(2)
+    expect(slugs.every((s) => s.startsWith("2026-04-22--news-example-com--"))).toBe(true)
+    expect(await countSources(dir)).toBe(2)
+  })
+
+  it("second pass over the same feed results in zero new pages (dedup on collision)", async () => {
+    const dir = await mkVault()
+    const mockFetch = makeFetch({
+      "https://feeds.example.com/combined.xml": { body: rss2Fixture },
+      "https://news.example.com/2026/04/22/boj-holds": {
+        body: htmlFor("BoJ holds rates", "BoJ held the policy rate steady.\npadding padding padding."),
+      },
+      "https://news.example.com/2026/04/21/mi-senate": {
+        body: htmlFor("Senate MI", "Michigan Senate race competitive.\npadding padding padding."),
+      },
+    })
+    const runOnce = Effect.gen(function* () {
+      const feedSvc = yield* FeedService
+      const ingestSvc = yield* IngestService
+      const feed = yield* feedSvc.fetchFeed("https://feeds.example.com/combined.xml")
+      const results: Array<string> = []
+      for (const item of feed.items) {
+        if (!item.link) continue
+        const r = yield* ingestSvc
+          .ingestUrl({
+            url: item.link,
+            date: "2026-04-22",
+            topicSlugs: ["japan-macro", "us-midterms-2026"],
+            minWordCount: 3,
+            overwrite: false,
+            forceTopics: ["japan-macro"],
+          })
+          .pipe(
+            Effect.map((r) => ({ kind: "ok" as const, slug: r.slug })),
+            Effect.catchTag("IngestError", (e) =>
+              Effect.succeed({ kind: e.kind, slug: null as string | null }),
+            ),
+          )
+        results.push(r.kind)
+      }
+      return results
+    })
+    const layer = Layer.mergeAll(
+      FileSystemProfileLive(dir),
+      FileSystemVaultLive(dir),
+      HttpFeedLive.pipe(
+        Layer.provide(Layer.succeed(HttpFeedConfigTag, { fetch: mockFetch })),
+      ),
+      HttpIngestLive.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            FileSystemVaultLive(dir),
+            Layer.succeed(HttpIngestConfigTag, { fetch: mockFetch }),
+          ),
+        ),
+      ),
+    )
+
+    const first = await Effect.runPromise(runOnce.pipe(Effect.provide(layer)))
+    const firstOk = first.filter((k) => k === "ok").length
+    expect(firstOk).toBeGreaterThanOrEqual(2) // two recent + maybe ancient (no window here)
+    const countAfterFirst = await countSources(dir)
+
+    const second = await Effect.runPromise(runOnce.pipe(Effect.provide(layer)))
+    const secondOk = second.filter((k) => k === "ok").length
+    const secondCollisions = second.filter((k) => k === "collision").length
+    expect(secondOk).toBe(0)
+    expect(secondCollisions).toBeGreaterThanOrEqual(2)
+    expect(await countSources(dir)).toBe(countAfterFirst)
+  })
+
+  it("feed fetch failure surfaces an IngestError and does not blow up", async () => {
+    const dir = await mkVault()
+    const mockFetch = makeFetch({}) // all URLs 404
+    const program = Effect.gen(function* () {
+      const feedSvc = yield* FeedService
+      return yield* feedSvc.fetchFeed("https://feeds.example.com/combined.xml").pipe(
+        Effect.map(() => "ok" as const),
+        Effect.catchTag("IngestError", (e) => Effect.succeed(e.kind)),
+      )
+    })
+    const layer = HttpFeedLive.pipe(
+      Layer.provide(Layer.succeed(HttpFeedConfigTag, { fetch: mockFetch })),
+    )
+    const out = await Effect.runPromise(program.pipe(Effect.provide(layer)))
+    expect(out).toBe("fetch_failed")
+  })
+})
+
+// Silence unused-import warning in isolatedModules mode.
+void Context

--- a/apps/uebermensch/tests/send.test.ts
+++ b/apps/uebermensch/tests/send.test.ts
@@ -1,0 +1,166 @@
+import { Effect, Exit } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { HttpDelivererLive, _internal } from "../src/adapters/HttpDeliverer.js"
+import { DelivererService } from "../src/services/DelivererService.js"
+
+const { splitChunks, stripFrontmatter, resolveEnvRef, kernelBase } = _internal
+
+describe("HttpDeliverer pure helpers", () => {
+  it("splits long content on line boundaries", () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n")
+    const chunks = splitChunks(lines, 30)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(30)
+    expect(chunks.join("\n")).toBe(lines)
+  })
+
+  it("returns one chunk when content fits", () => {
+    expect(splitChunks("short", 100)).toEqual(["short"])
+  })
+
+  it("strips YAML frontmatter", () => {
+    const md = "---\nfoo: bar\n---\n\n# Title\n\nBody"
+    expect(stripFrontmatter(md)).toBe("# Title\n\nBody")
+  })
+
+  it("leaves body-only markdown unchanged", () => {
+    expect(stripFrontmatter("# Title\n\nBody")).toBe("# Title\n\nBody")
+  })
+
+  it("resolves env-backed target refs", () => {
+    process.env.TEST_CHAT_ID = "42"
+    expect(resolveEnvRef("tg:chat:env:TEST_CHAT_ID", "tg:chat:")).toBe("42")
+    expect(resolveEnvRef("tg:chat:123", "tg:chat:")).toBe("123")
+    expect(resolveEnvRef("dc:webhook:https://x", "tg:chat:")).toBe(null)
+    delete process.env.TEST_CHAT_ID
+  })
+
+  it("strips trailing slash from GCTRL_KERNEL_URL", () => {
+    const prev = process.env.GCTRL_KERNEL_URL
+    process.env.GCTRL_KERNEL_URL = "http://kernel.local:4318/"
+    expect(kernelBase()).toBe("http://kernel.local:4318")
+    process.env.GCTRL_KERNEL_URL = prev
+  })
+})
+
+describe("HttpDeliverer send (kernel-routed)", () => {
+  const originalFetch = globalThis.fetch
+  const prevKernel = process.env.GCTRL_KERNEL_URL
+
+  beforeEach(() => {
+    process.env.GCTRL_KERNEL_URL = "http://kernel.test"
+    process.env.TEST_CHAT_ID = "99"
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.env.GCTRL_KERNEL_URL = prevKernel
+    delete process.env.TEST_CHAT_ID
+  })
+
+  it("POSTs telegram to kernel driver and returns external id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, message_id: 777 }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "---\nx: 1\n---\n\n# Brief\n\nhi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(HttpDelivererLive)),
+    )
+
+    expect(result.externalIds).toEqual(["777"])
+    expect(result.parts).toBe(1)
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("http://kernel.test/api/telegram/send")
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.chat_id).toBe("99")
+    expect(body.text).toBe("# Brief\n\nhi")
+    expect(body.disable_notification).toBe(false)
+  })
+
+  it("POSTs discord to kernel driver with webhook url in body", async () => {
+    process.env.TEST_WEBHOOK = "https://discord.com/api/webhooks/1/abc"
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "discord_feed",
+          driver: "discord",
+          targetRef: "dc:webhook:env:TEST_WEBHOOK",
+          silent: false,
+          content: "hello",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(HttpDelivererLive)),
+    )
+
+    expect(result.parts).toBe(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe("http://kernel.test/api/discord/send")
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.webhook_url).toBe("https://discord.com/api/webhooks/1/abc")
+    expect(body.content).toBe("hello")
+    delete process.env.TEST_WEBHOOK
+  })
+
+  it("surfaces kernel 503 as config error", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "TELEGRAM_BOT_TOKEN not configured",
+    }) as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(HttpDelivererLive)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("fails with config error when telegram target_ref env var is empty", async () => {
+    delete process.env.TEST_CHAT_ID
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(HttpDelivererLive)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+})

--- a/apps/uebermensch/tests/send.test.ts
+++ b/apps/uebermensch/tests/send.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { HttpDelivererLive, _internal } from "../src/adapters/HttpDeliverer.js"
 import { DelivererService } from "../src/services/DelivererService.js"
 
-const { splitChunks, stripFrontmatter, resolveEnvRef, kernelBase } = _internal
+const { splitChunks, splitBrief, stripFrontmatter, resolveEnvRef, kernelBase } = _internal
 
 describe("HttpDeliverer pure helpers", () => {
   it("splits long content on line boundaries", () => {
@@ -40,6 +40,59 @@ describe("HttpDeliverer pure helpers", () => {
     process.env.GCTRL_KERNEL_URL = "http://kernel.local:4318/"
     expect(kernelBase()).toBe("http://kernel.local:4318")
     process.env.GCTRL_KERNEL_URL = prev
+  })
+})
+
+describe("splitBrief (item-boundary chunking)", () => {
+  const sampleBrief = [
+    "---",
+    "page_type: brief",
+    "slug: brief-2026-04-22",
+    "---",
+    "",
+    "# Daily brief — 2026-04-22",
+    "",
+    "## 1. First item",
+    "",
+    "Summary of first item with [[some-page]].",
+    "",
+    "## 2. Second item",
+    "",
+    "Summary of second item.",
+    "",
+    "## 3. Third item",
+    "",
+    "Summary of third item.",
+  ].join("\n")
+
+  it("splits a brief into one chunk per numbered item", () => {
+    const chunks = splitBrief(sampleBrief, 3800)
+    expect(chunks).toHaveLength(3)
+    expect(chunks[0]).toMatch(/^## 1\. First item/)
+    expect(chunks[1]).toMatch(/^## 2\. Second item/)
+    expect(chunks[2]).toMatch(/^## 3\. Third item/)
+  })
+
+  it("drops frontmatter and the top-level H1", () => {
+    const chunks = splitBrief(sampleBrief, 3800)
+    for (const c of chunks) {
+      expect(c).not.toContain("page_type: brief")
+      expect(c).not.toContain("# Daily brief")
+    }
+  })
+
+  it("falls back to byte-chunking when no item headings are present", () => {
+    const raw = "plain markdown with no item headings at all, just prose"
+    expect(splitBrief(raw, 3800)).toEqual([raw])
+  })
+
+  it("sub-chunks an overlong item on line boundaries", () => {
+    const bigLines = Array.from({ length: 100 }, (_, i) => `line ${i}`).join("\n")
+    const md = `## 1. Big item\n\n${bigLines}\n\n## 2. Small item\n\nhi`
+    const chunks = splitBrief(md, 200)
+    expect(chunks.length).toBeGreaterThan(2)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(200)
+    expect(chunks[chunks.length - 1]).toMatch(/^## 2\. Small item/)
   })
 })
 

--- a/apps/uebermensch/tests/sync.test.ts
+++ b/apps/uebermensch/tests/sync.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { R2SyncConfigTag, R2SyncLive } from "../src/adapters/R2Sync.js"
+import { SyncService } from "../src/services/SyncService.js"
+
+// A fake wrangler that writes its stdin to a log file so we can count uploads
+// without hitting the network.
+const makeFakeWrangler = async (logDir: string) => {
+  const log = join(logDir, "fake-wrangler.log")
+  const script = join(logDir, "fake-wrangler.js")
+  await writeFile(
+    script,
+    `#!/usr/bin/env node
+const fs = require('node:fs')
+const chunks = []
+process.stdin.on('data', (d) => chunks.push(d))
+process.stdin.on('end', () => {
+  fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({argv: process.argv.slice(2), bytes: Buffer.concat(chunks).length}) + '\\n')
+  process.exit(0)
+})
+`,
+    { mode: 0o755 },
+  )
+  return { cmd: ["node", script] as const, log }
+}
+
+const seedVault = async (dir: string) => {
+  await mkdir(join(dir, "reports"), { recursive: true })
+  await mkdir(join(dir, "wiki", "sources"), { recursive: true })
+  await writeFile(join(dir, "reports", "2026-W17.md"), "# Weekly\n", "utf8")
+  await writeFile(join(dir, "wiki", "sources", "a.md"), "# A\n", "utf8")
+  await writeFile(join(dir, "wiki", "sources", "b.md"), "# B\n", "utf8")
+}
+
+const runSync = (vaultDir: string, wranglerCmd: ReadonlyArray<string>, opts: { force?: boolean; dryRun?: boolean } = {}) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const sync = yield* SyncService
+      return yield* sync.run({
+        vaultDir,
+        prefixes: ["reports", "wiki/sources"],
+        dryRun: opts.dryRun ?? false,
+        force: opts.force ?? false,
+      })
+    }).pipe(
+      Effect.provide(
+        R2SyncLive.pipe(
+          Layer.provide(
+            Layer.succeed(R2SyncConfigTag, {
+              bucket: "gctrl-vault-test",
+              wranglerCmd,
+              concurrency: 2,
+            }),
+          ),
+        ),
+      ),
+    ),
+  )
+
+describe("R2 sync dedup via local manifest", () => {
+  it("first run uploads every file; second run skips all", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-sync-"))
+    await seedVault(dir)
+    const { cmd, log } = await makeFakeWrangler(dir)
+
+    const first = await runSync(dir, cmd)
+    expect(first.uploaded).toBe(3)
+    expect(first.skipped).toBe(0)
+    expect(first.failed).toBe(0)
+
+    const logContents1 = await readFile(log, "utf8")
+    expect(logContents1.trim().split("\n")).toHaveLength(3)
+
+    const manifest = JSON.parse(
+      await readFile(join(dir, ".uber-sync-state.json"), "utf8"),
+    )
+    expect(manifest.version).toBe(1)
+    expect(Object.keys(manifest.entries)).toHaveLength(3)
+
+    const second = await runSync(dir, cmd)
+    expect(second.uploaded).toBe(0)
+    expect(second.skipped).toBe(3)
+    expect(second.failed).toBe(0)
+
+    // No new wrangler invocations.
+    const logContents2 = await readFile(log, "utf8")
+    expect(logContents2.trim().split("\n")).toHaveLength(3)
+  })
+
+  it("re-uploads only files whose sha256 changed", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-sync-"))
+    await seedVault(dir)
+    const { cmd, log } = await makeFakeWrangler(dir)
+
+    await runSync(dir, cmd) // seed manifest
+
+    await writeFile(join(dir, "reports", "2026-W17.md"), "# Weekly — edited\n", "utf8")
+
+    const second = await runSync(dir, cmd)
+    expect(second.uploaded).toBe(1)
+    expect(second.skipped).toBe(2)
+    expect(second.failed).toBe(0)
+
+    const logLines = (await readFile(log, "utf8")).trim().split("\n")
+    // 3 (initial) + 1 (re-upload edited file) = 4
+    expect(logLines).toHaveLength(4)
+  })
+
+  it("--force bypasses the manifest and re-uploads everything", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-sync-"))
+    await seedVault(dir)
+    const { cmd, log } = await makeFakeWrangler(dir)
+
+    await runSync(dir, cmd)
+
+    const forced = await runSync(dir, cmd, { force: true })
+    expect(forced.uploaded).toBe(3)
+    expect(forced.skipped).toBe(0)
+
+    const logLines = (await readFile(log, "utf8")).trim().split("\n")
+    expect(logLines).toHaveLength(6) // 3 + 3
+  })
+
+  it("--dry-run uploads nothing and does not write the manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-sync-"))
+    await seedVault(dir)
+    const { cmd, log } = await makeFakeWrangler(dir)
+
+    const result = await runSync(dir, cmd, { dryRun: true })
+    expect(result.uploaded).toBe(3) // would-be uploads counted
+    expect(result.skipped).toBe(0)
+
+    // Fake wrangler not invoked.
+    const logExists = await readFile(log, "utf8").catch(() => "")
+    expect(logExists).toBe("")
+
+    // No manifest written (nothing to track yet).
+    const hasManifest = await readFile(join(dir, ".uber-sync-state.json"), "utf8").then(
+      () => true,
+      () => false,
+    )
+    expect(hasManifest).toBe(false)
+  })
+})

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -149,6 +149,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Wrangler driver (LKM — delegates to native `wrangler` CLI)
         .route("/api/wrangler/whoami", get(wrangler_whoami))
         .route("/api/wrangler/exec", post(wrangler_exec_passthrough))
+        // Messaging drivers (LKM — outbound to Telegram Bot API and Discord webhooks)
+        .route("/api/telegram/send", post(telegram_send))
+        .route("/api/discord/send", post(discord_send))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -2540,6 +2543,114 @@ async fn net_screenshot(
         }))
         .into_response(),
         Err(e) => (net_error_status(&e), e.to_string()).into_response(),
+    }
+}
+
+// --- Messaging Drivers (LKM — outbound to Telegram Bot API + Discord webhooks) ---
+
+#[derive(Deserialize)]
+struct TelegramSendBody {
+    chat_id: String,
+    text: String,
+    #[serde(default)]
+    disable_notification: bool,
+}
+
+#[derive(Deserialize)]
+struct DiscordSendBody {
+    webhook_url: String,
+    content: String,
+}
+
+fn messaging_upstream_status(status: reqwest::StatusCode) -> StatusCode {
+    match status.as_u16() {
+        429 => StatusCode::TOO_MANY_REQUESTS,
+        400 | 401 | 403 | 404 => StatusCode::BAD_REQUEST,
+        s if s >= 500 => StatusCode::BAD_GATEWAY,
+        _ => StatusCode::BAD_GATEWAY,
+    }
+}
+
+async fn telegram_send(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<TelegramSendBody>,
+) -> impl IntoResponse {
+    let Ok(token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "TELEGRAM_BOT_TOKEN not configured",
+        )
+            .into_response();
+    };
+    let url = format!("https://api.telegram.org/bot{token}/sendMessage");
+    let payload = serde_json::json!({
+        "chat_id": body.chat_id,
+        "text": body.text,
+        "disable_notification": body.disable_notification,
+    });
+    match state.http_client.post(&url).json(&payload).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if status.is_success() {
+                let parsed: serde_json::Value =
+                    serde_json::from_str(&text).unwrap_or(serde_json::Value::Null);
+                let message_id = parsed
+                    .get("result")
+                    .and_then(|r| r.get("message_id"))
+                    .and_then(|m| m.as_i64());
+                Json(serde_json::json!({
+                    "ok": true,
+                    "message_id": message_id,
+                }))
+                .into_response()
+            } else {
+                (messaging_upstream_status(status), text).into_response()
+            }
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("telegram request failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn discord_send(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<DiscordSendBody>,
+) -> impl IntoResponse {
+    if !body.webhook_url.starts_with("https://discord.com/api/webhooks/")
+        && !body.webhook_url.starts_with("https://discordapp.com/api/webhooks/")
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            "webhook_url must be a discord.com/api/webhooks/... URL",
+        )
+            .into_response();
+    }
+    let payload = serde_json::json!({ "content": body.content });
+    match state
+        .http_client
+        .post(&body.webhook_url)
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            if status.is_success() {
+                Json(serde_json::json!({ "ok": true })).into_response()
+            } else {
+                let text = resp.text().await.unwrap_or_default();
+                (messaging_upstream_status(status), text).into_response()
+            }
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("discord request failed: {e}"),
+        )
+            .into_response(),
     }
 }
 

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -152,6 +152,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Messaging drivers (LKM — outbound to Telegram Bot API and Discord webhooks)
         .route("/api/telegram/send", post(telegram_send))
         .route("/api/discord/send", post(discord_send))
+        // LLM driver (LKM — outbound to Anthropic Messages API)
+        .route("/api/llm/messages", post(llm_messages))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -2649,6 +2651,49 @@ async fn discord_send(
         Err(e) => (
             StatusCode::BAD_GATEWAY,
             format!("discord request failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+// --- LLM Driver (LKM — outbound to Anthropic Messages API) ---
+
+async fn llm_messages(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let Ok(key) = std::env::var("ANTHROPIC_API_KEY") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ANTHROPIC_API_KEY not configured",
+        )
+            .into_response();
+    };
+    match state
+        .http_client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if status.is_success() {
+                match serde_json::from_str::<serde_json::Value>(&text) {
+                    Ok(v) => Json(v).into_response(),
+                    Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
+                }
+            } else {
+                (messaging_upstream_status(status), text).into_response()
+            }
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("anthropic request failed: {e}"),
         )
             .into_response(),
     }

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -2656,29 +2656,63 @@ async fn discord_send(
     }
 }
 
-// --- LLM Driver (LKM — outbound to Anthropic Messages API) ---
+// --- LLM Driver (LKM — outbound via Cloudflare AI Gateway) ---
+//
+// Forwards Anthropic-shape `/v1/messages` payloads through Cloudflare AI Gateway
+// for centralized observability, caching, and optional managed provider keys.
+//
+// Required env:
+//   CLOUDFLARE_ACCOUNT_ID        — CF account owning the gateway
+//   CLOUDFLARE_AI_GATEWAY_ID     — slug of the AI Gateway
+// At least one of:
+//   ANTHROPIC_API_KEY                — BYOK mode, forwarded as `x-api-key`
+//   CLOUDFLARE_AI_GATEWAY_TOKEN      — Authenticated-Gateway mode, forwarded as
+//                                      `cf-aig-authorization: Bearer …`
+//                                      (gateway injects its managed Anthropic
+//                                      key — no Anthropic key needed locally)
 
 async fn llm_messages(
     State(state): State<Arc<AppState>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let Ok(key) = std::env::var("ANTHROPIC_API_KEY") else {
+    let Ok(account_id) = std::env::var("CLOUDFLARE_ACCOUNT_ID") else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
-            "ANTHROPIC_API_KEY not configured",
+            "CLOUDFLARE_ACCOUNT_ID not configured",
         )
             .into_response();
     };
-    match state
+    let Ok(gateway_id) = std::env::var("CLOUDFLARE_AI_GATEWAY_ID") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CLOUDFLARE_AI_GATEWAY_ID not configured",
+        )
+            .into_response();
+    };
+    let anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok();
+    let gateway_token = std::env::var("CLOUDFLARE_AI_GATEWAY_TOKEN").ok();
+    if anthropic_key.is_none() && gateway_token.is_none() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "one of ANTHROPIC_API_KEY (BYOK) or CLOUDFLARE_AI_GATEWAY_TOKEN (managed) must be set",
+        )
+            .into_response();
+    }
+    let url = format!(
+        "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic/v1/messages"
+    );
+    let mut req = state
         .http_client
-        .post("https://api.anthropic.com/v1/messages")
-        .header("x-api-key", key)
+        .post(&url)
         .header("anthropic-version", "2023-06-01")
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-    {
+        .header("content-type", "application/json");
+    if let Some(k) = anthropic_key {
+        req = req.header("x-api-key", k);
+    }
+    if let Some(t) = gateway_token {
+        req = req.header("cf-aig-authorization", format!("Bearer {t}"));
+    }
+    match req.json(&body).send().await {
         Ok(resp) => {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
@@ -2693,7 +2727,7 @@ async fn llm_messages(
         }
         Err(e) => (
             StatusCode::BAD_GATEWAY,
-            format!("anthropic request failed: {e}"),
+            format!("ai gateway request failed: {e}"),
         )
             .into_response(),
     }

--- a/kernel/crates/gctrl-otel/tests/net_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/net_routes.rs
@@ -172,6 +172,34 @@ async fn discord_send_rejects_non_webhook_url() {
 }
 
 #[tokio::test]
+async fn llm_messages_returns_503_without_api_key() {
+    // Guard: isolate from any ambient ANTHROPIC_API_KEY in the test env.
+    // SAFETY: tests in this crate run single-threaded by default; no concurrent env mutation.
+    let prev = std::env::var("ANTHROPIC_API_KEY").ok();
+    unsafe {
+        std::env::remove_var("ANTHROPIC_API_KEY");
+    }
+    let app = router_with(NetConfig::default());
+    let (status, body) = post_json(
+        &app,
+        "/api/llm/messages",
+        serde_json::json!({
+            "model": "claude-opus-4-7",
+            "max_tokens": 16,
+            "messages": [{ "role": "user", "content": "hi" }],
+        }),
+    )
+    .await;
+    if let Some(v) = prev {
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", v);
+        }
+    }
+    assert_eq!(status, 503);
+    assert!(body.contains("ANTHROPIC_API_KEY"));
+}
+
+#[tokio::test]
 async fn net_fetch_browser_returns_503_without_cf_creds() {
     let app = router_with(NetConfig::default());
     let (status, body) = post_json(

--- a/kernel/crates/gctrl-otel/tests/net_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/net_routes.rs
@@ -135,6 +135,43 @@ async fn net_fetch_static_works_without_cf_creds() {
 }
 
 #[tokio::test]
+async fn telegram_send_returns_503_without_token() {
+    // Guard: isolate from any ambient TELEGRAM_BOT_TOKEN in the test env.
+    // SAFETY: tests in this crate run single-threaded by default; no concurrent env mutation.
+    let prev = std::env::var("TELEGRAM_BOT_TOKEN").ok();
+    unsafe {
+        std::env::remove_var("TELEGRAM_BOT_TOKEN");
+    }
+    let app = router_with(NetConfig::default());
+    let (status, body) = post_json(
+        &app,
+        "/api/telegram/send",
+        serde_json::json!({ "chat_id": "123", "text": "hi" }),
+    )
+    .await;
+    if let Some(v) = prev {
+        unsafe {
+            std::env::set_var("TELEGRAM_BOT_TOKEN", v);
+        }
+    }
+    assert_eq!(status, 503);
+    assert!(body.contains("TELEGRAM_BOT_TOKEN"));
+}
+
+#[tokio::test]
+async fn discord_send_rejects_non_webhook_url() {
+    let app = router_with(NetConfig::default());
+    let (status, body) = post_json(
+        &app,
+        "/api/discord/send",
+        serde_json::json!({ "webhook_url": "https://example.com/evil", "content": "hi" }),
+    )
+    .await;
+    assert_eq!(status, 400);
+    assert!(body.contains("discord.com/api/webhooks"));
+}
+
+#[tokio::test]
 async fn net_fetch_browser_returns_503_without_cf_creds() {
     let app = router_with(NetConfig::default());
     let (status, body) = post_json(

--- a/kernel/crates/gctrl-otel/tests/net_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/net_routes.rs
@@ -172,31 +172,63 @@ async fn discord_send_rejects_non_webhook_url() {
 }
 
 #[tokio::test]
-async fn llm_messages_returns_503_without_api_key() {
-    // Guard: isolate from any ambient ANTHROPIC_API_KEY in the test env.
+async fn llm_messages_fails_closed_without_gateway_config() {
+    // Guard: isolate from any ambient CF/Anthropic creds in the test env.
     // SAFETY: tests in this crate run single-threaded by default; no concurrent env mutation.
-    let prev = std::env::var("ANTHROPIC_API_KEY").ok();
+    let prev_acct = std::env::var("CLOUDFLARE_ACCOUNT_ID").ok();
+    let prev_gw = std::env::var("CLOUDFLARE_AI_GATEWAY_ID").ok();
+    let prev_gw_tok = std::env::var("CLOUDFLARE_AI_GATEWAY_TOKEN").ok();
+    let prev_anth = std::env::var("ANTHROPIC_API_KEY").ok();
     unsafe {
+        std::env::remove_var("CLOUDFLARE_ACCOUNT_ID");
+        std::env::remove_var("CLOUDFLARE_AI_GATEWAY_ID");
+        std::env::remove_var("CLOUDFLARE_AI_GATEWAY_TOKEN");
         std::env::remove_var("ANTHROPIC_API_KEY");
     }
     let app = router_with(NetConfig::default());
-    let (status, body) = post_json(
-        &app,
-        "/api/llm/messages",
-        serde_json::json!({
-            "model": "claude-opus-4-7",
-            "max_tokens": 16,
-            "messages": [{ "role": "user", "content": "hi" }],
-        }),
-    )
-    .await;
-    if let Some(v) = prev {
-        unsafe {
+    let probe_body = serde_json::json!({
+        "model": "claude-opus-4-7",
+        "max_tokens": 16,
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+
+    // 1. Missing CLOUDFLARE_ACCOUNT_ID → 503
+    let (status, body) = post_json(&app, "/api/llm/messages", probe_body.clone()).await;
+    assert_eq!(status, 503);
+    assert!(body.contains("CLOUDFLARE_ACCOUNT_ID"));
+
+    // 2. Account id set but missing gateway id → 503
+    unsafe { std::env::set_var("CLOUDFLARE_ACCOUNT_ID", "acct-test") };
+    let (status, body) = post_json(&app, "/api/llm/messages", probe_body.clone()).await;
+    assert_eq!(status, 503);
+    assert!(body.contains("CLOUDFLARE_AI_GATEWAY_ID"));
+
+    // 3. Account + gateway set but no auth → 503
+    unsafe { std::env::set_var("CLOUDFLARE_AI_GATEWAY_ID", "gw-test") };
+    let (status, body) = post_json(&app, "/api/llm/messages", probe_body).await;
+    assert_eq!(status, 503);
+    assert!(
+        body.contains("ANTHROPIC_API_KEY") && body.contains("CLOUDFLARE_AI_GATEWAY_TOKEN"),
+        "body was: {body}"
+    );
+
+    // Restore ambient env.
+    unsafe {
+        std::env::remove_var("CLOUDFLARE_ACCOUNT_ID");
+        std::env::remove_var("CLOUDFLARE_AI_GATEWAY_ID");
+        if let Some(v) = prev_acct {
+            std::env::set_var("CLOUDFLARE_ACCOUNT_ID", v);
+        }
+        if let Some(v) = prev_gw {
+            std::env::set_var("CLOUDFLARE_AI_GATEWAY_ID", v);
+        }
+        if let Some(v) = prev_gw_tok {
+            std::env::set_var("CLOUDFLARE_AI_GATEWAY_TOKEN", v);
+        }
+        if let Some(v) = prev_anth {
             std::env::set_var("ANTHROPIC_API_KEY", v);
         }
     }
-    assert_eq!(status, 503);
-    assert!(body.contains("ANTHROPIC_API_KEY"));
 }
 
 #[tokio::test]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       effect:
         specifier: ^3.14.0
         version: 3.21.0
+      fast-xml-parser:
+        specifier: ^5.7.1
+        version: 5.7.1
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -127,6 +130,31 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  apps/uebermensch-pages:
+    dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.14
+      marked:
+        specifier: ^14.0.0
+        version: 14.1.4
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20240925.0
+        version: 4.20260405.1
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      wrangler:
+        specifier: ^4.84.0
+        version: 4.84.1(@cloudflare/workers-types@4.20260405.1)
 
   shell/gctrl-shell:
     dependencies:
@@ -256,6 +284,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260421.1':
+    resolution: {integrity: sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20251011.0':
     resolution: {integrity: sha512-1WuFBGwZd15p4xssGN/48OE2oqokIuc51YvHvyNivyV8IYnAs3G9bJNGWth1X7iMDPe4g44pZrKhRnISS2+5dA==}
     engines: {node: '>=16'}
@@ -264,6 +298,12 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20260401.1':
     resolution: {integrity: sha512-7UKWF+IUZ3NXMVPsDg8Cjg0r58b+uYlfvs5Yt8bvtU+geCtW4P2MxRHmRSEo8SryckXOJjb/b8tcncgCykFu8g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260421.1':
+    resolution: {integrity: sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -280,6 +320,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260421.1':
+    resolution: {integrity: sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20251011.0':
     resolution: {integrity: sha512-79o/216lsbAbKEVDZYXR24ivEIE2ysDL9jvo0rDTkViLWju9dAp3CpyetglpJatbSi3uWBPKZBEOqN68zIjVsQ==}
     engines: {node: '>=16'}
@@ -292,6 +338,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260421.1':
+    resolution: {integrity: sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20251011.0':
     resolution: {integrity: sha512-RIXUQRchFdqEvaUqn1cXZXSKjpqMaSaVAkI5jNZ8XzAw/bw2bcdOVUtakrflgxDprltjFb0PTNtuss1FKtH9Jg==}
     engines: {node: '>=16'}
@@ -300,6 +352,12 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20260401.1':
     resolution: {integrity: sha512-HBLzcQF5iF4Qv20tQ++pG7xs3OsCnaIbc+GAi6fmhUKZhvmzvml/jwrQzLJ+MPm0cQo41K5OO/U3T4S8tvJetQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260421.1':
+    resolution: {integrity: sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1472,6 +1530,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nx/devkit@20.8.4':
     resolution: {integrity: sha512-3r+6QmIXXAWL6K7m8vAbW31aniAZmZAZXeMhOhWcJoOAU7ggpCQaM8JP8/kO5ov/Bmhyf0i/SSVXI6kwiR5WNQ==}
     peerDependencies:
@@ -2434,6 +2495,13 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2540,6 +2608,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2756,6 +2828,11 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  marked@14.1.4:
+    resolution: {integrity: sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2787,6 +2864,11 @@ packages:
 
   miniflare@4.20260401.0:
     resolution: {integrity: sha512-lngHPzZFN9sxYG/mhzvnWiBMNVAN5MsO/7g32ttJ07rymtiK/ZBalODTKb8Od+BQdlU5DOR4CjVt9NydjnUyYg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  miniflare@4.20260421.0:
+    resolution: {integrity: sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2872,6 +2954,10 @@ packages:
   ora@5.3.0:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
     engines: {node: '>=10'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3092,6 +3178,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3210,6 +3299,10 @@ packages:
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.21:
@@ -3368,6 +3461,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260421.1:
+    resolution: {integrity: sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.44.0:
     resolution: {integrity: sha512-BLOUigckcWZ0r4rm7b5PuaTpb9KP9as0XeCRSJ8kqcNgXcKoUD3Ij8FlPvN25KybLnFnetaO0ZdfRYUPWle4qw==}
     engines: {node: '>=18.0.0'}
@@ -3384,6 +3482,16 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260401.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.84.1:
+    resolution: {integrity: sha512-Xe1S/Bik7pNdtdJ+asHsEZC2dX9k3WxYn2BbxFtOrrLVxN/LKi750zsrjX41jSAk00M/O1l7jzyQV4sQqw8ftg==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260421.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3496,6 +3604,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260401.1
 
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260421.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260421.1
+
   '@cloudflare/unenv-preset@2.7.8(unenv@2.0.0-rc.21)(workerd@1.20251011.0)':
     dependencies:
       unenv: 2.0.0-rc.21
@@ -3525,10 +3639,16 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260401.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260421.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20251011.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260421.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20251011.0':
@@ -3537,16 +3657,25 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20260401.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260421.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20251011.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260401.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260421.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20251011.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260421.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260405.1': {}
@@ -4434,6 +4563,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@nx/devkit@20.8.4(nx@21.6.10)':
     dependencies:
       ejs: 3.1.10
@@ -5263,6 +5394,17 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.1:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5359,6 +5501,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.14: {}
 
   human-signals@2.1.0: {}
 
@@ -5512,6 +5656,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.1.4: {}
+
   math-intrinsics@1.1.0: {}
 
   merge-stream@2.0.0: {}
@@ -5550,6 +5696,18 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.4
       workerd: 1.20260401.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@4.20260421.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260421.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -5678,6 +5836,8 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
@@ -5943,6 +6103,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.2.3: {}
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -6056,6 +6218,8 @@ snapshots:
   undici@7.14.0: {}
 
   undici@7.24.4: {}
+
+  undici@7.24.8: {}
 
   unenv@2.0.0-rc.21:
     dependencies:
@@ -6202,6 +6366,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260401.1
       '@cloudflare/workerd-windows-64': 1.20260401.1
 
+  workerd@1.20260421.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260421.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260421.1
+      '@cloudflare/workerd-linux-64': 1.20260421.1
+      '@cloudflare/workerd-linux-arm64': 1.20260421.1
+      '@cloudflare/workerd-windows-64': 1.20260421.1
+
   wrangler@4.44.0(@cloudflare/workers-types@4.20260405.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
@@ -6229,6 +6401,23 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260401.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260405.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.84.1(@cloudflare/workers-types@4.20260405.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260421.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260421.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260421.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260405.1
       fsevents: 2.3.3


### PR DESCRIPTION
## Summary

This branch grew past its original scope (real-LLM `uber brief` + kernel messaging drivers were already merged in earlier commits on this branch) and now also adds weekly research reports, RSS ingestion, R2 sync, a public Cloudflare Pages site, and an ingest-quality pass.

Four coherent chapters:

### 1. Weekly research reports — `uber report`
- New vault folder `research/*.md` — one file per research interest, references topic/source slugs from `topics.md` / `sources.md` (no duplication).
- `uber report [--date --since-days 7 --max-items-per-interest 5 --dry-run --send --sync --llm kernel|stub]` generates a sectioned weekly report, one section per interest, written to `reports/<YYYY>-W<week>.md`.
- `LlmService.generateReport` with strict `[[stem]]` citation rules; renderer verifies citations and drops empty sections.
- Seed research interests added: `japan-macro`, `japan-aging-healthcare`, `us-midterms-2026`.

### 2. RSS ingestion — `uber ingest sources`
- `lib/rss.ts` parses RSS 2.0 + Atom via `fast-xml-parser`.
- New `FeedService` port + `HttpFeed` adapter (browser-like UA to get past feeds that 403 default crawlers).
- `uber ingest sources [--driver rss --since-hours 168 --limit 10 ...]` walks feeds from `sources.md` and pipes each item through the existing `HttpIngest`.
- Slug collision fix: `<date>--<domain>` → `<date>--<domain>--<path-stem>`.

### 3. Ingest quality pass (paywall + topic narrowing + insight-only prompt)
- FT / Bloomberg / SCMP / Seeking Alpha pages were previously ~90% paywall boilerplate. `HttpIngest` now detects paywall patterns and falls back to the RSS `<description>` (publisher-authored teaser — 100% ToS-compliant). `quality.paywalled` + `quality.body_source` frontmatter; paywalled pages get a 0.5× weight in `selectCandidates`.
- `classifyTopics` now expands via the topic's `watchlist[]`, so `japan-macro` matches "boj", "yen", "jgb"... And `HttpIngest` **intersects** with the feed's declared topics rather than unioning — a Singapore property article no longer inherits `japan-aging-healthcare` just because it came through `ft-asia`.
- `REPORT_SYSTEM_PROMPT` gains strict insight-only rules: banned absence commentary ("No X this week"), empty sections get dropped, `Suggested action` lines must target the substantive domain.

### 4. R2 sync + public Cloudflare Pages site
- `uber sync r2 [--dry-run --force]` pushes `reports/`, `briefs/`, `wiki/sources/` to an R2 bucket via `wrangler r2 object put` (reuses the user's CF token — no R2 API token click-ops).
- Dedup via local `.uber-sync-state.json` manifest keyed on vault path + SHA-256.
- `apps/uebermensch-pages/` — Hono on CF Pages Functions with R2 binding, renders the synced markdown at request time. Routes: `/`, `/reports/:slug`, `/briefs/:slug`, `/wiki/:slug`. Wikilinks rewritten pre-marked (safe inside code blocks). `robots.txt Disallow: /` + `<meta name="robots" content="noindex,nofollow">` for privacy-through-obscurity.
- `UBER_PUBLIC_BASE_URL` prefixes a clickable link into every delivered message (Telegram / Discord / app). When `--send` is on and a base URL is configured, R2 sync auto-runs first so the link resolves.

## Test plan
- [x] 92 tests passing locally across 12 files (`pnpm -F uebermensch test` → 78, `pnpm -F uebermensch-pages test` → 14)
- [x] `pnpm -F uebermensch exec tsc --noEmit` — green
- [x] `pnpm -F uebermensch-pages exec tsc --noEmit` — green
- [x] End-to-end: `uber ingest sources --since-hours 168 --limit 8` ingested 122 pages from 24 feeds
- [x] `uber report --send` delivered 13-item, $0.43 Claude Opus 4.7 report to Telegram (msg ids 101/102/103) + Discord (6 parts)
- [x] `uber sync r2` uploaded 184 files to `gctrl-vault` R2 bucket (manifest persisted)
- [x] Public URL live at https://uebermensch-pages.debuggingfuturecors.workers.dev
- [x] Wikilinks resolve end-to-end from report → `/wiki/<stem>`

## Known limitations (follow-ups, not blocking)
- 5 feeds still 403 despite browser UA (criticalthreats, sabato-crystalball, fec-updates has 404, BoJ partial). Would need per-publisher UA tricks or a scraper driver.
- Old FT / Bloomberg pages ingested before the paywall fix remain in the vault (RSS GUIDs rotated out, so `--overwrite` doesn't touch them). They fade naturally via paywall penalty + recency decay.
- R2 sync logs every file on first run (expected); subsequent runs quiet when nothing changed.

## Out of scope (intentionally deferred)
- Paywall bypass via 12ft.io / Google cache / archive.org — against publisher ToS and risky to automate on an identified account.
- Split into 4 stacked PRs — commit history is already thematic; reviewer can walk the diff top-down by the PR chapters above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
