### PR TITLE
feat(kernel+uber): route @cf/* models through Workers AI via AI Gateway

### DIFF
--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -10,9 +10,9 @@ import {
 } from "../services/LlmService.js";
 import type { CuratedItem } from "../services/RendererService.js";
 
-const MODEL = "claude-opus-4-7";
-const INPUT_COST_PER_MTOK = 5.0;
-const OUTPUT_COST_PER_MTOK = 25.0;
+const DEFAULT_MODEL = "claude-opus-4-7";
+const ANTHROPIC_INPUT_COST_PER_MTOK = 5.0;
+const ANTHROPIC_OUTPUT_COST_PER_MTOK = 25.0;
 const MAX_CANDIDATE_EXCERPT = 2000;
 const DEFAULT_MAX_TOKENS = 16000;
 
@@ -23,6 +23,10 @@ const SUMMARY_INPUT_COST_PER_MTOK = 1.0;
 const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0;
 const SUMMARY_MAX_TOKENS = 800;
 const SUMMARY_INPUT_CHARS_CAP = 12000;
+
+const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL;
+
+const isWorkersAiModel = (model: string): boolean => model.startsWith("@cf/");
 
 const kernelBase = (): string =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
@@ -117,6 +121,19 @@ type AnthropicResponse = {
   readonly model?: string;
 };
 
+type OpenAiChatResponse = {
+  readonly choices?: ReadonlyArray<{ readonly message?: { readonly content?: string } }>;
+  readonly usage?: { readonly prompt_tokens?: number; readonly completion_tokens?: number };
+  readonly model?: string;
+};
+
+type NormalizedResponse = {
+  readonly text: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly model: string;
+};
+
 const extractJson = (text: string): string | null => {
   const fenced = text.match(/```json\s*([\s\S]*?)```/);
   if (fenced) return fenced[1].trim();
@@ -137,28 +154,118 @@ const classifyKernelStatus = (status: number): LlmError["kind"] => {
   return "invalid";
 };
 
-const postMessages = (body: unknown): Effect.Effect<AnthropicResponse, LlmError> =>
+const tokensCost = (
+  inputTokens: number,
+  outputTokens: number,
+  inputRate: number,
+  outputRate: number,
+): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000;
+
+const postAnthropic = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  maxTokens: number,
+  thinking: boolean,
+): Effect.Effect<NormalizedResponse, LlmError> =>
   Effect.tryPromise({
     try: async () => {
+      const body: Record<string, unknown> = {
+        model,
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: "user", content: userPrompt }],
+      };
+      if (thinking) body.thinking = { type: "adaptive" };
       const res = await fetch(`${kernelBase()}/api/llm/messages`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       });
-      const text = await res.text();
+      const raw = await res.text();
       if (!res.ok) {
         throw llmErr(
           classifyKernelStatus(res.status),
-          `kernel /api/llm/messages HTTP ${res.status}: ${text.slice(0, 500)}`,
+          `kernel /api/llm/messages HTTP ${res.status}: ${raw.slice(0, 500)}`,
         );
       }
-      return text.length > 0 ? (JSON.parse(text) as AnthropicResponse) : ({} as AnthropicResponse);
+      const parsed = (raw.length > 0 ? JSON.parse(raw) : {}) as AnthropicResponse;
+      const textBlock = (parsed.content ?? []).find(
+        (b): b is { type: string; text: string } =>
+          b.type === "text" && typeof b.text === "string",
+      );
+      if (!textBlock) {
+        throw llmErr("invalid", "kernel response missing text content block");
+      }
+      return {
+        text: textBlock.text,
+        inputTokens: parsed.usage?.input_tokens ?? 0,
+        outputTokens: parsed.usage?.output_tokens ?? 0,
+        model: parsed.model ?? model,
+      };
     },
     catch: (e) =>
       e instanceof LlmError
         ? e
         : llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`),
   });
+
+const postWorkersAi = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  maxTokens: number,
+): Effect.Effect<NormalizedResponse, LlmError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const body = {
+        model,
+        max_tokens: maxTokens,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: userPrompt },
+        ],
+      };
+      const res = await fetch(`${kernelBase()}/api/llm/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const raw = await res.text();
+      if (!res.ok) {
+        throw llmErr(
+          classifyKernelStatus(res.status),
+          `kernel /api/llm/completions HTTP ${res.status}: ${raw.slice(0, 500)}`,
+        );
+      }
+      const parsed = (raw.length > 0 ? JSON.parse(raw) : {}) as OpenAiChatResponse;
+      const content = parsed.choices?.[0]?.message?.content;
+      if (typeof content !== "string") {
+        throw llmErr("invalid", "kernel response missing choices[0].message.content string");
+      }
+      return {
+        text: content,
+        inputTokens: parsed.usage?.prompt_tokens ?? 0,
+        outputTokens: parsed.usage?.completion_tokens ?? 0,
+        model: parsed.model ?? model,
+      };
+    },
+    catch: (e) =>
+      e instanceof LlmError
+        ? e
+        : llmErr("unavailable", `kernel /api/llm/completions fetch failed: ${String(e)}`),
+  });
+
+const postLlm = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  maxTokens: number,
+  thinking: boolean,
+): Effect.Effect<NormalizedResponse, LlmError> =>
+  isWorkersAiModel(model)
+    ? postWorkersAi(model, system, userPrompt, maxTokens)
+    : postAnthropic(model, system, userPrompt, maxTokens, thinking);
 
 const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst that produces a weekly research report grouped by research interest.
 
@@ -290,26 +397,14 @@ const normalizeInsights = (raw: string): string => {
 };
 
 export const KernelLlmLive = Layer.succeed(LlmService, {
-  name: () => `kernel-llm@${MODEL}`,
+  name: () => `kernel-llm@${modelFor()}`,
   generateBrief: (req) =>
     Effect.gen(function* () {
+      const model = modelFor();
       const userPrompt = buildUserPrompt(req);
       const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const body = {
-        model: MODEL,
-        max_tokens: DEFAULT_MAX_TOKENS,
-        thinking: { type: "adaptive" },
-        system: SYSTEM_PROMPT,
-        messages: [{ role: "user", content: userPrompt }],
-      };
-      const res = yield* postMessages(body);
-      const textBlock = (res.content ?? []).find(
-        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
-      );
-      if (!textBlock) {
-        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"));
-      }
-      const raw = extractJson(textBlock.text);
+      const res = yield* postLlm(model, SYSTEM_PROMPT, userPrompt, DEFAULT_MAX_TOKENS, true);
+      const raw = extractJson(res.text);
       if (raw === null) {
         return yield* Effect.fail(
           llmErr("invalid", "kernel response text did not contain a JSON object"),
@@ -326,10 +421,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const decoded = yield* Schema.decodeUnknown(LlmOutputSchema)(parsed).pipe(
         Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
       );
-      const costUsd =
-        ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
-          (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
-        1_000_000;
+      const costUsd = isWorkersAiModel(res.model)
+        ? 0
+        : tokensCost(
+            res.inputTokens,
+            res.outputTokens,
+            ANTHROPIC_INPUT_COST_PER_MTOK,
+            ANTHROPIC_OUTPUT_COST_PER_MTOK,
+          );
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -345,28 +444,22 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         thesesCovered: decoded.thesesCovered,
         promptHash,
         costUsd,
-        model: res.model ?? MODEL,
+        model: res.model,
       };
     }),
   generateReport: (req) =>
     Effect.gen(function* () {
+      const model = modelFor();
       const userPrompt = buildReportUserPrompt(req);
       const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const body = {
-        model: MODEL,
-        max_tokens: DEFAULT_MAX_TOKENS,
-        thinking: { type: "adaptive" },
-        system: REPORT_SYSTEM_PROMPT,
-        messages: [{ role: "user", content: userPrompt }],
-      };
-      const res = yield* postMessages(body);
-      const textBlock = (res.content ?? []).find(
-        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
+      const res = yield* postLlm(
+        model,
+        REPORT_SYSTEM_PROMPT,
+        userPrompt,
+        DEFAULT_MAX_TOKENS,
+        true,
       );
-      if (!textBlock) {
-        return yield* Effect.fail(llmErr("invalid", "kernel response missing text content block"));
-      }
-      const raw = extractJson(textBlock.text);
+      const raw = extractJson(res.text);
       if (raw === null) {
         return yield* Effect.fail(
           llmErr("invalid", "kernel response text did not contain a JSON object"),
@@ -383,10 +476,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const decoded = yield* Schema.decodeUnknown(ReportOutputSchema)(parsed).pipe(
         Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
       );
-      const costUsd =
-        ((res.usage?.input_tokens ?? 0) * INPUT_COST_PER_MTOK +
-          (res.usage?.output_tokens ?? 0) * OUTPUT_COST_PER_MTOK) /
-        1_000_000;
+      const costUsd = isWorkersAiModel(res.model)
+        ? 0
+        : tokensCost(
+            res.inputTokens,
+            res.outputTokens,
+            ANTHROPIC_INPUT_COST_PER_MTOK,
+            ANTHROPIC_OUTPUT_COST_PER_MTOK,
+          );
       const sections: ReadonlyArray<ReportSection> = decoded.sections.map((s) => ({
         interestSlug: s.interestSlug,
         summary_md: s.summary_md,
@@ -404,7 +501,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         sections,
         promptHash,
         costUsd,
-        model: res.model ?? MODEL,
+        model: res.model,
       };
     }),
   summarizeSource: (req) =>
@@ -415,34 +512,30 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
           : req.text;
       const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
       const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const body = {
-        model: SUMMARY_MODEL,
-        max_tokens: SUMMARY_MAX_TOKENS,
-        system: SUMMARY_SYSTEM_PROMPT,
-        messages: [{ role: "user", content: userPrompt }],
-      };
-      const res = yield* postMessages(body);
-      const textBlock = (res.content ?? []).find(
-        (b): b is { type: string; text: string } => b.type === "text" && typeof b.text === "string",
+      const res = yield* postLlm(
+        SUMMARY_MODEL,
+        SUMMARY_SYSTEM_PROMPT,
+        userPrompt,
+        SUMMARY_MAX_TOKENS,
+        false,
       );
-      if (!textBlock) {
-        return yield* Effect.fail(
-          llmErr("invalid", "kernel summarize response missing text content block"),
-        );
-      }
-      const insightsMd = normalizeInsights(textBlock.text);
+      const insightsMd = normalizeInsights(res.text);
       if (insightsMd.length === 0) {
         return yield* Effect.fail(llmErr("invalid", "kernel summarize returned empty insights"));
       }
-      const costUsd =
-        ((res.usage?.input_tokens ?? 0) * SUMMARY_INPUT_COST_PER_MTOK +
-          (res.usage?.output_tokens ?? 0) * SUMMARY_OUTPUT_COST_PER_MTOK) /
-        1_000_000;
+      const costUsd = isWorkersAiModel(res.model)
+        ? 0
+        : tokensCost(
+            res.inputTokens,
+            res.outputTokens,
+            SUMMARY_INPUT_COST_PER_MTOK,
+            SUMMARY_OUTPUT_COST_PER_MTOK,
+          );
       return {
         insightsMd,
         promptHash,
         costUsd,
-        model: res.model ?? SUMMARY_MODEL,
+        model: res.model,
       };
     }),
 });
@@ -459,6 +552,9 @@ export const _internal = {
   SYSTEM_PROMPT,
   REPORT_SYSTEM_PROMPT,
   SUMMARY_SYSTEM_PROMPT,
-  MODEL,
+  MODEL: DEFAULT_MODEL,
+  DEFAULT_MODEL,
   SUMMARY_MODEL,
+  modelFor,
+  isWorkersAiModel,
 };

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -197,7 +197,8 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     // 500 * $1/M + 200 * $5/M = $0.0005 + $0.001 = $0.0015
     expect(res.costUsd).toBeCloseTo(0.0015, 6)
 
-    const [, init] = fetchMock.mock.calls[0]!
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(`${kernelBase()}/api/llm/messages`)
     const body = JSON.parse((init as { body: string }).body)
     expect(body.model).toBe(SUMMARY_MODEL)
     expect(body.system).toContain("uebermensch-ingest")
@@ -208,6 +209,82 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     const out = normalizeInsights("Here are your insights:\n\n## Key Insights\n\n- one\n- two\n")
     expect(out.startsWith("## Key Insights")).toBe(true)
     expect(out).not.toMatch(/Here are your insights/)
+  })
+
+  it("routes @cf/* models to /api/llm/completions with OpenAI-compat body + response", async () => {
+    const prevModel = process.env.UBER_LLM_MODEL
+    process.env.UBER_LLM_MODEL = "@cf/google/gemma-4-26b-a4b-it"
+    const openaiJson = {
+      model: "@cf/google/gemma-4-26b-a4b-it",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content:
+              '```json\n' +
+              JSON.stringify({
+                items: [
+                  {
+                    kind: "news",
+                    title: "Gemma rendered",
+                    summary_md: "Cite [[2026-04-18--foo]].",
+                    topic: "alpha",
+                    thesis: null,
+                    source_candidate_ids: ["cand-0000"],
+                    suggested_action: null,
+                  },
+                ],
+                topicsCovered: ["alpha"],
+                thesesCovered: [],
+              }) +
+              "\n```",
+          },
+        },
+      ],
+      usage: { prompt_tokens: 100, completion_tokens: 200 },
+    }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(openaiJson),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    try {
+      const res = await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: ["alpha"],
+            thesesSlugs: [],
+            candidates: [candidate("cand-0000", "2026-04-18--foo", "Foo body text.", ["alpha"])],
+            maxItems: 3,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      expect(res.items).toHaveLength(1)
+      expect(res.items[0].title).toBe("Gemma rendered")
+      expect(res.model).toBe("@cf/google/gemma-4-26b-a4b-it")
+      // Workers AI cost tracking deferred — reported as 0 until per-model rates land.
+      expect(res.costUsd).toBe(0)
+      expect(fetchMock).toHaveBeenCalledOnce()
+      const [url, init] = fetchMock.mock.calls[0]!
+      expect(url).toBe(`${kernelBase()}/api/llm/completions`)
+      const body = JSON.parse((init as { body: string }).body)
+      expect(body.model).toBe("@cf/google/gemma-4-26b-a4b-it")
+      expect(body.thinking).toBeUndefined()
+      expect(body.messages[0]).toEqual({
+        role: "system",
+        content: expect.stringContaining("uebermensch-curator"),
+      })
+      expect(body.messages[1].role).toBe("user")
+      expect(body.messages[1].content).toContain("cand-0000")
+    } finally {
+      if (prevModel === undefined) delete process.env.UBER_LLM_MODEL
+      else process.env.UBER_LLM_MODEL = prevModel
+    }
   })
 
   it("fails with invalid when response text has no JSON", async () => {

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -152,8 +152,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Messaging drivers (LKM — outbound to Telegram Bot API and Discord webhooks)
         .route("/api/telegram/send", post(telegram_send))
         .route("/api/discord/send", post(discord_send))
-        // LLM driver (LKM — outbound to Anthropic Messages API)
+        // LLM driver (LKM — outbound via Cloudflare AI Gateway)
+        // /messages  → Anthropic-shape upstream (Claude models)
+        // /completions → Workers AI OpenAI-compat upstream (e.g. @cf/google/gemma-*)
         .route("/api/llm/messages", post(llm_messages))
+        .route("/api/llm/completions", post(llm_completions))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -2712,6 +2715,71 @@ async fn llm_messages(
     if let Some(t) = gateway_token {
         req = req.header("cf-aig-authorization", format!("Bearer {t}"));
     }
+    match req.json(&body).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            if status.is_success() {
+                match serde_json::from_str::<serde_json::Value>(&text) {
+                    Ok(v) => Json(v).into_response(),
+                    Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
+                }
+            } else {
+                (messaging_upstream_status(status), text).into_response()
+            }
+        }
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            format!("ai gateway request failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+// --- LLM Driver: Workers AI (OpenAI-compat Chat Completions) ---
+//
+// Forwards OpenAI-shape Chat Completions payloads through Cloudflare AI Gateway
+// to Cloudflare Workers AI models (e.g. `@cf/google/gemma-4-26b-a4b-it`).
+//
+// Required env:
+//   CLOUDFLARE_ACCOUNT_ID        — CF account owning the gateway
+//   CLOUDFLARE_AI_GATEWAY_ID     — slug of the AI Gateway
+//   CF_API_TOKEN                 — Cloudflare API token with Workers AI read
+//                                  scope, forwarded as `Authorization: Bearer …`
+
+async fn llm_completions(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let Ok(account_id) = std::env::var("CLOUDFLARE_ACCOUNT_ID") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CLOUDFLARE_ACCOUNT_ID not configured",
+        )
+            .into_response();
+    };
+    let Ok(gateway_id) = std::env::var("CLOUDFLARE_AI_GATEWAY_ID") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CLOUDFLARE_AI_GATEWAY_ID not configured",
+        )
+            .into_response();
+    };
+    let Ok(api_token) = std::env::var("CF_API_TOKEN") else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CF_API_TOKEN not configured",
+        )
+            .into_response();
+    };
+    let url = format!(
+        "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai/v1/chat/completions"
+    );
+    let req = state
+        .http_client
+        .post(&url)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {api_token}"));
     match req.json(&body).send().await {
         Ok(resp) => {
             let status = resp.status();

--- a/kernel/crates/gctrl-otel/tests/net_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/net_routes.rs
@@ -10,8 +10,15 @@ use gctrl_otel::create_router_full;
 use gctrl_storage::{DuckDbStore, SqliteStore};
 use http::Request;
 use http_body_util::BodyExt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use tower::ServiceExt;
+
+/// Serializes tests that mutate process env vars (otherwise they race in parallel
+/// and clobber each other's CLOUDFLARE_* / *_API_KEY state).
+fn env_mutex() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
 
 fn router_with(net_config: NetConfig) -> axum::Router {
     let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
@@ -173,8 +180,8 @@ async fn discord_send_rejects_non_webhook_url() {
 
 #[tokio::test]
 async fn llm_messages_fails_closed_without_gateway_config() {
+    let _guard = env_mutex().lock().unwrap();
     // Guard: isolate from any ambient CF/Anthropic creds in the test env.
-    // SAFETY: tests in this crate run single-threaded by default; no concurrent env mutation.
     let prev_acct = std::env::var("CLOUDFLARE_ACCOUNT_ID").ok();
     let prev_gw = std::env::var("CLOUDFLARE_AI_GATEWAY_ID").ok();
     let prev_gw_tok = std::env::var("CLOUDFLARE_AI_GATEWAY_TOKEN").ok();
@@ -227,6 +234,57 @@ async fn llm_messages_fails_closed_without_gateway_config() {
         }
         if let Some(v) = prev_anth {
             std::env::set_var("ANTHROPIC_API_KEY", v);
+        }
+    }
+}
+
+#[tokio::test]
+async fn llm_completions_fails_closed_without_gateway_config() {
+    let _guard = env_mutex().lock().unwrap();
+    // Isolate from any ambient CF creds in the test env.
+    let prev_acct = std::env::var("CLOUDFLARE_ACCOUNT_ID").ok();
+    let prev_gw = std::env::var("CLOUDFLARE_AI_GATEWAY_ID").ok();
+    let prev_cf_tok = std::env::var("CF_API_TOKEN").ok();
+    unsafe {
+        std::env::remove_var("CLOUDFLARE_ACCOUNT_ID");
+        std::env::remove_var("CLOUDFLARE_AI_GATEWAY_ID");
+        std::env::remove_var("CF_API_TOKEN");
+    }
+    let app = router_with(NetConfig::default());
+    let probe_body = serde_json::json!({
+        "model": "@cf/google/gemma-4-26b-a4b-it",
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+
+    // 1. Missing CLOUDFLARE_ACCOUNT_ID → 503
+    let (status, body) = post_json(&app, "/api/llm/completions", probe_body.clone()).await;
+    assert_eq!(status, 503);
+    assert!(body.contains("CLOUDFLARE_ACCOUNT_ID"));
+
+    // 2. Account id set but missing gateway id → 503
+    unsafe { std::env::set_var("CLOUDFLARE_ACCOUNT_ID", "acct-test") };
+    let (status, body) = post_json(&app, "/api/llm/completions", probe_body.clone()).await;
+    assert_eq!(status, 503);
+    assert!(body.contains("CLOUDFLARE_AI_GATEWAY_ID"));
+
+    // 3. Account + gateway set but no CF_API_TOKEN → 503
+    unsafe { std::env::set_var("CLOUDFLARE_AI_GATEWAY_ID", "gw-test") };
+    let (status, body) = post_json(&app, "/api/llm/completions", probe_body).await;
+    assert_eq!(status, 503);
+    assert!(body.contains("CF_API_TOKEN"), "body was: {body}");
+
+    // Restore ambient env.
+    unsafe {
+        std::env::remove_var("CLOUDFLARE_ACCOUNT_ID");
+        std::env::remove_var("CLOUDFLARE_AI_GATEWAY_ID");
+        if let Some(v) = prev_acct {
+            std::env::set_var("CLOUDFLARE_ACCOUNT_ID", v);
+        }
+        if let Some(v) = prev_gw {
+            std::env::set_var("CLOUDFLARE_AI_GATEWAY_ID", v);
+        }
+        if let Some(v) = prev_cf_tok {
+            std::env::set_var("CF_API_TOKEN", v);
         }
     }
 }


### PR DESCRIPTION
**Stacks on #46** (`feat/uber-kernel-messaging-drivers`) — merge that first.

## Summary

Adds a second kernel LLM route so Cloudflare Workers AI models (e.g. `@cf/google/gemma-4-26b-a4b-it`) are reachable alongside the existing Anthropic path. Uebermensch's `KernelLlm` adapter now picks the upstream at runtime by model prefix.

### Kernel (`gctrl-otel`)
- New route **`POST /api/llm/completions`** (OpenAI-compat Chat Completions shape) → `https://gateway.ai.cloudflare.com/v1/{account}/{gateway}/workers-ai/v1/chat/completions`.
- Auth: `Authorization: Bearer $CF_API_TOKEN` — the same token already required by the net / browser-rendering routes. No new secret.
- Fail-closed on missing env: 503 if any of `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_ID`, `CF_API_TOKEN` is absent. Matches the shape of `llm_messages`.
- Integration test: `llm_completions_fails_closed_without_gateway_config`. Added a shared `env_mutex` so the two env-mutating fail-closed tests don't race under the default parallel runner (this also fixes a latent flake in the existing `llm_messages_fails_closed_without_gateway_config` test — the "single-threaded by default" comment was incorrect).

### Uebermensch (`KernelLlm.ts`)
- Provider-switch by model prefix:
  - `@cf/*` → `/api/llm/completions` with OpenAI-compat body + response (`system` + `user` messages, `choices[0].message.content`, `prompt_tokens` / `completion_tokens`).
  - anything else → existing `/api/llm/messages` with Anthropic shape (unchanged path, same `thinking: { type: "adaptive" }` body).
- Model selected at runtime via `UBER_LLM_MODEL` env var; defaults to `claude-opus-4-7` so existing deployments are unaffected.
- New unit test covers the Gemma routing path (URL, body shape, system-message placement, no `thinking` field).

### How to run Gemma now

```sh
export UBER_LLM_MODEL=@cf/google/gemma-4-26b-a4b-it
export CLOUDFLARE_ACCOUNT_ID=...
export CLOUDFLARE_AI_GATEWAY_ID=...
export CF_API_TOKEN=...          # CF API token w/ Workers AI read scope
uber report --dry-run            # or brief
```

Leaving `UBER_LLM_MODEL` unset keeps the current Anthropic path.

### Known follow-ups (intentionally deferred)
- **Workers AI cost accounting** — CF billing isn't in the response envelope, so `costUsd` is reported as `0` for `@cf/*` models. Observability still flows through the Gateway; kernel spans still record the call.
- **Per-persona model overrides** — today `UBER_LLM_MODEL` is a single global. `personas.md` / `profile.delivery.personas` as per spec is the target-state config surface; wiring that in belongs in a follow-up so this PR stays focused on the kernel route.

## Test plan
- [x] `cargo test -p gctrl-otel` — 67 tests pass (includes the new `llm_completions_fails_closed_without_gateway_config` + the pre-existing fail-closed case under the shared `env_mutex`)
- [x] `pnpm --filter uebermensch test` — 79 / 79
- [x] `pnpm --filter uebermensch exec tsc --noEmit` — clean
- [x] `pnpm --filter uebermensch build` — clean
- [ ] Reviewer: live-smoke the Gemma path against a real Workers AI gateway (`UBER_LLM_MODEL=@cf/google/gemma-4-26b-a4b-it uber brief --dry-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
