### PR TITLE
feat(uebermensch): clean ingest + LLM key-insights summary

### DIFF
--- a/apps/uebermensch/src/adapters/HttpIngest.ts
+++ b/apps/uebermensch/src/adapters/HttpIngest.ts
@@ -1,14 +1,15 @@
-import { Context, Effect, Layer } from "effect"
-import { IngestError, type VaultError } from "../errors.js"
-import { domainKebab, extractFromHtml, slugForSource } from "../lib/html-extract.js"
-import { sha256 } from "../lib/hash.js"
-import { IngestService } from "../services/IngestService.js"
-import { VaultService } from "../services/VaultService.js"
+import { Context, Effect, Either, Layer, Option } from "effect";
+import { IngestError, type VaultError } from "../errors.js";
+import { sha256 } from "../lib/hash.js";
+import { domainKebab, extractFromHtml, slugForSource } from "../lib/html-extract.js";
+import { IngestService } from "../services/IngestService.js";
+import { LlmService } from "../services/LlmService.js";
+import { VaultService } from "../services/VaultService.js";
 
 export type HttpIngestConfig = {
-  readonly fetch?: typeof fetch
-  readonly userAgent?: string
-}
+  readonly fetch?: typeof fetch;
+  readonly userAgent?: string;
+};
 
 export class HttpIngestConfigTag extends Context.Tag("uebermensch/HttpIngestConfig")<
   HttpIngestConfigTag,
@@ -17,8 +18,8 @@ export class HttpIngestConfigTag extends Context.Tag("uebermensch/HttpIngestConf
 
 // Browser-like UA — bare `uebermensch-ingest` gets 403'd by FT, Bloomberg, SCMP, BoJ.
 const DEFAULT_UA =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
-const MAX_BODY_CHARS = 8000
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36";
+const MAX_BODY_CHARS = 8000;
 
 // Patterns that indicate a paywalled / metered article. If any match the extracted
 // body we consider the fetched content unusable and fall back to the RSS description
@@ -34,26 +35,28 @@ const PAYWALL_PATTERNS: ReadonlyArray<RegExp> = [
   /complete digital access/i,
   /your subscription (?:gives|grants|provides)/i,
   /register (?:for free|to continue)/i,
-]
+];
 
 export type PaywallCheck = {
-  readonly paywalled: boolean
-  readonly matched: string | null
-}
+  readonly paywalled: boolean;
+  readonly matched: string | null;
+};
 
 export const detectPaywall = (body: string): PaywallCheck => {
   for (const re of PAYWALL_PATTERNS) {
-    const hit = body.match(re)
-    if (hit) return { paywalled: true, matched: hit[0] }
+    const hit = body.match(re);
+    if (hit) return { paywalled: true, matched: hit[0] };
   }
-  return { paywalled: false, matched: null }
-}
+  return { paywalled: false, matched: null };
+};
 
 const ingestErr = (kind: IngestError["kind"], url: string, message: string): IngestError =>
-  new IngestError({ kind, url, message })
+  new IngestError({ kind, url, message });
 
-const vaultToIngest = (url: string) => (e: VaultError): IngestError =>
-  ingestErr(e.kind === "collision" ? "collision" : "io_failure", url, e.message)
+const vaultToIngest =
+  (url: string) =>
+  (e: VaultError): IngestError =>
+    ingestErr(e.kind === "collision" ? "collision" : "io_failure", url, e.message);
 
 // A slug "japan-macro" as plain text rarely appears in articles — but its watchlist
 // terms (boj, yen, jgb, ueda…) do. classifyTopics matches against BOTH:
@@ -65,104 +68,113 @@ export const classifyTopics = (
   topicSlugs: ReadonlyArray<string>,
   watchlists: Readonly<Record<string, ReadonlyArray<string>>> = {},
 ): ReadonlyArray<string> => {
-  const haystack = text.toLowerCase()
-  const hits: Array<string> = []
+  const haystack = text.toLowerCase();
+  const hits: Array<string> = [];
   for (const slug of topicSlugs) {
-    const phrase = slug.toLowerCase().replace(/-/g, " ")
-    let matched = haystack.includes(phrase)
+    const phrase = slug.toLowerCase().replace(/-/g, " ");
+    let matched = haystack.includes(phrase);
     if (!matched) {
       for (const term of watchlists[slug] ?? []) {
-        const t = term.toLowerCase()
-        if (!t) continue
+        const t = term.toLowerCase();
+        if (!t) continue;
         // Word-boundary match on kebab/space/punct so "us" doesn't match "usual".
-        const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[ \\-/]")
-        const re = new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`, "i")
+        const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[ \\-/]");
+        const re = new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`, "i");
         if (re.test(haystack)) {
-          matched = true
-          break
+          matched = true;
+          break;
         }
       }
     }
-    if (matched) hits.push(slug)
+    if (matched) hits.push(slug);
   }
-  return hits
-}
+  return hits;
+};
 
 const yamlEscape = (s: string): string => {
-  if (/^[A-Za-z0-9._\-:/ ]+$/.test(s) && !s.includes(": ") && !s.startsWith("-")) return s
-  return `"${s.replace(/"/g, '\\"')}"`
-}
+  if (/^[A-Za-z0-9._\-:/ ]+$/.test(s) && !s.includes(": ") && !s.startsWith("-")) return s;
+  return `"${s.replace(/"/g, '\\"')}"`;
+};
 
 const renderFrontmatter = (fields: Record<string, unknown>): string => {
-  const lines: Array<string> = ["---"]
+  const lines: Array<string> = ["---"];
   for (const [key, value] of Object.entries(fields)) {
-    if (value === null || value === undefined) continue
+    if (value === null || value === undefined) continue;
     if (Array.isArray(value)) {
-      const items = value.map((v) => yamlEscape(String(v))).join(", ")
-      lines.push(`${key}: [${items}]`)
+      const items = value.map((v) => yamlEscape(String(v))).join(", ");
+      lines.push(`${key}: [${items}]`);
     } else if (typeof value === "object") {
-      lines.push(`${key}:`)
+      lines.push(`${key}:`);
       for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        if (v === null || v === undefined) continue
-        lines.push(`  ${k}: ${yamlEscape(String(v))}`)
+        if (v === null || v === undefined) continue;
+        lines.push(`  ${k}: ${yamlEscape(String(v))}`);
       }
     } else {
-      lines.push(`${key}: ${yamlEscape(String(value))}`)
+      lines.push(`${key}: ${yamlEscape(String(value))}`);
     }
   }
-  lines.push("---")
-  return lines.join("\n")
-}
+  lines.push("---");
+  return lines.join("\n");
+};
 
-const renderSourceBody = (title: string, url: string, text: string, paywalled: boolean, bodySource: "extracted" | "rss_description"): string => {
+type BodySource = "extracted" | "rss_description" | "llm_insights";
+
+const renderSourceBody = (
+  title: string,
+  url: string,
+  text: string,
+  paywalled: boolean,
+  bodySource: BodySource,
+): string => {
   const truncated =
-    text.length > MAX_BODY_CHARS ? `${text.slice(0, MAX_BODY_CHARS)}\n\n…(truncated)` : text
+    text.length > MAX_BODY_CHARS ? `${text.slice(0, MAX_BODY_CHARS)}\n\n…(truncated)` : text;
   const note =
-    bodySource === "rss_description"
-      ? "_Body below is the RSS publisher-supplied description; the linked article is paywalled._"
-      : paywalled
-        ? "_Extracted content may be truncated by a paywall._"
-        : ""
-  const parts = [`# ${title}`, "", `Source: <${url}>`, ""]
-  if (note) parts.push(note, "")
-  parts.push(truncated, "")
-  return parts.join("\n")
-}
+    bodySource === "llm_insights"
+      ? "_Below is an LLM-generated key-insights summary of the source article._"
+      : bodySource === "rss_description"
+        ? "_Body below is the RSS publisher-supplied description; the linked article is paywalled._"
+        : paywalled
+          ? "_Extracted content may be truncated by a paywall._"
+          : "";
+  const parts = [`# ${title}`, "", `Source: <${url}>`, ""];
+  if (note) parts.push(note, "");
+  parts.push(truncated, "");
+  return parts.join("\n");
+};
 
-const MIN_FEED_DESCRIPTION_CHARS = 80
+const MIN_FEED_DESCRIPTION_CHARS = 80;
 
 const narrowTopics = (
   classified: ReadonlyArray<string>,
   forceTopics: ReadonlyArray<string> | undefined,
 ): ReadonlyArray<string> => {
   if (!forceTopics || forceTopics.length === 0) {
-    return Array.from(new Set(classified))
+    return Array.from(new Set(classified));
   }
-  const ceiling = new Set(forceTopics)
-  const narrowed = classified.filter((t) => ceiling.has(t))
-  return Array.from(new Set(narrowed))
-}
+  const ceiling = new Set(forceTopics);
+  const narrowed = classified.filter((t) => ceiling.has(t));
+  return Array.from(new Set(narrowed));
+};
 
 export const HttpIngestLive = Layer.effect(
   IngestService,
   Effect.gen(function* () {
-    const config = yield* HttpIngestConfigTag
-    const vault = yield* VaultService
-    const doFetch = config.fetch ?? fetch
-    const userAgent = config.userAgent ?? DEFAULT_UA
+    const config = yield* HttpIngestConfigTag;
+    const vault = yield* VaultService;
+    const doFetch = config.fetch ?? fetch;
+    const userAgent = config.userAgent ?? DEFAULT_UA;
 
     return {
       ingestUrl: (req) =>
         Effect.gen(function* () {
-          const fetchedAt = new Date().toISOString()
+          const fetchedAt = new Date().toISOString();
 
           const response = yield* Effect.tryPromise({
             try: () =>
               doFetch(req.url, {
                 headers: {
                   "user-agent": userAgent,
-                  accept:
-                    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                  accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                   "accept-language": "en-US,en;q=0.9",
                 },
               }),
@@ -172,26 +184,27 @@ export const HttpIngestLive = Layer.effect(
               (r) => r.ok,
               (r) => ingestErr("fetch_failed", req.url, `fetch returned ${r.status}`),
             ),
-          )
+          );
 
           const html = yield* Effect.tryPromise({
             try: () => response.text(),
             catch: (e) => ingestErr("fetch_failed", req.url, `read body failed: ${String(e)}`),
-          })
+          });
 
           const extracted = yield* Effect.try({
             try: () => extractFromHtml(html),
             catch: (e) => ingestErr("extract_failed", req.url, `extract failed: ${String(e)}`),
-          })
+          });
 
           // Decide which body to use. Paywall detection runs on the extracted text;
           // if it hits, we fall back to the RSS description (when long enough).
-          const paywall = detectPaywall(extracted.text)
-          const feedDesc = (req.descriptionFromFeed ?? "").trim()
-          const useFeedDesc = paywall.paywalled && feedDesc.length >= MIN_FEED_DESCRIPTION_CHARS
-          const bodySource: "extracted" | "rss_description" = useFeedDesc ? "rss_description" : "extracted"
-          const bodyText = useFeedDesc ? feedDesc : extracted.text
-          const effectiveWordCount = bodyText.split(/\s+/).filter(Boolean).length
+          const paywall = detectPaywall(extracted.text);
+          const feedDesc = (req.descriptionFromFeed ?? "").trim();
+          const useFeedDesc = paywall.paywalled && feedDesc.length >= MIN_FEED_DESCRIPTION_CHARS;
+          let bodySource: BodySource = useFeedDesc ? "rss_description" : "extracted";
+          const sourceText = useFeedDesc ? feedDesc : extracted.text;
+          let bodyText = sourceText;
+          const effectiveWordCount = sourceText.split(/\s+/).filter(Boolean).length;
 
           // Quality gate: if still below minWordCount after the description fallback,
           // reject. Title-only pages are not useful to the curator.
@@ -202,23 +215,61 @@ export const HttpIngestLive = Layer.effect(
                 req.url,
                 `effective word_count ${effectiveWordCount} < min ${req.minWordCount} (paywalled=${paywall.paywalled}, feedDesc=${feedDesc.length})`,
               ),
-            )
+            );
           }
 
-          const slug = slugForSource(req.url, req.date)
-          const domain = domainKebab(req.url).replace(/-/g, ".")
+          const slug = slugForSource(req.url, req.date);
+          const domain = domainKebab(req.url).replace(/-/g, ".");
 
-          const classifyText = `${extracted.title}\n${bodyText.slice(0, 2000)}\n${feedDesc.slice(0, 1000)}`
+          // Classification runs on the full extracted text (not the summary)
+          // so watchlist-term matches don't lose recall after summarization.
+          const classifyText = `${extracted.title}\n${sourceText.slice(0, 2000)}\n${feedDesc.slice(0, 1000)}`;
           const classified = classifyTopics(
             classifyText,
             req.topicSlugs,
             req.topicWatchlists ?? {},
-          )
-          const topicsMatched = narrowTopics(classified, req.forceTopics)
-          const contentHash = sha256(bodyText)
+          );
+          const topicsMatched = narrowTopics(classified, req.forceTopics);
 
-          const body = renderSourceBody(extracted.title, req.url, bodyText, paywall.paywalled, bodySource)
-          const frontmatter = renderFrontmatter({
+          // Optional LLM summarization. Only fires when the caller opts in
+          // AND an LlmService is present in the context. On LLM failure we
+          // keep the extracted/RSS body — ingestion must not break because
+          // the summarizer is unreachable.
+          let summaryModel: string | undefined;
+          let summaryCostUsd: number | undefined;
+          if (req.summarize) {
+            const llmOpt = yield* Effect.serviceOption(LlmService);
+            if (Option.isSome(llmOpt)) {
+              const llm = llmOpt.value;
+              const summary = yield* llm
+                .summarizeSource({
+                  title: extracted.title,
+                  url: req.url,
+                  text: sourceText,
+                  topics: topicsMatched,
+                })
+                .pipe(Effect.either);
+              Either.match(summary, {
+                onLeft: () => {},
+                onRight: (s) => {
+                  bodyText = s.insightsMd;
+                  bodySource = "llm_insights";
+                  summaryModel = s.model;
+                  summaryCostUsd = s.costUsd;
+                },
+              });
+            }
+          }
+          const contentHash = sha256(bodyText);
+
+          const body = renderSourceBody(
+            extracted.title,
+            req.url,
+            bodyText,
+            paywall.paywalled,
+            bodySource,
+          );
+          const frontmatterFields: Record<string, unknown> = {
             page_type: "source",
             slug,
             title: extracted.title,
@@ -236,12 +287,19 @@ export const HttpIngestLive = Layer.effect(
               paywalled: paywall.paywalled,
               body_source: bodySource,
             },
-          })
-          const full = `${frontmatter}\n\n${body}`
+          };
+          if (summaryModel !== undefined) {
+            frontmatterFields.summary = {
+              model: summaryModel,
+              cost_usd: summaryCostUsd ?? 0,
+            };
+          }
+          const frontmatter = renderFrontmatter(frontmatterFields);
+          const full = `${frontmatter}\n\n${body}`;
 
           const written = yield* vault
             .writeSource(slug, full, { overwrite: req.overwrite })
-            .pipe(Effect.catchTag("VaultError", (e) => Effect.fail(vaultToIngest(req.url)(e))))
+            .pipe(Effect.catchTag("VaultError", (e) => Effect.fail(vaultToIngest(req.url)(e))));
 
           return {
             slug,
@@ -254,10 +312,12 @@ export const HttpIngestLive = Layer.effect(
             contentHash: written.contentHash,
             paywalled: paywall.paywalled,
             bodySource,
-          }
+            summaryModel,
+            summaryCostUsd,
+          };
         }),
-    }
+    };
   }),
-)
+);
 
-export const HttpIngestDefaultConfig = Layer.succeed(HttpIngestConfigTag, {})
+export const HttpIngestDefaultConfig = Layer.succeed(HttpIngestConfigTag, {});

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,48 +1,56 @@
-import { Effect, Layer, Schema } from "effect"
-import { LlmError } from "../errors.js"
-import type { CandidateRef } from "../lib/candidates.js"
-import { sha256 } from "../lib/hash.js"
+import { Effect, Layer, Schema } from "effect";
+import { LlmError } from "../errors.js";
+import type { CandidateRef } from "../lib/candidates.js";
+import { sha256 } from "../lib/hash.js";
 import {
-  LlmService,
   type BriefRequest,
+  LlmService,
   type ReportRequest,
   type ReportSection,
-} from "../services/LlmService.js"
-import type { CuratedItem } from "../services/RendererService.js"
+} from "../services/LlmService.js";
+import type { CuratedItem } from "../services/RendererService.js";
 
-const MODEL = "claude-opus-4-7"
-const INPUT_COST_PER_MTOK = 5.0
-const OUTPUT_COST_PER_MTOK = 25.0
-const MAX_CANDIDATE_EXCERPT = 2000
-const DEFAULT_MAX_TOKENS = 16000
+const MODEL = "claude-opus-4-7";
+const INPUT_COST_PER_MTOK = 5.0;
+const OUTPUT_COST_PER_MTOK = 25.0;
+const MAX_CANDIDATE_EXCERPT = 2000;
+const DEFAULT_MAX_TOKENS = 16000;
+
+// Per-article summarization uses a cheaper model. Kernel /api/llm/messages
+// routes through the AI Gateway so any model in the provider registry works.
+const SUMMARY_MODEL = "claude-haiku-4-5-20251001";
+const SUMMARY_INPUT_COST_PER_MTOK = 1.0;
+const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0;
+const SUMMARY_MAX_TOKENS = 800;
+const SUMMARY_INPUT_CHARS_CAP = 12000;
 
 const kernelBase = (): string =>
-  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
+  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
 
 const excerptOf = (body: string, max: number): string => {
-  const trimmed = body.trim()
-  if (trimmed.length <= max) return trimmed
-  return `${trimmed.slice(0, max)}…`
-}
+  const trimmed = body.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max)}…`;
+};
 
 const candidateBlock = (c: CandidateRef): string => {
-  const fm = c.page.frontmatter
-  const title = (fm.title as string | undefined) ?? c.page.stem
-  const topics = ((fm.topics as ReadonlyArray<string> | undefined) ?? []).join(", ")
-  const url = (fm.url as string | undefined) ?? ""
+  const fm = c.page.frontmatter;
+  const title = (fm.title as string | undefined) ?? c.page.stem;
+  const topics = ((fm.topics as ReadonlyArray<string> | undefined) ?? []).join(", ");
+  const url = (fm.url as string | undefined) ?? "";
   const lines: Array<string> = [
     `- id: ${c.id}`,
     `  stem: ${c.page.stem}`,
     `  title: ${title}`,
     `  topics: [${topics}]`,
-  ]
-  if (url) lines.push(`  url: ${url}`)
-  lines.push(`  score: ${c.score.toFixed(3)}`)
-  lines.push(`  excerpt: |`)
-  const excerptBody = excerptOf(c.page.body, MAX_CANDIDATE_EXCERPT)
-  for (const line of excerptBody.split("\n")) lines.push(`    ${line}`)
-  return lines.join("\n")
-}
+  ];
+  if (url) lines.push(`  url: ${url}`);
+  lines.push(`  score: ${c.score.toFixed(3)}`);
+  lines.push(`  excerpt: |`);
+  const excerptBody = excerptOf(c.page.body, MAX_CANDIDATE_EXCERPT);
+  for (const line of excerptBody.split("\n")) lines.push(`    ${line}`);
+  return lines.join("\n");
+};
 
 const SYSTEM_PROMPT = `You are uebermensch-curator, a chief-of-staff curator that produces a daily brief from a set of wiki pages.
 
@@ -70,22 +78,22 @@ CURATION RULES:
 - Merge near-duplicate candidates into one item referencing multiple sources.
 - \`topic\` is the single most relevant topic slug from the profile, or null.
 - Produce at most \`maxItems\` items; prefer high-scored, topic-aligned candidates.
-- If there are no usable candidates, return \`{ "items": [], "topicsCovered": [], "thesesCovered": [] }\`.`
+- If there are no usable candidates, return \`{ "items": [], "topicsCovered": [], "thesesCovered": [] }\`.`;
 
 const buildUserPrompt = (req: BriefRequest): string => {
-  const lines: Array<string> = []
-  lines.push(`date: ${req.date}`)
-  lines.push(`profile: ${req.profileName}`)
-  lines.push(`maxItems: ${req.maxItems}`)
-  lines.push(`topics: [${req.topics.join(", ")}]`)
-  lines.push(`theses: [${req.thesesSlugs.join(", ")}]`)
-  lines.push("")
-  lines.push("candidates:")
-  for (const c of req.candidates) lines.push(candidateBlock(c))
-  lines.push("")
-  lines.push("Return ONLY a fenced ```json block with the schema above.")
-  return lines.join("\n")
-}
+  const lines: Array<string> = [];
+  lines.push(`date: ${req.date}`);
+  lines.push(`profile: ${req.profileName}`);
+  lines.push(`maxItems: ${req.maxItems}`);
+  lines.push(`topics: [${req.topics.join(", ")}]`);
+  lines.push(`theses: [${req.thesesSlugs.join(", ")}]`);
+  lines.push("");
+  lines.push("candidates:");
+  for (const c of req.candidates) lines.push(candidateBlock(c));
+  lines.push("");
+  lines.push("Return ONLY a fenced ```json block with the schema above.");
+  return lines.join("\n");
+};
 
 const ItemSchema = Schema.Struct({
   kind: Schema.Literal("news", "update", "action", "alert"),
@@ -95,39 +103,39 @@ const ItemSchema = Schema.Struct({
   thesis: Schema.NullOr(Schema.String),
   source_candidate_ids: Schema.Array(Schema.String),
   suggested_action: Schema.NullOr(Schema.String),
-})
+});
 
 const LlmOutputSchema = Schema.Struct({
   items: Schema.Array(ItemSchema),
   topicsCovered: Schema.Array(Schema.String),
   thesesCovered: Schema.Array(Schema.String),
-})
+});
 
 type AnthropicResponse = {
-  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>
-  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number }
-  readonly model?: string
-}
+  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
+  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number };
+  readonly model?: string;
+};
 
 const extractJson = (text: string): string | null => {
-  const fenced = text.match(/```json\s*([\s\S]*?)```/)
-  if (fenced) return fenced[1].trim()
-  const start = text.indexOf("{")
-  const end = text.lastIndexOf("}")
-  if (start === -1 || end === -1 || end < start) return null
-  return text.slice(start, end + 1)
-}
+  const fenced = text.match(/```json\s*([\s\S]*?)```/);
+  if (fenced) return fenced[1].trim();
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) return null;
+  return text.slice(start, end + 1);
+};
 
 const llmErr = (kind: LlmError["kind"], message: string): LlmError =>
-  new LlmError({ kind, message })
+  new LlmError({ kind, message });
 
 const classifyKernelStatus = (status: number): LlmError["kind"] => {
-  if (status === 503) return "unavailable"
-  if (status === 429) return "rate_limited"
-  if (status === 400 || status === 401 || status === 403) return "invalid"
-  if (status >= 500) return "unavailable"
-  return "invalid"
-}
+  if (status === 503) return "unavailable";
+  if (status === 429) return "rate_limited";
+  if (status === 400 || status === 401 || status === 403) return "invalid";
+  if (status >= 500) return "unavailable";
+  return "invalid";
+};
 
 const postMessages = (body: unknown): Effect.Effect<AnthropicResponse, LlmError> =>
   Effect.tryPromise({
@@ -136,21 +144,21 @@ const postMessages = (body: unknown): Effect.Effect<AnthropicResponse, LlmError>
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
-      })
-      const text = await res.text()
+      });
+      const text = await res.text();
       if (!res.ok) {
         throw llmErr(
           classifyKernelStatus(res.status),
           `kernel /api/llm/messages HTTP ${res.status}: ${text.slice(0, 500)}`,
-        )
+        );
       }
-      return text.length > 0 ? (JSON.parse(text) as AnthropicResponse) : ({} as AnthropicResponse)
+      return text.length > 0 ? (JSON.parse(text) as AnthropicResponse) : ({} as AnthropicResponse);
     },
     catch: (e) =>
       e instanceof LlmError
         ? e
         : llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`),
-  })
+  });
 
 const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst that produces a weekly research report grouped by research interest.
 
@@ -189,100 +197,139 @@ INSIGHT-ONLY RULES (strict — enforced by reviewer):
 - BANNED phrases and patterns: "No direct X...", "No fresh X...", "appeared in the candidate set", "This week was quiet for...", "Candidate pool was thin...", "Most items were only indirectly relevant...", "Reference pages were also indexed but carry no new information", "Treat this week as a quiet one for...".
 - If a section has no candidates OR no substantive signal, return {"interestSlug": slug, "summary_md": "", "items": []} — the renderer will drop empty sections. Do NOT apologize or meta-commentate.
 - If the candidate pool contains only adjacent signal (no direct hit on the interest's question), lead with the adjacent signal as a concrete claim. Example: "BHP–China iron ore deal resets seaborne pricing relevant to Japanese steelmaker input costs." Do NOT frame it as "No direct X but adjacent Y...".
-- No "Suggested action" lines about expanding ingestion, adding feeds, or describing the system itself. Actions must target the substantive domain (markets, policy, company behavior).`
+- No "Suggested action" lines about expanding ingestion, adding feeds, or describing the system itself. Actions must target the substantive domain (markets, policy, company behavior).`;
 
-const reportCandidateBlock = (c: CandidateRef): string => candidateBlock(c)
+const reportCandidateBlock = (c: CandidateRef): string => candidateBlock(c);
 
 const buildReportUserPrompt = (req: ReportRequest): string => {
-  const lines: Array<string> = []
-  lines.push(`period: ${req.periodLabel}`)
-  lines.push(`periodStart: ${req.periodStart}`)
-  lines.push(`periodEnd: ${req.periodEnd}`)
-  lines.push(`profile: ${req.profileName}`)
-  lines.push(`maxItemsPerInterest: ${req.maxItemsPerInterest}`)
-  lines.push("")
-  lines.push("interests:")
+  const lines: Array<string> = [];
+  lines.push(`period: ${req.periodLabel}`);
+  lines.push(`periodStart: ${req.periodStart}`);
+  lines.push(`periodEnd: ${req.periodEnd}`);
+  lines.push(`profile: ${req.profileName}`);
+  lines.push(`maxItemsPerInterest: ${req.maxItemsPerInterest}`);
+  lines.push("");
+  lines.push("interests:");
   for (const it of req.interests) {
-    lines.push(`- slug: ${it.slug}`)
-    lines.push(`  title: ${it.title}`)
-    if (it.question) lines.push(`  question: ${it.question}`)
-    lines.push(`  topics: [${it.topics.join(", ")}]`)
+    lines.push(`- slug: ${it.slug}`);
+    lines.push(`  title: ${it.title}`);
+    if (it.question) lines.push(`  question: ${it.question}`);
+    lines.push(`  topics: [${it.topics.join(", ")}]`);
     if (it.notes) {
-      lines.push(`  notes: |`)
-      for (const line of it.notes.split("\n")) lines.push(`    ${line}`)
+      lines.push(`  notes: |`);
+      for (const line of it.notes.split("\n")) lines.push(`    ${line}`);
     }
-    lines.push(`  candidates:`)
+    lines.push(`  candidates:`);
     if (it.candidates.length === 0) {
-      lines.push(`    (none)`)
+      lines.push(`    (none)`);
     } else {
       for (const c of it.candidates) {
         const block = reportCandidateBlock(c)
           .split("\n")
           .map((l) => `  ${l}`)
-          .join("\n")
-        lines.push(block)
+          .join("\n");
+        lines.push(block);
       }
     }
   }
-  lines.push("")
-  lines.push("Return ONLY a fenced ```json block with the schema above.")
-  return lines.join("\n")
-}
+  lines.push("");
+  lines.push("Return ONLY a fenced ```json block with the schema above.");
+  return lines.join("\n");
+};
 
 const ReportSectionSchema = Schema.Struct({
   interestSlug: Schema.String,
   summary_md: Schema.String,
   items: Schema.Array(ItemSchema),
-})
+});
 
 const ReportOutputSchema = Schema.Struct({
   sections: Schema.Array(ReportSectionSchema),
-})
+});
+
+const SUMMARY_SYSTEM_PROMPT = `You are uebermensch-ingest, an assistant that condenses a single news article into a compact set of key insights for a research wiki.
+
+OUTPUT CONTRACT:
+- Output ONLY markdown — no preamble, no JSON, no fenced blocks.
+- Start with a heading "## Key Insights" on its own line.
+- Follow with 3 to 6 bullet lines starting with "- ".
+- Each bullet: one substantive fact or causal claim in 1–2 sentences, concrete, specific, lifted from the article.
+- After the bullets, optionally add a heading "## Why it matters" with one or two bullet lines of implication for the reader's research topics.
+
+STYLE RULES:
+- Substantive insight only — no meta commentary about the article, no "the article discusses…", no hedging.
+- Prefer numbers, named entities, dates, and policy specifics over generalities.
+- Do NOT restate the title.
+- Do NOT write UI/boilerplate like "read more", "share", photo credits, or bylines.
+- Do NOT output anything outside the headings + bullets structure above.`;
+
+const buildSummaryUserPrompt = (
+  title: string,
+  url: string,
+  topics: ReadonlyArray<string>,
+  text: string,
+): string => {
+  const lines: Array<string> = [];
+  lines.push(`title: ${title}`);
+  lines.push(`url: ${url}`);
+  lines.push(`topics: [${topics.join(", ")}]`);
+  lines.push("");
+  lines.push("article:");
+  lines.push(text);
+  return lines.join("\n");
+};
+
+// Clip any preamble before the "## Key Insights" heading; trim trailing
+// whitespace. Models occasionally prefix with "Here are the key insights:" —
+// drop everything up to the first heading.
+const normalizeInsights = (raw: string): string => {
+  const trimmed = raw.trim();
+  const idx = trimmed.search(/^##\s+Key Insights/im);
+  const body = idx >= 0 ? trimmed.slice(idx) : trimmed;
+  return body.trim();
+};
 
 export const KernelLlmLive = Layer.succeed(LlmService, {
   name: () => `kernel-llm@${MODEL}`,
   generateBrief: (req) =>
     Effect.gen(function* () {
-      const userPrompt = buildUserPrompt(req)
-      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const userPrompt = buildUserPrompt(req);
+      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
       const body = {
         model: MODEL,
         max_tokens: DEFAULT_MAX_TOKENS,
         thinking: { type: "adaptive" },
         system: SYSTEM_PROMPT,
         messages: [{ role: "user", content: userPrompt }],
-      }
-      const res = yield* postMessages(body)
+      };
+      const res = yield* postMessages(body);
       const textBlock = (res.content ?? []).find(
-        (b): b is { type: string; text: string } =>
-          b.type === "text" && typeof b.text === "string",
-      )
+        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
+      );
       if (!textBlock) {
-        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"))
+        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"));
       }
-      const raw = extractJson(textBlock.text)
+      const raw = extractJson(textBlock.text);
       if (raw === null) {
         return yield* Effect.fail(
           llmErr("invalid", "kernel response text did not contain a JSON object"),
-        )
+        );
       }
-      let parsed: unknown
+      let parsed: unknown;
       try {
-        parsed = JSON.parse(raw)
+        parsed = JSON.parse(raw);
       } catch (e) {
         return yield* Effect.fail(
           llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
-        )
+        );
       }
       const decoded = yield* Schema.decodeUnknown(LlmOutputSchema)(parsed).pipe(
-        Effect.mapError((e) =>
-          llmErr("invalid", `kernel response schema mismatch: ${String(e)}`),
-        ),
-      )
+        Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
+      );
       const costUsd =
         ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
           (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
-        1_000_000
+        1_000_000;
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -291,7 +338,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         thesis: i.thesis,
         source_candidate_ids: i.source_candidate_ids,
         suggested_action: i.suggested_action,
-      }))
+      }));
       return {
         items,
         topicsCovered: decoded.topicsCovered,
@@ -299,52 +346,47 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         promptHash,
         costUsd,
         model: res.model ?? MODEL,
-      }
+      };
     }),
   generateReport: (req) =>
     Effect.gen(function* () {
-      const userPrompt = buildReportUserPrompt(req)
-      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const userPrompt = buildReportUserPrompt(req);
+      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
       const body = {
         model: MODEL,
         max_tokens: DEFAULT_MAX_TOKENS,
         thinking: { type: "adaptive" },
         system: REPORT_SYSTEM_PROMPT,
         messages: [{ role: "user", content: userPrompt }],
-      }
-      const res = yield* postMessages(body)
+      };
+      const res = yield* postMessages(body);
       const textBlock = (res.content ?? []).find(
-        (b): b is { type: string; text: string } =>
-          b.type === "text" && typeof b.text === "string",
-      )
+        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
+      );
       if (!textBlock) {
-        return yield* Effect.fail(
-          llmErr("invalid", "kernel response missing text content block"),
-        )
+        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"));
       }
-      const raw = extractJson(textBlock.text)
+      const raw = extractJson(textBlock.text);
       if (raw === null) {
         return yield* Effect.fail(
           llmErr("invalid", "kernel response text did not contain a JSON object"),
-        )
+        );
       }
-      let parsed: unknown
+      let parsed: unknown;
       try {
-        parsed = JSON.parse(raw)
+        parsed = JSON.parse(raw);
       } catch (e) {
         return yield* Effect.fail(
           llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
-        )
+        );
       }
       const decoded = yield* Schema.decodeUnknown(ReportOutputSchema)(parsed).pipe(
-        Effect.mapError((e) =>
-          llmErr("invalid", `kernel response schema mismatch: ${String(e)}`),
-        ),
-      )
+        Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
+      );
       const costUsd =
         ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
           (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
-        1_000_000
+        1_000_000;
       const sections: ReadonlyArray<ReportSection> = decoded.sections.map((s) => ({
         interestSlug: s.interestSlug,
         summary_md: s.summary_md,
@@ -357,24 +399,66 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
           source_candidate_ids: i.source_candidate_ids,
           suggested_action: i.suggested_action,
         })),
-      }))
+      }));
       return {
         sections,
         promptHash,
         costUsd,
         model: res.model ?? MODEL,
-      }
+      };
     }),
-})
+  summarizeSource: (req) =>
+    Effect.gen(function* () {
+      const capped =
+        req.text.length > SUMMARY_INPUT_CHARS_CAP
+          ? `${req.text.slice(0, SUMMARY_INPUT_CHARS_CAP)}…`
+          : req.text;
+      const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
+      const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const body = {
+        model: SUMMARY_MODEL,
+        max_tokens: SUMMARY_MAX_TOKENS,
+        system: SUMMARY_SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userPrompt }],
+      };
+      const res = yield* postMessages(body);
+      const textBlock = (res.content ?? []).find(
+        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
+      );
+      if (!textBlock) {
+        return yield* Effect.fail(
+          llmErr("invalid", "kernel summarize response missing text content block"),
+        );
+      }
+      const insightsMd = normalizeInsights(textBlock.text);
+      if (insightsMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "kernel summarize returned empty insights"));
+      }
+      const costUsd =
+        ((res.usage?.input_tokens ?? 0) * SUMMARY_INPUT_COST_PER_MTOK +
+          (res.usage?.output_tokens ?? 0) * SUMMARY_OUTPUT_COST_PER_MTOK) /
+        1_000_000;
+      return {
+        insightsMd,
+        promptHash,
+        costUsd,
+        model: res.model ?? SUMMARY_MODEL,
+      };
+    }),
+});
 
 export const _internal = {
   buildUserPrompt,
   buildReportUserPrompt,
+  buildSummaryUserPrompt,
   extractJson,
   kernelBase,
   LlmOutputSchema,
   ReportOutputSchema,
+  normalizeInsights,
   SYSTEM_PROMPT,
   REPORT_SYSTEM_PROMPT,
+  SUMMARY_SYSTEM_PROMPT,
   MODEL,
-}
+  SUMMARY_MODEL,
+};

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -1,9 +1,9 @@
-import { Effect, Layer } from "effect"
-import { sha256 } from "../lib/hash.js"
-import { LlmService, type ReportSection } from "../services/LlmService.js"
-import type { CuratedItem } from "../services/RendererService.js"
+import { Effect, Layer } from "effect";
+import { sha256 } from "../lib/hash.js";
+import { LlmService, type ReportSection } from "../services/LlmService.js";
+import type { CuratedItem } from "../services/RendererService.js";
 
-const STUB_MODEL = "stub-llm@0.1"
+const STUB_MODEL = "stub-llm@0.1";
 
 const renderPrompt = (
   date: string,
@@ -17,23 +17,22 @@ const renderPrompt = (
     `profile: ${profileName}`,
     `topics: ${topics.join(",")}`,
     `candidates: ${candidateIds.join(",")}`,
-  ].join("\n")
+  ].join("\n");
 
 export const StubLlmLive = Layer.succeed(LlmService, {
   name: () => STUB_MODEL,
   generateBrief: (req) =>
     Effect.sync(() => {
-      const candidateIds = req.candidates.map((c) => c.id)
-      const prompt = renderPrompt(req.date, req.profileName, req.topics, candidateIds)
-      const promptHash = sha256(prompt)
+      const candidateIds = req.candidates.map((c) => c.id);
+      const prompt = renderPrompt(req.date, req.profileName, req.topics, candidateIds);
+      const promptHash = sha256(prompt);
       const topCandidates = [...req.candidates]
         .sort((a, b) => b.score - a.score)
-        .slice(0, req.maxItems)
+        .slice(0, req.maxItems);
       const items: Array<CuratedItem> = topCandidates.map((c) => {
-        const title =
-          (c.page.frontmatter.title as string | undefined) ?? c.page.stem
-        const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
-        const topic = pageTopics[0] ?? null
+        const title = (c.page.frontmatter.title as string | undefined) ?? c.page.stem;
+        const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? [];
+        const topic = pageTopics[0] ?? null;
         return {
           kind: "news",
           title,
@@ -42,11 +41,11 @@ export const StubLlmLive = Layer.succeed(LlmService, {
           thesis: null,
           source_candidate_ids: [c.id],
           suggested_action: null,
-        }
-      })
+        };
+      });
       const topicsCovered = Array.from(
         new Set(items.map((i) => i.topic).filter((t): t is string => t !== null)),
-      )
+      );
       return {
         items,
         topicsCovered,
@@ -54,29 +53,41 @@ export const StubLlmLive = Layer.succeed(LlmService, {
         promptHash,
         costUsd: 0,
         model: STUB_MODEL,
-      }
+      };
+    }),
+  summarizeSource: (req) =>
+    Effect.sync(() => {
+      const sentences = req.text
+        .replace(/\s+/g, " ")
+        .split(/(?<=[.!?])\s+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+        .slice(0, 3);
+      const bullets =
+        sentences.length > 0 ? sentences.map((s) => `- ${s}`).join("\n") : "- (no content)";
+      const insightsMd = `## Key Insights\n\n${bullets}\n`;
+      const promptHash = sha256(`stub-summarize\n${req.url}\n${req.text}`);
+      return { insightsMd, promptHash, costUsd: 0, model: STUB_MODEL };
     }),
   generateReport: (req) =>
     Effect.sync(() => {
-      const candidateIds = req.interests.flatMap((it) => it.candidates.map((c) => c.id))
+      const candidateIds = req.interests.flatMap((it) => it.candidates.map((c) => c.id));
       const prompt = [
         "persona: uber-researcher/stub",
         `period: ${req.periodLabel}`,
         `profile: ${req.profileName}`,
         `interests: ${req.interests.map((i) => i.slug).join(",")}`,
         `candidates: ${candidateIds.join(",")}`,
-      ].join("\n")
-      const promptHash = sha256(prompt)
+      ].join("\n");
+      const promptHash = sha256(prompt);
       const sections: Array<ReportSection> = req.interests.map((it) => {
         const top = [...it.candidates]
           .sort((a, b) => b.score - a.score)
-          .slice(0, req.maxItemsPerInterest)
+          .slice(0, req.maxItemsPerInterest);
         const items: Array<CuratedItem> = top.map((c) => {
-          const title =
-            (c.page.frontmatter.title as string | undefined) ?? c.page.stem
-          const pageTopics =
-            (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
-          const topic = pageTopics[0] ?? null
+          const title = (c.page.frontmatter.title as string | undefined) ?? c.page.stem;
+          const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? [];
+          const topic = pageTopics[0] ?? null;
           return {
             kind: "news",
             title,
@@ -85,19 +96,19 @@ export const StubLlmLive = Layer.succeed(LlmService, {
             thesis: null,
             source_candidate_ids: [c.id],
             suggested_action: null,
-          }
-        })
+          };
+        });
         const summary_md =
           items.length === 0
             ? `No new candidates this week for ${it.title}.`
-            : `Stub weekly overview for ${it.title} covering ${items.length} item(s).`
-        return { interestSlug: it.slug, summary_md, items }
-      })
+            : `Stub weekly overview for ${it.title} covering ${items.length} item(s).`;
+        return { interestSlug: it.slug, summary_md, items };
+      });
       return {
         sections,
         promptHash,
         costUsd: 0,
         model: STUB_MODEL,
-      }
+      };
     }),
-})
+});

--- a/apps/uebermensch/src/commands/ingest.ts
+++ b/apps/uebermensch/src/commands/ingest.ts
@@ -1,50 +1,72 @@
-import { Command, Options } from "@effect/cli"
-import { Console, Effect, Either, Layer, Option } from "effect"
-import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
-import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
-import { HttpFeedDefaultConfig, HttpFeedLive } from "../adapters/HttpFeed.js"
-import { HttpIngestDefaultConfig, HttpIngestLive } from "../adapters/HttpIngest.js"
-import { resolveVaultDir } from "../lib/env.js"
-import { FeedService } from "../services/FeedService.js"
-import { IngestService } from "../services/IngestService.js"
-import { ProfileService } from "../services/ProfileService.js"
+import { Command, Options } from "@effect/cli";
+import { Console, Effect, Either, Layer, Option } from "effect";
+import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js";
+import { FileSystemVaultLive } from "../adapters/FileSystemVault.js";
+import { HttpFeedDefaultConfig, HttpFeedLive } from "../adapters/HttpFeed.js";
+import { HttpIngestDefaultConfig, HttpIngestLive } from "../adapters/HttpIngest.js";
+import { KernelLlmLive } from "../adapters/KernelLlm.js";
+import { resolveVaultDir } from "../lib/env.js";
+import { FeedService } from "../services/FeedService.js";
+import { IngestService } from "../services/IngestService.js";
+import { ProfileService } from "../services/ProfileService.js";
+
+// UBER_INGEST_SUMMARIZE=0 disables the default-on LLM summarization from env.
+// Any other truthy value or unset keeps the default behavior from the flag.
+const summarizeDefaultFromEnv = (): boolean => {
+  const raw = (process.env.UBER_INGEST_SUMMARIZE ?? "").trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") return false;
+  return true;
+};
 
 const urlOpt = Options.text("url").pipe(
   Options.withDescription("URL to fetch and store under wiki/sources/"),
-)
+);
 
 const dateOpt = Options.text("date").pipe(
   Options.withDescription("Override fetched_at date (YYYY-MM-DD); defaults to today"),
   Options.optional,
-)
+);
 
 const minWordsOpt = Options.integer("min-words").pipe(
   Options.withDescription("Reject pages with fewer words than this (default 50)"),
   Options.withDefault(50),
-)
+);
 
 const overwriteOpt = Options.boolean("overwrite").pipe(
   Options.withDescription("Overwrite an existing wiki/sources/<slug>.md"),
   Options.withDefault(false),
-)
+);
 
-const today = () => new Date().toISOString().slice(0, 10)
+const summarizeOpt = Options.boolean("summarize").pipe(
+  Options.withDescription(
+    "Replace the stored body with an LLM-generated key-insights summary (default on; set UBER_INGEST_SUMMARIZE=0 to disable)",
+  ),
+  Options.withDefault(summarizeDefaultFromEnv()),
+);
+
+const today = () => new Date().toISOString().slice(0, 10);
 
 const url = Command.make(
   "url",
-  { urlOpt, dateOpt, minWordsOpt, overwriteOpt },
-  ({ urlOpt: u, dateOpt: dateOptVal, minWordsOpt: minWords, overwriteOpt: overwrite }) =>
+  { urlOpt, dateOpt, minWordsOpt, overwriteOpt, summarizeOpt },
+  ({
+    urlOpt: u,
+    dateOpt: dateOptVal,
+    minWordsOpt: minWords,
+    overwriteOpt: overwrite,
+    summarizeOpt: summarize,
+  }) =>
     Effect.gen(function* () {
-      const vaultDir = yield* resolveVaultDir()
-      const date = Option.getOrElse(dateOptVal, today)
+      const vaultDir = yield* resolveVaultDir();
+      const date = Option.getOrElse(dateOptVal, today);
 
       const program = Effect.gen(function* () {
-        const profileSvc = yield* ProfileService
-        const ingest = yield* IngestService
-        const profile = yield* profileSvc.load()
-        const topicSlugs = profile.topics.topics.map((t) => t.slug)
+        const profileSvc = yield* ProfileService;
+        const ingest = yield* IngestService;
+        const profile = yield* profileSvc.load();
+        const topicSlugs = profile.topics.topics.map((t) => t.slug);
 
-        yield* Console.log(`ingesting ${u} into ${vaultDir} (date=${date})`)
+        yield* Console.log(`ingesting ${u} into ${vaultDir} (date=${date})`);
 
         const result = yield* ingest.ingestUrl({
           url: u,
@@ -52,60 +74,70 @@ const url = Command.make(
           topicSlugs,
           minWordCount: minWords,
           overwrite,
-        })
+          summarize,
+        });
 
         yield* Console.log(
-          `✓ wrote ${result.relPath} — ${result.wordCount} words, topics=[${result.topicsMatched.join(", ")}]`,
-        )
-        yield* Console.log(`  content_hash: ${result.contentHash}`)
-      })
+          `✓ wrote ${result.relPath} — ${result.wordCount} words, topics=[${result.topicsMatched.join(", ")}]${result.bodySource === "llm_insights" ? ` (insights via ${result.summaryModel ?? "llm"})` : ""}`,
+        );
+        yield* Console.log(`  content_hash: ${result.contentHash}`);
+      });
 
-      const vaultLayer = FileSystemVaultLive(vaultDir)
+      const vaultLayer = FileSystemVaultLive(vaultDir);
       const ingestLayer = HttpIngestLive.pipe(
         Layer.provide(Layer.mergeAll(vaultLayer, HttpIngestDefaultConfig)),
-      )
+      );
+      // KernelLlmLive is merged at the outer level (not consumed by Layer.provide)
+      // so HttpIngest's runtime Effect.serviceOption(LlmService) can see it.
       yield* program.pipe(
         Effect.provide(
-          Layer.mergeAll(FileSystemProfileLive(vaultDir), vaultLayer, ingestLayer),
+          Layer.mergeAll(FileSystemProfileLive(vaultDir), vaultLayer, ingestLayer, KernelLlmLive),
         ),
-      )
+      );
     }),
-).pipe(Command.withDescription("Fetch a URL and write wiki/sources/<date>--<domain>.md"))
+).pipe(Command.withDescription("Fetch a URL and write wiki/sources/<date>--<domain>.md"));
 
 const driverOpt = Options.text("driver").pipe(
   Options.withDescription("Only ingest sources with this driver (default: rss)"),
   Options.withDefault("rss"),
-)
+);
 
 const sinceHoursOpt = Options.integer("since-hours").pipe(
   Options.withDescription("Only ingest feed items published within the last N hours"),
   Options.withDefault(168), // 7 days
-)
+);
 
 const sourceSlugOpt = Options.text("source").pipe(
   Options.withDescription("Restrict to a single source slug from sources.md"),
   Options.optional,
-)
+);
 
 const perFeedLimitOpt = Options.integer("limit").pipe(
   Options.withDescription("Max items to ingest per feed"),
   Options.withDefault(10),
-)
+);
 
 const sourcesMinWordsOpt = Options.integer("min-words").pipe(
   Options.withDescription("Reject ingested pages with fewer words (default 50)"),
   Options.withDefault(50),
-)
+);
 
 const sourcesOverwriteOpt = Options.boolean("overwrite").pipe(
   Options.withDescription("Overwrite existing pages (default: skip on collision)"),
   Options.withDefault(false),
-)
+);
 
 const sourcesDryRunOpt = Options.boolean("dry-run").pipe(
   Options.withDescription("Show what would be ingested without writing"),
   Options.withDefault(false),
-)
+);
+
+const sourcesSummarizeOpt = Options.boolean("summarize").pipe(
+  Options.withDescription(
+    "Replace each stored body with an LLM-generated key-insights summary (default on; set UBER_INGEST_SUMMARIZE=0 to disable)",
+  ),
+  Options.withDefault(summarizeDefaultFromEnv()),
+);
 
 const sources = Command.make(
   "sources",
@@ -117,6 +149,7 @@ const sources = Command.make(
     sourcesMinWordsOpt,
     sourcesOverwriteOpt,
     sourcesDryRunOpt,
+    sourcesSummarizeOpt,
   },
   ({
     driverOpt: driver,
@@ -126,52 +159,53 @@ const sources = Command.make(
     sourcesMinWordsOpt: minWords,
     sourcesOverwriteOpt: overwrite,
     sourcesDryRunOpt: dryRun,
+    sourcesSummarizeOpt: summarize,
   }) =>
     Effect.gen(function* () {
-      const vaultDir = yield* resolveVaultDir()
-      const onlySlug = Option.getOrNull(onlySlugVal)
-      const now = new Date()
-      const cutoff = new Date(now.getTime() - sinceHours * 3_600_000)
-      const date = now.toISOString().slice(0, 10)
+      const vaultDir = yield* resolveVaultDir();
+      const onlySlug = Option.getOrNull(onlySlugVal);
+      const now = new Date();
+      const cutoff = new Date(now.getTime() - sinceHours * 3_600_000);
+      const date = now.toISOString().slice(0, 10);
 
       yield* Console.log(
         `ingesting sources from ${vaultDir} (driver=${driver}, since ${cutoff.toISOString()})`,
-      )
+      );
 
       const program = Effect.gen(function* () {
-        const profileSvc = yield* ProfileService
-        const feedSvc = yield* FeedService
-        const ingestSvc = yield* IngestService
-        const profile = yield* profileSvc.load()
+        const profileSvc = yield* ProfileService;
+        const feedSvc = yield* FeedService;
+        const ingestSvc = yield* IngestService;
+        const profile = yield* profileSvc.load();
 
-        const allTopicSlugs = profile.topics.topics.map((t) => t.slug)
-        const topicWatchlists: Record<string, ReadonlyArray<string>> = {}
+        const allTopicSlugs = profile.topics.topics.map((t) => t.slug);
+        const topicWatchlists: Record<string, ReadonlyArray<string>> = {};
         for (const t of profile.topics.topics) {
-          topicWatchlists[t.slug] = t.watchlist ?? []
+          topicWatchlists[t.slug] = t.watchlist ?? [];
         }
         const selected = profile.sources.sources.filter((s) => {
-          if (onlySlug !== null) return s.slug === onlySlug
-          return s.driver === driver
-        })
+          if (onlySlug !== null) return s.slug === onlySlug;
+          return s.driver === driver;
+        });
         if (selected.length === 0) {
           yield* Console.log(
             onlySlug !== null
               ? `  no source with slug "${onlySlug}"`
               : `  no sources with driver=${driver}`,
-          )
-          return
+          );
+          return;
         }
-        yield* Console.log(`  ${selected.length} source(s) selected`)
+        yield* Console.log(`  ${selected.length} source(s) selected`);
 
-        let totalFetched = 0
-        let totalIngested = 0
-        let totalSkipped = 0
-        let totalFailed = 0
+        let totalFetched = 0;
+        let totalIngested = 0;
+        let totalSkipped = 0;
+        let totalFailed = 0;
 
         for (const src of selected) {
           if (!src.url) {
-            yield* Console.log(`  - ${src.slug}: no url (driver=${src.driver}), skipping`)
-            continue
+            yield* Console.log(`  - ${src.slug}: no url (driver=${src.driver}), skipping`);
+            continue;
           }
           const fetched = yield* feedSvc.fetchFeed(src.url).pipe(
             Effect.tap((f) =>
@@ -181,26 +215,26 @@ const sources = Command.make(
               Console.log(`  - ${src.slug}: feed fetch failed — ${e.kind}: ${e.message}`),
             ),
             Effect.either,
-          )
-          const feed = Either.getOrNull(fetched)
+          );
+          const feed = Either.getOrNull(fetched);
           if (feed === null) {
-            totalFailed += 1
-            continue
+            totalFailed += 1;
+            continue;
           }
           const windowItems = feed.items.filter((it) => {
-            if (!it.link) return false
-            if (!it.publishedAt) return true // include undated items
-            return it.publishedAt >= cutoff
-          })
-          const batch = windowItems.slice(0, limit)
-          totalFetched += batch.length
+            if (!it.link) return false;
+            if (!it.publishedAt) return true; // include undated items
+            return it.publishedAt >= cutoff;
+          });
+          const batch = windowItems.slice(0, limit);
+          totalFetched += batch.length;
           yield* Console.log(
             `    ${batch.length}/${windowItems.length} within window (limit=${limit})`,
-          )
+          );
           for (const item of batch) {
             if (dryRun) {
-              yield* Console.log(`    [dry-run] ${item.link}`)
-              continue
+              yield* Console.log(`    [dry-run] ${item.link}`);
+              continue;
             }
             const result = yield* ingestSvc
               .ingestUrl({
@@ -212,39 +246,38 @@ const sources = Command.make(
                 forceTopics: src.topics,
                 topicWatchlists,
                 descriptionFromFeed: item.description ?? undefined,
+                summarize,
               })
               .pipe(
                 Effect.tap((r) =>
                   Console.log(
-                    `    ✓ ${r.relPath} (${r.wordCount}w${r.paywalled ? ", paywalled" : ""}${r.bodySource === "rss_description" ? ", rss-desc" : ""}, topics=[${r.topicsMatched.join(", ")}])`,
+                    `    ✓ ${r.relPath} (${r.wordCount}w${r.paywalled ? ", paywalled" : ""}${r.bodySource === "rss_description" ? ", rss-desc" : r.bodySource === "llm_insights" ? ", insights" : ""}, topics=[${r.topicsMatched.join(", ")}])`,
                   ),
                 ),
-                Effect.tapError((e) =>
-                  Console.log(`    ✗ ${item.link} — ${e.kind}: ${e.message}`),
-                ),
+                Effect.tapError((e) => Console.log(`    ✗ ${item.link} — ${e.kind}: ${e.message}`)),
                 Effect.either,
-              )
+              );
             Either.match(result, {
               onLeft: (e) => {
-                if (e.kind === "collision") totalSkipped += 1
-                else totalFailed += 1
+                if (e.kind === "collision") totalSkipped += 1;
+                else totalFailed += 1;
               },
               onRight: () => {
-                totalIngested += 1
+                totalIngested += 1;
               },
-            })
+            });
           }
         }
         yield* Console.log(
           `\ntotals: fetched=${totalFetched} ingested=${totalIngested} skipped=${totalSkipped} failed=${totalFailed}`,
-        )
-      })
+        );
+      });
 
-      const vaultLayer = FileSystemVaultLive(vaultDir)
+      const vaultLayer = FileSystemVaultLive(vaultDir);
       const ingestLayer = HttpIngestLive.pipe(
         Layer.provide(Layer.mergeAll(vaultLayer, HttpIngestDefaultConfig)),
-      )
-      const feedLayer = HttpFeedLive.pipe(Layer.provide(HttpFeedDefaultConfig))
+      );
+      const feedLayer = HttpFeedLive.pipe(Layer.provide(HttpFeedDefaultConfig));
       yield* program.pipe(
         Effect.provide(
           Layer.mergeAll(
@@ -252,17 +285,18 @@ const sources = Command.make(
             vaultLayer,
             ingestLayer,
             feedLayer,
+            KernelLlmLive,
           ),
         ),
-      )
+      );
     }),
 ).pipe(
   Command.withDescription(
     "Walk sources.md, fetch each feed, and ingest recent items through the source pipeline",
   ),
-)
+);
 
 export const ingest = Command.make("ingest").pipe(
   Command.withSubcommands([url, sources]),
   Command.withDescription("Ingest external sources into the vault"),
-)
+);

--- a/apps/uebermensch/src/lib/html-extract.ts
+++ b/apps/uebermensch/src/lib/html-extract.ts
@@ -1,12 +1,12 @@
 export type ExtractedPage = {
-  readonly title: string
-  readonly text: string
-  readonly wordCount: number
-  readonly publishedAt: string | null
-}
+  readonly title: string;
+  readonly text: string;
+  readonly wordCount: number;
+  readonly publishedAt: string | null;
+};
 
 const BLOCK_LEVEL_TAGS =
-  /<\/?(p|div|section|article|header|footer|nav|aside|main|br|li|ul|ol|h[1-6]|blockquote|pre|table|tr|td|th|figure|figcaption)\b[^>]*>/gi
+  /<\/?(p|div|section|article|header|footer|nav|aside|main|br|li|ul|ol|h[1-6]|blockquote|pre|table|tr|td|th|figure|figcaption)\b[^>]*>/gi;
 
 const decodeEntities = (s: string): string =>
   s
@@ -16,87 +16,163 @@ const decodeEntities = (s: string): string =>
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
-    .replace(/&#(\d+);/g, (_m, n) => String.fromCharCode(Number(n)))
+    .replace(/&#(\d+);/g, (_m, n) => String.fromCharCode(Number(n)));
 
-const stripBlock = (html: string, tagRe: RegExp): string => html.replace(tagRe, "")
+const stripBlock = (html: string, tagRe: RegExp): string => html.replace(tagRe, "");
 
 const extractTag = (html: string, tag: string): string | null => {
-  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i")
-  const m = re.exec(html)
-  return m?.[1] ?? null
-}
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i");
+  const m = re.exec(html);
+  return m?.[1] ?? null;
+};
 
 const extractMetaContent = (html: string, nameOrProp: string): string | null => {
   const re = new RegExp(
     `<meta\\s+(?:(?:name|property)\\s*=\\s*["']${nameOrProp}["'])[^>]*content\\s*=\\s*["']([^"']*)["'][^>]*>`,
     "i",
-  )
-  const m = re.exec(html)
-  if (m?.[1]) return m[1]
+  );
+  const m = re.exec(html);
+  if (m?.[1]) return m[1];
   // flipped order (content before name)
   const reFlipped = new RegExp(
     `<meta\\s+[^>]*content\\s*=\\s*["']([^"']*)["'][^>]*(?:name|property)\\s*=\\s*["']${nameOrProp}["'][^>]*>`,
     "i",
-  )
-  return reFlipped.exec(html)?.[1] ?? null
-}
+  );
+  return reFlipped.exec(html)?.[1] ?? null;
+};
 
 const collapseWhitespace = (s: string): string =>
   s
     .replace(/\r\n?/g, "\n")
     .replace(/[ \t]+/g, " ")
     .replace(/\n{3,}/g, "\n\n")
-    .trim()
+    .trim();
+
+// Patterns for lines that are almost certainly UI chrome / widgets / photo
+// credits and not article content. Matched on fully trimmed lines.
+const BOILERPLATE_LINE_PATTERNS: ReadonlyArray<RegExp> = [
+  /^share\s*save$/i,
+  /^sharesave$/i,
+  /^(share|save|copy link|copy url|print|email)$/i,
+  /^add\s+as\s+preferred\s+on\s+google\b.*$/i,
+  /^\s*\d+\s+(second|minute|hour|day|week|month|year)s?\s+ago(\s+sharesave)?$/i,
+  /^(afp|ap|reuters|epa|bloomberg|getty images|getty)\s*(via\s+[a-z][a-z .&-]+)?\s*(images?)?$/i,
+  /^(photo|image|picture|video)\s*:?\s*(getty|afp|ap|reuters|epa|bloomberg)\b.*$/i,
+  /^via\s+(getty|afp|ap|reuters|epa|bloomberg)\b.*$/i,
+  /^(advertisement|sponsored|promoted content|continue reading|read more)$/i,
+  /^(follow us|subscribe|sign up for our newsletter).*$/i,
+  /^related\s+(stories|articles|news|topics)\s*:?$/i,
+  /^most\s+(read|popular|viewed)\s*$/i,
+  /^skip to (main )?content$/i,
+  /^cookies?\s+(policy|settings)$/i,
+];
+
+const isBoilerplateLine = (line: string): boolean => {
+  const t = line.trim();
+  if (t.length === 0) return true;
+  for (const re of BOILERPLATE_LINE_PATTERNS) {
+    if (re.test(t)) return true;
+  }
+  return false;
+};
+
+// Drop UI chrome, collapse duplicates, and trim trailing single-word
+// category tags that news sites append (e.g. "Asia", "Japan" at page end).
+export const cleanBoilerplate = (text: string): string => {
+  const raw = text.split("\n");
+  const kept: Array<string> = [];
+  let prev: string | null = null;
+  for (const line of raw) {
+    const t = line.trim();
+    if (isBoilerplateLine(t)) {
+      if (prev !== "") kept.push("");
+      prev = "";
+      continue;
+    }
+    if (t === prev) continue;
+    kept.push(t);
+    prev = t;
+  }
+  // Strip trailing run of short "tag-like" lines (< 25 chars, no sentence
+  // punctuation). These are typically category chips at the end of an article.
+  while (kept.length > 0) {
+    const last = kept[kept.length - 1];
+    if (last === "") {
+      kept.pop();
+      continue;
+    }
+    if (last.length < 25 && !/[.!?;:"']/.test(last)) {
+      kept.pop();
+      continue;
+    }
+    break;
+  }
+  return kept
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+};
 
 export const extractFromHtml = (html: string): ExtractedPage => {
   const title =
-    extractMetaContent(html, "og:title") ??
-    extractTag(html, "title")?.trim() ??
-    "Untitled"
+    extractMetaContent(html, "og:title") ?? extractTag(html, "title")?.trim() ?? "Untitled";
   const publishedAt =
     extractMetaContent(html, "article:published_time") ??
     extractMetaContent(html, "datePublished") ??
-    null
+    null;
 
   // Prefer the body (or main/article) region
-  let region = extractTag(html, "article") ?? extractTag(html, "main") ?? extractTag(html, "body") ?? html
-  region = stripBlock(region, /<script[\s\S]*?<\/script>/gi)
-  region = stripBlock(region, /<style[\s\S]*?<\/style>/gi)
-  region = stripBlock(region, /<noscript[\s\S]*?<\/noscript>/gi)
-  region = stripBlock(region, /<!--[\s\S]*?-->/g)
-  region = region.replace(BLOCK_LEVEL_TAGS, "\n")
-  region = region.replace(/<[^>]+>/g, "")
-  const text = collapseWhitespace(decodeEntities(region))
-  const wordCount = text.split(/\s+/).filter(Boolean).length
-  return { title: decodeEntities(title).trim(), text, wordCount, publishedAt }
-}
+  let region =
+    extractTag(html, "article") ?? extractTag(html, "main") ?? extractTag(html, "body") ?? html;
+  region = stripBlock(region, /<script[\s\S]*?<\/script>/gi);
+  region = stripBlock(region, /<style[\s\S]*?<\/style>/gi);
+  region = stripBlock(region, /<noscript[\s\S]*?<\/noscript>/gi);
+  region = stripBlock(region, /<!--[\s\S]*?-->/g);
+  // Drop nav/aside/header/footer and their inner content — these carry UI
+  // chrome (share widgets, "Add as preferred on Google", related links)
+  // that leaks into the body when only the tags are stripped.
+  region = stripBlock(region, /<nav\b[\s\S]*?<\/nav>/gi);
+  region = stripBlock(region, /<aside\b[\s\S]*?<\/aside>/gi);
+  region = stripBlock(region, /<header\b[\s\S]*?<\/header>/gi);
+  region = stripBlock(region, /<footer\b[\s\S]*?<\/footer>/gi);
+  region = stripBlock(region, /<form\b[\s\S]*?<\/form>/gi);
+  region = region.replace(BLOCK_LEVEL_TAGS, "\n");
+  region = region.replace(/<[^>]+>/g, "");
+  const rawText = collapseWhitespace(decodeEntities(region));
+  const text = cleanBoilerplate(rawText);
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  return { title: decodeEntities(title).trim(), text, wordCount, publishedAt };
+};
 
 export const domainKebab = (url: string): string => {
-  const host = new URL(url).hostname.toLowerCase().replace(/^www\./, "")
-  return host.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
-}
+  const host = new URL(url).hostname.toLowerCase().replace(/^www\./, "");
+  return host.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+};
 
 const kebab = (s: string): string =>
-  s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 
 // Short, stable, deterministic 8-char hash of the URL for disambiguation.
 const urlHashShort = (url: string): string => {
-  let h = 2166136261 >>> 0 // FNV-1a 32-bit
+  let h = 2166136261 >>> 0; // FNV-1a 32-bit
   for (let i = 0; i < url.length; i += 1) {
-    h ^= url.charCodeAt(i)
-    h = Math.imul(h, 16777619) >>> 0
+    h ^= url.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
   }
-  return h.toString(16).padStart(8, "0")
-}
+  return h.toString(16).padStart(8, "0");
+};
 
 export const pathStem = (url: string): string => {
-  const u = new URL(url)
-  const parts = u.pathname.split("/").filter(Boolean)
-  const last = parts[parts.length - 1] ?? ""
-  const noExt = last.replace(/\.[a-z0-9]{1,6}$/i, "")
-  const stem = kebab(noExt).slice(0, 40)
-  return stem || urlHashShort(url)
-}
+  const u = new URL(url);
+  const parts = u.pathname.split("/").filter(Boolean);
+  const last = parts[parts.length - 1] ?? "";
+  const noExt = last.replace(/\.[a-z0-9]{1,6}$/i, "");
+  const stem = kebab(noExt).slice(0, 40);
+  return stem || urlHashShort(url);
+};
 
 export const slugForSource = (url: string, date: string): string =>
-  `${date}--${domainKebab(url)}--${pathStem(url)}`
+  `${date}--${domainKebab(url)}--${pathStem(url)}`;

--- a/apps/uebermensch/src/services/IngestService.ts
+++ b/apps/uebermensch/src/services/IngestService.ts
@@ -1,41 +1,46 @@
-import { Context, type Effect } from "effect"
-import type { IngestError } from "../errors.js"
+import { Context, type Effect } from "effect";
+import type { IngestError } from "../errors.js";
 
 export type IngestUrlRequest = {
-  readonly url: string
-  readonly date: string
-  readonly topicSlugs: ReadonlyArray<string>
-  readonly minWordCount: number
-  readonly overwrite: boolean
+  readonly url: string;
+  readonly date: string;
+  readonly topicSlugs: ReadonlyArray<string>;
+  readonly minWordCount: number;
+  readonly overwrite: boolean;
   // Topics this source CAN cover (from sources.md). Used as a ceiling — the final
   // set is (forceTopics ∩ classified). Pass undefined to skip the intersection and
   // use classifier results alone (e.g. from manual `uber ingest url`).
-  readonly forceTopics?: ReadonlyArray<string>
+  readonly forceTopics?: ReadonlyArray<string>;
   // Per-topic watchlist terms from topics.md. Expanded during classification so
   // a page matches `japan-macro` when its text mentions "boj", "yen", "jgb" etc.
-  readonly topicWatchlists?: Readonly<Record<string, ReadonlyArray<string>>>
+  readonly topicWatchlists?: Readonly<Record<string, ReadonlyArray<string>>>;
   // Free description/summary from the feed item (RSS <description> / Atom <summary>).
   // Used as body when the fetched article turns out to be paywalled.
-  readonly descriptionFromFeed?: string
-}
+  readonly descriptionFromFeed?: string;
+  // When true, call LlmService.summarizeSource and store the resulting
+  // Key Insights block as the page body instead of the full extracted text.
+  // Requires an LlmService to be provided in the layer. Silently falls back
+  // to extracted text on LLM failure.
+  readonly summarize?: boolean;
+};
 
 export type IngestedSource = {
-  readonly slug: string
-  readonly relPath: string
-  readonly absPath: string
-  readonly title: string
-  readonly domain: string
-  readonly wordCount: number
-  readonly topicsMatched: ReadonlyArray<string>
-  readonly contentHash: string
-  readonly paywalled: boolean
-  readonly bodySource: "extracted" | "rss_description"
-}
+  readonly slug: string;
+  readonly relPath: string;
+  readonly absPath: string;
+  readonly title: string;
+  readonly domain: string;
+  readonly wordCount: number;
+  readonly topicsMatched: ReadonlyArray<string>;
+  readonly contentHash: string;
+  readonly paywalled: boolean;
+  readonly bodySource: "extracted" | "rss_description" | "llm_insights";
+  readonly summaryModel?: string;
+  readonly summaryCostUsd?: number;
+};
 
 export interface IngestServiceShape {
-  readonly ingestUrl: (
-    req: IngestUrlRequest,
-  ) => Effect.Effect<IngestedSource, IngestError>
+  readonly ingestUrl: (req: IngestUrlRequest) => Effect.Effect<IngestedSource, IngestError>;
 }
 
 export class IngestService extends Context.Tag("uebermensch/IngestService")<

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -1,61 +1,78 @@
-import { Context, type Effect } from "effect"
-import type { LlmError } from "../errors.js"
-import type { CandidateRef } from "../lib/candidates.js"
-import type { CuratedItem } from "./RendererService.js"
+import { Context, type Effect } from "effect";
+import type { LlmError } from "../errors.js";
+import type { CandidateRef } from "../lib/candidates.js";
+import type { CuratedItem } from "./RendererService.js";
 
 export type BriefRequest = {
-  readonly date: string
-  readonly profileName: string
-  readonly topics: ReadonlyArray<string>
-  readonly thesesSlugs: ReadonlyArray<string>
-  readonly candidates: ReadonlyArray<CandidateRef>
-  readonly maxItems: number
-}
+  readonly date: string;
+  readonly profileName: string;
+  readonly topics: ReadonlyArray<string>;
+  readonly thesesSlugs: ReadonlyArray<string>;
+  readonly candidates: ReadonlyArray<CandidateRef>;
+  readonly maxItems: number;
+};
 
 export type BriefResponse = {
-  readonly items: ReadonlyArray<CuratedItem>
-  readonly topicsCovered: ReadonlyArray<string>
-  readonly thesesCovered: ReadonlyArray<string>
-  readonly promptHash: string
-  readonly costUsd: number
-  readonly model: string
-}
+  readonly items: ReadonlyArray<CuratedItem>;
+  readonly topicsCovered: ReadonlyArray<string>;
+  readonly thesesCovered: ReadonlyArray<string>;
+  readonly promptHash: string;
+  readonly costUsd: number;
+  readonly model: string;
+};
 
 export type ReportInterestInput = {
-  readonly slug: string
-  readonly title: string
-  readonly question: string | null
-  readonly topics: ReadonlyArray<string>
-  readonly notes: string
-  readonly candidates: ReadonlyArray<CandidateRef>
-}
+  readonly slug: string;
+  readonly title: string;
+  readonly question: string | null;
+  readonly topics: ReadonlyArray<string>;
+  readonly notes: string;
+  readonly candidates: ReadonlyArray<CandidateRef>;
+};
 
 export type ReportRequest = {
-  readonly periodLabel: string
-  readonly periodStart: string
-  readonly periodEnd: string
-  readonly profileName: string
-  readonly interests: ReadonlyArray<ReportInterestInput>
-  readonly maxItemsPerInterest: number
-}
+  readonly periodLabel: string;
+  readonly periodStart: string;
+  readonly periodEnd: string;
+  readonly profileName: string;
+  readonly interests: ReadonlyArray<ReportInterestInput>;
+  readonly maxItemsPerInterest: number;
+};
 
 export type ReportSection = {
-  readonly interestSlug: string
-  readonly summary_md: string
-  readonly items: ReadonlyArray<CuratedItem>
-}
+  readonly interestSlug: string;
+  readonly summary_md: string;
+  readonly items: ReadonlyArray<CuratedItem>;
+};
 
 export type ReportResponse = {
-  readonly sections: ReadonlyArray<ReportSection>
-  readonly promptHash: string
-  readonly costUsd: number
-  readonly model: string
-}
+  readonly sections: ReadonlyArray<ReportSection>;
+  readonly promptHash: string;
+  readonly costUsd: number;
+  readonly model: string;
+};
+
+export type SourceSummaryRequest = {
+  readonly title: string;
+  readonly url: string;
+  readonly text: string;
+  readonly topics: ReadonlyArray<string>;
+};
+
+export type SourceSummaryResponse = {
+  readonly insightsMd: string;
+  readonly promptHash: string;
+  readonly costUsd: number;
+  readonly model: string;
+};
 
 export interface LlmServiceShape {
-  readonly name: () => string
-  readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>
-  readonly generateReport: (req: ReportRequest) => Effect.Effect<ReportResponse, LlmError>
+  readonly name: () => string;
+  readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>;
+  readonly generateReport: (req: ReportRequest) => Effect.Effect<ReportResponse, LlmError>;
+  readonly summarizeSource: (
+    req: SourceSummaryRequest,
+  ) => Effect.Effect<SourceSummaryResponse, LlmError>;
 }
 
 export class LlmService extends Context.Tag("uebermensch/LlmService")<

--- a/apps/uebermensch/tests/ingest.test.ts
+++ b/apps/uebermensch/tests/ingest.test.ts
@@ -9,9 +9,10 @@ import {
   HttpIngestConfigTag,
   HttpIngestLive,
 } from "../src/adapters/HttpIngest.js"
-import { IngestError } from "../src/errors.js"
-import { domainKebab, extractFromHtml, slugForSource } from "../src/lib/html-extract.js"
+import { IngestError, LlmError } from "../src/errors.js"
+import { cleanBoilerplate, domainKebab, extractFromHtml, slugForSource } from "../src/lib/html-extract.js"
 import { IngestService } from "../src/services/IngestService.js"
+import { LlmService } from "../src/services/LlmService.js"
 
 describe("html-extract", () => {
   it("pulls title from <title> and strips scripts/styles", () => {
@@ -51,6 +52,64 @@ describe("html-extract", () => {
     const html = `<html><body><article><p>Tom &amp; Jerry &#8212; &quot;pals&quot;</p></article></body></html>`
     expect(extractFromHtml(html).text).toContain('Tom & Jerry')
     expect(extractFromHtml(html).text).toContain('"pals"')
+  })
+
+  it("drops nav/header/footer/aside content so UI chrome does not leak in", () => {
+    const html = `<html><body>
+      <header><nav><a href="/">home</a><a href="/reports">reports</a></nav></header>
+      <article>
+        <p>The real lede of the article is here and is substantive.</p>
+        <p>A second paragraph with actual reporting from the ground.</p>
+      </article>
+      <aside>Add as preferred on Google</aside>
+      <footer>ShareSave</footer>
+    </body></html>`
+    const out = extractFromHtml(html)
+    expect(out.text).toContain("real lede")
+    expect(out.text).not.toMatch(/home\s+reports/i)
+    expect(out.text).not.toMatch(/add as preferred on google/i)
+    expect(out.text).not.toMatch(/sharesave/i)
+  })
+
+  it("strips BBC-style chrome lines embedded in article body", () => {
+    const html = `<html><body><article>
+      <p>Headline Re-Stated</p>
+      <p>1 day ago</p>
+      <p>ShareSave</p>
+      <p>Add as preferred on Google</p>
+      <p>AFP via Getty Images</p>
+      <p>The substantive first paragraph of the article explains the policy shift.</p>
+      <p>AFP via Getty Images</p>
+      <p>A second paragraph with more context about what is actually happening.</p>
+      <p>Asia</p>
+      <p>Japan</p>
+    </article></body></html>`
+    const out = extractFromHtml(html)
+    expect(out.text).toContain("substantive first paragraph")
+    expect(out.text).toContain("more context")
+    expect(out.text).not.toMatch(/^ShareSave$/m)
+    expect(out.text).not.toMatch(/^1 day ago/im)
+    expect(out.text).not.toMatch(/add as preferred on google/i)
+    expect(out.text).not.toMatch(/afp via getty images/i)
+    // trailing single-word tags should be pruned
+    expect(out.text.trim().endsWith("Japan")).toBe(false)
+    expect(out.text.trim().endsWith("Asia")).toBe(false)
+  })
+})
+
+describe("cleanBoilerplate", () => {
+  it("collapses adjacent duplicate lines", () => {
+    const input = "Photo\nPhoto\nThe real first paragraph carries on normally."
+    expect(cleanBoilerplate(input)).not.toMatch(/Photo\nPhoto/)
+  })
+
+  it("keeps real quoted lines even when short", () => {
+    const input = [
+      "\"We must keep going,\" said the senator.",
+      "Quote ends here but discussion continues in follow-up reporting.",
+    ].join("\n")
+    const out = cleanBoilerplate(input)
+    expect(out).toContain("keep going")
   })
 })
 
@@ -181,5 +240,108 @@ describe("HttpIngest adapter", () => {
     expect(err).toBeInstanceOf(IngestError)
     expect(err.kind).toBe("fetch_failed")
     expect(err.url).toBe("u")
+  })
+})
+
+describe("HttpIngest with summarization", () => {
+  const fakeLlmLayer = (insights: string, calls: { count: number }) =>
+    Layer.succeed(LlmService, {
+      name: () => "fake-llm",
+      generateBrief: () => Effect.die("not used"),
+      generateReport: () => Effect.die("not used"),
+      summarizeSource: () =>
+        Effect.sync(() => {
+          calls.count += 1
+          return {
+            insightsMd: insights,
+            promptHash: "sha256:deadbeef",
+            costUsd: 0.0001,
+            model: "fake-llm@1",
+          }
+        }),
+    })
+
+  const runIngestWithLlm = async (
+    vaultDir: string,
+    fakeFetch: typeof fetch,
+    llmLayer: Layer.Layer<LlmService>,
+    req: typeof seedReq & { summarize: boolean },
+  ) => {
+    const ingestLayer = HttpIngestLive.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          FileSystemVaultLive(vaultDir),
+          Layer.succeed(HttpIngestConfigTag, { fetch: fakeFetch }),
+        ),
+      ),
+    )
+    return Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const svc = yield* IngestService
+        return yield* svc.ingestUrl(req)
+      }).pipe(Effect.provide(Layer.mergeAll(ingestLayer, llmLayer))),
+    )
+  }
+
+  it("replaces body with LLM insights when summarize=true", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-ingest-sum-"))
+    const longBody = `<p>${"sentence about Tokyo arms exports. ".repeat(40)}</p>`
+    const html = `<html><head><title>Arms Exports</title></head><body><article>${longBody}</article></body></html>`
+    const calls = { count: 0 }
+    const insights =
+      "## Key Insights\n\n- Japan lifted arms-export restrictions to 17 partner countries.\n- The move targets lethal weapons for the first time.\n"
+    const exit = await runIngestWithLlm(
+      dir,
+      mkFetch(200, html),
+      fakeLlmLayer(insights, calls),
+      { ...seedReq, summarize: true },
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(calls.count).toBe(1)
+    if (!Exit.isSuccess(exit)) return
+    const res = exit.value
+    expect(res.bodySource).toBe("llm_insights")
+    expect(res.summaryModel).toBe("fake-llm@1")
+
+    const onDisk = await readFile(join(dir, res.relPath), "utf8")
+    const parsed = matter(onDisk)
+    expect(parsed.content).toContain("Key Insights")
+    expect(parsed.content).toContain("17 partner countries")
+    expect(parsed.content).not.toContain("sentence about Tokyo arms exports")
+    expect((parsed.data.quality as { body_source: string }).body_source).toBe("llm_insights")
+    expect((parsed.data.summary as { model: string }).model).toBe("fake-llm@1")
+  })
+
+  it("falls back to extracted body when LLM fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-ingest-sum-"))
+    const html = `<html><head><title>T</title></head><body><article>${"word ".repeat(50)}</article></body></html>`
+    const failingLlm = Layer.succeed(LlmService, {
+      name: () => "broken-llm",
+      generateBrief: () => Effect.die("not used"),
+      generateReport: () => Effect.die("not used"),
+      summarizeSource: () =>
+        Effect.fail(new LlmError({ message: "upstream 503", kind: "unavailable" })),
+    })
+    const exit = await runIngestWithLlm(dir, mkFetch(200, html), failingLlm, {
+      ...seedReq,
+      summarize: true,
+    })
+    expect(Exit.isSuccess(exit)).toBe(true)
+    if (!Exit.isSuccess(exit)) return
+    expect(exit.value.bodySource).toBe("extracted")
+  })
+
+  it("skips LLM entirely when summarize=false", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-ingest-sum-"))
+    const html = `<html><head><title>T</title></head><body><article>${"word ".repeat(50)}</article></body></html>`
+    const calls = { count: 0 }
+    const exit = await runIngestWithLlm(
+      dir,
+      mkFetch(200, html),
+      fakeLlmLayer("## Key Insights\n- x", calls),
+      { ...seedReq, summarize: false },
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(calls.count).toBe(0)
   })
 })

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -5,7 +5,8 @@ import type { CandidateRef } from "../src/lib/candidates.js"
 import { LlmService } from "../src/services/LlmService.js"
 import type { WikiPage } from "../src/services/VaultService.js"
 
-const { extractJson, buildUserPrompt, kernelBase, MODEL } = _internal
+const { extractJson, buildUserPrompt, kernelBase, MODEL, SUMMARY_MODEL, normalizeInsights } =
+  _internal
 
 const page = (stem: string, body: string, topics: ReadonlyArray<string> = []): WikiPage => ({
   relPath: `wiki/sources/${stem}.md`,
@@ -158,6 +159,55 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
       }).pipe(Effect.provide(KernelLlmLive)),
     )
     expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("summarizeSource posts to kernel with SUMMARY_MODEL and returns insights", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          model: SUMMARY_MODEL,
+          usage: { input_tokens: 500, output_tokens: 200 },
+          content: [
+            {
+              type: "text",
+              text: "Here you go:\n\n## Key Insights\n\n- Tokyo lifted restrictions.\n- Sales now cover 17 allies.\n",
+            },
+          ],
+        }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const res = await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.summarizeSource({
+          title: "Arms Exports",
+          url: "https://example.com/arms",
+          text: "long article body ".repeat(100),
+          topics: ["japan-politics"],
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+
+    expect(res.model).toBe(SUMMARY_MODEL)
+    expect(res.insightsMd.startsWith("## Key Insights")).toBe(true)
+    expect(res.insightsMd).toContain("17 allies")
+    // 500 * $1/M + 200 * $5/M = $0.0005 + $0.001 = $0.0015
+    expect(res.costUsd).toBeCloseTo(0.0015, 6)
+
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.model).toBe(SUMMARY_MODEL)
+    expect(body.system).toContain("uebermensch-ingest")
+    expect(body.messages[0].content).toContain("Arms Exports")
+  })
+
+  it("normalizeInsights strips preamble before the heading", () => {
+    const out = normalizeInsights("Here are your insights:\n\n## Key Insights\n\n- one\n- two\n")
+    expect(out.startsWith("## Key Insights")).toBe(true)
+    expect(out).not.toMatch(/Here are your insights/)
   })
 
   it("fails with invalid when response text has no JSON", async () => {


### PR DESCRIPTION
## Summary

Fixes the rendered source pages on the uebermensch wiki, which leaked
UI chrome and carried the full article body instead of a summary.

**Motivating example** — [BBC article on Japanese arms exports](https://uebermensch-pages.debuggingfuturecors.workers.dev/wiki/2026-04-22--bbc-com--clyx4vlqy4vo)
had lines like `1 day ago ShareSave`, `Add as preferred on Google`,
duplicated `AFP via Getty Images` credits, and trailing `Asia`/`Japan`
category chips — plus the whole article body.

### What changed

- **`html-extract`**: drop `nav`/`aside`/`header`/`footer`/`form` subtrees
  (not only the tags), filter boilerplate lines (share widgets, "N days
  ago", photo credits, newsletter prompts, "Skip to content"), collapse
  adjacent duplicates, trim trailing single-word category chips.
- **`LlmService`**: new `summarizeSource(title, url, text, topics)`
  returning a `## Key Insights` markdown block with 3–6 concrete bullets.
- **`KernelLlm`**: summarizer uses `claude-haiku-4-5` for cost (still
  routed through the CF AI Gateway `/api/llm/messages` path, like the
  opus-based curator/reporter).
- **`HttpIngest`**: when `summarize=true` and `LlmService` is provided,
  replaces the stored body with the insights block and records
  `summary.model` + `summary.cost_usd` in frontmatter. Classification
  still runs on the full extracted text so watchlist recall is
  preserved. On LLM failure the ingest silently falls back to the
  cleaned extracted body — ingestion does not break because of a
  kernel/gateway hiccup.
- **CLI**: `uber ingest url` and `uber ingest sources` get `--summarize`
  (default on). Override via `UBER_INGEST_SUMMARIZE=0` env.

### Default LLM clarification

Per the project memory the intended default for
curator/deepdive is `@cf/google/gemma-4-26b-a4b-it`, but the kernel's
`/api/llm/messages` currently only forwards to
`.../anthropic/v1/messages` via the CF AI Gateway — so actual traffic
still goes to Anthropic models. This PR keeps that path and uses
`claude-haiku-4-5` for the per-article summarizer. Routing gemma via
Workers AI would require a kernel-side change (new gateway path + a
non-Anthropic request shape) and is not in scope here.

## Test plan
- [x] `pnpm test` in `apps/uebermensch` — 87 passing (was 78)
  - new coverage: nav/header/footer dropped, BBC-style chrome lines
    filtered, `cleanBoilerplate` keeps real quoted lines, summarize
    success path, LLM failure fallback, summarize=false bypass,
    KernelLlm summarize wiring, `normalizeInsights` preamble trim
- [x] `pnpm build` (tsup) succeeds
- [x] biome check clean on touched files
- [ ] Manual: `UBER_INGEST_SUMMARIZE=1 uber ingest url --url <news URL>` against
      a running kernel with `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_AI_GATEWAY_ID`
      and an Anthropic key (BYOK or managed); verify the rendered page
      on `uebermensch-pages` shows "Key Insights" with no UI chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
