### PR TITLE
feat(uebermensch): per-interest deep weekly reports

### DIFF
--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -494,6 +494,8 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         items,
         promptHash,
         costUsd,
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
         model: res.model,
       };
     }),

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -4,9 +4,8 @@ import type { CandidateRef } from "../lib/candidates.js";
 import { sha256 } from "../lib/hash.js";
 import {
   type BriefRequest,
+  type InterestReportRequest,
   LlmService,
-  type ReportRequest,
-  type ReportSection,
 } from "../services/LlmService.js";
 import type { CuratedItem } from "../services/RendererService.js";
 
@@ -267,20 +266,27 @@ const postLlm = (
     ? postWorkersAi(model, system, userPrompt, maxTokens)
     : postAnthropic(model, system, userPrompt, maxTokens, thinking);
 
-const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst that produces a weekly research report grouped by research interest.
+const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst. Your task is to produce a DEEP weekly research report for ONE research interest.
 
 OUTPUT CONTRACT:
 - Output MUST be a single JSON object wrapped in a triple-backtick json fenced block. No prose outside the fence.
-- Shape: { "sections": ReportSection[] }
-- ReportSection: {
-    "interestSlug": string,  // MUST match one of the provided interest slugs
-    "summary_md": string,    // 3–6 sentence overview of the week for this interest; may cite candidates via [[stem]]
-    "items": CuratedItem[]   // up to maxItemsPerInterest per section
-  }
+- Shape: { "analysis_md": string, "items": CuratedItem[] }
+- analysis_md: 600–1500 words of substantive long-form analysis, structured with level-3 markdown headers in this EXACT order:
+    ### Thesis
+    ### Key developments
+    ### Cross-currents
+    ### Implications
+    ### Open questions
+  - Thesis (1 short paragraph): the single most important claim of the week for this interest, stated sharply.
+  - Key developments (2–5 paragraphs): concrete, specific developments grounded in the candidate excerpts. Tight bullets are acceptable here, but prefer prose that synthesizes across candidates.
+  - Cross-currents (1–3 paragraphs): tensions, disagreements, or contradictions between sources; second-order effects; what is being priced in vs. not.
+  - Implications (1–3 paragraphs): what this means for the interest's question. Concrete, falsifiable, decision-relevant.
+  - Open questions (3–6 bullets): what would change the thesis, what to watch next, what evidence is missing.
+- items (0 to maxItems): discrete curated news/updates/actions/alerts surfaced as evidence alongside the analysis.
 - CuratedItem: {
     "kind": "news" | "update" | "action" | "alert",
     "title": string,
-    "summary_md": string,
+    "summary_md": string,   // 2–4 sentences, concrete
     "topic": string | null,
     "thesis": string | null,
     "source_candidate_ids": string[],
@@ -288,70 +294,59 @@ OUTPUT CONTRACT:
   }
 
 CITATION RULES (strict — report generation will FAIL if violated):
-- Every \`[[link]]\` in any \`summary_md\` MUST match a candidate's \`stem\` field exactly.
+- Every \`[[link]]\` in \`analysis_md\` or any item \`summary_md\` MUST match a candidate's \`stem\` field exactly.
 - Do NOT use typed-prefix links like \`[[source:x]]\` or \`[[thesis:x]]\` — bare stems only.
-- \`source_candidate_ids\` MUST be a subset of the provided candidate \`id\` values for THAT interest section. Never fabricate.
-CURATION RULES:
-- Produce one section per provided interest, in the order given. Use the exact interestSlug.
-- For each section, use ONLY the candidates listed under that interest.
-- summary_md in each item: 2–4 sentences, substantive and concrete, derived from candidate excerpts. No hedging.
-- Merge near-duplicate candidates into one item referencing multiple sources.
-- topic: the single most relevant topic slug for that interest, or null.
-- Produce at most maxItemsPerInterest items per section; prefer high-scored candidates aligned with the interest's question.
+- \`source_candidate_ids\` on each item MUST be a subset of the provided candidate \`id\` values. Never fabricate.
+- Aim for ≥ 1 \`[[stem]]\` citation per paragraph in "Key developments" and at least 2 across "Cross-currents" + "Implications".
+
+DEPTH RULES:
+- Prefer concrete, falsifiable claims over hedged restatements of candidate excerpts.
+- Synthesize across candidates: where do they agree, diverge, or contradict?
+- Name actors, numbers, dates, and mechanisms. Avoid generic macro prose.
+- Do NOT meta-describe the candidate pool ("the sources cover X", "based on these articles"). Write as a first-party analyst.
 
 INSIGHT-ONLY RULES (strict — enforced by reviewer):
 - Write substantive insight only. NEVER describe what is absent, thin, missing, or quiet in the candidate pool.
 - BANNED phrases and patterns: "No direct X...", "No fresh X...", "appeared in the candidate set", "This week was quiet for...", "Candidate pool was thin...", "Most items were only indirectly relevant...", "Reference pages were also indexed but carry no new information", "Treat this week as a quiet one for...".
-- If a section has no candidates OR no substantive signal, return {"interestSlug": slug, "summary_md": "", "items": []} — the renderer will drop empty sections. Do NOT apologize or meta-commentate.
-- If the candidate pool contains only adjacent signal (no direct hit on the interest's question), lead with the adjacent signal as a concrete claim. Example: "BHP–China iron ore deal resets seaborne pricing relevant to Japanese steelmaker input costs." Do NOT frame it as "No direct X but adjacent Y...".
+- If the candidate pool has no substantive signal at all (not even adjacent), return {"analysis_md": "", "items": []} — the caller will drop the empty report. Do NOT apologize or meta-commentate.
+- If the candidate pool contains only adjacent signal (no direct hit on the interest's question), lead the Thesis with the adjacent signal as a concrete claim. Do NOT frame it as "No direct X but adjacent Y...".
 - No "Suggested action" lines about expanding ingestion, adding feeds, or describing the system itself. Actions must target the substantive domain (markets, policy, company behavior).`;
 
 const reportCandidateBlock = (c: CandidateRef): string => candidateBlock(c);
 
-const buildReportUserPrompt = (req: ReportRequest): string => {
+const buildInterestReportUserPrompt = (req: InterestReportRequest): string => {
+  const it = req.interest;
   const lines: Array<string> = [];
   lines.push(`period: ${req.periodLabel}`);
   lines.push(`periodStart: ${req.periodStart}`);
   lines.push(`periodEnd: ${req.periodEnd}`);
   lines.push(`profile: ${req.profileName}`);
-  lines.push(`maxItemsPerInterest: ${req.maxItemsPerInterest}`);
+  lines.push(`maxItems: ${req.maxItems}`);
   lines.push("");
-  lines.push("interests:");
-  for (const it of req.interests) {
-    lines.push(`- slug: ${it.slug}`);
-    lines.push(`  title: ${it.title}`);
-    if (it.question) lines.push(`  question: ${it.question}`);
-    lines.push(`  topics: [${it.topics.join(", ")}]`);
-    if (it.notes) {
-      lines.push(`  notes: |`);
-      for (const line of it.notes.split("\n")) lines.push(`    ${line}`);
-    }
-    lines.push(`  candidates:`);
-    if (it.candidates.length === 0) {
-      lines.push(`    (none)`);
-    } else {
-      for (const c of it.candidates) {
-        const block = reportCandidateBlock(c)
-          .split("\n")
-          .map((l) => `  ${l}`)
-          .join("\n");
-        lines.push(block);
-      }
-    }
+  lines.push("interest:");
+  lines.push(`  slug: ${it.slug}`);
+  lines.push(`  title: ${it.title}`);
+  if (it.question) lines.push(`  question: ${it.question}`);
+  lines.push(`  topics: [${it.topics.join(", ")}]`);
+  if (it.notes) {
+    lines.push(`  notes: |`);
+    for (const line of it.notes.split("\n")) lines.push(`    ${line}`);
+  }
+  lines.push("");
+  lines.push("candidates:");
+  if (it.candidates.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const c of it.candidates) lines.push(reportCandidateBlock(c));
   }
   lines.push("");
   lines.push("Return ONLY a fenced ```json block with the schema above.");
   return lines.join("\n");
 };
 
-const ReportSectionSchema = Schema.Struct({
-  interestSlug: Schema.String,
-  summary_md: Schema.String,
+const InterestReportOutputSchema = Schema.Struct({
+  analysis_md: Schema.String,
   items: Schema.Array(ItemSchema),
-});
-
-const ReportOutputSchema = Schema.Struct({
-  sections: Schema.Array(ReportSectionSchema),
 });
 
 const SUMMARY_SYSTEM_PROMPT = `You are uebermensch-ingest, an assistant that condenses a single news article into a compact set of key insights for a research wiki.
@@ -447,10 +442,10 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         model: res.model,
       };
     }),
-  generateReport: (req) =>
+  generateInterestReport: (req) =>
     Effect.gen(function* () {
       const model = modelFor();
-      const userPrompt = buildReportUserPrompt(req);
+      const userPrompt = buildInterestReportUserPrompt(req);
       const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
       const res = yield* postLlm(
         model,
@@ -473,7 +468,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
           llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
         );
       }
-      const decoded = yield* Schema.decodeUnknown(ReportOutputSchema)(parsed).pipe(
+      const decoded = yield* Schema.decodeUnknown(InterestReportOutputSchema)(parsed).pipe(
         Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
       );
       const costUsd = isWorkersAiModel(res.model)
@@ -484,21 +479,19 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
             ANTHROPIC_INPUT_COST_PER_MTOK,
             ANTHROPIC_OUTPUT_COST_PER_MTOK,
           );
-      const sections: ReadonlyArray<ReportSection> = decoded.sections.map((s) => ({
-        interestSlug: s.interestSlug,
-        summary_md: s.summary_md,
-        items: s.items.map((i) => ({
-          kind: i.kind,
-          title: i.title,
-          summary_md: i.summary_md,
-          topic: i.topic,
-          thesis: i.thesis,
-          source_candidate_ids: i.source_candidate_ids,
-          suggested_action: i.suggested_action,
-        })),
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
       }));
       return {
-        sections,
+        interestSlug: req.interest.slug,
+        analysis_md: decoded.analysis_md,
+        items,
         promptHash,
         costUsd,
         model: res.model,
@@ -542,12 +535,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
 
 export const _internal = {
   buildUserPrompt,
-  buildReportUserPrompt,
+  buildInterestReportUserPrompt,
   buildSummaryUserPrompt,
   extractJson,
   kernelBase,
   LlmOutputSchema,
-  ReportOutputSchema,
+  InterestReportOutputSchema,
   normalizeInsights,
   SYSTEM_PROMPT,
   REPORT_SYSTEM_PROMPT,

--- a/apps/uebermensch/src/adapters/StrictRenderer.ts
+++ b/apps/uebermensch/src/adapters/StrictRenderer.ts
@@ -4,11 +4,12 @@ import { citedSentences, claimSentences, extractLinks, isTypedPrefix } from "../
 import {
   RendererService,
   type CuratedItem,
+  type InterestReportRenderInput,
+  type InterestReportRenderResult,
   type RenderInput,
   type RenderResult,
-  type ReportRenderInput,
-  type ReportRenderResult,
-  type ReportSectionInput,
+  type ReportIndexRenderInput,
+  type ReportIndexRenderResult,
 } from "../services/RendererService.js"
 
 const verifyItemCitations = (
@@ -88,36 +89,39 @@ const renderItem = (item: CuratedItem, idx: number): string => {
   return lines.join("\n")
 }
 
-const verifySectionCitations = (
-  section: ReportSectionInput,
-  sectionIdx: number,
+const verifyAnalysisCitations = (
+  analysis_md: string,
+  interestSlug: string,
   vaultSlugs: ReadonlySet<string>,
 ): CitationError | null => {
-  const links = extractLinks(section.summary_md)
+  const links = extractLinks(analysis_md)
   for (const link of links) {
     if (isTypedPrefix(link.target)) {
       return new CitationError({
-        message: `section ${sectionIdx} (${section.interestSlug}): typed prefix forbidden in ${link.raw}`,
+        message: `analysis (${interestSlug}): typed prefix forbidden in ${link.raw}`,
         kind: "typed_prefix",
         link: link.raw,
-        itemIndex: sectionIdx,
+        itemIndex: -1,
       })
     }
     if (!vaultSlugs.has(link.target)) {
       return new CitationError({
-        message: `section ${sectionIdx} (${section.interestSlug}): unresolved wikilink ${link.raw}`,
+        message: `analysis (${interestSlug}): unresolved wikilink ${link.raw}`,
         kind: "unresolved",
         link: link.raw,
-        itemIndex: sectionIdx,
+        itemIndex: -1,
       })
     }
   }
   return null
 }
 
-const renderReportFrontmatter = (
-  input: ReportRenderInput,
-  sectionCount: number,
+const interestReportSlug = (periodLabel: string, interestSlug: string): string =>
+  `${periodLabel}--${interestSlug}`
+
+const renderInterestReportFrontmatter = (
+  input: InterestReportRenderInput,
+  slug: string,
   itemCount: number,
   citedClaims: number,
   totalClaims: number,
@@ -125,47 +129,43 @@ const renderReportFrontmatter = (
   [
     "---",
     "page_type: report",
-    `slug: report-${input.periodLabel}`,
+    `slug: report-${slug}`,
     'kind: "weekly"',
+    `period_label: "${input.periodLabel}"`,
+    `period_start: "${input.periodStart}"`,
+    `period_end: "${input.periodEnd}"`,
+    `interest_slug: "${input.interestSlug}"`,
+    `interest_title: "${input.interestTitle.replace(/"/g, '\\"')}"`,
+    `generator: "${input.generator}"`,
+    `model: "${input.model}"`,
+    `prompt_hash: "${input.promptHash}"`,
+    `cost_usd: ${input.costUsd}`,
+    `item_count: ${itemCount}`,
+    `cited_claims: ${citedClaims}`,
+    `total_claims: ${totalClaims}`,
+    `topics: ${yamlList(input.interestTopics)}`,
+    "---",
+  ].join("\n")
+
+const renderReportIndexFrontmatter = (
+  input: ReportIndexRenderInput,
+  interestCount: number,
+): string =>
+  [
+    "---",
+    "page_type: report_index",
+    `slug: report-${input.periodLabel}`,
+    'kind: "weekly_index"',
     `period_label: "${input.periodLabel}"`,
     `period_start: "${input.periodStart}"`,
     `period_end: "${input.periodEnd}"`,
     `generator: "${input.generator}"`,
     `model: "${input.model}"`,
-    `prompt_hash: "${input.promptHash}"`,
-    `cost_usd: ${input.costUsd}`,
-    `section_count: ${sectionCount}`,
-    `item_count: ${itemCount}`,
-    `cited_claims: ${citedClaims}`,
-    `total_claims: ${totalClaims}`,
-    `interests: ${yamlList(input.sections.map((s) => s.interestSlug))}`,
+    `total_cost_usd: ${input.totalCostUsd}`,
+    `interest_count: ${interestCount}`,
+    `interests: ${yamlList(input.entries.map((e) => e.interestSlug))}`,
     "---",
   ].join("\n")
-
-const renderReportSection = (section: ReportSectionInput): string => {
-  const lines: Array<string> = []
-  lines.push(`## ${section.interestTitle}`)
-  lines.push("")
-  if (section.interestQuestion) {
-    lines.push(`> ${section.interestQuestion}`)
-    lines.push("")
-  }
-  lines.push(section.summary_md.trim())
-  if (section.items.length > 0) {
-    lines.push("")
-    section.items.forEach((item, idx) => {
-      lines.push(`### ${idx + 1}. ${item.title}`)
-      lines.push("")
-      lines.push(item.summary_md.trim())
-      if (item.suggested_action) {
-        lines.push("")
-        lines.push(`**Suggested action:** ${item.suggested_action.trim()}`)
-      }
-      lines.push("")
-    })
-  }
-  return lines.join("\n").trimEnd()
-}
 
 export const StrictRendererLive = Layer.succeed(RendererService, {
   render: (input) =>
@@ -190,39 +190,99 @@ export const StrictRendererLive = Layer.succeed(RendererService, {
       }
       return result
     }),
-  renderReport: (input) =>
+  renderInterestReport: (input) =>
     Effect.gen(function* () {
-      let sIdx = 0
-      for (const section of input.sections) {
-        const sErr = verifySectionCitations(section, sIdx, input.vaultSlugs)
-        if (sErr) return yield* Effect.fail(sErr)
-        const candidateIds = new Set(section.candidates.map((c) => c.id))
-        let iIdx = 0
-        for (const item of section.items) {
-          const err = verifyItemCitations(item, iIdx, input.vaultSlugs, candidateIds)
-          if (err) return yield* Effect.fail(err)
-          iIdx += 1
-        }
-        sIdx += 1
+      const aErr = verifyAnalysisCitations(
+        input.analysis_md,
+        input.interestSlug,
+        input.vaultSlugs,
+      )
+      if (aErr) return yield* Effect.fail(aErr)
+      const candidateIds = new Set(input.candidates.map((c) => c.id))
+      let iIdx = 0
+      for (const item of input.items) {
+        const err = verifyItemCitations(item, iIdx, input.vaultSlugs, candidateIds)
+        if (err) return yield* Effect.fail(err)
+        iIdx += 1
       }
-      const body = input.sections.map(renderReportSection).join("\n\n")
+
+      const slug = interestReportSlug(input.periodLabel, input.interestSlug)
+      const bodyParts: Array<string> = []
+      const analysis = input.analysis_md.trim()
+      if (analysis.length > 0) bodyParts.push(analysis)
+      if (input.items.length > 0) {
+        const itemLines: Array<string> = ["## Evidence"]
+        input.items.forEach((item, idx) => {
+          itemLines.push("")
+          itemLines.push(`### ${idx + 1}. ${item.title}`)
+          itemLines.push("")
+          itemLines.push(item.summary_md.trim())
+          if (item.suggested_action) {
+            itemLines.push("")
+            itemLines.push(`**Suggested action:** ${item.suggested_action.trim()}`)
+          }
+        })
+        bodyParts.push(itemLines.join("\n"))
+      }
+      const body = bodyParts.join("\n\n")
       const totalClaims = claimSentences(body)
       const citedClaims = citedSentences(body)
-      const itemCount = input.sections.reduce((n, s) => n + s.items.length, 0)
-      const frontmatter = renderReportFrontmatter(
+      const frontmatter = renderInterestReportFrontmatter(
         input,
-        input.sections.length,
-        itemCount,
+        slug,
+        input.items.length,
         citedClaims,
         totalClaims,
       )
-      const markdown = `${frontmatter}\n\n# Weekly research report — ${input.periodLabel}\n\n_Period ${input.periodStart} → ${input.periodEnd}_\n\n${body}\n`
-      const result: ReportRenderResult = {
+      const header = `# ${input.interestTitle} — ${input.periodLabel}`
+      const periodLine = `_Period ${input.periodStart} → ${input.periodEnd}_`
+      const questionLine = input.interestQuestion
+        ? `> ${input.interestQuestion}\n\n`
+        : ""
+      const markdown = `${frontmatter}\n\n${header}\n\n${periodLine}\n\n${questionLine}${body}\n`
+      const result: InterestReportRenderResult = {
         markdown,
-        sectionCount: input.sections.length,
-        itemCount,
+        slug,
+        itemCount: input.items.length,
         citedClaims,
         totalClaims,
+      }
+      return result
+    }),
+  renderReportIndex: (input) =>
+    Effect.sync(() => {
+      const frontmatter = renderReportIndexFrontmatter(input, input.entries.length)
+      const lines: Array<string> = []
+      lines.push(`# Weekly research reports — ${input.periodLabel}`)
+      lines.push("")
+      lines.push(`_Period ${input.periodStart} → ${input.periodEnd}_`)
+      lines.push("")
+      if (input.entries.length === 0) {
+        lines.push("_No interests had substantive signal this week._")
+      } else {
+        for (const entry of input.entries) {
+          const link = entry.publicUrl
+            ? `[${entry.interestTitle}](${entry.publicUrl})`
+            : `[[${entry.reportSlug}|${entry.interestTitle}]]`
+          lines.push(`## ${link}`)
+          lines.push("")
+          if (entry.interestQuestion) {
+            lines.push(`> ${entry.interestQuestion}`)
+            lines.push("")
+          }
+          if (entry.headline) {
+            lines.push(entry.headline.trim())
+            lines.push("")
+          }
+          lines.push(`_${entry.itemCount} item(s)_`)
+          lines.push("")
+        }
+      }
+      const markdown = `${frontmatter}\n\n${lines.join("\n").trimEnd()}\n`
+      const result: ReportIndexRenderResult = {
+        markdown,
+        slug: input.periodLabel,
+        interestCount: input.entries.length,
       }
       return result
     }),

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect";
 import { sha256 } from "../lib/hash.js";
-import { LlmService, type ReportSection } from "../services/LlmService.js";
+import { LlmService } from "../services/LlmService.js";
 import type { CuratedItem } from "../services/RendererService.js";
 
 const STUB_MODEL = "stub-llm@0.1";
@@ -69,43 +69,62 @@ export const StubLlmLive = Layer.succeed(LlmService, {
       const promptHash = sha256(`stub-summarize\n${req.url}\n${req.text}`);
       return { insightsMd, promptHash, costUsd: 0, model: STUB_MODEL };
     }),
-  generateReport: (req) =>
+  generateInterestReport: (req) =>
     Effect.sync(() => {
-      const candidateIds = req.interests.flatMap((it) => it.candidates.map((c) => c.id));
+      const it = req.interest;
       const prompt = [
         "persona: uber-researcher/stub",
         `period: ${req.periodLabel}`,
         `profile: ${req.profileName}`,
-        `interests: ${req.interests.map((i) => i.slug).join(",")}`,
-        `candidates: ${candidateIds.join(",")}`,
+        `interest: ${it.slug}`,
+        `candidates: ${it.candidates.map((c) => c.id).join(",")}`,
       ].join("\n");
       const promptHash = sha256(prompt);
-      const sections: Array<ReportSection> = req.interests.map((it) => {
-        const top = [...it.candidates]
-          .sort((a, b) => b.score - a.score)
-          .slice(0, req.maxItemsPerInterest);
-        const items: Array<CuratedItem> = top.map((c) => {
-          const title = (c.page.frontmatter.title as string | undefined) ?? c.page.stem;
-          const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? [];
-          const topic = pageTopics[0] ?? null;
-          return {
-            kind: "news",
-            title,
-            summary_md: `Stub summary for [[${c.page.stem}]].`,
-            topic,
-            thesis: null,
-            source_candidate_ids: [c.id],
-            suggested_action: null,
-          };
-        });
-        const summary_md =
-          items.length === 0
-            ? `No new candidates this week for ${it.title}.`
-            : `Stub weekly overview for ${it.title} covering ${items.length} item(s).`;
-        return { interestSlug: it.slug, summary_md, items };
+      const top = [...it.candidates].sort((a, b) => b.score - a.score).slice(0, req.maxItems);
+      const items: Array<CuratedItem> = top.map((c) => {
+        const title = (c.page.frontmatter.title as string | undefined) ?? c.page.stem;
+        const pageTopics = (c.page.frontmatter.topics as ReadonlyArray<string> | undefined) ?? [];
+        const topic = pageTopics[0] ?? null;
+        return {
+          kind: "news",
+          title,
+          summary_md: `Stub summary for [[${c.page.stem}]].`,
+          topic,
+          thesis: null,
+          source_candidate_ids: [c.id],
+          suggested_action: null,
+        };
       });
+      const citedStems = top.map((c) => `[[${c.page.stem}]]`).join(", ");
+      const analysis_md =
+        top.length === 0
+          ? ""
+          : [
+              "### Thesis",
+              "",
+              `Stub thesis for ${it.title}.`,
+              "",
+              "### Key developments",
+              "",
+              `Stub key developments citing ${citedStems}.`,
+              "",
+              "### Cross-currents",
+              "",
+              "Stub cross-currents.",
+              "",
+              "### Implications",
+              "",
+              "Stub implications.",
+              "",
+              "### Open questions",
+              "",
+              "- Stub open question 1",
+              "- Stub open question 2",
+            ].join("\n");
       return {
-        sections,
+        interestSlug: it.slug,
+        analysis_md,
+        items,
         promptHash,
         costUsd: 0,
         model: STUB_MODEL,

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -127,6 +127,8 @@ export const StubLlmLive = Layer.succeed(LlmService, {
         items,
         promptHash,
         costUsd: 0,
+        inputTokens: 0,
+        outputTokens: 0,
         model: STUB_MODEL,
       };
     }),

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -45,9 +45,18 @@ const maxItemsOpt = Options.integer("max-items-per-interest").pipe(
   Options.withDefault(5),
 )
 
+const envConcurrency = (): number => {
+  const raw = process.env.UBER_REPORT_CONCURRENCY
+  if (!raw) return 3
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : 3
+}
+
 const concurrencyOpt = Options.integer("concurrency").pipe(
-  Options.withDescription("Concurrent LLM calls across interests"),
-  Options.withDefault(3),
+  Options.withDescription(
+    "Concurrent LLM calls across interests (default 3, overridable via UBER_REPORT_CONCURRENCY)",
+  ),
+  Options.withDefault(envConcurrency()),
 )
 
 const dryRunOpt = Options.boolean("dry-run").pipe(
@@ -128,10 +137,11 @@ const weightedTopicsFor = (
 }
 
 // First paragraph of analysis_md (the Thesis section body), trimmed for index headlines.
+// Matches any markdown heading level so occasional model drift (## / #### Thesis) still works.
 const thesisHeadline = (analysis_md: string): string | null => {
   const trimmed = analysis_md.trim()
   if (trimmed.length === 0) return null
-  const match = trimmed.match(/###\s+Thesis\s*\n+([\s\S]*?)(?=\n###\s|$)/)
+  const match = trimmed.match(/^#{2,4}\s+Thesis\s*\n+([\s\S]*?)(?=\n#{2,4}\s|$)/m)
   const block = (match ? match[1] : trimmed).trim()
   if (block.length === 0) return null
   const firstPara = block.split(/\n\s*\n/, 1)[0].trim()
@@ -311,6 +321,9 @@ export const report = Command.make(
             yield* Console.log(
               `  ✓ ${w.relPath} (${w.contentHash}) — ${rendered.itemCount} item(s), ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
             )
+            yield* Console.log(
+              `    cost: $${response.costUsd.toFixed(4)} (in=${response.inputTokens}t out=${response.outputTokens}t model=${response.model})`,
+            )
           }
           written.push({
             interest: ii,
@@ -404,6 +417,13 @@ export const report = Command.make(
         if (!doSend) {
           yield* Console.log("")
           yield* Console.log(indexRendered.markdown)
+          return
+        }
+
+        if (written.length === 0) {
+          yield* Console.log(
+            "  no interests produced substantive signal — skipping delivery",
+          )
           return
         }
 

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -13,13 +13,13 @@ import { publicReportUrl, resolveVaultDir } from "../lib/env.js"
 import { DelivererService } from "../services/DelivererService.js"
 import {
   LlmService,
+  type InterestReportResponse,
   type ReportInterestInput,
-  type ReportSection,
 } from "../services/LlmService.js"
 import { ProfileService } from "../services/ProfileService.js"
 import {
   RendererService,
-  type ReportSectionInput,
+  type ReportIndexEntry,
 } from "../services/RendererService.js"
 import { SyncService } from "../services/SyncService.js"
 import {
@@ -41,23 +41,30 @@ const dateOpt = Options.text("date").pipe(
 )
 
 const maxItemsOpt = Options.integer("max-items-per-interest").pipe(
-  Options.withDescription("Cap items per research interest section"),
+  Options.withDescription("Cap evidence items per interest report"),
   Options.withDefault(5),
 )
 
+const concurrencyOpt = Options.integer("concurrency").pipe(
+  Options.withDescription("Concurrent LLM calls across interests"),
+  Options.withDefault(3),
+)
+
 const dryRunOpt = Options.boolean("dry-run").pipe(
-  Options.withDescription("Do not write the report file or send; print to stdout"),
+  Options.withDescription("Do not write the report files or send; print to stdout"),
   Options.withDefault(false),
 )
 
 const sendOpt = Options.boolean("send").pipe(
-  Options.withDescription("After generating, deliver to enabled telegram/discord channels"),
+  Options.withDescription(
+    "After generating, deliver the index to enabled telegram/discord channels",
+  ),
   Options.withDefault(false),
 )
 
 const syncOpt = Options.boolean("sync").pipe(
   Options.withDescription(
-    "After writing, upload report + briefs + wiki/sources to R2 (auto-on when --send and UBER_PUBLIC_BASE_URL are set)",
+    "After writing, upload reports + briefs + wiki/sources to R2 (auto-on when --send and UBER_PUBLIC_BASE_URL are set)",
   ),
   Options.withDefault(false),
 )
@@ -120,13 +127,34 @@ const weightedTopicsFor = (
     .map((t) => ({ slug: t.slug, weight: t.weight * boost }))
 }
 
+// First paragraph of analysis_md (the Thesis section body), trimmed for index headlines.
+const thesisHeadline = (analysis_md: string): string | null => {
+  const trimmed = analysis_md.trim()
+  if (trimmed.length === 0) return null
+  const match = trimmed.match(/###\s+Thesis\s*\n+([\s\S]*?)(?=\n###\s|$)/)
+  const block = (match ? match[1] : trimmed).trim()
+  if (block.length === 0) return null
+  const firstPara = block.split(/\n\s*\n/, 1)[0].trim()
+  return firstPara.length > 0 ? firstPara : null
+}
+
 export const report = Command.make(
   "report",
-  { sinceDaysOpt, dateOpt, maxItemsOpt, dryRunOpt, sendOpt, syncOpt, llmOpt },
+  {
+    sinceDaysOpt,
+    dateOpt,
+    maxItemsOpt,
+    concurrencyOpt,
+    dryRunOpt,
+    sendOpt,
+    syncOpt,
+    llmOpt,
+  },
   ({
     sinceDaysOpt: sinceDays,
     dateOpt: dateOptVal,
     maxItemsOpt: maxItems,
+    concurrencyOpt: concurrency,
     dryRunOpt: dryRun,
     sendOpt: doSend,
     syncOpt: doSyncOpt,
@@ -140,7 +168,7 @@ export const report = Command.make(
       const periodEnd = anchor
       const periodStart = toYmd(addDays(anchorDate, -sinceDays))
       yield* Console.log(
-        `generating weekly report ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind})`,
+        `generating weekly reports ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind}, concurrency=${concurrency})`,
       )
 
       const program = Effect.gen(function* () {
@@ -209,68 +237,138 @@ export const report = Command.make(
         })
 
         for (const ii of interestInputs) {
-          yield* Console.log(
-            `    ${ii.slug}: ${ii.candidates.length} candidate(s)`,
-          )
+          yield* Console.log(`    ${ii.slug}: ${ii.candidates.length} candidate(s)`)
         }
 
-        const response = yield* llm.generateReport({
-          periodLabel,
-          periodStart,
-          periodEnd,
-          profileName: profile.profile.identity.name,
-          interests: interestInputs,
-          maxItemsPerInterest: maxItems,
-        })
-
-        // Merge by slug so renderer has access to candidates per section.
-        const sectionBySlug = new Map<string, ReportSection>()
-        for (const s of response.sections) sectionBySlug.set(s.interestSlug, s)
-
-        const rendererSections: Array<ReportSectionInput> = interestInputs
-          .map((ii) => {
-            const s = sectionBySlug.get(ii.slug)
-            return {
-              interestSlug: ii.slug,
-              interestTitle: ii.title,
-              interestQuestion: ii.question,
-              summary_md: s?.summary_md?.trim() ?? "",
-              items: s?.items ?? [],
-              candidates: ii.candidates,
-            }
-          })
-          // Insight-only: drop sections the LLM chose to leave empty.
-          .filter((s) => s.summary_md.length > 0 || s.items.length > 0)
-
         const vaultSlugs = yield* vaultSvc.listSlugs()
-        const rendered = yield* renderer.renderReport({
+
+        // One LLM call per interest, run with bounded concurrency.
+        const responses: ReadonlyArray<{
+          readonly input: (typeof interestInputs)[number]
+          readonly response: InterestReportResponse
+        }> = yield* Effect.all(
+          interestInputs.map((ii) =>
+            Effect.gen(function* () {
+              yield* Console.log(`  → ${ii.slug}: requesting deep analysis ...`)
+              const response = yield* llm.generateInterestReport({
+                periodLabel,
+                periodStart,
+                periodEnd,
+                profileName: profile.profile.identity.name,
+                interest: ii,
+                maxItems,
+              })
+              return { input: ii, response }
+            }),
+          ),
+          { concurrency },
+        )
+
+        // Render per-interest reports; drop empty ones (insight-only).
+        type Written = {
+          readonly interest: (typeof interestInputs)[number]
+          readonly response: InterestReportResponse
+          readonly markdown: string
+          readonly reportSlug: string
+          readonly relPath: string | null
+          readonly itemCount: number
+          readonly citedClaims: number
+          readonly totalClaims: number
+        }
+        const written: Array<Written> = []
+        let totalCost = 0
+        for (const { input: ii, response } of responses) {
+          totalCost += response.costUsd
+          const analysisTrim = response.analysis_md.trim()
+          if (analysisTrim.length === 0 && response.items.length === 0) {
+            yield* Console.log(
+              `  ${ii.slug}: empty (no substantive signal) — skipping write`,
+            )
+            continue
+          }
+          const rendered = yield* renderer.renderInterestReport({
+            periodLabel,
+            periodStart,
+            periodEnd,
+            generator: llm.name(),
+            model: response.model,
+            promptHash: response.promptHash,
+            costUsd: response.costUsd,
+            profileName: profile.profile.identity.name,
+            interestSlug: ii.slug,
+            interestTitle: ii.title,
+            interestQuestion: ii.question,
+            interestTopics: ii.topics,
+            analysis_md: response.analysis_md,
+            items: response.items,
+            candidates: ii.candidates,
+            vaultSlugs,
+          })
+          let relPath: string | null = null
+          if (!dryRun) {
+            const w = yield* vaultSvc.writeReport(rendered.slug, rendered.markdown)
+            relPath = w.relPath
+            yield* Console.log(
+              `  ✓ ${w.relPath} (${w.contentHash}) — ${rendered.itemCount} item(s), ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
+            )
+          }
+          written.push({
+            interest: ii,
+            response,
+            markdown: rendered.markdown,
+            reportSlug: rendered.slug,
+            relPath,
+            itemCount: rendered.itemCount,
+            citedClaims: rendered.citedClaims,
+            totalClaims: rendered.totalClaims,
+          })
+        }
+
+        // Build the weekly index (one entry per surviving interest report).
+        const entries: Array<ReportIndexEntry> = written.map((w) => ({
+          interestSlug: w.interest.slug,
+          interestTitle: w.interest.title,
+          interestQuestion: w.interest.question,
+          reportSlug: w.reportSlug,
+          publicUrl: publicReportUrl(w.reportSlug),
+          itemCount: w.itemCount,
+          headline: thesisHeadline(w.response.analysis_md),
+        }))
+        const indexModel =
+          written.length > 0 ? written[0].response.model : llm.name()
+        const indexRendered = yield* renderer.renderReportIndex({
           periodLabel,
           periodStart,
           periodEnd,
           generator: llm.name(),
-          model: response.model,
-          promptHash: response.promptHash,
-          costUsd: response.costUsd,
+          model: indexModel,
+          totalCostUsd: totalCost,
           profileName: profile.profile.identity.name,
-          sections: rendererSections,
-          vaultSlugs,
+          entries,
         })
 
         if (dryRun) {
           yield* Console.log("(dry-run — not writing)")
           yield* Console.log("")
-          yield* Console.log(rendered.markdown)
+          yield* Console.log(indexRendered.markdown)
+          for (const w of written) {
+            yield* Console.log("")
+            yield* Console.log(`--- ${w.reportSlug} ---`)
+            yield* Console.log(w.markdown)
+          }
           return
         }
 
-        const written = yield* vaultSvc.writeReport(periodLabel, rendered.markdown)
+        const writtenIndex = yield* vaultSvc.writeReport(
+          indexRendered.slug,
+          indexRendered.markdown,
+        )
         yield* Console.log(
-          `✓ wrote ${written.relPath} (${written.contentHash}) — ${rendered.sectionCount} section(s), ${rendered.itemCount} item(s), ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
+          `✓ ${writtenIndex.relPath} (${writtenIndex.contentHash}) — ${indexRendered.interestCount} interest report(s), $${totalCost.toFixed(4)} total`,
         )
 
-        const reportUrl = publicReportUrl(periodLabel)
-        // Auto-sync when sending, so the URL in the delivered message resolves.
-        const doSync = doSyncOpt || (doSend && reportUrl !== null)
+        const indexUrl = publicReportUrl(periodLabel)
+        const doSync = doSyncOpt || (doSend && indexUrl !== null)
         if (doSync) {
           yield* Console.log(`syncing vault → R2 ...`)
           const syncResult = yield* Effect.serviceOption(SyncService).pipe(
@@ -305,13 +403,13 @@ export const report = Command.make(
 
         if (!doSend) {
           yield* Console.log("")
-          yield* Console.log(rendered.markdown)
+          yield* Console.log(indexRendered.markdown)
           return
         }
 
-        const deliveryContent = reportUrl
-          ? `🌐 ${reportUrl}\n\n${rendered.markdown}`
-          : rendered.markdown
+        const deliveryContent = indexUrl
+          ? `🌐 ${indexUrl}\n\n${indexRendered.markdown}`
+          : indexRendered.markdown
 
         const deliverer = yield* DelivererService
         const channels = yield* resolveChannels(
@@ -357,6 +455,6 @@ export const report = Command.make(
     }),
 ).pipe(
   Command.withDescription(
-    "Generate a weekly research report from research/ interests (optionally --send to channels)",
+    "Generate deep weekly research reports (one file per interest) from research/ (optionally --send the index to channels)",
   ),
 )

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -45,6 +45,8 @@ export type InterestReportResponse = {
   readonly items: ReadonlyArray<CuratedItem>;
   readonly promptHash: string;
   readonly costUsd: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
   readonly model: string;
 };
 

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -30,23 +30,19 @@ export type ReportInterestInput = {
   readonly candidates: ReadonlyArray<CandidateRef>;
 };
 
-export type ReportRequest = {
+export type InterestReportRequest = {
   readonly periodLabel: string;
   readonly periodStart: string;
   readonly periodEnd: string;
   readonly profileName: string;
-  readonly interests: ReadonlyArray<ReportInterestInput>;
-  readonly maxItemsPerInterest: number;
+  readonly interest: ReportInterestInput;
+  readonly maxItems: number;
 };
 
-export type ReportSection = {
+export type InterestReportResponse = {
   readonly interestSlug: string;
-  readonly summary_md: string;
+  readonly analysis_md: string;
   readonly items: ReadonlyArray<CuratedItem>;
-};
-
-export type ReportResponse = {
-  readonly sections: ReadonlyArray<ReportSection>;
   readonly promptHash: string;
   readonly costUsd: number;
   readonly model: string;
@@ -69,7 +65,9 @@ export type SourceSummaryResponse = {
 export interface LlmServiceShape {
   readonly name: () => string;
   readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>;
-  readonly generateReport: (req: ReportRequest) => Effect.Effect<ReportResponse, LlmError>;
+  readonly generateInterestReport: (
+    req: InterestReportRequest,
+  ) => Effect.Effect<InterestReportResponse, LlmError>;
   readonly summarizeSource: (
     req: SourceSummaryRequest,
   ) => Effect.Effect<SourceSummaryResponse, LlmError>;

--- a/apps/uebermensch/src/services/RendererService.ts
+++ b/apps/uebermensch/src/services/RendererService.ts
@@ -33,16 +33,7 @@ export type RenderResult = {
   readonly totalClaims: number
 }
 
-export type ReportSectionInput = {
-  readonly interestSlug: string
-  readonly interestTitle: string
-  readonly interestQuestion: string | null
-  readonly summary_md: string
-  readonly items: ReadonlyArray<CuratedItem>
-  readonly candidates: ReadonlyArray<CandidateRef>
-}
-
-export type ReportRenderInput = {
+export type InterestReportRenderInput = {
   readonly periodLabel: string
   readonly periodStart: string
   readonly periodEnd: string
@@ -51,23 +42,59 @@ export type ReportRenderInput = {
   readonly promptHash: string
   readonly costUsd: number
   readonly profileName: string
-  readonly sections: ReadonlyArray<ReportSectionInput>
+  readonly interestSlug: string
+  readonly interestTitle: string
+  readonly interestQuestion: string | null
+  readonly interestTopics: ReadonlyArray<string>
+  readonly analysis_md: string
+  readonly items: ReadonlyArray<CuratedItem>
+  readonly candidates: ReadonlyArray<CandidateRef>
   readonly vaultSlugs: ReadonlySet<string>
 }
 
-export type ReportRenderResult = {
+export type InterestReportRenderResult = {
   readonly markdown: string
-  readonly sectionCount: number
+  readonly slug: string
   readonly itemCount: number
   readonly citedClaims: number
   readonly totalClaims: number
 }
 
+export type ReportIndexEntry = {
+  readonly interestSlug: string
+  readonly interestTitle: string
+  readonly interestQuestion: string | null
+  readonly reportSlug: string
+  readonly publicUrl: string | null
+  readonly itemCount: number
+  readonly headline: string | null
+}
+
+export type ReportIndexRenderInput = {
+  readonly periodLabel: string
+  readonly periodStart: string
+  readonly periodEnd: string
+  readonly generator: string
+  readonly model: string
+  readonly totalCostUsd: number
+  readonly profileName: string
+  readonly entries: ReadonlyArray<ReportIndexEntry>
+}
+
+export type ReportIndexRenderResult = {
+  readonly markdown: string
+  readonly slug: string
+  readonly interestCount: number
+}
+
 export interface RendererServiceShape {
   readonly render: (input: RenderInput) => Effect.Effect<RenderResult, CitationError>
-  readonly renderReport: (
-    input: ReportRenderInput,
-  ) => Effect.Effect<ReportRenderResult, CitationError>
+  readonly renderInterestReport: (
+    input: InterestReportRenderInput,
+  ) => Effect.Effect<InterestReportRenderResult, CitationError>
+  readonly renderReportIndex: (
+    input: ReportIndexRenderInput,
+  ) => Effect.Effect<ReportIndexRenderResult, CitationError>
 }
 
 export class RendererService extends Context.Tag("uebermensch/RendererService")<

--- a/apps/uebermensch/tests/ingest.test.ts
+++ b/apps/uebermensch/tests/ingest.test.ts
@@ -248,7 +248,7 @@ describe("HttpIngest with summarization", () => {
     Layer.succeed(LlmService, {
       name: () => "fake-llm",
       generateBrief: () => Effect.die("not used"),
-      generateReport: () => Effect.die("not used"),
+      generateInterestReport: () => Effect.die("not used"),
       summarizeSource: () =>
         Effect.sync(() => {
           calls.count += 1
@@ -318,7 +318,7 @@ describe("HttpIngest with summarization", () => {
     const failingLlm = Layer.succeed(LlmService, {
       name: () => "broken-llm",
       generateBrief: () => Effect.die("not used"),
-      generateReport: () => Effect.die("not used"),
+      generateInterestReport: () => Effect.die("not used"),
       summarizeSource: () =>
         Effect.fail(new LlmError({ message: "upstream 503", kind: "unavailable" })),
     })

--- a/apps/uebermensch/tests/report.test.ts
+++ b/apps/uebermensch/tests/report.test.ts
@@ -10,7 +10,7 @@ import { selectCandidates } from "../src/lib/candidates.js"
 import { LlmService } from "../src/services/LlmService.js"
 import {
   RendererService,
-  type ReportSectionInput,
+  type ReportIndexEntry,
 } from "../src/services/RendererService.js"
 import { VaultService } from "../src/services/VaultService.js"
 
@@ -20,7 +20,7 @@ const seedPage = async (root: string, rel: string, frontmatter: string, body: st
   await writeFile(full, `---\n${frontmatter}---\n\n${body}\n`, "utf8")
 }
 
-describe("weekly report (research interests + stub LLM + strict renderer)", () => {
+describe("weekly report (per-interest deep analysis + stub LLM + strict renderer)", () => {
   let vaultDir: string
 
   beforeEach(async () => {
@@ -51,7 +51,7 @@ describe("weekly report (research interests + stub LLM + strict renderer)", () =
     )
   })
 
-  it("lists interests, scopes candidates per interest, and renders a report", async () => {
+  it("generates one deep-analysis report file per interest + a weekly index", async () => {
     const program = Effect.gen(function* () {
       const vault = yield* VaultService
       const llm = yield* LlmService
@@ -91,57 +91,126 @@ describe("weekly report (research interests + stub LLM + strict renderer)", () =
       // Each interest sees only its own candidate.
       for (const ii of inputs) expect(ii.candidates).toHaveLength(1)
 
-      const response = yield* llm.generateReport({
-        periodLabel: "2026-W17",
-        periodStart: "2026-04-15",
-        periodEnd: "2026-04-22",
-        profileName: "Test",
-        interests: inputs,
-        maxItemsPerInterest: 3,
-      })
-      expect(response.sections).toHaveLength(2)
+      const vaultSlugs = yield* vault.listSlugs()
 
-      const bySlug = new Map(response.sections.map((s) => [s.interestSlug, s]))
-      const sections: Array<ReportSectionInput> = inputs.map((ii) => {
-        const s = bySlug.get(ii.slug)!
-        return {
+      const written: Array<{
+        readonly interestSlug: string
+        readonly reportSlug: string
+        readonly relPath: string
+        readonly itemCount: number
+      }> = []
+      const entries: Array<ReportIndexEntry> = []
+
+      for (const ii of inputs) {
+        const response = yield* llm.generateInterestReport({
+          periodLabel: "2026-W17",
+          periodStart: "2026-04-15",
+          periodEnd: "2026-04-22",
+          profileName: "Test",
+          interest: ii,
+          maxItems: 3,
+        })
+        expect(response.interestSlug).toBe(ii.slug)
+        expect(response.analysis_md).toContain("### Thesis")
+        expect(response.items).toHaveLength(1)
+
+        const rendered = yield* renderer.renderInterestReport({
+          periodLabel: "2026-W17",
+          periodStart: "2026-04-15",
+          periodEnd: "2026-04-22",
+          generator: llm.name(),
+          model: response.model,
+          promptHash: response.promptHash,
+          costUsd: response.costUsd,
+          profileName: "Test",
           interestSlug: ii.slug,
           interestTitle: ii.title,
           interestQuestion: ii.question,
-          summary_md: s.summary_md,
-          items: s.items,
+          interestTopics: ii.topics,
+          analysis_md: response.analysis_md,
+          items: response.items,
           candidates: ii.candidates,
-        }
-      })
+          vaultSlugs,
+        })
+        expect(rendered.slug).toBe(`2026-W17--${ii.slug}`)
 
-      const vaultSlugs = yield* vault.listSlugs()
-      const rendered = yield* renderer.renderReport({
+        const w = yield* vault.writeReport(rendered.slug, rendered.markdown)
+        written.push({
+          interestSlug: ii.slug,
+          reportSlug: rendered.slug,
+          relPath: w.relPath,
+          itemCount: rendered.itemCount,
+        })
+        entries.push({
+          interestSlug: ii.slug,
+          interestTitle: ii.title,
+          interestQuestion: ii.question,
+          reportSlug: rendered.slug,
+          publicUrl: null,
+          itemCount: rendered.itemCount,
+          headline: response.analysis_md.slice(0, 80),
+        })
+      }
+
+      const indexRendered = yield* renderer.renderReportIndex({
         periodLabel: "2026-W17",
         periodStart: "2026-04-15",
         periodEnd: "2026-04-22",
         generator: llm.name(),
-        model: response.model,
-        promptHash: response.promptHash,
-        costUsd: response.costUsd,
+        model: "stub-llm@0.1",
+        totalCostUsd: 0,
         profileName: "Test",
-        sections,
-        vaultSlugs,
+        entries,
       })
-      return yield* vault.writeReport("2026-W17", rendered.markdown)
+      expect(indexRendered.slug).toBe("2026-W17")
+      const writtenIndex = yield* vault.writeReport(
+        indexRendered.slug,
+        indexRendered.markdown,
+      )
+
+      return { written, writtenIndex }
     }).pipe(
       Effect.provide(
         Layer.mergeAll(FileSystemVaultLive(vaultDir), StubLlmLive, StrictRendererLive),
       ),
     )
 
-    const written = await Effect.runPromise(program)
-    expect(written.relPath).toBe("reports/2026-W17.md")
-    const onDisk = await readFile(join(vaultDir, written.relPath), "utf8")
-    expect(onDisk).toContain("page_type: report")
-    expect(onDisk).toContain("slug: report-2026-W17")
-    expect(onDisk).toContain("[[2026-04-22--wikipedia-boj]]")
-    expect(onDisk).toContain("[[2026-04-22--wikipedia-2026-senate]]")
-    expect(onDisk).toContain("## Japan macro")
-    expect(onDisk).toContain("## US 2026 midterms")
+    const result = await Effect.runPromise(program)
+
+    expect(result.writtenIndex.relPath).toBe("reports/2026-W17.md")
+    const indexOnDisk = await readFile(
+      join(vaultDir, result.writtenIndex.relPath),
+      "utf8",
+    )
+    expect(indexOnDisk).toContain("page_type: report_index")
+    expect(indexOnDisk).toContain('slug: report-2026-W17')
+    expect(indexOnDisk).toContain("interest_count: 2")
+    expect(indexOnDisk).toContain("Japan macro")
+    expect(indexOnDisk).toContain("US 2026 midterms")
+
+    expect(result.written.map((w) => w.reportSlug).sort()).toEqual([
+      "2026-W17--japan-macro",
+      "2026-W17--us-midterms-2026",
+    ])
+
+    const jpOnDisk = await readFile(
+      join(vaultDir, "reports/2026-W17--japan-macro.md"),
+      "utf8",
+    )
+    expect(jpOnDisk).toContain("page_type: report")
+    expect(jpOnDisk).toContain('slug: report-2026-W17--japan-macro')
+    expect(jpOnDisk).toContain('interest_slug: "japan-macro"')
+    expect(jpOnDisk).toContain("### Thesis")
+    expect(jpOnDisk).toContain("[[2026-04-22--wikipedia-boj]]")
+    // The other interest's source must NOT appear in this file.
+    expect(jpOnDisk).not.toContain("[[2026-04-22--wikipedia-2026-senate]]")
+
+    const usOnDisk = await readFile(
+      join(vaultDir, "reports/2026-W17--us-midterms-2026.md"),
+      "utf8",
+    )
+    expect(usOnDisk).toContain('interest_slug: "us-midterms-2026"')
+    expect(usOnDisk).toContain("[[2026-04-22--wikipedia-2026-senate]]")
+    expect(usOnDisk).not.toContain("[[2026-04-22--wikipedia-boj]]")
   })
 })


### PR DESCRIPTION
## Summary
- Replace uebermensch's single bulk weekly report with **one deep-analysis file per research interest** (`reports/<period>--<slug>.md`) plus a thin index at `reports/<period>.md`.
- New `REPORT_SYSTEM_PROMPT` instructs the LLM to produce structured long-form analysis: **Thesis / Key developments / Cross-currents / Implications / Open questions** with tightened citation + depth rules (insight-only still enforced).
- `uber report` now loops interests with bounded concurrency (`--concurrency`, default 3), drops empty interests, and delivers the **index** on `--send` (one message with per-interest links), not each report.

## Key changes
- `LlmService`: `generateReport(ReportRequest)` → `generateInterestReport(InterestReportRequest)` returning `{ analysis_md, items, ... }`.
- `KernelLlm`: deep-analysis prompt + schema (`InterestReportOutputSchema`).
- `StrictRenderer`: `renderInterestReport` (per-interest file) + `renderReportIndex` (week index); still verifies citations against vault slugs + candidate ids.
- `report.ts`: `Effect.all(..., { concurrency })` across interests; per-file writes; index with thesis headline + public URLs.
- `StubLlm` produces analysis with the same section headers for tests.

## Cost / behaviour
- N Opus 4.7 calls per run instead of 1. With 3–6 interests at ~4k input + 3k output, budget shifts from ~$0.15 to ~$0.30–0.80 per weekly run.
- Pages site (`/reports/:slug`) needs no changes — it already maps `:slug` to `reports/<slug>.md`, so both `2026-W17` (index) and `2026-W17--japan-macro` resolve.
- R2 sync unchanged; new files land under the existing `reports/` prefix.

## Test plan
- [x] `pnpm typecheck` (apps/uebermensch) — clean
- [x] `pnpm test` (apps/uebermensch) — 78/78 passing, including rewritten `report.test.ts` that asserts per-interest files + index and cross-interest citation isolation
- [x] `pnpm build` (apps/uebermensch) — tsup clean
- [x] Workspace `biome lint shell/*/src/ apps/*/src/` — clean
- [ ] Smoke: `UBER_VAULT_DIR=... uber report --llm=stub --dry-run` prints index + per-interest drafts

🤖 Generated with [Claude Code](https://claude.com/claude-code)