### PR TITLE
feat(board): acceptance checks on issues

### DIFF
--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -43,14 +43,9 @@ async function proxyAcceptanceRollup(id: string, env: Env): Promise<Response> {
   const base = (env.KERNEL_URL ?? KERNEL_URL_DEFAULT).replace(/\/$/, "")
   try {
     const upstream = await fetch(`${base}/api/board/issues/${id}/acceptance`)
-    const body = await upstream.text()
-    return new Response(body, {
-      status: upstream.status,
-      headers: {
-        "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
-        "Access-Control-Allow-Origin": "*",
-      },
-    })
+    if (!upstream.ok) return jsonResponse(EMPTY_ROLLUP)
+    const data = await upstream.json()
+    return jsonResponse(data)
   } catch {
     return jsonResponse(EMPTY_ROLLUP)
   }

--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -15,6 +15,45 @@ import { D1Client, D1Error, makeD1Client } from "./d1.js"
 interface Env {
   ASSETS: Fetcher
   DB: D1Database
+  /**
+   * Optional base URL for the gctrl kernel daemon. When set, the Worker
+   * proxies acceptance-rollup reads to the kernel (kernel is source of
+   * truth). Defaults to localhost for dev.
+   */
+  KERNEL_URL?: string
+}
+
+const KERNEL_URL_DEFAULT = "http://127.0.0.1:4318"
+
+const EMPTY_ROLLUP = {
+  total: 0,
+  passed: 0,
+  failed: 0,
+  pending: 0,
+  running: 0,
+  checks: [],
+}
+
+/**
+ * Proxy `GET /api/board/issues/:id/acceptance` to the kernel. Kernel owns
+ * the acceptance_checks table; the Worker is a read facade. Falls back to
+ * an empty rollup when the kernel is unreachable so the UI can keep rendering.
+ */
+async function proxyAcceptanceRollup(id: string, env: Env): Promise<Response> {
+  const base = (env.KERNEL_URL ?? KERNEL_URL_DEFAULT).replace(/\/$/, "")
+  try {
+    const upstream = await fetch(`${base}/api/board/issues/${id}/acceptance`)
+    const body = await upstream.text()
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    })
+  } catch {
+    return jsonResponse(EMPTY_ROLLUP)
+  }
 }
 
 // ── HTTP helpers ──
@@ -543,6 +582,15 @@ export default {
             "Access-Control-Allow-Headers": "Content-Type",
           },
         })
+      }
+
+      // Kernel-proxy routes (kernel is source of truth) — handle before the
+      // D1-backed matchRoute so we don't fall through to "not found".
+      if (request.method === "GET") {
+        const acc = url.pathname.match(
+          /^\/api\/board\/issues\/([^/]+)\/acceptance$/,
+        )
+        if (acc) return proxyAcceptanceRollup(acc[1], env)
       }
 
       const effect = matchRoute(request, url.pathname)

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AcceptanceRollup,
   Issue,
   MoveIssueResult,
   Project,
@@ -120,6 +121,8 @@ export const api = {
     events: (id: string) => request<IssueEvent[]>(`${BASE}/issues/${id}/events`),
 
     comments: (id: string) => request<Comment[]>(`${BASE}/issues/${id}/comments`),
+
+    acceptance: (id: string) => request<AcceptanceRollup>(`${BASE}/issues/${id}/acceptance`),
 
     linkSession: (
       id: string,

--- a/apps/gctrl-board/web/src/components/AcceptanceBadge.tsx
+++ b/apps/gctrl-board/web/src/components/AcceptanceBadge.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react"
+import type { AcceptanceRollup } from "../types"
+import { api } from "../api/client"
+
+interface Props {
+  issueId: string
+  /** Optional rollup passed in from the parent. Skips the fetch when present. */
+  rollup?: AcceptanceRollup
+}
+
+export function AcceptanceBadge({ issueId, rollup: passed }: Props) {
+  const [rollup, setRollup] = useState<AcceptanceRollup | undefined>(passed)
+
+  useEffect(() => {
+    if (passed) return
+    let alive = true
+    api.issues
+      .acceptance(issueId)
+      .then((r) => {
+        if (alive) setRollup(r)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [issueId, passed])
+
+  if (!rollup || rollup.total === 0) return null
+
+  const allPassed = rollup.passed === rollup.total
+  const anyFailed = rollup.failed > 0
+  const tone = anyFailed
+    ? "bg-rose-500/10 text-rose-400 border-rose-500/20"
+    : allPassed
+      ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
+      : "bg-amber-500/10 text-amber-300 border-amber-500/20"
+
+  return (
+    <span
+      data-testid={`acceptance-badge-${issueId}`}
+      title={
+        `Acceptance: ${rollup.passed}/${rollup.total} passed` +
+        (rollup.failed ? ` · ${rollup.failed} failed` : "") +
+        (rollup.pending ? ` · ${rollup.pending} pending` : "")
+      }
+      className={`inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 border ${tone}`}
+    >
+      <span className="opacity-60">AC</span>
+      {rollup.passed}/{rollup.total}
+      {allPassed ? " ✓" : anyFailed ? " ✗" : ""}
+    </span>
+  )
+}

--- a/apps/gctrl-board/web/src/components/IssueCard.tsx
+++ b/apps/gctrl-board/web/src/components/IssueCard.tsx
@@ -1,4 +1,5 @@
 import type { Issue, Priority } from "../types"
+import { AcceptanceBadge } from "./AcceptanceBadge"
 
 const PRIORITY_COLORS: Record<Priority, string> = {
   urgent: "bg-rose-500",
@@ -92,6 +93,8 @@ export function IssueCard({ issue, onClick, isOverlay, isDragging }: Props) {
               ${issue.total_cost_usd.toFixed(2)}
             </span>
           )}
+
+          <AcceptanceBadge issueId={issue.id} />
 
           {issue.labels.map((label) => (
             <span

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -321,3 +321,29 @@ export interface InboxStats {
   by_urgency: Record<string, number>
   by_kind: Record<string, number>
 }
+
+export type AcceptanceKind = "shell" | "test" | "http"
+export type AcceptanceStatus = "pending" | "running" | "pass" | "fail"
+
+export interface AcceptanceCheckRow {
+  id: string
+  issue_id: string
+  check_idx: number
+  kind: AcceptanceKind
+  command: string
+  status: AcceptanceStatus
+  last_session_id: string | null
+  last_run_at: string | null
+  output: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AcceptanceRollup {
+  total: number
+  passed: number
+  failed: number
+  pending: number
+  running: number
+  checks: AcceptanceCheckRow[]
+}

--- a/kernel/crates/gctrl-cli/src/commands/board.rs
+++ b/kernel/crates/gctrl-cli/src/commands/board.rs
@@ -99,6 +99,7 @@ pub fn create_issue(
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     };
 
     store.insert_board_issue(&issue)?;

--- a/kernel/crates/gctrl-cli/src/commands/orch.rs
+++ b/kernel/crates/gctrl-cli/src/commands/orch.rs
@@ -33,6 +33,8 @@ pub async fn run(
         max_per_pass,
         task_timeout: Duration::from_secs(timeout_secs),
         dry_run,
+        kernel_base_url: std::env::var("GCTL_KERNEL_BASE_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:4318".to_string()),
     };
 
     tracing::info!(

--- a/kernel/crates/gctrl-core/src/acceptance.rs
+++ b/kernel/crates/gctrl-core/src/acceptance.rs
@@ -1,0 +1,267 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptanceKind {
+    Shell,
+    Test,
+    Http,
+}
+
+impl AcceptanceKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Shell => "shell",
+            Self::Test => "test",
+            Self::Http => "http",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "shell" => Some(Self::Shell),
+            "test" => Some(Self::Test),
+            "http" => Some(Self::Http),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcceptanceStatus {
+    Pending,
+    Running,
+    Pass,
+    Fail,
+}
+
+impl AcceptanceStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "running" => Some(Self::Running),
+            "pass" => Some(Self::Pass),
+            "fail" => Some(Self::Fail),
+            _ => None,
+        }
+    }
+}
+
+/// A check parsed from an issue's `acceptance_criteria` markdown. No DB state
+/// yet — see `AcceptanceCheckRow` for the persisted form.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcceptanceCheck {
+    pub idx: usize,
+    pub kind: AcceptanceKind,
+    pub command: String,
+}
+
+/// A row in `board_acceptance_checks`. `check_idx` pairs with `issue_id` as
+/// the natural key — agents call back with `(issue_id, check_idx)` to report
+/// results.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcceptanceCheckRow {
+    pub id: String,
+    pub issue_id: String,
+    pub check_idx: i64,
+    pub kind: AcceptanceKind,
+    pub command: String,
+    pub status: AcceptanceStatus,
+    pub last_session_id: Option<String>,
+    pub last_run_at: Option<DateTime<Utc>>,
+    pub output: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Response shape for `GET /api/board/issues/:id/acceptance`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AcceptanceRollup {
+    pub total: u64,
+    pub passed: u64,
+    pub failed: u64,
+    pub pending: u64,
+    pub running: u64,
+    pub checks: Vec<AcceptanceCheckRow>,
+}
+
+/// Parse an `acceptance_criteria` markdown body into structured checks.
+///
+/// Recognized: `- [ ] kind: command` (or `[x]`, `* [ ]`, `+ [ ]`) where `kind`
+/// is `shell` | `test` | `http`. Checkbox state on the line is ignored — the
+/// authoritative status is the row in `board_acceptance_checks`. Unrecognized
+/// lines (prose, headings, unknown kinds, empty commands) are silently skipped
+/// so issue authors can mix free-form context with their checklist.
+pub fn parse_acceptance_criteria(input: &str) -> Vec<AcceptanceCheck> {
+    let mut checks = Vec::new();
+    for line in input.lines() {
+        let Some(after_box) = strip_checkbox_prefix(line.trim_start()) else {
+            continue;
+        };
+        let Some((kind_str, command)) = after_box.split_once(':') else {
+            continue;
+        };
+        let Some(kind) = AcceptanceKind::from_str(kind_str.trim()) else {
+            continue;
+        };
+        let command = command.trim().to_string();
+        if command.is_empty() {
+            continue;
+        }
+        checks.push(AcceptanceCheck {
+            idx: checks.len(),
+            kind,
+            command,
+        });
+    }
+    checks
+}
+
+/// Strip `- [ ]`, `* [x]`, `+ [X]` and similar prefixes. Returns the rest of
+/// the line or None if the line isn't a checklist item.
+fn strip_checkbox_prefix(s: &str) -> Option<&str> {
+    let rest = s
+        .strip_prefix('-')
+        .or_else(|| s.strip_prefix('*'))
+        .or_else(|| s.strip_prefix('+'))?;
+    let rest = rest.trim_start().strip_prefix('[')?;
+    let mut chars = rest.chars();
+    let marker = chars.next()?;
+    if !matches!(marker, ' ' | 'x' | 'X') {
+        return None;
+    }
+    let rest = chars.as_str().strip_prefix(']')?;
+    Some(rest.trim_start())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_input() {
+        assert!(parse_acceptance_criteria("").is_empty());
+        assert!(parse_acceptance_criteria("   \n\n   ").is_empty());
+    }
+
+    #[test]
+    fn parses_single_shell_check() {
+        let out = parse_acceptance_criteria("- [ ] shell: `curl :8080/health` → 200");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].idx, 0);
+        assert_eq!(out[0].kind, AcceptanceKind::Shell);
+        assert_eq!(out[0].command, "`curl :8080/health` → 200");
+    }
+
+    #[test]
+    fn parses_mixed_kinds_and_assigns_sequential_indexes() {
+        let md = "\
+- [ ] shell: curl :8080/health
+- [ ] test: pnpm test foo.test.ts
+- [ ] http: GET /api/sessions
+";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].idx, 0);
+        assert_eq!(out[0].kind, AcceptanceKind::Shell);
+        assert_eq!(out[1].idx, 1);
+        assert_eq!(out[1].kind, AcceptanceKind::Test);
+        assert_eq!(out[2].idx, 2);
+        assert_eq!(out[2].kind, AcceptanceKind::Http);
+    }
+
+    #[test]
+    fn ignores_non_checklist_lines() {
+        let md = "\
+# Acceptance Tests
+
+Some prose line with colons: like this.
+
+- [ ] shell: echo hi
+
+More prose.
+";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].command, "echo hi");
+    }
+
+    #[test]
+    fn ignores_unknown_kinds() {
+        let md = "- [ ] weird: some command\n- [ ] shell: echo ok";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].kind, AcceptanceKind::Shell);
+        assert_eq!(out[0].idx, 0);
+    }
+
+    #[test]
+    fn ignores_empty_commands() {
+        let md = "- [ ] shell: \n- [ ] test: pnpm test";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].kind, AcceptanceKind::Test);
+    }
+
+    #[test]
+    fn accepts_checked_box() {
+        let md = "- [x] shell: echo hi\n- [X] test: pnpm test";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].command, "echo hi");
+        assert_eq!(out[1].kind, AcceptanceKind::Test);
+    }
+
+    #[test]
+    fn preserves_colons_inside_commands() {
+        let md = "- [ ] shell: curl http://foo:8080/x → 200";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].command, "curl http://foo:8080/x → 200");
+    }
+
+    #[test]
+    fn accepts_asterisk_and_plus_bullets() {
+        let md = "* [ ] shell: one\n+ [ ] test: two";
+        let out = parse_acceptance_criteria(md);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].kind, AcceptanceKind::Shell);
+        assert_eq!(out[1].kind, AcceptanceKind::Test);
+    }
+
+    #[test]
+    fn kind_from_str_roundtrip() {
+        for k in [
+            AcceptanceKind::Shell,
+            AcceptanceKind::Test,
+            AcceptanceKind::Http,
+        ] {
+            assert_eq!(AcceptanceKind::from_str(k.as_str()), Some(k.clone()));
+        }
+        assert_eq!(AcceptanceKind::from_str("bogus"), None);
+    }
+
+    #[test]
+    fn status_from_str_roundtrip() {
+        for s in [
+            AcceptanceStatus::Pending,
+            AcceptanceStatus::Running,
+            AcceptanceStatus::Pass,
+            AcceptanceStatus::Fail,
+        ] {
+            assert_eq!(AcceptanceStatus::from_str(s.as_str()), Some(s.clone()));
+        }
+        assert_eq!(AcceptanceStatus::from_str("bogus"), None);
+    }
+}

--- a/kernel/crates/gctrl-core/src/lib.rs
+++ b/kernel/crates/gctrl-core/src/lib.rs
@@ -1,9 +1,11 @@
+pub mod acceptance;
 pub mod config;
 pub mod context;
 pub mod error;
 pub mod memory;
 pub mod types;
 
+pub use acceptance::*;
 pub use config::*;
 pub use context::*;
 pub use error::*;

--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -134,9 +134,9 @@ impl SpanStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SpanType {
-    Generation,  // LLM API call
-    Span,        // Tool execution or logical grouping
-    Event,       // Point-in-time marker (no duration)
+    Generation, // LLM API call
+    Span,       // Tool execution or logical grouping
+    Event,      // Point-in-time marker (no duration)
 }
 
 impl SpanType {
@@ -347,12 +347,12 @@ pub struct SyncManifest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Score {
     pub id: String,
-    pub target_type: String,  // "session", "span", "generation"
+    pub target_type: String, // "session", "span", "generation"
     pub target_id: String,
     pub name: String,
     pub value: f64,
     pub comment: Option<String>,
-    pub source: String,  // "human", "auto", "model"
+    pub source: String, // "human", "auto", "model"
     pub scored_by: Option<String>,
     pub created_at: DateTime<Utc>,
 }
@@ -548,6 +548,11 @@ pub struct BoardIssue {
     /// Gantt scheduling: planned due date as `YYYY-MM-DD` (project-local).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub due_date: Option<String>,
+    /// Markdown checklist of acceptance tests. Parsed by
+    /// `parse_acceptance_criteria` to seed `board_acceptance_checks` when the
+    /// issue promotes to in_progress.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/kernel/crates/gctrl-orch/src/config.rs
+++ b/kernel/crates/gctrl-orch/src/config.rs
@@ -28,4 +28,9 @@ pub struct OrchConfig {
     /// If true, don't spawn anything — just log what would happen and
     /// return the task to the Unclaimed pool.
     pub dry_run: bool,
+
+    /// Base URL the agent uses to POST acceptance-check results back to the
+    /// kernel (e.g. `http://127.0.0.1:4318`). Injected into the brief's
+    /// `## Acceptance Tests` section.
+    pub kernel_base_url: String,
 }

--- a/kernel/crates/gctrl-orch/src/prompt.rs
+++ b/kernel/crates/gctrl-orch/src/prompt.rs
@@ -1,18 +1,59 @@
-use gctrl_core::{BoardComment, BoardIssue};
+use gctrl_core::{AcceptanceCheck, BoardComment, BoardIssue};
 
-/// Pick the freshest dispatch comment posted by gctrl-board when the Issue
-/// moved to `in_progress`. The board UI posts them with a distinctive
-/// `## Agent:` section — we key off that so regular chat comments don't
-/// get mistaken for an agent brief.
+/// Build the full brief the agent sees on stdin.
 ///
-/// Falls back to building a minimal prompt from title+description if no
-/// dispatch comment is found — lets `gctrld board move ... in_progress`
-/// work even without a persona match.
-pub fn build_prompt(issue: &BoardIssue, comments: &[BoardComment]) -> String {
-    if let Some(dispatch) = latest_dispatch_comment(comments) {
-        return dispatch.body.clone();
+/// Layers (concatenated in order):
+/// 1. The persona body — freshest `## Agent:` dispatch comment from the
+///    board UI, or a minimal fallback if none exists.
+/// 2. A `## Acceptance Tests` section (only if `checks` is non-empty)
+///    listing each check and the HTTP callback URL the agent must POST
+///    results to.
+pub fn build_prompt(
+    issue: &BoardIssue,
+    comments: &[BoardComment],
+    checks: &[AcceptanceCheck],
+    kernel_base_url: &str,
+) -> String {
+    let base = latest_dispatch_comment(comments)
+        .map(|c| c.body.clone())
+        .unwrap_or_else(|| fallback_prompt(issue));
+    if checks.is_empty() {
+        return base;
     }
-    fallback_prompt(issue)
+    let mut out = base;
+    if !out.ends_with("\n\n") {
+        if out.ends_with('\n') {
+            out.push('\n');
+        } else {
+            out.push_str("\n\n");
+        }
+    }
+    out.push_str(&render_acceptance_section(issue, checks, kernel_base_url));
+    out
+}
+
+fn render_acceptance_section(
+    issue: &BoardIssue,
+    checks: &[AcceptanceCheck],
+    kernel_base_url: &str,
+) -> String {
+    let url = kernel_base_url.trim_end_matches('/');
+    let mut s = String::from("## Acceptance Tests\n\n");
+    s.push_str(&format!(
+        "Run each check below and report the result by POSTing to:\n\
+         `{url}/api/board/issues/{id}/acceptance/checks/<IDX>`\n\n\
+         Body: `{{\"status\":\"pass\"|\"fail\",\"output\":\"<trimmed stdout/stderr>\"}}`\n\n",
+        id = issue.id,
+    ));
+    for check in checks {
+        s.push_str(&format!(
+            "- [{idx}] {kind}: {cmd}\n",
+            idx = check.idx,
+            kind = check.kind.as_str(),
+            cmd = check.command,
+        ));
+    }
+    s
 }
 
 fn latest_dispatch_comment(comments: &[BoardComment]) -> Option<&BoardComment> {
@@ -39,7 +80,7 @@ fn fallback_prompt(issue: &BoardIssue) -> String {
 mod tests {
     use super::*;
     use chrono::{Duration, Utc};
-    use gctrl_core::{BoardIssue, IssueStatus};
+    use gctrl_core::{AcceptanceKind, BoardIssue, IssueStatus};
 
     fn issue() -> BoardIssue {
         let now = Utc::now();
@@ -72,6 +113,7 @@ mod tests {
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         }
     }
 
@@ -95,14 +137,14 @@ mod tests {
             comment("c2", "## Agent: Engineer\nnew brief", 1),
             comment("c3", "regular human comment", 2),
         ];
-        let out = build_prompt(&issue(), &comments);
+        let out = build_prompt(&issue(), &comments, &[], "http://127.0.0.1:4318");
         assert!(out.contains("new brief"), "got: {out}");
         assert!(!out.contains("old brief"));
     }
 
     #[test]
     fn falls_back_to_title_and_description() {
-        let out = build_prompt(&issue(), &[]);
+        let out = build_prompt(&issue(), &[], &[], "http://127.0.0.1:4318");
         assert!(out.contains("BACK-1"));
         assert!(out.contains("Fix thing"));
         assert!(out.contains("describe"));
@@ -117,9 +159,65 @@ mod tests {
             author_type: "human".into(),
             ..comments[0].clone()
         };
-        let out = build_prompt(&issue(), &[human]);
+        let out = build_prompt(&issue(), &[human], &[], "http://127.0.0.1:4318");
         // Should fall back to title/description since no dispatch matches.
         assert!(out.contains("Fix thing"));
         assert!(!out.contains("human note"));
+    }
+
+    #[test]
+    fn appends_acceptance_section_with_callback_url() {
+        let checks = vec![
+            AcceptanceCheck {
+                idx: 0,
+                kind: AcceptanceKind::Shell,
+                command: "curl :8080/health → 200".into(),
+            },
+            AcceptanceCheck {
+                idx: 1,
+                kind: AcceptanceKind::Test,
+                command: "pnpm test foo.test.ts".into(),
+            },
+        ];
+        let out = build_prompt(&issue(), &[], &checks, "http://127.0.0.1:4318");
+        assert!(out.contains("## Acceptance Tests"));
+        assert!(out.contains("/api/board/issues/BACK-1/acceptance/checks/<IDX>"));
+        assert!(out.contains("- [0] shell: curl :8080/health → 200"));
+        assert!(out.contains("- [1] test: pnpm test foo.test.ts"));
+    }
+
+    #[test]
+    fn omits_acceptance_section_when_no_checks() {
+        let out = build_prompt(&issue(), &[], &[], "http://127.0.0.1:4318");
+        assert!(!out.contains("## Acceptance Tests"));
+    }
+
+    #[test]
+    fn acceptance_section_follows_dispatch_body() {
+        let comments = vec![comment("c1", "## Agent: Engineer\npersona brief body", 1)];
+        let checks = vec![AcceptanceCheck {
+            idx: 0,
+            kind: AcceptanceKind::Shell,
+            command: "echo ok".into(),
+        }];
+        let out = build_prompt(&issue(), &comments, &checks, "http://127.0.0.1:4318");
+        let persona_pos = out.find("persona brief body").expect("persona present");
+        let acceptance_pos = out.find("## Acceptance Tests").expect("acceptance present");
+        assert!(
+            persona_pos < acceptance_pos,
+            "acceptance must come after persona"
+        );
+    }
+
+    #[test]
+    fn trims_trailing_slash_from_kernel_url() {
+        let checks = vec![AcceptanceCheck {
+            idx: 0,
+            kind: AcceptanceKind::Shell,
+            command: "x".into(),
+        }];
+        let out = build_prompt(&issue(), &[], &checks, "http://127.0.0.1:4318/");
+        assert!(out.contains("http://127.0.0.1:4318/api/board/issues/BACK-1"));
+        assert!(!out.contains("4318//api"));
     }
 }

--- a/kernel/crates/gctrl-orch/src/worker.rs
+++ b/kernel/crates/gctrl-orch/src/worker.rs
@@ -90,7 +90,12 @@ impl Worker {
             .get_board_issue(issue_id)?
             .ok_or_else(|| anyhow::anyhow!("issue {issue_id} disappeared"))?;
         let comments = self.store.list_board_comments(issue_id)?;
-        let prompt = prompt::build_prompt(&issue, &comments);
+        let checks = issue
+            .acceptance_criteria
+            .as_deref()
+            .map(gctrl_core::parse_acceptance_criteria)
+            .unwrap_or_default();
+        let prompt = prompt::build_prompt(&issue, &comments, &checks, &self.config.kernel_base_url);
 
         if self.config.dry_run {
             tracing::info!(
@@ -111,28 +116,21 @@ impl Worker {
         // Spawn first, *then* transition Claimed → Running. This matches the
         // Lean spec: `dispatchFailed` (Claimed → Released) vs `agentLaunched`
         // (Claimed → Running) vs `agentExitAbnormal` (Running → RetryQueued).
-        let child = match agent::spawn_agent(
-            &self.config.agent_cmd,
-            &self.config.working_dir,
-            &prompt,
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                let body = format!("## Agent run failed (spawn)\n\n{e}");
-                self.post_completion_comment(issue_id, &body, false)?;
-                self.strict_transition(
-                    &task.id,
-                    Task::CLAIM_CLAIMED,
-                    Task::CLAIM_RELEASED,
-                )?;
-                tracing::warn!(task_id = %task.id, err = %e, "orch: dispatchFailed");
-                return Ok(DispatchOutcome::Retried {
-                    task_id: task.id.clone(),
-                });
-            }
-        };
+        let child =
+            match agent::spawn_agent(&self.config.agent_cmd, &self.config.working_dir, &prompt)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    let body = format!("## Agent run failed (spawn)\n\n{e}");
+                    self.post_completion_comment(issue_id, &body, false)?;
+                    self.strict_transition(&task.id, Task::CLAIM_CLAIMED, Task::CLAIM_RELEASED)?;
+                    tracing::warn!(task_id = %task.id, err = %e, "orch: dispatchFailed");
+                    return Ok(DispatchOutcome::Retried {
+                        task_id: task.id.clone(),
+                    });
+                }
+            };
 
         // agentLaunched.
         self.strict_transition(&task.id, Task::CLAIM_CLAIMED, Task::CLAIM_RUNNING)?;
@@ -140,11 +138,7 @@ impl Worker {
         match agent::await_agent(child, self.config.task_timeout).await {
             Ok(result) => {
                 self.post_completion_comment(issue_id, &result.stdout, true)?;
-                self.strict_transition(
-                    &task.id,
-                    Task::CLAIM_RUNNING,
-                    Task::CLAIM_RELEASED,
-                )?;
+                self.strict_transition(&task.id, Task::CLAIM_RUNNING, Task::CLAIM_RELEASED)?;
                 tracing::info!(task_id = %task.id, "orch: released on clean exit");
                 Ok(DispatchOutcome::Released {
                     task_id: task.id.clone(),
@@ -153,11 +147,7 @@ impl Worker {
             Err(e) => {
                 let body = format!("## Agent run failed\n\n{e}");
                 self.post_completion_comment(issue_id, &body, false)?;
-                self.strict_transition(
-                    &task.id,
-                    Task::CLAIM_RUNNING,
-                    Task::CLAIM_RETRY_QUEUED,
-                )?;
+                self.strict_transition(&task.id, Task::CLAIM_RUNNING, Task::CLAIM_RETRY_QUEUED)?;
                 tracing::warn!(task_id = %task.id, err = %e, "orch: retry-queued");
                 Ok(DispatchOutcome::Retried {
                     task_id: task.id.clone(),

--- a/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
+++ b/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
@@ -50,6 +50,7 @@ fn seed_dispatchable_issue(store: &SqliteStore, issue_id: &str) -> Task {
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     };
     store.insert_board_issue(&issue).unwrap();
 
@@ -67,7 +68,9 @@ fn seed_dispatchable_issue(store: &SqliteStore, issue_id: &str) -> Task {
     };
     store.insert_board_comment(&comment).unwrap();
 
-    store.promote_issue_to_task(issue_id, "claude-code").unwrap()
+    store
+        .promote_issue_to_task(issue_id, "claude-code")
+        .unwrap()
 }
 
 fn cat_config() -> OrchConfig {
@@ -78,6 +81,7 @@ fn cat_config() -> OrchConfig {
         max_per_pass: 4,
         task_timeout: Duration::from_secs(5),
         dry_run: false,
+        kernel_base_url: "http://127.0.0.1:4318".into(),
     }
 }
 

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -132,10 +132,16 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/sessions/stream", get(stream_sessions))
         .route("/api/sessions/{session_id}/stream", get(stream_session))
         // Auto-score and session lifecycle
-        .route("/api/sessions/{session_id}/auto-score", post(auto_score_session))
+        .route(
+            "/api/sessions/{session_id}/auto-score",
+            post(auto_score_session),
+        )
         .route("/api/sessions/{session_id}/end", post(end_session))
         .route("/api/sessions/{session_id}/loops", get(detect_loops))
-        .route("/api/sessions/{session_id}/cost-breakdown", get(session_cost_breakdown))
+        .route(
+            "/api/sessions/{session_id}/cost-breakdown",
+            get(session_cost_breakdown),
+        )
         // Context management
         .route("/api/context", get(context_list).post(context_upsert))
         .route("/api/context/compact", get(context_compact))
@@ -143,8 +149,14 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/context/{id}", get(context_get).delete(context_delete))
         .route("/api/context/{id}/content", get(context_content))
         // Board application
-        .route("/api/board/projects", get(board_list_projects).post(board_create_project))
-        .route("/api/board/issues", get(board_list_issues).post(board_create_issue))
+        .route(
+            "/api/board/projects",
+            get(board_list_projects).post(board_create_project),
+        )
+        .route(
+            "/api/board/issues",
+            get(board_list_issues).post(board_create_issue),
+        )
         .route("/api/board/issues/{id}", get(board_get_issue))
         .route("/api/board/issues/{id}/move", post(board_move_issue))
         .route("/api/board/issues/{id}/assign", post(board_assign_issue))
@@ -154,11 +166,19 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/board/issues/{id}/link-session", post(board_link_session))
         .route("/api/board/issues/{id}/schedule", patch(board_schedule_issue))
         .route("/api/board/projects/{id}/gantt", get(board_gantt_for_project))
+        .route("/api/board/issues/{id}/acceptance", get(board_acceptance_rollup))
+        .route(
+            "/api/board/issues/{id}/acceptance/checks/{idx}",
+            post(board_acceptance_report),
+        )
         .route("/api/board/import", post(board_import_markdown))
         .route("/api/board/export", post(board_export_markdown))
         .route("/api/board/projects/{id}/github", post(board_link_github))
         // GitHub driver (LKM — delegates to native `gh` CLI)
-        .route("/api/github/issues", get(gh_list_issues).post(gh_create_issue))
+        .route(
+            "/api/github/issues",
+            get(gh_list_issues).post(gh_create_issue),
+        )
         .route("/api/github/issues/{number}", get(gh_get_issue))
         .route("/api/github/prs", get(gh_list_prs))
         .route("/api/github/prs/{number}", get(gh_get_pr))
@@ -188,17 +208,29 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Persona management (kernel extension)
         .route("/api/personas", get(persona_list).post(persona_upsert))
         .route("/api/personas/seed", post(persona_seed))
-        .route("/api/personas/review-rules", get(persona_review_rules_list).post(persona_review_rules_upsert))
-        .route("/api/personas/{id}", get(persona_get).delete(persona_delete))
+        .route(
+            "/api/personas/review-rules",
+            get(persona_review_rules_list).post(persona_review_rules_upsert),
+        )
+        .route(
+            "/api/personas/{id}",
+            get(persona_get).delete(persona_delete),
+        )
         // Team composition
         .route("/api/team/recommend", post(team_recommend))
         .route("/api/team/render", post(team_render))
         // Inbox application
-        .route("/api/inbox/messages", get(inbox_list_messages).post(inbox_create_message))
+        .route(
+            "/api/inbox/messages",
+            get(inbox_list_messages).post(inbox_create_message),
+        )
         .route("/api/inbox/messages/{id}", get(inbox_get_message))
         .route("/api/inbox/threads", get(inbox_list_threads))
         .route("/api/inbox/threads/{id}", get(inbox_get_thread))
-        .route("/api/inbox/actions", get(inbox_list_actions).post(inbox_create_action))
+        .route(
+            "/api/inbox/actions",
+            get(inbox_list_actions).post(inbox_create_action),
+        )
         .route("/api/inbox/batch-action", post(inbox_batch_action))
         .route("/api/inbox/stats", get(inbox_stats))
         // Sync (SQLite → D1 push)
@@ -213,7 +245,10 @@ fn build_router(state: Arc<AppState>) -> Router {
 }
 
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let storage = state.store.get_health_info().unwrap_or(serde_json::json!({}));
+    let storage = state
+        .store
+        .get_health_info()
+        .unwrap_or(serde_json::json!({}));
     Json(serde_json::json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
@@ -238,7 +273,11 @@ async fn list_sessions(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListParams>,
 ) -> impl IntoResponse {
-    match state.store.list_sessions_filtered(params.limit, params.agent.as_deref(), params.status.as_deref()) {
+    match state.store.list_sessions_filtered(
+        params.limit,
+        params.agent.as_deref(),
+        params.status.as_deref(),
+    ) {
         Ok(sessions) => Json(serde_json::to_value(&sessions).unwrap()).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -248,9 +287,16 @@ async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
-    match state.store.get_session(&gctrl_core::SessionId(session_id.clone())) {
+    match state
+        .store
+        .get_session(&gctrl_core::SessionId(session_id.clone()))
+    {
         Ok(Some(session)) => Json(serde_json::to_value(&session).unwrap()).into_response(),
-        Ok(None) => (StatusCode::NOT_FOUND, format!("session {session_id} not found")).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            format!("session {session_id} not found"),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -272,23 +318,37 @@ async fn get_trace_tree(
     let sid = gctrl_core::SessionId(session_id.clone());
     let session = match state.store.get_session(&sid) {
         Ok(Some(s)) => s,
-        Ok(None) => return (StatusCode::NOT_FOUND, format!("session {session_id} not found")).into_response(),
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("session {session_id} not found"),
+            )
+                .into_response()
+        }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
     let spans = match state.store.query_spans(&sid) {
         Ok(s) => s,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
-    let scores = state.store.get_scores("session", &session_id).unwrap_or_default();
-    let tags = state.store.get_tags("session", &session_id).unwrap_or_default();
+    let scores = state
+        .store
+        .get_scores("session", &session_id)
+        .unwrap_or_default();
+    let tags = state
+        .store
+        .get_tags("session", &session_id)
+        .unwrap_or_default();
 
     // Build tree: root spans (no parent) with children nested
-    let root_spans: Vec<&gctrl_core::Span> = spans.iter()
+    let root_spans: Vec<&gctrl_core::Span> = spans
+        .iter()
         .filter(|s| s.parent_span_id.is_none())
         .collect();
 
     let build_node = |span: &gctrl_core::Span| -> serde_json::Value {
-        let children: Vec<serde_json::Value> = spans.iter()
+        let children: Vec<serde_json::Value> = spans
+            .iter()
             .filter(|s| s.parent_span_id.as_ref().map(|p| &p.0) == Some(&span.span_id.0))
             .map(|child| {
                 serde_json::json!({
@@ -460,7 +520,9 @@ async fn auto_score_session(
     Path(session_id): Path<String>,
 ) -> impl IntoResponse {
     match state.store.auto_score_session(&session_id) {
-        Ok(scores) => (StatusCode::OK, Json(serde_json::to_value(&scores).unwrap())).into_response(),
+        Ok(scores) => {
+            (StatusCode::OK, Json(serde_json::to_value(&scores).unwrap())).into_response()
+        }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -481,7 +543,10 @@ async fn end_session(
             // Auto-score on session end
             let _ = state.store.auto_score_session(&session_id);
             // Check for error loops
-            let loops = state.store.detect_error_loops(&session_id, 3).unwrap_or_default();
+            let loops = state
+                .store
+                .detect_error_loops(&session_id, 3)
+                .unwrap_or_default();
             if !loops.is_empty() {
                 // Create a loop detection score
                 let loop_score = gctrl_core::Score {
@@ -505,7 +570,8 @@ async fn end_session(
                 "session_id": session_id,
                 "status": status,
                 "loops_detected": loops.len(),
-            })).into_response()
+            }))
+            .into_response()
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -520,7 +586,8 @@ async fn detect_loops(
             "session_id": session_id,
             "loops": loops,
             "count": loops.len(),
-        })).into_response(),
+        }))
+        .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -535,7 +602,8 @@ async fn session_cost_breakdown(
             "breakdown": breakdown.iter().map(|(m, c, i, o, n)| serde_json::json!({
                 "model": m, "cost_usd": c, "input_tokens": i, "output_tokens": o, "span_count": n
             })).collect::<Vec<_>>(),
-        })).into_response(),
+        }))
+        .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -587,7 +655,8 @@ async fn analytics_scores(
             "total": pass + fail,
             "pass_rate": if pass + fail > 0 { pass as f64 / (pass + fail) as f64 } else { 0.0 },
             "avg_value": avg,
-        })).into_response(),
+        }))
+        .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -617,8 +686,14 @@ async fn create_score(
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let score = gctrl_core::Score {
-        id: payload["id"].as_str().unwrap_or(&uuid::Uuid::new_v4().to_string()).to_string(),
-        target_type: payload["target_type"].as_str().unwrap_or("session").to_string(),
+        id: payload["id"]
+            .as_str()
+            .unwrap_or(&uuid::Uuid::new_v4().to_string())
+            .to_string(),
+        target_type: payload["target_type"]
+            .as_str()
+            .unwrap_or("session")
+            .to_string(),
         target_id: payload["target_id"].as_str().unwrap_or("").to_string(),
         name: payload["name"].as_str().unwrap_or("").to_string(),
         value: payload["value"].as_f64().unwrap_or(0.0),
@@ -628,7 +703,11 @@ async fn create_score(
         created_at: chrono::Utc::now(),
     };
     match state.store.insert_score(&score) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::json!({"id": score.id}))).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({"id": score.id})),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -638,8 +717,14 @@ async fn create_tag(
     Json(payload): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let tag = gctrl_core::Tag {
-        id: payload["id"].as_str().unwrap_or(&uuid::Uuid::new_v4().to_string()).to_string(),
-        target_type: payload["target_type"].as_str().unwrap_or("session").to_string(),
+        id: payload["id"]
+            .as_str()
+            .unwrap_or(&uuid::Uuid::new_v4().to_string())
+            .to_string(),
+        target_type: payload["target_type"]
+            .as_str()
+            .unwrap_or("session")
+            .to_string(),
         target_id: payload["target_id"].as_str().unwrap_or("").to_string(),
         key: payload["key"].as_str().unwrap_or("").to_string(),
         value: payload["value"].as_str().unwrap_or("").to_string(),
@@ -677,7 +762,12 @@ async fn ingest_traces(
     let mut started_emit: Vec<gctrl_core::Session> = Vec::new();
     for span in &spans {
         if seen_sessions.insert(span.session_id.0.clone()) {
-            if state.store.get_session(&span.session_id).unwrap_or(None).is_none() {
+            if state
+                .store
+                .get_session(&span.session_id)
+                .unwrap_or(None)
+                .is_none()
+            {
                 let session = gctrl_core::Session {
                     id: span.session_id.clone(),
                     workspace_id: gctrl_core::WorkspaceId("default".into()),
@@ -730,7 +820,10 @@ async fn ingest_traces(
             // Check alert rules
             if let Ok(rules) = state.store.list_alert_rules() {
                 for session_id_str in &seen_sessions {
-                    if let Ok(Some(session)) = state.store.get_session(&gctrl_core::SessionId(session_id_str.clone())) {
+                    if let Ok(Some(session)) = state
+                        .store
+                        .get_session(&gctrl_core::SessionId(session_id_str.clone()))
+                    {
                         for rule in &rules {
                             let should_fire = match rule.condition_type.as_str() {
                                 "session_cost" => session.total_cost_usd > rule.threshold,
@@ -744,7 +837,11 @@ async fn ingest_traces(
                                     timestamp: chrono::Utc::now(),
                                     message: format!(
                                         "[{}] {}: session {} cost ${:.2} exceeds threshold ${:.2}",
-                                        rule.action, rule.name, session_id_str, session.total_cost_usd, rule.threshold
+                                        rule.action,
+                                        rule.name,
+                                        session_id_str,
+                                        session.total_cost_usd,
+                                        rule.threshold
                                     ),
                                     acknowledged: false,
                                 };
@@ -792,10 +889,17 @@ async fn context_list(
     Query(params): Query<ContextListParams>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     let filter = gctrl_core::context::ContextFilter {
-        kind: params.kind.as_deref().and_then(gctrl_core::context::ContextKind::from_str),
+        kind: params
+            .kind
+            .as_deref()
+            .and_then(gctrl_core::context::ContextKind::from_str),
         tag: params.tag,
         source: params.source,
         search: params.search,
@@ -821,23 +925,51 @@ struct ContextUpsertBody {
     source_ref: Option<String>,
 }
 
-fn default_context_kind() -> String { "document".into() }
-fn default_context_source() -> String { "human".into() }
+fn default_context_kind() -> String {
+    "document".into()
+}
+fn default_context_source() -> String {
+    "human".into()
+}
 
 async fn context_upsert(
     State(state): State<Arc<AppState>>,
     Json(body): Json<ContextUpsertBody>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     let kind = match gctrl_core::context::ContextKind::from_str(&body.kind) {
         Some(k) => k,
-        None => return (StatusCode::BAD_REQUEST, format!("invalid kind: {}", body.kind)).into_response(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("invalid kind: {}", body.kind),
+            )
+                .into_response()
+        }
     };
-    let source = gctrl_core::context::ContextSource::from_parts(&body.source_type, body.source_ref.as_deref());
-    match ctx.upsert(&kind, &body.path, &body.title, &body.content, &source, &body.tags) {
-        Ok(entry) => (StatusCode::CREATED, Json(serde_json::to_value(&entry).unwrap())).into_response(),
+    let source = gctrl_core::context::ContextSource::from_parts(
+        &body.source_type,
+        body.source_ref.as_deref(),
+    );
+    match ctx.upsert(
+        &kind,
+        &body.path,
+        &body.title,
+        &body.content,
+        &source,
+        &body.tags,
+    ) {
+        Ok(entry) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&entry).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -847,7 +979,11 @@ async fn context_get(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     match ctx.get(&id).or_else(|_| ctx.get_by_path(&id)) {
         Ok(entry) => Json(serde_json::to_value(&entry).unwrap()).into_response(),
@@ -860,9 +996,16 @@ async fn context_content(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
-    match ctx.read_content(&id).or_else(|_| ctx.read_content_by_path(&id)) {
+    match ctx
+        .read_content(&id)
+        .or_else(|_| ctx.read_content_by_path(&id))
+    {
         Ok(content) => content.into_response(),
         Err(_) => (StatusCode::NOT_FOUND, format!("not found: {}", id)).into_response(),
     }
@@ -873,7 +1016,11 @@ async fn context_delete(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     match ctx.remove(&id).or_else(|_| ctx.remove_by_path(&id)) {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
@@ -892,10 +1039,17 @@ async fn context_compact(
     Query(params): Query<ContextCompactParams>,
 ) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     let filter = gctrl_core::context::ContextFilter {
-        kind: params.kind.as_deref().and_then(gctrl_core::context::ContextKind::from_str),
+        kind: params
+            .kind
+            .as_deref()
+            .and_then(gctrl_core::context::ContextKind::from_str),
         tag: params.tag,
         ..Default::default()
     };
@@ -907,7 +1061,11 @@ async fn context_compact(
 
 async fn context_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let Some(ref ctx) = state.context else {
-        return (StatusCode::SERVICE_UNAVAILABLE, "context manager not initialized").into_response();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "context manager not initialized",
+        )
+            .into_response();
     };
     match ctx.stats() {
         Ok(stats) => Json(serde_json::to_value(&stats).unwrap()).into_response(),
@@ -936,7 +1094,10 @@ async fn memory_list(
     Query(params): Query<MemoryListParams>,
 ) -> impl IntoResponse {
     let filter = gctrl_core::memory::MemoryFilter {
-        memory_type: params.memory_type.as_deref().and_then(gctrl_core::memory::MemoryType::from_str),
+        memory_type: params
+            .memory_type
+            .as_deref()
+            .and_then(gctrl_core::memory::MemoryType::from_str),
         tag: params.tag,
         search: params.search,
         limit: Some(params.limit),
@@ -971,7 +1132,13 @@ async fn memory_upsert(
 ) -> impl IntoResponse {
     let memory_type = match gctrl_core::memory::MemoryType::from_str(&body.memory_type) {
         Some(t) => t,
-        None => return (StatusCode::BAD_REQUEST, format!("invalid type: {}", body.memory_type)).into_response(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("invalid type: {}", body.memory_type),
+            )
+                .into_response()
+        }
     };
     if body.name.trim().is_empty() {
         return (StatusCode::BAD_REQUEST, "name is required").into_response();
@@ -983,7 +1150,8 @@ async fn memory_upsert(
     let now = chrono::Utc::now();
     let entry = gctrl_core::memory::MemoryEntry {
         id: gctrl_core::memory::MemoryEntryId(
-            body.id.unwrap_or_else(|| format!("mem-{}", uuid::Uuid::new_v4())),
+            body.id
+                .unwrap_or_else(|| format!("mem-{}", uuid::Uuid::new_v4())),
         ),
         memory_type,
         name: body.name,
@@ -997,7 +1165,11 @@ async fn memory_upsert(
     };
 
     match state.sqlite.upsert_memory(&entry) {
-        Ok(_) => (StatusCode::CREATED, Json(serde_json::to_value(&entry).unwrap())).into_response(),
+        Ok(_) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&entry).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -1051,11 +1223,22 @@ async fn board_create_project(
         github_repo: None,
     };
     match state.sqlite.create_board_project(&project) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::to_value(&project).unwrap())).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&project).unwrap()),
+        )
+            .into_response(),
         Err(e) => {
             let msg = e.to_string();
-            if msg.contains("Duplicate key") || msg.contains("Constraint Error") || msg.contains("UNIQUE constraint failed") {
-                (StatusCode::CONFLICT, format!("project with key '{}' already exists", project.key)).into_response()
+            if msg.contains("Duplicate key")
+                || msg.contains("Constraint Error")
+                || msg.contains("UNIQUE constraint failed")
+            {
+                (
+                    StatusCode::CONFLICT,
+                    format!("project with key '{}' already exists", project.key),
+                )
+                    .into_response()
             } else {
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             }
@@ -1080,13 +1263,14 @@ async fn board_link_github(
     Path(id): Path<String>,
     Json(body): Json<BoardLinkGithubBody>,
 ) -> impl IntoResponse {
-    match state.sqlite.update_board_project_github_repo(&id, &body.github_repo) {
-        Ok(()) => {
-            match state.sqlite.get_board_project(&id) {
-                Ok(Some(project)) => Json(serde_json::to_value(&project).unwrap()).into_response(),
-                _ => (StatusCode::NOT_FOUND, "project not found".to_string()).into_response(),
-            }
-        }
+    match state
+        .sqlite
+        .update_board_project_github_repo(&id, &body.github_repo)
+    {
+        Ok(()) => match state.sqlite.get_board_project(&id) {
+            Ok(Some(project)) => Json(serde_json::to_value(&project).unwrap()).into_response(),
+            _ => (StatusCode::NOT_FOUND, "project not found".to_string()).into_response(),
+        },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -1111,10 +1295,16 @@ struct BoardCreateIssueBody {
     github_issue_number: Option<u32>,
     #[serde(default)]
     github_url: Option<String>,
+    #[serde(default)]
+    acceptance_criteria: Option<String>,
 }
 
-fn default_priority() -> String { "none".into() }
-fn default_human() -> String { "human".into() }
+fn default_priority() -> String {
+    "none".into()
+}
+fn default_human() -> String {
+    "human".into()
+}
 
 async fn board_create_issue(
     State(state): State<Arc<AppState>>,
@@ -1123,7 +1313,9 @@ async fn board_create_issue(
     // Auto-generate ID from project key + counter
     let counter = match state.sqlite.increment_project_counter(&body.project_id) {
         Ok(c) => c,
-        Err(e) => return (StatusCode::BAD_REQUEST, format!("project not found: {}", e)).into_response(),
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, format!("project not found: {}", e)).into_response()
+        }
     };
     let project = match state.sqlite.get_board_project(&body.project_id) {
         Ok(Some(p)) => p,
@@ -1160,10 +1352,15 @@ async fn board_create_issue(
         github_url: body.github_url,
         start_date: None,
         due_date: None,
+        acceptance_criteria: body.acceptance_criteria,
     };
 
     match state.sqlite.insert_board_issue(&issue) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::to_value(&issue).unwrap())).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&issue).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -1178,7 +1375,9 @@ struct BoardIssueListParams {
     limit: usize,
 }
 
-fn default_issue_limit() -> usize { 50 }
+fn default_issue_limit() -> usize {
+    50
+}
 
 async fn board_list_issues(
     State(state): State<Arc<AppState>>,
@@ -1284,13 +1483,16 @@ async fn board_assign_issue(
     Path(id): Path<String>,
     Json(body): Json<BoardAssignBody>,
 ) -> impl IntoResponse {
-    match state.sqlite.assign_board_issue(&id, &body.assignee_id, &body.assignee_name, &body.assignee_type) {
-        Ok(()) => {
-            match state.sqlite.get_board_issue(&id) {
-                Ok(Some(issue)) => Json(serde_json::to_value(&issue).unwrap()).into_response(),
-                _ => StatusCode::OK.into_response(),
-            }
-        }
+    match state.sqlite.assign_board_issue(
+        &id,
+        &body.assignee_id,
+        &body.assignee_name,
+        &body.assignee_type,
+    ) {
+        Ok(()) => match state.sqlite.get_board_issue(&id) {
+            Ok(Some(issue)) => Json(serde_json::to_value(&issue).unwrap()).into_response(),
+            _ => StatusCode::OK.into_response(),
+        },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -1322,7 +1524,11 @@ async fn board_add_comment(
         session_id: body.session_id,
     };
     match state.sqlite.insert_board_comment(&comment) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::to_value(&comment).unwrap())).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&comment).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -1361,7 +1567,10 @@ async fn board_link_session(
     Path(id): Path<String>,
     Json(body): Json<BoardLinkSessionBody>,
 ) -> impl IntoResponse {
-    match state.sqlite.link_session_to_issue(&id, &body.session_id, body.cost_usd, body.tokens) {
+    match state
+        .sqlite
+        .link_session_to_issue(&id, &body.session_id, body.cost_usd, body.tokens)
+    {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -1487,6 +1696,57 @@ async fn board_gantt_for_project(
     }
 }
 
+async fn board_acceptance_rollup(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.acceptance_rollup(&id) {
+        Ok(rollup) => Json(serde_json::to_value(&rollup).unwrap()).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct BoardAcceptanceReportBody {
+    status: String,
+    #[serde(default)]
+    output: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
+async fn board_acceptance_report(
+    State(state): State<Arc<AppState>>,
+    Path((id, idx)): Path<(String, i64)>,
+    Json(body): Json<BoardAcceptanceReportBody>,
+) -> impl IntoResponse {
+    let Some(status) = gctrl_core::AcceptanceStatus::from_str(&body.status) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "invalid status '{}' (expected pending|running|pass|fail)",
+                body.status
+            ),
+        )
+            .into_response();
+    };
+    match state.sqlite.upsert_acceptance_result(
+        &id,
+        idx,
+        status,
+        body.output.as_deref(),
+        body.session_id.as_deref(),
+    ) {
+        Ok(true) => StatusCode::OK.into_response(),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            format!("no check at idx {idx} for issue {id}"),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
 #[derive(Deserialize)]
 struct BoardImportBody {
     path: String,
@@ -1498,7 +1758,11 @@ async fn board_import_markdown(
 ) -> impl IntoResponse {
     let dir = std::path::Path::new(&body.path);
     if !dir.is_dir() {
-        return (StatusCode::BAD_REQUEST, format!("not a directory: {}", body.path)).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("not a directory: {}", body.path),
+        )
+            .into_response();
     }
 
     let projects = match state.sqlite.list_board_projects() {
@@ -1579,7 +1843,9 @@ struct GhRepoQuery {
     branch: Option<String>,
 }
 
-fn default_gh_limit() -> usize { 10 }
+fn default_gh_limit() -> usize {
+    10
+}
 
 /// Run `gh` CLI and return stdout as JSON Value.
 async fn gh_exec(args: &[&str]) -> Result<serde_json::Value, (StatusCode, String)> {
@@ -1587,7 +1853,12 @@ async fn gh_exec(args: &[&str]) -> Result<serde_json::Value, (StatusCode, String
         .args(args)
         .output()
         .await
-        .map_err(|e| (StatusCode::SERVICE_UNAVAILABLE, format!("gh CLI not available: {e}")))?;
+        .map_err(|e| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("gh CLI not available: {e}"),
+            )
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1595,18 +1866,28 @@ async fn gh_exec(args: &[&str]) -> Result<serde_json::Value, (StatusCode, String
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str(&stdout)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("gh JSON parse error: {e}")))
+    serde_json::from_str(&stdout).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("gh JSON parse error: {e}"),
+        )
+    })
 }
 
 async fn gh_list_issues(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let limit_str = q.limit.to_string();
     match gh_exec(&[
-        "issue", "list",
-        "--repo", &q.repo,
-        "--limit", &limit_str,
-        "--json", "number,title,state,author,labels,createdAt,url,body",
-    ]).await {
+        "issue",
+        "list",
+        "--repo",
+        &q.repo,
+        "--limit",
+        &limit_str,
+        "--json",
+        "number,title,state,author,labels,createdAt,url,body",
+    ])
+    .await
+    {
         Ok(val) => {
             // gh returns labels as [{name:"x"}], flatten to ["x"]
             let issues = normalize_gh_issues(val);
@@ -1616,16 +1897,19 @@ async fn gh_list_issues(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     }
 }
 
-async fn gh_get_issue(
-    Path(number): Path<u64>,
-    Query(q): Query<GhRepoQuery>,
-) -> impl IntoResponse {
+async fn gh_get_issue(Path(number): Path<u64>, Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let num_str = number.to_string();
     match gh_exec(&[
-        "issue", "view", &num_str,
-        "--repo", &q.repo,
-        "--json", "number,title,state,author,labels,createdAt,url,body",
-    ]).await {
+        "issue",
+        "view",
+        &num_str,
+        "--repo",
+        &q.repo,
+        "--json",
+        "number,title,state,author,labels,createdAt,url,body",
+    ])
+    .await
+    {
         Ok(val) => {
             let issue = normalize_gh_issue(val);
             Json(issue).into_response()
@@ -1648,9 +1932,12 @@ async fn gh_create_issue(
     Json(input): Json<GhCreateIssueBody>,
 ) -> impl IntoResponse {
     let mut args = vec![
-        "issue".to_string(), "create".to_string(),
-        "--repo".to_string(), q.repo.clone(),
-        "--title".to_string(), input.title.clone(),
+        "issue".to_string(),
+        "create".to_string(),
+        "--repo".to_string(),
+        q.repo.clone(),
+        "--title".to_string(),
+        input.title.clone(),
     ];
     if let Some(ref body) = input.body {
         args.push("--body".to_string());
@@ -1676,7 +1963,9 @@ async fn gh_create_issue(
             let stdout = String::from_utf8_lossy(&out.stdout);
             // gh issue create prints the URL on success, parse issue number from it
             let url = stdout.trim().to_string();
-            let number = url.rsplit('/').next()
+            let number = url
+                .rsplit('/')
+                .next()
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(0);
 
@@ -1693,20 +1982,34 @@ async fn gh_create_issue(
         }
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
-            (StatusCode::BAD_GATEWAY, format!("gh issue create failed: {stderr}")).into_response()
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("gh issue create failed: {stderr}"),
+            )
+                .into_response()
         }
-        Err(e) => (StatusCode::SERVICE_UNAVAILABLE, format!("gh CLI not available: {e}")).into_response(),
+        Err(e) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("gh CLI not available: {e}"),
+        )
+            .into_response(),
     }
 }
 
 async fn gh_list_prs(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let limit_str = q.limit.to_string();
     match gh_exec(&[
-        "pr", "list",
-        "--repo", &q.repo,
-        "--limit", &limit_str,
-        "--json", "number,title,state,author,headRefName,url",
-    ]).await {
+        "pr",
+        "list",
+        "--repo",
+        &q.repo,
+        "--limit",
+        &limit_str,
+        "--json",
+        "number,title,state,author,headRefName,url",
+    ])
+    .await
+    {
         Ok(val) => {
             let prs = normalize_gh_prs(val);
             Json(prs).into_response()
@@ -1715,16 +2018,19 @@ async fn gh_list_prs(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     }
 }
 
-async fn gh_get_pr(
-    Path(number): Path<u64>,
-    Query(q): Query<GhRepoQuery>,
-) -> impl IntoResponse {
+async fn gh_get_pr(Path(number): Path<u64>, Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let num_str = number.to_string();
     match gh_exec(&[
-        "pr", "view", &num_str,
-        "--repo", &q.repo,
-        "--json", "number,title,state,author,headRefName,url",
-    ]).await {
+        "pr",
+        "view",
+        &num_str,
+        "--repo",
+        &q.repo,
+        "--json",
+        "number,title,state,author,headRefName,url",
+    ])
+    .await
+    {
         Ok(val) => {
             let pr = normalize_gh_pr(val);
             Json(pr).into_response()
@@ -1736,10 +2042,14 @@ async fn gh_get_pr(
 async fn gh_list_runs(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let limit_str = q.limit.to_string();
     let mut args = vec![
-        "run", "list",
-        "--repo", &q.repo,
-        "--limit", &limit_str,
-        "--json", "databaseId,name,status,conclusion,headBranch,url",
+        "run",
+        "list",
+        "--repo",
+        &q.repo,
+        "--limit",
+        &limit_str,
+        "--json",
+        "databaseId,name,status,conclusion,headBranch,url",
     ];
     let branch_val;
     if let Some(ref b) = q.branch {
@@ -1756,16 +2066,19 @@ async fn gh_list_runs(Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     }
 }
 
-async fn gh_get_run(
-    Path(run_id): Path<u64>,
-    Query(q): Query<GhRepoQuery>,
-) -> impl IntoResponse {
+async fn gh_get_run(Path(run_id): Path<u64>, Query(q): Query<GhRepoQuery>) -> impl IntoResponse {
     let id_str = run_id.to_string();
     match gh_exec(&[
-        "run", "view", &id_str,
-        "--repo", &q.repo,
-        "--json", "databaseId,name,status,conclusion,headBranch,url",
-    ]).await {
+        "run",
+        "view",
+        &id_str,
+        "--repo",
+        &q.repo,
+        "--json",
+        "databaseId,name,status,conclusion,headBranch,url",
+    ])
+    .await
+    {
         Ok(val) => {
             let run = normalize_gh_run(val);
             Json(run).into_response()
@@ -1795,8 +2108,13 @@ fn normalize_gh_issue(mut v: serde_json::Value) -> serde_json::Value {
         // labels: [{name: "x"}] → ["x"]
         if let Some(labels) = obj.get("labels").cloned() {
             if let Some(arr) = labels.as_array() {
-                let flat: Vec<serde_json::Value> = arr.iter()
-                    .filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(|s| serde_json::Value::String(s.into())))
+                let flat: Vec<serde_json::Value> = arr
+                    .iter()
+                    .filter_map(|l| {
+                        l.get("name")
+                            .and_then(|n| n.as_str())
+                            .map(|s| serde_json::Value::String(s.into()))
+                    })
                     .collect();
                 obj.insert("labels".into(), serde_json::Value::Array(flat));
             }
@@ -1919,9 +2237,17 @@ async fn wrangler_whoami() -> impl IntoResponse {
         }
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
-            (StatusCode::BAD_GATEWAY, format!("wrangler whoami failed: {stderr}")).into_response()
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("wrangler whoami failed: {stderr}"),
+            )
+                .into_response()
         }
-        Err(e) => (StatusCode::SERVICE_UNAVAILABLE, format!("wrangler CLI not available: {e}")).into_response(),
+        Err(e) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("wrangler CLI not available: {e}"),
+        )
+            .into_response(),
     }
 }
 
@@ -2029,7 +2355,11 @@ async fn persona_upsert(
         source_hash: body.source_hash,
     };
     match state.sqlite.upsert_persona(&persona) {
-        Ok(true) => (StatusCode::CREATED, Json(serde_json::to_value(&persona).unwrap())).into_response(),
+        Ok(true) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&persona).unwrap()),
+        )
+            .into_response(),
         Ok(false) => Json(serde_json::to_value(&persona).unwrap()).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -2116,7 +2446,11 @@ async fn persona_review_rules_upsert(
         persona_ids: body.persona_ids,
     };
     match state.sqlite.upsert_review_rule(&rule) {
-        Ok(_) => (StatusCode::CREATED, Json(serde_json::to_value(&rule).unwrap())).into_response(),
+        Ok(_) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&rule).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -2201,7 +2535,8 @@ async fn team_render(
     Json(body): Json<TeamRenderBody>,
 ) -> impl IntoResponse {
     let mut agents = Vec::new();
-    let context_str = body.context
+    let context_str = body
+        .context
         .as_ref()
         .map(|c| serde_json::to_string_pretty(c).unwrap_or_default())
         .unwrap_or_default();
@@ -2220,7 +2555,10 @@ async fn team_render(
                     }
                 }
                 if !persona.review_focus.is_empty() {
-                    prompt.push_str(&format!("\n## Your Review Focus\n{}\n", persona.review_focus));
+                    prompt.push_str(&format!(
+                        "\n## Your Review Focus\n{}\n",
+                        persona.review_focus
+                    ));
                 }
                 agents.push(gctrl_core::RenderedPersonaPrompt {
                     persona_id: persona.id,
@@ -2229,7 +2567,11 @@ async fn team_render(
                 });
             }
             Ok(None) => {
-                return (StatusCode::NOT_FOUND, format!("persona '{}' not found", pid)).into_response();
+                return (
+                    StatusCode::NOT_FOUND,
+                    format!("persona '{}' not found", pid),
+                )
+                    .into_response();
             }
             Err(e) => {
                 return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
@@ -2272,22 +2614,44 @@ struct InboxCreateMessageBody {
     project_key: Option<String>,
 }
 
-fn default_inbox_urgency() -> String { "medium".into() }
-fn default_inbox_context() -> serde_json::Value { serde_json::json!({}) }
+fn default_inbox_urgency() -> String {
+    "medium".into()
+}
+fn default_inbox_context() -> serde_json::Value {
+    serde_json::json!({})
+}
 
 async fn inbox_create_message(
     State(state): State<Arc<AppState>>,
     Json(body): Json<InboxCreateMessageBody>,
 ) -> impl IntoResponse {
     // Validate enum fields
-    const VALID_KINDS: &[&str] = &["permission_request", "budget_warning", "budget_exceeded", "agent_question", "clarification", "review_request", "eval_request", "status_update", "custom"];
+    const VALID_KINDS: &[&str] = &[
+        "permission_request",
+        "budget_warning",
+        "budget_exceeded",
+        "agent_question",
+        "clarification",
+        "review_request",
+        "eval_request",
+        "status_update",
+        "custom",
+    ];
     const VALID_URGENCIES: &[&str] = &["critical", "high", "medium", "low", "info"];
 
     if !VALID_KINDS.contains(&body.kind.as_str()) {
-        return (StatusCode::BAD_REQUEST, format!("invalid kind: {}", body.kind)).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid kind: {}", body.kind),
+        )
+            .into_response();
     }
     if !VALID_URGENCIES.contains(&body.urgency.as_str()) {
-        return (StatusCode::BAD_REQUEST, format!("invalid urgency: {}", body.urgency)).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid urgency: {}", body.urgency),
+        )
+            .into_response();
     }
 
     let now = chrono::Utc::now().to_rfc3339();
@@ -2295,14 +2659,22 @@ async fn inbox_create_message(
     // Resolve or create thread
     let thread_id = if let Some(tid) = body.thread_id {
         tid
-    } else if let (Some(ct), Some(cr)) = (body.context_type.as_deref(), body.context_ref.as_deref()) {
+    } else if let (Some(ct), Some(cr)) = (body.context_type.as_deref(), body.context_ref.as_deref())
+    {
         let title = body.thread_title.as_deref().unwrap_or(cr);
-        match state.sqlite.get_or_create_inbox_thread(ct, cr, title, body.project_key.as_deref()) {
+        match state
+            .sqlite
+            .get_or_create_inbox_thread(ct, cr, title, body.project_key.as_deref())
+        {
             Ok(t) => t.id,
             Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         }
     } else {
-        return (StatusCode::BAD_REQUEST, "either thread_id or (context_type + context_ref) required".to_string()).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            "either thread_id or (context_type + context_ref) required".to_string(),
+        )
+            .into_response();
     };
 
     let msg = gctrl_core::InboxMessage {
@@ -2325,7 +2697,11 @@ async fn inbox_create_message(
     };
 
     match state.sqlite.create_inbox_message(&msg) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::to_value(&msg).unwrap())).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&msg).unwrap()),
+        )
+            .into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -2352,7 +2728,9 @@ struct InboxMessageListParams {
     limit: usize,
 }
 
-fn default_inbox_limit() -> usize { 50 }
+fn default_inbox_limit() -> usize {
+    50
+}
 
 async fn inbox_list_messages(
     State(state): State<Arc<AppState>>,
@@ -2379,7 +2757,9 @@ async fn inbox_get_thread(
 ) -> impl IntoResponse {
     let thread = match state.sqlite.get_inbox_thread(&id) {
         Ok(Some(t)) => t,
-        Ok(None) => return (StatusCode::NOT_FOUND, format!("thread not found: {}", id)).into_response(),
+        Ok(None) => {
+            return (StatusCode::NOT_FOUND, format!("thread not found: {}", id)).into_response()
+        }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
     // Include messages for the thread (shell expects InboxThreadWithMessages)
@@ -2411,7 +2791,11 @@ async fn inbox_list_threads(
     State(state): State<Arc<AppState>>,
     Query(params): Query<InboxThreadListParams>,
 ) -> impl IntoResponse {
-    match state.sqlite.list_inbox_threads(params.project.as_deref(), params.has_pending, Some(params.limit)) {
+    match state.sqlite.list_inbox_threads(
+        params.project.as_deref(),
+        params.has_pending,
+        Some(params.limit),
+    ) {
         Ok(threads) => Json(serde_json::to_value(&threads).unwrap()).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -2431,27 +2815,53 @@ struct InboxCreateActionBody {
     actor_name: String,
 }
 
-fn default_inbox_actor_id() -> String { "default".into() }
-fn default_inbox_actor_name() -> String { "human".into() }
+fn default_inbox_actor_id() -> String {
+    "default".into()
+}
+fn default_inbox_actor_name() -> String {
+    "human".into()
+}
 
 async fn inbox_create_action(
     State(state): State<Arc<AppState>>,
     Json(body): Json<InboxCreateActionBody>,
 ) -> impl IntoResponse {
-    const VALID_ACTIONS: &[&str] = &["approve", "deny", "acknowledge", "defer", "delegate", "escalate", "reply"];
+    const VALID_ACTIONS: &[&str] = &[
+        "approve",
+        "deny",
+        "acknowledge",
+        "defer",
+        "delegate",
+        "escalate",
+        "reply",
+    ];
     if !VALID_ACTIONS.contains(&body.action_type.as_str()) {
-        return (StatusCode::BAD_REQUEST, format!("invalid action_type: {}", body.action_type)).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid action_type: {}", body.action_type),
+        )
+            .into_response();
     }
     if let Some(ref reason) = body.reason {
         if reason.len() > 2000 {
-            return (StatusCode::BAD_REQUEST, "reason exceeds 2000 character limit").into_response();
+            return (
+                StatusCode::BAD_REQUEST,
+                "reason exceeds 2000 character limit",
+            )
+                .into_response();
         }
     }
 
     // Look up message to get thread_id
     let msg = match state.sqlite.get_inbox_message(&body.message_id) {
         Ok(Some(m)) => m,
-        Ok(None) => return (StatusCode::NOT_FOUND, format!("message not found: {}", body.message_id)).into_response(),
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                format!("message not found: {}", body.message_id),
+            )
+                .into_response()
+        }
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
 
@@ -2468,7 +2878,11 @@ async fn inbox_create_action(
     };
 
     match state.sqlite.create_inbox_action(&action) {
-        Ok(()) => (StatusCode::CREATED, Json(serde_json::to_value(&action).unwrap())).into_response(),
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(&action).unwrap()),
+        )
+            .into_response(),
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("expected 'pending'") {
@@ -2499,13 +2913,29 @@ async fn inbox_batch_action(
     if body.message_ids.len() > 100 {
         return (StatusCode::BAD_REQUEST, "batch size exceeds limit of 100").into_response();
     }
-    const VALID_ACTIONS: &[&str] = &["approve", "deny", "acknowledge", "defer", "delegate", "escalate", "reply"];
+    const VALID_ACTIONS: &[&str] = &[
+        "approve",
+        "deny",
+        "acknowledge",
+        "defer",
+        "delegate",
+        "escalate",
+        "reply",
+    ];
     if !VALID_ACTIONS.contains(&body.action_type.as_str()) {
-        return (StatusCode::BAD_REQUEST, format!("invalid action_type: {}", body.action_type)).into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid action_type: {}", body.action_type),
+        )
+            .into_response();
     }
     if let Some(ref reason) = body.reason {
         if reason.len() > 2000 {
-            return (StatusCode::BAD_REQUEST, "reason exceeds 2000 character limit").into_response();
+            return (
+                StatusCode::BAD_REQUEST,
+                "reason exceeds 2000 character limit",
+            )
+                .into_response();
         }
     }
 
@@ -2734,8 +3164,12 @@ struct NetFetchBody {
     min_words: usize,
 }
 
-fn default_readability() -> bool { true }
-fn default_min_words() -> usize { 50 }
+fn default_readability() -> bool {
+    true
+}
+fn default_min_words() -> usize {
+    50
+}
 
 async fn net_fetch(
     State(state): State<Arc<AppState>>,
@@ -2768,10 +3202,18 @@ fn cf_backend_from_state(
     wait_for: Option<String>,
 ) -> Result<gctrl_net::CfBrowserBackend, axum::response::Response> {
     let account_id = state.net_config.cf_account_id.clone().ok_or_else(|| {
-        (StatusCode::SERVICE_UNAVAILABLE, "CF_ACCOUNT_ID not configured").into_response()
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CF_ACCOUNT_ID not configured",
+        )
+            .into_response()
     })?;
     let api_token = state.net_config.cf_api_token.clone().ok_or_else(|| {
-        (StatusCode::SERVICE_UNAVAILABLE, "CF_API_TOKEN not configured").into_response()
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "CF_API_TOKEN not configured",
+        )
+            .into_response()
     })?;
     Ok(gctrl_net::CfBrowserBackend::with_client(
         state.http_client.clone(),
@@ -2789,7 +3231,9 @@ async fn net_render(
         Ok(b) => b,
         Err(resp) => return resp,
     };
-    match <gctrl_net::CfBrowserBackend as gctrl_net::RenderBackend>::render(&backend, &body.url).await {
+    match <gctrl_net::CfBrowserBackend as gctrl_net::RenderBackend>::render(&backend, &body.url)
+        .await
+    {
         Ok(rendered) => Json(serde_json::json!({
             "url": rendered.url,
             "status": rendered.status,
@@ -2816,7 +3260,10 @@ async fn net_scrape(
         Ok(b) => b,
         Err(resp) => return resp,
     };
-    match backend.scrape(&body.url, body.elements, body.wait_for).await {
+    match backend
+        .scrape(&body.url, body.elements, body.wait_for)
+        .await
+    {
         Ok(v) => Json(v).into_response(),
         Err(e) => (net_error_status(&e), e.to_string()).into_response(),
     }
@@ -3394,7 +3841,10 @@ mod tests {
     #[tokio::test]
     async fn test_analytics_cost_empty() {
         let app = test_app();
-        let req = Request::builder().uri("/api/analytics/cost").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/api/analytics/cost")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -3405,7 +3855,10 @@ mod tests {
     #[tokio::test]
     async fn test_analytics_latency_empty() {
         let app = test_app();
-        let req = Request::builder().uri("/api/analytics/latency").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/api/analytics/latency")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
@@ -3466,17 +3919,19 @@ mod tests {
     async fn test_analytics_scores_query() {
         let store = DuckDbStore::open(":memory:").unwrap();
         // Insert a score directly
-        store.insert_score(&gctrl_core::Score {
-            id: "s1".into(),
-            target_type: "session".into(),
-            target_id: "sess1".into(),
-            name: "tests_pass".into(),
-            value: 1.0,
-            comment: None,
-            source: "auto".into(),
-            scored_by: None,
-            created_at: chrono::Utc::now(),
-        }).unwrap();
+        store
+            .insert_score(&gctrl_core::Score {
+                id: "s1".into(),
+                target_type: "session".into(),
+                target_id: "sess1".into(),
+                name: "tests_pass".into(),
+                value: 1.0,
+                comment: None,
+                source: "auto".into(),
+                scored_by: None,
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
 
         let app = create_router(store);
         let req = Request::builder()
@@ -3494,7 +3949,10 @@ mod tests {
     #[tokio::test]
     async fn test_health_detailed() {
         let app = test_app();
-        let req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
@@ -3508,18 +3966,20 @@ mod tests {
     #[tokio::test]
     async fn test_session_cost_breakdown_endpoint() {
         let store = DuckDbStore::open(":memory:").unwrap();
-        store.insert_session(&gctrl_core::Session {
-            id: gctrl_core::SessionId("s1".into()),
-            workspace_id: gctrl_core::WorkspaceId("ws1".into()),
-            device_id: gctrl_core::DeviceId("dev1".into()),
-            agent_name: "claude".into(),
-            started_at: chrono::Utc::now(),
-            ended_at: None,
-            status: gctrl_core::SessionStatus::Active,
-            total_cost_usd: 0.0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-        }).unwrap();
+        store
+            .insert_session(&gctrl_core::Session {
+                id: gctrl_core::SessionId("s1".into()),
+                workspace_id: gctrl_core::WorkspaceId("ws1".into()),
+                device_id: gctrl_core::DeviceId("dev1".into()),
+                agent_name: "claude".into(),
+                started_at: chrono::Utc::now(),
+                ended_at: None,
+                status: gctrl_core::SessionStatus::Active,
+                total_cost_usd: 0.0,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+            })
+            .unwrap();
 
         let app = create_router(store);
         let req = Request::builder()
@@ -4017,7 +4477,10 @@ Getting User settings...
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert!(json["stdout"].as_str().unwrap().contains("hello from cli_exec"));
+        assert!(json["stdout"]
+            .as_str()
+            .unwrap()
+            .contains("hello from cli_exec"));
         assert_eq!(json["exitCode"], 0);
         assert!(json["durationMs"].is_number());
     }
@@ -4025,7 +4488,10 @@ Getting User settings...
     #[tokio::test]
     async fn test_cli_exec_nonzero_exit_still_200() {
         // `false` exits 1 without spawning failure — envelope should carry the code.
-        let body = CliExecBody { args: vec![], cwd: None };
+        let body = CliExecBody {
+            args: vec![],
+            cwd: None,
+        };
         let resp = cli_exec("false", body).await;
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
@@ -4035,7 +4501,10 @@ Getting User settings...
 
     #[tokio::test]
     async fn test_cli_exec_missing_binary_502() {
-        let body = CliExecBody { args: vec![], cwd: None };
+        let body = CliExecBody {
+            args: vec![],
+            cwd: None,
+        };
         let resp = cli_exec("gctrl-definitely-not-a-binary-xyz", body).await;
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }

--- a/kernel/crates/gctrl-otel/tests/acceptance_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/acceptance_routes.rs
@@ -1,0 +1,218 @@
+//! HTTP contract tests for the acceptance routes:
+//!
+//! - `POST /api/board/issues/{id}/acceptance/checks/{idx}` — agent callback
+//! - `GET  /api/board/issues/{id}/acceptance` — rollup for the badge
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use gctrl_core::{BoardIssue, BoardProject, IssueStatus};
+use gctrl_otel::create_router_dual;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn make_issue(project_id: &str, id: &str, criteria: Option<&str>) -> BoardIssue {
+    let now = Utc::now();
+    BoardIssue {
+        id: id.into(),
+        project_id: project_id.into(),
+        title: format!("Test {id}"),
+        description: None,
+        status: IssueStatus::Todo,
+        priority: "none".into(),
+        assignee_id: None,
+        assignee_name: None,
+        assignee_type: None,
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: Some(id.into()),
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+        start_date: None,
+        due_date: None,
+        acceptance_criteria: criteria.map(String::from),
+    }
+}
+
+fn test_app_with_criteria(criteria: Option<&str>) -> (axum::Router, Arc<SqliteStore>) {
+    let duck = Arc::new(DuckDbStore::open(":memory:").expect("duckdb"));
+    let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite"));
+
+    let project = BoardProject {
+        id: "BACK-project".into(),
+        name: "BACK".into(),
+        key: "BACK".into(),
+        counter: 1,
+        github_repo: None,
+    };
+    sqlite.create_board_project(&project).expect("project");
+    sqlite
+        .insert_board_issue(&make_issue("BACK-project", "BACK-42", criteria))
+        .expect("issue");
+    let router = create_router_dual(duck, Arc::clone(&sqlite));
+    (router, sqlite)
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: Value) -> (u16, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, body)
+}
+
+async fn get_json(app: &axum::Router, uri: &str) -> (u16, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, body)
+}
+
+async fn promote(app: &axum::Router, id: &str) {
+    let (status, body) = post_json(
+        app,
+        &format!("/api/board/issues/{id}/move"),
+        json!({"status":"in_progress","actor_id":"u","actor_name":"User"}),
+    )
+    .await;
+    assert_eq!(status, 200, "promote failed: {body}");
+}
+
+#[tokio::test]
+async fn rollup_is_empty_when_issue_has_no_criteria() {
+    let (app, _sqlite) = test_app_with_criteria(None);
+    let (status, body) = get_json(&app, "/api/board/issues/BACK-42/acceptance").await;
+    assert_eq!(status, 200);
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["passed"], 0);
+    assert_eq!(body["checks"].as_array().map(|a| a.len()), Some(0));
+}
+
+#[tokio::test]
+async fn post_pass_updates_rollup() {
+    let criteria = "\
+- [ ] shell: curl :8080/health
+- [ ] test: pnpm test
+";
+    let (app, _sqlite) = test_app_with_criteria(Some(criteria));
+    promote(&app, "BACK-42").await;
+
+    let (status, _body) = post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/0",
+        json!({"status":"pass","output":"HTTP/1.1 200 OK"}),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let (status, body) = get_json(&app, "/api/board/issues/BACK-42/acceptance").await;
+    assert_eq!(status, 200);
+    assert_eq!(body["total"], 2);
+    assert_eq!(body["passed"], 1);
+    assert_eq!(body["pending"], 1);
+    assert_eq!(body["checks"][0]["status"], "pass");
+    assert_eq!(body["checks"][0]["output"], "HTTP/1.1 200 OK");
+}
+
+#[tokio::test]
+async fn post_rejects_invalid_status_with_400() {
+    let criteria = "- [ ] shell: echo";
+    let (app, _sqlite) = test_app_with_criteria(Some(criteria));
+    promote(&app, "BACK-42").await;
+
+    let (status, _body) = post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/0",
+        json!({"status":"maybe"}),
+    )
+    .await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn post_returns_404_for_unknown_idx() {
+    let criteria = "- [ ] shell: echo";
+    let (app, _sqlite) = test_app_with_criteria(Some(criteria));
+    promote(&app, "BACK-42").await;
+
+    let (status, _body) = post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/99",
+        json!({"status":"pass"}),
+    )
+    .await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn rollup_mixed_statuses_match_counts() {
+    let criteria = "\
+- [ ] shell: a
+- [ ] shell: b
+- [ ] shell: c
+- [ ] shell: d
+";
+    let (app, _sqlite) = test_app_with_criteria(Some(criteria));
+    promote(&app, "BACK-42").await;
+    post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/0",
+        json!({"status":"pass"}),
+    )
+    .await;
+    post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/1",
+        json!({"status":"pass"}),
+    )
+    .await;
+    post_json(
+        &app,
+        "/api/board/issues/BACK-42/acceptance/checks/2",
+        json!({"status":"fail","output":"boom"}),
+    )
+    .await;
+    // idx 3 left as pending.
+
+    let (_, body) = get_json(&app, "/api/board/issues/BACK-42/acceptance").await;
+    assert_eq!(body["total"], 4);
+    assert_eq!(body["passed"], 2);
+    assert_eq!(body["failed"], 1);
+    assert_eq!(body["pending"], 1);
+}

--- a/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
+++ b/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
@@ -54,6 +54,7 @@ fn make_issue(project_id: &str, id: &str) -> BoardIssue {
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     }
 }
 

--- a/kernel/crates/gctrl-otel/tests/board_schedule.rs
+++ b/kernel/crates/gctrl-otel/tests/board_schedule.rs
@@ -48,6 +48,7 @@ fn make_issue(project_id: &str, id: &str) -> BoardIssue {
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     }
 }
 

--- a/kernel/crates/gctrl-storage/src/board_markdown.rs
+++ b/kernel/crates/gctrl-storage/src/board_markdown.rs
@@ -225,6 +225,7 @@ pub fn import_markdown_dir(
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         };
 
         results.push((issue, id));
@@ -419,6 +420,7 @@ The rate limiting middleware stores tokens in plaintext.
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         };
 
         let md = issue_to_markdown(&issue, "BACK");
@@ -482,6 +484,7 @@ The rate limiting middleware stores tokens in plaintext.
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         }];
 
         // Export

--- a/kernel/crates/gctrl-storage/src/duckdb_store.rs
+++ b/kernel/crates/gctrl-storage/src/duckdb_store.rs
@@ -3,11 +3,10 @@ use std::sync::Mutex;
 
 use duckdb::{params, Connection};
 use gctrl_core::{
-    AgentAnalytics, AlertEvent, AlertRule, Analytics, DailyAggregate, GctlError, ModelAnalytics,
-    InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
-    PersonaDefinition, PersonaReviewRule,
-    PromptVersion, Result, Score, Session, SessionId, SessionStatus, Span, SpanStatus, SpanType, Tag,
-    TrafficFilter, TrafficRecord, TrafficStats,
+    AgentAnalytics, AlertEvent, AlertRule, Analytics, DailyAggregate, GctlError, InboxAction,
+    InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread, ModelAnalytics,
+    PersonaDefinition, PersonaReviewRule, PromptVersion, Result, Score, Session, SessionId,
+    SessionStatus, Span, SpanStatus, SpanType, Tag, TrafficFilter, TrafficRecord, TrafficStats,
 };
 
 use crate::schema;
@@ -197,7 +196,12 @@ impl DuckDbStore {
         Ok(sessions)
     }
 
-    pub fn list_sessions_filtered(&self, limit: usize, agent: Option<&str>, status: Option<&str>) -> Result<Vec<Session>> {
+    pub fn list_sessions_filtered(
+        &self,
+        limit: usize,
+        agent: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<Vec<Session>> {
         let conn = self.conn.lock().unwrap();
         let mut sql = "SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens FROM sessions WHERE 1=1".to_string();
         let mut bound_params: Vec<Box<dyn duckdb::ToSql>> = Vec::new();
@@ -213,9 +217,14 @@ impl DuckDbStore {
         sql.push_str(" ORDER BY started_at DESC");
         sql.push_str(&format!(" LIMIT {}", limit));
 
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let params_refs: Vec<&dyn duckdb::ToSql> = bound_params.iter().map(|p| p.as_ref()).collect();
-        let mut rows = stmt.query(params_refs.as_slice()).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let params_refs: Vec<&dyn duckdb::ToSql> =
+            bound_params.iter().map(|p| p.as_ref()).collect();
+        let mut rows = stmt
+            .query(params_refs.as_slice())
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut sessions = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
@@ -291,7 +300,8 @@ impl DuckDbStore {
             let _ = param_idx;
         }
 
-        let params_refs: Vec<&dyn duckdb::ToSql> = bound_params.iter().map(|p| p.as_ref()).collect();
+        let params_refs: Vec<&dyn duckdb::ToSql> =
+            bound_params.iter().map(|p| p.as_ref()).collect();
         let mut rows = stmt
             .query(params_refs.as_slice())
             .map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -356,9 +366,12 @@ impl DuckDbStore {
             let mut stmt = conn
                 .prepare("SELECT agent_name, COUNT(*), COALESCE(SUM(total_cost_usd), 0) FROM sessions GROUP BY agent_name ORDER BY SUM(total_cost_usd) DESC")
                 .map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
-                let agent_name: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
+                let agent_name: String =
+                    row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
                 let count: i64 = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
                 let cost: f64 = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
                 by_agent.push(AgentAnalytics {
@@ -375,7 +388,9 @@ impl DuckDbStore {
             let mut stmt = conn
                 .prepare("SELECT model, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cost_usd), 0) FROM spans WHERE model IS NOT NULL GROUP BY model ORDER BY SUM(cost_usd) DESC")
                 .map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let model: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
                 let count: i64 = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -418,7 +433,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, target_type, target_id, name, value, comment, source, scored_by, created_at FROM scores WHERE target_type = ? AND target_id = ? ORDER BY created_at DESC"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query(params![target_type, target_id]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(params![target_type, target_id])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut scores = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             scores.push(row_to_score(row)?);
@@ -429,15 +446,27 @@ impl DuckDbStore {
     pub fn get_score_summary(&self, name: &str) -> Result<(u64, u64, f64)> {
         // Returns (pass_count, fail_count, avg_value)
         let conn = self.conn.lock().unwrap();
-        let total: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM scores WHERE name = ?", params![name], |row| row.get(0)
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let pass: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM scores WHERE name = ? AND value >= 1.0", params![name], |row| row.get(0)
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let avg: f64 = conn.query_row(
-            "SELECT COALESCE(AVG(value), 0) FROM scores WHERE name = ?", params![name], |row| row.get(0)
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let total: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM scores WHERE name = ?",
+                params![name],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let pass: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM scores WHERE name = ? AND value >= 1.0",
+                params![name],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let avg: f64 = conn
+            .query_row(
+                "SELECT COALESCE(AVG(value), 0) FROM scores WHERE name = ?",
+                params![name],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok((pass as u64, (total - pass) as u64, avg))
     }
 
@@ -459,7 +488,10 @@ impl DuckDbStore {
         });
 
         // Score: error_count
-        let error_count = spans.iter().filter(|s| matches!(s.status, SpanStatus::Error(_))).count();
+        let error_count = spans
+            .iter()
+            .filter(|s| matches!(s.status, SpanStatus::Error(_)))
+            .count();
         scores.push(Score {
             id: format!("auto-{session_id}-error_count"),
             target_type: "session".into(),
@@ -473,7 +505,10 @@ impl DuckDbStore {
         });
 
         // Score: generation_count
-        let gen_count = spans.iter().filter(|s| s.span_type == SpanType::Generation).count();
+        let gen_count = spans
+            .iter()
+            .filter(|s| s.span_type == SpanType::Generation)
+            .count();
         scores.push(Score {
             id: format!("auto-{session_id}-generation_count"),
             target_type: "session".into(),
@@ -526,7 +561,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, target_type, target_id, key, value FROM tags WHERE target_type = ? AND target_id = ?"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query(params![target_type, target_id]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(params![target_type, target_id])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut tags = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let id: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -534,7 +571,13 @@ impl DuckDbStore {
             let ti: String = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
             let k: String = row.get(3).map_err(|e| GctlError::Storage(e.to_string()))?;
             let v: String = row.get(4).map_err(|e| GctlError::Storage(e.to_string()))?;
-            tags.push(Tag { id, target_type: tt, target_id: ti, key: k, value: v });
+            tags.push(Tag {
+                id,
+                target_type: tt,
+                target_id: ti,
+                key: k,
+                value: v,
+            });
         }
         Ok(tags)
     }
@@ -554,7 +597,8 @@ impl DuckDbStore {
         conn.execute(
             "INSERT OR IGNORE INTO session_prompts (session_id, prompt_hash) VALUES (?, ?)",
             params![session_id, prompt_hash],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
 
@@ -563,7 +607,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT hash, content, file_path, label, created_at, token_count FROM prompt_versions WHERE hash = ?"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query(params![hash]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(params![hash])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         if let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             Ok(Some(row_to_prompt_version(row)?))
         } else {
@@ -576,7 +622,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT hash, content, file_path, label, created_at, token_count FROM prompt_versions ORDER BY created_at DESC"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut pvs = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             pvs.push(row_to_prompt_version(row)?);
@@ -599,14 +647,21 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT date, metric, dimension, value FROM daily_aggregates ORDER BY date DESC LIMIT ?"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query(params![(days * 10) as i64]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(params![(days * 10) as i64])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut aggs = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let date: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
             let metric: String = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
             let dimension: String = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
             let value: f64 = row.get(3).map_err(|e| GctlError::Storage(e.to_string()))?;
-            aggs.push(DailyAggregate { date, metric, dimension, value });
+            aggs.push(DailyAggregate {
+                date,
+                metric,
+                dimension,
+                value,
+            });
         }
         Ok(aggs)
     }
@@ -617,20 +672,34 @@ impl DuckDbStore {
         let mut aggs = Vec::new();
 
         // Total cost for the day
-        let cost: f64 = conn.query_row(
-            "SELECT COALESCE(SUM(total_cost_usd), 0) FROM sessions WHERE started_at LIKE ?",
-            params![format!("{date}%")],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        aggs.push(DailyAggregate { date: date.into(), metric: "cost".into(), dimension: "total".into(), value: cost });
+        let cost: f64 = conn
+            .query_row(
+                "SELECT COALESCE(SUM(total_cost_usd), 0) FROM sessions WHERE started_at LIKE ?",
+                params![format!("{date}%")],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        aggs.push(DailyAggregate {
+            date: date.into(),
+            metric: "cost".into(),
+            dimension: "total".into(),
+            value: cost,
+        });
 
         // Session count
-        let sessions: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM sessions WHERE started_at LIKE ?",
-            params![format!("{date}%")],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        aggs.push(DailyAggregate { date: date.into(), metric: "sessions".into(), dimension: "total".into(), value: sessions as f64 });
+        let sessions: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE started_at LIKE ?",
+                params![format!("{date}%")],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        aggs.push(DailyAggregate {
+            date: date.into(),
+            metric: "sessions".into(),
+            dimension: "total".into(),
+            value: sessions as f64,
+        });
 
         // Total tokens
         let tokens: i64 = conn.query_row(
@@ -638,15 +707,27 @@ impl DuckDbStore {
             params![format!("{date}%")],
             |row| row.get(0),
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        aggs.push(DailyAggregate { date: date.into(), metric: "tokens".into(), dimension: "total".into(), value: tokens as f64 });
+        aggs.push(DailyAggregate {
+            date: date.into(),
+            metric: "tokens".into(),
+            dimension: "total".into(),
+            value: tokens as f64,
+        });
 
         // Span count
-        let spans: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM spans WHERE started_at LIKE ?",
-            params![format!("{date}%")],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        aggs.push(DailyAggregate { date: date.into(), metric: "spans".into(), dimension: "total".into(), value: spans as f64 });
+        let spans: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM spans WHERE started_at LIKE ?",
+                params![format!("{date}%")],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        aggs.push(DailyAggregate {
+            date: date.into(),
+            metric: "spans".into(),
+            dimension: "total".into(),
+            value: spans as f64,
+        });
 
         drop(conn);
 
@@ -672,7 +753,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, condition_type, threshold, action, enabled FROM alert_rules WHERE enabled = TRUE"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut rules = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let id: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -681,7 +764,14 @@ impl DuckDbStore {
             let threshold: f64 = row.get(3).map_err(|e| GctlError::Storage(e.to_string()))?;
             let action: String = row.get(4).map_err(|e| GctlError::Storage(e.to_string()))?;
             let enabled: bool = row.get(5).map_err(|e| GctlError::Storage(e.to_string()))?;
-            rules.push(AlertRule { id, name, condition_type: ct, threshold, action, enabled });
+            rules.push(AlertRule {
+                id,
+                name,
+                condition_type: ct,
+                threshold,
+                action,
+                enabled,
+            });
         }
         Ok(rules)
     }
@@ -701,7 +791,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT model, COALESCE(SUM(cost_usd), 0), COUNT(*) FROM spans WHERE model IS NOT NULL GROUP BY model ORDER BY SUM(cost_usd) DESC"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut results = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let model: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -717,7 +809,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT agent_name, COALESCE(SUM(total_cost_usd), 0), COUNT(*) FROM sessions GROUP BY agent_name ORDER BY SUM(total_cost_usd) DESC"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut results = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let agent: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -729,12 +823,17 @@ impl DuckDbStore {
     }
 
     /// Get per-model cost breakdown for a specific session.
-    pub fn get_session_cost_breakdown(&self, session_id: &str) -> Result<Vec<(String, f64, u64, u64, u64)>> {
+    pub fn get_session_cost_breakdown(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<(String, f64, u64, u64, u64)>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT COALESCE(model, 'unknown'), COALESCE(SUM(cost_usd), 0), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COUNT(*) FROM spans WHERE session_id = ? GROUP BY model ORDER BY SUM(cost_usd) DESC"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query(params![session_id]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(params![session_id])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut results = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let model: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -750,15 +849,20 @@ impl DuckDbStore {
     /// Get span type distribution: count of Generation, Span, Event types.
     pub fn get_span_type_distribution(&self) -> Result<Vec<(String, u64, f64)>> {
         let conn = self.conn.lock().unwrap();
-        let total: i64 = conn.query_row("SELECT COUNT(*) FROM spans", [], |row| row.get(0))
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM spans", [], |row| row.get(0))
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         if total == 0 {
             return Ok(Vec::new());
         }
-        let mut stmt = conn.prepare(
-            "SELECT span_type, COUNT(*) FROM spans GROUP BY span_type ORDER BY COUNT(*) DESC"
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT span_type, COUNT(*) FROM spans GROUP BY span_type ORDER BY COUNT(*) DESC",
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut results = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let span_type: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -772,13 +876,21 @@ impl DuckDbStore {
     /// Return table counts for health endpoint.
     pub fn get_health_info(&self) -> Result<serde_json::Value> {
         let conn = self.conn.lock().unwrap();
-        let sessions: i64 = conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        let sessions: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
             .map_err(|e| GctlError::Storage(e.to_string()))?;
-        let spans: i64 = conn.query_row("SELECT COUNT(*) FROM spans", [], |row| row.get(0))
+        let spans: i64 = conn
+            .query_row("SELECT COUNT(*) FROM spans", [], |row| row.get(0))
             .map_err(|e| GctlError::Storage(e.to_string()))?;
-        let traffic: i64 = conn.query_row("SELECT COUNT(*) FROM traffic", [], |row| row.get(0))
+        let traffic: i64 = conn
+            .query_row("SELECT COUNT(*) FROM traffic", [], |row| row.get(0))
             .map_err(|e| GctlError::Storage(e.to_string()))?;
-        let alerts: i64 = conn.query_row("SELECT COUNT(*) FROM alert_rules WHERE enabled = TRUE", [], |row| row.get(0))
+        let alerts: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM alert_rules WHERE enabled = TRUE",
+                [],
+                |row| row.get(0),
+            )
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(serde_json::json!({
             "sessions": sessions,
@@ -795,7 +907,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT model, PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_ms), PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms), PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY duration_ms) FROM spans WHERE model IS NOT NULL GROUP BY model"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut results = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let model: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -834,22 +948,28 @@ impl DuckDbStore {
                     github_repo: row.get(4)?,
                 })
             },
-        ).ok().map(Ok).transpose()
+        )
+        .ok()
+        .map(Ok)
+        .transpose()
     }
 
     pub fn list_board_projects(&self) -> Result<Vec<gctrl_core::BoardProject>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT id, name, key, counter, github_repo FROM board_projects ORDER BY name")
+        let mut stmt = conn
+            .prepare("SELECT id, name, key, counter, github_repo FROM board_projects ORDER BY name")
             .map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([], |row| {
-            Ok(gctrl_core::BoardProject {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                key: row.get(2)?,
-                counter: row.get(3)?,
-                github_repo: row.get(4)?,
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(gctrl_core::BoardProject {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    key: row.get(2)?,
+                    counter: row.get(3)?,
+                    github_repo: row.get(4)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -858,7 +978,8 @@ impl DuckDbStore {
         conn.execute(
             "UPDATE board_projects SET github_repo = ?1 WHERE id = ?2",
             params![github_repo, id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
 
@@ -867,20 +988,23 @@ impl DuckDbStore {
         conn.execute(
             "UPDATE board_projects SET counter = counter + 1 WHERE id = ?1",
             [project_id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let counter: i32 = conn.query_row(
-            "SELECT counter FROM board_projects WHERE id = ?1",
-            [project_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let counter: i32 = conn
+            .query_row(
+                "SELECT counter FROM board_projects WHERE id = ?1",
+                [project_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(counter)
     }
 
     pub fn insert_board_issue(&self, issue: &gctrl_core::BoardIssue) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 issue.id,
                 issue.project_id,
@@ -910,6 +1034,7 @@ impl DuckDbStore {
                 issue.github_url,
                 issue.start_date,
                 issue.due_date,
+                issue.acceptance_criteria,
             ],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
@@ -929,8 +1054,8 @@ impl DuckDbStore {
                 "UPDATE board_issues SET title = ?1, description = ?2, status = ?3, priority = ?4,
                  assignee_id = ?5, assignee_name = ?6, assignee_type = ?7,
                  labels = ?8, parent_id = ?9, updated_at = ?10,
-                 content_hash = ?11, source_path = ?12
-                 WHERE id = ?13",
+                 content_hash = ?11, source_path = ?12, acceptance_criteria = ?13
+                 WHERE id = ?14",
                 params![
                     issue.title,
                     issue.description,
@@ -944,9 +1069,11 @@ impl DuckDbStore {
                     chrono::Utc::now().to_rfc3339(),
                     issue.content_hash,
                     issue.source_path,
+                    issue.acceptance_criteria,
                     issue.id,
                 ],
-            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
             Ok(true)
         } else {
             self.insert_board_issue(issue)?;
@@ -957,16 +1084,19 @@ impl DuckDbStore {
     pub fn get_board_issue(&self, id: &str) -> Result<Option<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE id = ?1",
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria FROM board_issues WHERE id = ?1",
             [id],
             row_to_board_issue,
         ).ok().map(Ok).transpose()
     }
 
-    pub fn list_board_issues(&self, filter: &gctrl_core::BoardIssueFilter) -> Result<Vec<gctrl_core::BoardIssue>> {
+    pub fn list_board_issues(
+        &self,
+        filter: &gctrl_core::BoardIssueFilter,
+    ) -> Result<Vec<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         let mut sql = String::from(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE 1=1"
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria FROM board_issues WHERE 1=1"
         );
         let mut params_vec: Vec<Box<dyn duckdb::ToSql>> = Vec::new();
         let mut idx = 1;
@@ -993,23 +1123,35 @@ impl DuckDbStore {
         }
 
         let param_refs: Vec<&dyn duckdb::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_board_issue)
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_board_issue)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn update_board_issue_status(&self, id: &str, status: &str, actor_id: &str, actor_name: &str, actor_type: &str) -> Result<()> {
+    pub fn update_board_issue_status(
+        &self,
+        id: &str,
+        status: &str,
+        actor_id: &str,
+        actor_name: &str,
+        actor_type: &str,
+    ) -> Result<()> {
         let target = gctrl_core::IssueStatus::from_str(status)
             .ok_or_else(|| GctlError::Storage(format!("invalid status: {}", status)))?;
 
         // Get current status
         let conn = self.conn.lock().unwrap();
-        let current_str: String = conn.query_row(
-            "SELECT status FROM board_issues WHERE id = ?1",
-            [id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(format!("issue not found: {} ({})", id, e)))?;
+        let current_str: String = conn
+            .query_row(
+                "SELECT status FROM board_issues WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("issue not found: {} ({})", id, e)))?;
 
         let current = gctrl_core::IssueStatus::from_str(&current_str)
             .unwrap_or(gctrl_core::IssueStatus::Backlog);
@@ -1024,7 +1166,12 @@ impl DuckDbStore {
                 "invalid transition: {} → {} (allowed: {})",
                 current.as_str(),
                 target.as_str(),
-                current.valid_transitions().iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "),
+                current
+                    .valid_transitions()
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
             )));
         };
 
@@ -1036,7 +1183,8 @@ impl DuckDbStore {
             conn.execute(
                 "UPDATE board_issues SET status = ?1, updated_at = ?2 WHERE id = ?3",
                 params![step_str, now.to_rfc3339(), id],
-            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
             let event_id = uuid::Uuid::new_v4().to_string();
             conn.execute(
@@ -1053,7 +1201,13 @@ impl DuckDbStore {
         Ok(())
     }
 
-    pub fn assign_board_issue(&self, id: &str, assignee_id: &str, assignee_name: &str, assignee_type: &str) -> Result<()> {
+    pub fn assign_board_issue(
+        &self,
+        id: &str,
+        assignee_id: &str,
+        assignee_name: &str,
+        assignee_type: &str,
+    ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let now = chrono::Utc::now().to_rfc3339();
         conn.execute(
@@ -1083,22 +1237,24 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, type, actor_id, actor_name, actor_type, timestamp, data FROM board_events WHERE issue_id = ?1 ORDER BY timestamp"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([issue_id], |row| {
-            let ts: String = row.get(6)?;
-            let data_str: String = row.get(7)?;
-            Ok(gctrl_core::BoardEvent {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                event_type: row.get(2)?,
-                actor_id: row.get(3)?,
-                actor_name: row.get(4)?,
-                actor_type: row.get(5)?,
-                timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                data: serde_json::from_str(&data_str).unwrap_or(serde_json::Value::Null),
+        let rows = stmt
+            .query_map([issue_id], |row| {
+                let ts: String = row.get(6)?;
+                let data_str: String = row.get(7)?;
+                Ok(gctrl_core::BoardEvent {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    event_type: row.get(2)?,
+                    actor_id: row.get(3)?,
+                    actor_name: row.get(4)?,
+                    actor_type: row.get(5)?,
+                    timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    data: serde_json::from_str(&data_str).unwrap_or(serde_json::Value::Null),
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -1121,34 +1277,44 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, author_id, author_name, author_type, body, created_at, session_id FROM board_comments WHERE issue_id = ?1 ORDER BY created_at"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([issue_id], |row| {
-            let ts: String = row.get(6)?;
-            Ok(gctrl_core::BoardComment {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                author_id: row.get(2)?,
-                author_name: row.get(3)?,
-                author_type: row.get(4)?,
-                body: row.get(5)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                session_id: row.get(7)?,
+        let rows = stmt
+            .query_map([issue_id], |row| {
+                let ts: String = row.get(6)?;
+                Ok(gctrl_core::BoardComment {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    author_id: row.get(2)?,
+                    author_name: row.get(3)?,
+                    author_type: row.get(4)?,
+                    body: row.get(5)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    session_id: row.get(7)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn link_session_to_issue(&self, issue_id: &str, session_id: &str, cost: f64, tokens: u64) -> Result<()> {
+    pub fn link_session_to_issue(
+        &self,
+        issue_id: &str,
+        session_id: &str,
+        cost: f64,
+        tokens: u64,
+    ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let now = chrono::Utc::now().to_rfc3339();
 
         // Read current session_ids, append, write back
-        let current: String = conn.query_row(
-            "SELECT session_ids FROM board_issues WHERE id = ?1",
-            [issue_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let current: String = conn
+            .query_row(
+                "SELECT session_ids FROM board_issues WHERE id = ?1",
+                [issue_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut ids: Vec<String> = serde_json::from_str(&current).unwrap_or_default();
         if !ids.contains(&session_id.to_string()) {
@@ -1164,7 +1330,8 @@ impl DuckDbStore {
                 updated_at = ?4
              WHERE id = ?5",
             params![ids_json, cost, tokens as i64, now, issue_id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
 
@@ -1179,11 +1346,13 @@ impl DuckDbStore {
         let specs_json = serde_json::to_string(&persona.key_specs).unwrap_or_else(|_| "[]".into());
 
         // Check if exists
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM persona_definitions WHERE id = ?1",
-            [&persona.id],
-            |row| row.get(0),
-        ).unwrap_or(false);
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM persona_definitions WHERE id = ?1",
+                [&persona.id],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
 
         if exists {
             conn.execute(
@@ -1229,7 +1398,9 @@ impl DuckDbStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, focus, prompt_prefix, owns, review_focus, pushes_back, tools, key_specs, source_hash FROM persona_definitions ORDER BY name"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut personas = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let tools_str: String = row.get(7).unwrap_or_default();
@@ -1252,7 +1423,8 @@ impl DuckDbStore {
 
     pub fn delete_persona(&self, id: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let affected = conn.execute("DELETE FROM persona_definitions WHERE id = ?1", [id])
+        let affected = conn
+            .execute("DELETE FROM persona_definitions WHERE id = ?1", [id])
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(affected > 0)
     }
@@ -1263,11 +1435,13 @@ impl DuckDbStore {
         let ids_json = serde_json::to_string(&rule.persona_ids).unwrap_or_else(|_| "[]".into());
 
         // Check if exists by id
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM persona_review_rules WHERE id = ?1",
-            [&rule.id],
-            |row| row.get(0),
-        ).unwrap_or(false);
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM persona_review_rules WHERE id = ?1",
+                [&rule.id],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
 
         if exists {
             conn.execute(
@@ -1286,10 +1460,12 @@ impl DuckDbStore {
 
     pub fn list_review_rules(&self) -> Result<Vec<PersonaReviewRule>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT id, pr_type, persona_ids FROM persona_review_rules ORDER BY pr_type"
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT id, pr_type, persona_ids FROM persona_review_rules ORDER BY pr_type")
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut rules = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let ids_str: String = row.get(2).unwrap_or_default();
@@ -1315,7 +1491,10 @@ impl DuckDbStore {
                     persona_ids: serde_json::from_str(&ids_str).unwrap_or_default(),
                 })
             },
-        ).ok().map(Ok).transpose()
+        )
+        .ok()
+        .map(Ok)
+        .transpose()
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1408,7 +1587,11 @@ impl DuckDbStore {
         let conn = self.conn.lock().unwrap();
         let needs_join = filter.project.is_some();
         let col = |name: &str| -> String {
-            if needs_join { format!("m.{}", name) } else { name.to_string() }
+            if needs_join {
+                format!("m.{}", name)
+            } else {
+                name.to_string()
+            }
         };
 
         let base = if needs_join {
@@ -1460,8 +1643,11 @@ impl DuckDbStore {
         }
 
         let param_refs: Vec<&dyn duckdb::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_message)
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_message)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1507,8 +1693,11 @@ impl DuckDbStore {
         }
 
         let param_refs: Vec<&dyn duckdb::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_thread)
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_thread)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1517,11 +1706,13 @@ impl DuckDbStore {
         let conn = self.conn.lock().unwrap();
 
         // Validate message is pending
-        let status: String = conn.query_row(
-            "SELECT status FROM inbox_messages WHERE id = ?1",
-            [&action.message_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(format!("message not found: {}", e)))?;
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM inbox_messages WHERE id = ?1",
+                [&action.message_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("message not found: {}", e)))?;
 
         if status != "pending" {
             return Err(GctlError::Storage(format!(
@@ -1552,7 +1743,8 @@ impl DuckDbStore {
         conn.execute(
             "UPDATE inbox_messages SET status = 'acted', updated_at = ?1 WHERE id = ?2",
             params![now, action.message_id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         // Recalc thread counts
         self.recalc_thread_counts_with_conn(&conn, &action.thread_id)?;
@@ -1591,8 +1783,11 @@ impl DuckDbStore {
         }
 
         let param_refs: Vec<&dyn duckdb::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_action)
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_action)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1602,16 +1797,14 @@ impl DuckDbStore {
         self.recalc_thread_counts_with_conn(&conn, thread_id)
     }
 
-    fn recalc_thread_counts_with_conn(
-        &self,
-        conn: &Connection,
-        thread_id: &str,
-    ) -> Result<()> {
-        let pending_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'",
-            [thread_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+    fn recalc_thread_counts_with_conn(&self, conn: &Connection, thread_id: &str) -> Result<()> {
+        let pending_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'",
+                [thread_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         // Compute latest_urgency as the highest urgency among pending messages
         let urgency_order = ["critical", "high", "medium", "low", "info"];
@@ -1620,7 +1813,9 @@ impl DuckDbStore {
             let mut stmt = conn.prepare(
                 "SELECT DISTINCT urgency FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([thread_id]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([thread_id])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let u: String = row.get(0).unwrap_or_default();
                 let u_pos = urgency_order.iter().position(|&x| x == u).unwrap_or(4);
@@ -1646,17 +1841,25 @@ impl DuckDbStore {
     pub fn get_inbox_stats(&self) -> Result<serde_json::Value> {
         let conn = self.conn.lock().unwrap();
 
-        let total: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM inbox_messages", [], |row| row.get(0))
+            .unwrap_or(0);
 
-        let pending: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE status = 'pending'", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE status = 'pending'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
 
-        let acted: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE status = 'acted'", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let acted: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE status = 'acted'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
 
         // By urgency (pending only)
         let mut by_urgency = serde_json::Map::new();
@@ -1664,7 +1867,9 @@ impl DuckDbStore {
             let mut stmt = conn.prepare(
                 "SELECT urgency, COUNT(*) FROM inbox_messages WHERE status = 'pending' GROUP BY urgency"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let urgency: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1678,7 +1883,9 @@ impl DuckDbStore {
             let mut stmt = conn.prepare(
                 "SELECT kind, COUNT(*) FROM inbox_messages WHERE status = 'pending' GROUP BY kind"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let kind: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1711,7 +1918,8 @@ fn row_to_board_issue(row: &duckdb::Row<'_>) -> duckdb::Result<gctrl_core::Board
         project_id: row.get(1)?,
         title: row.get(2)?,
         description: row.get(3)?,
-        status: gctrl_core::IssueStatus::from_str(&status_str).unwrap_or(gctrl_core::IssueStatus::Backlog),
+        status: gctrl_core::IssueStatus::from_str(&status_str)
+            .unwrap_or(gctrl_core::IssueStatus::Backlog),
         priority: row.get(5)?,
         assignee_id: row.get(6)?,
         assignee_name: row.get(7)?,
@@ -1731,14 +1939,21 @@ fn row_to_board_issue(row: &duckdb::Row<'_>) -> duckdb::Result<gctrl_core::Board
         blocking: serde_json::from_str(&blocking_str).unwrap_or_default(),
         session_ids: serde_json::from_str(&session_ids_str).unwrap_or_default(),
         total_cost_usd: row.get(19)?,
-        total_tokens: { let v: i64 = row.get(20)?; v as u64 },
+        total_tokens: {
+            let v: i64 = row.get(20)?;
+            v as u64
+        },
         pr_numbers: serde_json::from_str(&pr_numbers_str).unwrap_or_default(),
         content_hash: row.get(22)?,
         source_path: row.get(23)?,
-        github_issue_number: { let v: Option<i32> = row.get(24)?; v.map(|n| n as u32) },
+        github_issue_number: {
+            let v: Option<i32> = row.get(24)?;
+            v.map(|n| n as u32)
+        },
         github_url: row.get(25)?,
         start_date: row.get(26)?,
         due_date: row.get(27)?,
+        acceptance_criteria: row.get(28)?,
     })
 }
 
@@ -1779,7 +1994,8 @@ fn row_to_session(row: &duckdb::Row<'_>) -> Result<Session> {
 fn row_to_span(row: &duckdb::Row<'_>) -> Result<Span> {
     let span_id: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
     let trace_id: String = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
-    let parent_span_id: Option<String> = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
+    let parent_span_id: Option<String> =
+        row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
     let session_id: String = row.get(3).map_err(|e| GctlError::Storage(e.to_string()))?;
     let agent_name: String = row.get(4).map_err(|e| GctlError::Storage(e.to_string()))?;
     let operation_name: String = row.get(5).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -1789,7 +2005,8 @@ fn row_to_span(row: &duckdb::Row<'_>) -> Result<Span> {
     let output_tokens: i64 = row.get(9).map_err(|e| GctlError::Storage(e.to_string()))?;
     let cost_usd: f64 = row.get(10).map_err(|e| GctlError::Storage(e.to_string()))?;
     let status: String = row.get(11).map_err(|e| GctlError::Storage(e.to_string()))?;
-    let error_message: Option<String> = row.get(12).map_err(|e| GctlError::Storage(e.to_string()))?;
+    let error_message: Option<String> =
+        row.get(12).map_err(|e| GctlError::Storage(e.to_string()))?;
     let started_at: String = row.get(13).map_err(|e| GctlError::Storage(e.to_string()))?;
     let duration_ms: i64 = row.get(14).map_err(|e| GctlError::Storage(e.to_string()))?;
     let attributes: String = row.get(15).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -1860,7 +2077,14 @@ fn row_to_score(row: &duckdb::Row<'_>) -> Result<Score> {
     let scored_by: Option<String> = row.get(7).map_err(|e| GctlError::Storage(e.to_string()))?;
     let created_at: String = row.get(8).map_err(|e| GctlError::Storage(e.to_string()))?;
     Ok(Score {
-        id, target_type, target_id, name, value, comment, source, scored_by,
+        id,
+        target_type,
+        target_id,
+        name,
+        value,
+        comment,
+        source,
+        scored_by,
         created_at: chrono::DateTime::parse_from_rfc3339(&created_at)
             .map_err(|e| GctlError::Storage(format!("parse timestamp: {e}")))?
             .with_timezone(&chrono::Utc),
@@ -1875,7 +2099,10 @@ fn row_to_prompt_version(row: &duckdb::Row<'_>) -> Result<PromptVersion> {
     let created_at: String = row.get(4).map_err(|e| GctlError::Storage(e.to_string()))?;
     let token_count: Option<i32> = row.get(5).map_err(|e| GctlError::Storage(e.to_string()))?;
     Ok(PromptVersion {
-        hash, content, file_path, label,
+        hash,
+        content,
+        file_path,
+        label,
         created_at: chrono::DateTime::parse_from_rfc3339(&created_at)
             .map_err(|e| GctlError::Storage(format!("parse timestamp: {e}")))?
             .with_timezone(&chrono::Utc),
@@ -1898,7 +2125,10 @@ fn row_to_inbox_message(row: &duckdb::Row<'_>) -> duckdb::Result<InboxMessage> {
         status: row.get(8)?,
         requires_action: row.get(9)?,
         payload: payload_str.and_then(|s| serde_json::from_str(&s).ok()),
-        duplicate_count: { let v: i32 = row.get(11)?; v as u32 },
+        duplicate_count: {
+            let v: i32 = row.get(11)?;
+            v as u32
+        },
         snoozed_until: row.get(12)?,
         expires_at: row.get(13)?,
         created_at: row.get(14)?,
@@ -2004,7 +2234,9 @@ mod tests {
     fn test_list_sessions() {
         let store = test_store();
         for i in 0..5 {
-            store.insert_session(&make_session(&format!("s{i}"))).unwrap();
+            store
+                .insert_session(&make_session(&format!("s{i}")))
+                .unwrap();
         }
         let sessions = store.list_sessions(3).unwrap();
         assert_eq!(sessions.len(), 3);
@@ -2096,7 +2328,7 @@ mod tests {
 
         // Session should now have aggregated totals
         let session = store.get_session(&SessionId("s1".into())).unwrap().unwrap();
-        assert_eq!(session.total_input_tokens, 3000);  // 3 * 1000
+        assert_eq!(session.total_input_tokens, 3000); // 3 * 1000
         assert_eq!(session.total_output_tokens, 1500); // 3 * 500
         assert!((session.total_cost_usd - 0.15).abs() < 0.001); // 3 * 0.05
     }
@@ -2250,11 +2482,13 @@ mod tests {
     fn test_cost_by_model() {
         let store = test_store();
         store.insert_session(&make_session("s1")).unwrap();
-        store.insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")]).unwrap();
+        store
+            .insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")])
+            .unwrap();
         let costs = store.get_cost_by_model().unwrap();
         assert_eq!(costs.len(), 1);
         assert_eq!(costs[0].0, "claude-opus-4-6");
-        assert!((costs[0].1 - 0.10).abs() < 0.001);  // 2 * 0.05
+        assert!((costs[0].1 - 0.10).abs() < 0.001); // 2 * 0.05
         assert_eq!(costs[0].2, 2);
     }
 
@@ -2272,7 +2506,9 @@ mod tests {
     fn test_latency_by_model() {
         let store = test_store();
         store.insert_session(&make_session("s1")).unwrap();
-        store.insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")]).unwrap();
+        store
+            .insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")])
+            .unwrap();
         let latencies = store.get_latency_by_model().unwrap();
         assert_eq!(latencies.len(), 1);
         assert_eq!(latencies[0].0, "claude-opus-4-6");
@@ -2282,7 +2518,9 @@ mod tests {
     fn test_auto_score_session() {
         let store = test_store();
         store.insert_session(&make_session("s1")).unwrap();
-        store.insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")]).unwrap();
+        store
+            .insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")])
+            .unwrap();
 
         let scores = store.auto_score_session("s1").unwrap();
         assert!(scores.len() >= 3);
@@ -2292,8 +2530,11 @@ mod tests {
         assert!((span_count.value - 2.0).abs() < f64::EPSILON);
 
         // Check generation_count
-        let gen_count = scores.iter().find(|s| s.name == "generation_count").unwrap();
-        assert!((gen_count.value - 2.0).abs() < f64::EPSILON);  // make_span creates Generation type
+        let gen_count = scores
+            .iter()
+            .find(|s| s.name == "generation_count")
+            .unwrap();
+        assert!((gen_count.value - 2.0).abs() < f64::EPSILON); // make_span creates Generation type
     }
 
     #[test]
@@ -2356,7 +2597,9 @@ mod tests {
         event_span.span_type = SpanType::Event;
         event_span.model = None;
 
-        store.insert_spans(&[gen_span, tool_span, event_span]).unwrap();
+        store
+            .insert_spans(&[gen_span, tool_span, event_span])
+            .unwrap();
 
         let dist = store.get_span_type_distribution().unwrap();
         assert_eq!(dist.len(), 3);
@@ -2389,7 +2632,9 @@ mod tests {
         store.insert_session(&s1).unwrap();
         store.insert_session(&s2).unwrap();
 
-        let filtered = store.list_sessions_filtered(20, Some("claude"), None).unwrap();
+        let filtered = store
+            .list_sessions_filtered(20, Some("claude"), None)
+            .unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].agent_name, "claude");
     }
@@ -2401,7 +2646,9 @@ mod tests {
         store.end_session("s1", "completed").unwrap();
         store.insert_session(&make_session("s2")).unwrap();
 
-        let filtered = store.list_sessions_filtered(20, None, Some("completed")).unwrap();
+        let filtered = store
+            .list_sessions_filtered(20, None, Some("completed"))
+            .unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id.0, "s1");
     }
@@ -2438,7 +2685,9 @@ mod tests {
     fn test_compute_daily_aggregates() {
         let store = test_store();
         store.insert_session(&make_session("s1")).unwrap();
-        store.insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")]).unwrap();
+        store
+            .insert_spans(&[make_span("sp1", "s1"), make_span("sp2", "s1")])
+            .unwrap();
 
         // Get the date from the session's started_at
         let session = store.get_session(&SessionId("s1".into())).unwrap().unwrap();
@@ -2501,6 +2750,7 @@ mod tests {
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         }
     }
 
@@ -2521,7 +2771,9 @@ mod tests {
     #[test]
     fn test_board_project_counter() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
 
         let c1 = store.increment_project_counter("p1").unwrap();
         assert_eq!(c1, 1);
@@ -2532,7 +2784,9 @@ mod tests {
     #[test]
     fn test_board_issue_crud() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
 
         let issue = make_issue("i1", "p1");
         store.insert_board_issue(&issue).unwrap();
@@ -2546,36 +2800,50 @@ mod tests {
     #[test]
     fn test_board_issue_list_filter() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
-        store.create_board_project(&make_project("p2", "FRONT")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
+        store
+            .create_board_project(&make_project("p2", "FRONT"))
+            .unwrap();
 
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
         store.insert_board_issue(&make_issue("i2", "p1")).unwrap();
         store.insert_board_issue(&make_issue("i3", "p2")).unwrap();
 
-        let all = store.list_board_issues(&gctrl_core::BoardIssueFilter::default()).unwrap();
+        let all = store
+            .list_board_issues(&gctrl_core::BoardIssueFilter::default())
+            .unwrap();
         assert_eq!(all.len(), 3);
 
-        let p1_only = store.list_board_issues(&gctrl_core::BoardIssueFilter {
-            project_id: Some("p1".into()),
-            ..Default::default()
-        }).unwrap();
+        let p1_only = store
+            .list_board_issues(&gctrl_core::BoardIssueFilter {
+                project_id: Some("p1".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(p1_only.len(), 2);
     }
 
     #[test]
     fn test_board_issue_status_update() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         // backlog → todo (valid)
-        store.update_board_issue_status("i1", "todo", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i1", "todo", "u1", "Alice", "human")
+            .unwrap();
         let fetched = store.get_board_issue("i1").unwrap().unwrap();
         assert_eq!(fetched.status, gctrl_core::IssueStatus::Todo);
 
         // todo → in_progress (valid)
-        store.update_board_issue_status("i1", "in_progress", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i1", "in_progress", "u1", "Alice", "human")
+            .unwrap();
         let fetched = store.get_board_issue("i1").unwrap().unwrap();
         assert_eq!(fetched.status, gctrl_core::IssueStatus::InProgress);
 
@@ -2588,11 +2856,15 @@ mod tests {
     #[test]
     fn test_board_auto_transit_forward() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         // backlog → in_progress auto-transits through todo
-        store.update_board_issue_status("i1", "in_progress", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i1", "in_progress", "u1", "Alice", "human")
+            .unwrap();
         let fetched = store.get_board_issue("i1").unwrap().unwrap();
         assert_eq!(fetched.status, gctrl_core::IssueStatus::InProgress);
 
@@ -2602,7 +2874,9 @@ mod tests {
 
         // backlog → done auto-transits through all intermediate steps
         store.insert_board_issue(&make_issue("i2", "p1")).unwrap();
-        store.update_board_issue_status("i2", "done", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i2", "done", "u1", "Alice", "human")
+            .unwrap();
         let fetched = store.get_board_issue("i2").unwrap().unwrap();
         assert_eq!(fetched.status, gctrl_core::IssueStatus::Done);
         let events = store.list_board_events("i2").unwrap();
@@ -2612,11 +2886,15 @@ mod tests {
     #[test]
     fn test_board_backward_transition_rejected() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         // Move to in_progress
-        store.update_board_issue_status("i1", "in_progress", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i1", "in_progress", "u1", "Alice", "human")
+            .unwrap();
 
         // in_progress → backlog is backward (not a direct valid transition, not forward)
         let result = store.update_board_issue_status("i1", "backlog", "u1", "Alice", "human");
@@ -2632,14 +2910,24 @@ mod tests {
     #[test]
     fn test_board_terminal_state_no_transitions() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         // Walk to done: backlog → todo → in_progress → in_review → done
-        store.update_board_issue_status("i1", "todo", "u1", "Alice", "human").unwrap();
-        store.update_board_issue_status("i1", "in_progress", "u1", "Alice", "human").unwrap();
-        store.update_board_issue_status("i1", "in_review", "u1", "Alice", "human").unwrap();
-        store.update_board_issue_status("i1", "done", "u1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("i1", "todo", "u1", "Alice", "human")
+            .unwrap();
+        store
+            .update_board_issue_status("i1", "in_progress", "u1", "Alice", "human")
+            .unwrap();
+        store
+            .update_board_issue_status("i1", "in_review", "u1", "Alice", "human")
+            .unwrap();
+        store
+            .update_board_issue_status("i1", "done", "u1", "Alice", "human")
+            .unwrap();
 
         // done → anything (rejected)
         let result = store.update_board_issue_status("i1", "backlog", "u1", "Alice", "human");
@@ -2649,29 +2937,47 @@ mod tests {
     #[test]
     fn test_board_cancel_from_any_non_terminal() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
 
         // Cancel from backlog
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
-        store.update_board_issue_status("i1", "cancelled", "u1", "Alice", "human").unwrap();
-        assert_eq!(store.get_board_issue("i1").unwrap().unwrap().status, gctrl_core::IssueStatus::Cancelled);
+        store
+            .update_board_issue_status("i1", "cancelled", "u1", "Alice", "human")
+            .unwrap();
+        assert_eq!(
+            store.get_board_issue("i1").unwrap().unwrap().status,
+            gctrl_core::IssueStatus::Cancelled
+        );
 
         // Cancel from in_progress
         let mut issue2 = make_issue("i2", "p1");
         issue2.status = gctrl_core::IssueStatus::Todo;
         store.insert_board_issue(&issue2).unwrap();
-        store.update_board_issue_status("i2", "in_progress", "u1", "Alice", "human").unwrap();
-        store.update_board_issue_status("i2", "cancelled", "u1", "Alice", "human").unwrap();
-        assert_eq!(store.get_board_issue("i2").unwrap().unwrap().status, gctrl_core::IssueStatus::Cancelled);
+        store
+            .update_board_issue_status("i2", "in_progress", "u1", "Alice", "human")
+            .unwrap();
+        store
+            .update_board_issue_status("i2", "cancelled", "u1", "Alice", "human")
+            .unwrap();
+        assert_eq!(
+            store.get_board_issue("i2").unwrap().unwrap().status,
+            gctrl_core::IssueStatus::Cancelled
+        );
     }
 
     #[test]
     fn test_board_issue_assign() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
-        store.assign_board_issue("i1", "agent1", "claude-code", "agent").unwrap();
+        store
+            .assign_board_issue("i1", "agent1", "claude-code", "agent")
+            .unwrap();
         let fetched = store.get_board_issue("i1").unwrap().unwrap();
         assert_eq!(fetched.assignee_id, Some("agent1".into()));
         assert_eq!(fetched.assignee_name, Some("claude-code".into()));
@@ -2681,7 +2987,9 @@ mod tests {
     #[test]
     fn test_board_events() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         let event = gctrl_core::BoardEvent {
@@ -2704,7 +3012,9 @@ mod tests {
     #[test]
     fn test_board_comments() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
         let comment = gctrl_core::BoardComment {
@@ -2727,11 +3037,17 @@ mod tests {
     #[test]
     fn test_board_link_session() {
         let store = test_store();
-        store.create_board_project(&make_project("p1", "BACK")).unwrap();
+        store
+            .create_board_project(&make_project("p1", "BACK"))
+            .unwrap();
         store.insert_board_issue(&make_issue("i1", "p1")).unwrap();
 
-        store.link_session_to_issue("i1", "sess-1", 1.50, 5000).unwrap();
-        store.link_session_to_issue("i1", "sess-2", 0.75, 2500).unwrap();
+        store
+            .link_session_to_issue("i1", "sess-1", 1.50, 5000)
+            .unwrap();
+        store
+            .link_session_to_issue("i1", "sess-2", 0.75, 2500)
+            .unwrap();
 
         let fetched = store.get_board_issue("i1").unwrap().unwrap();
         assert!((fetched.total_cost_usd - 2.25).abs() < 0.01);
@@ -2806,10 +3122,16 @@ mod tests {
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].persona_ids.len(), 3);
 
-        let found = store.get_review_rule_by_type("new_kernel_primitive").unwrap().unwrap();
+        let found = store
+            .get_review_rule_by_type("new_kernel_primitive")
+            .unwrap()
+            .unwrap();
         assert_eq!(found.persona_ids, vec!["engineer", "security", "tech-lead"]);
 
-        assert!(store.get_review_rule_by_type("nonexistent").unwrap().is_none());
+        assert!(store
+            .get_review_rule_by_type("nonexistent")
+            .unwrap()
+            .is_none());
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -2843,9 +3165,9 @@ mod tests {
         let store = test_store();
 
         // Create thread first
-        let thread = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
         assert_eq!(thread.context_type, "issue");
         assert_eq!(thread.context_ref, "BACK-42");
         assert_eq!(thread.pending_count, 0);
@@ -2866,19 +3188,25 @@ mod tests {
         assert_eq!(t.latest_urgency, "high");
 
         // List with filter
-        let all = store.list_inbox_messages(&InboxMessageFilter::default()).unwrap();
+        let all = store
+            .list_inbox_messages(&InboxMessageFilter::default())
+            .unwrap();
         assert_eq!(all.len(), 1);
 
-        let by_urgency = store.list_inbox_messages(&InboxMessageFilter {
-            urgency: Some("high".into()),
-            ..Default::default()
-        }).unwrap();
+        let by_urgency = store
+            .list_inbox_messages(&InboxMessageFilter {
+                urgency: Some("high".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(by_urgency.len(), 1);
 
-        let by_low = store.list_inbox_messages(&InboxMessageFilter {
-            urgency: Some("low".into()),
-            ..Default::default()
-        }).unwrap();
+        let by_low = store
+            .list_inbox_messages(&InboxMessageFilter {
+                urgency: Some("low".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(by_low.len(), 0);
 
         // Not found
@@ -2889,9 +3217,9 @@ mod tests {
     fn test_inbox_action_idempotency() {
         let store = test_store();
 
-        let thread = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
 
         let msg = make_inbox_message("msg-1", &thread.id, "high");
         store.create_inbox_message(&msg).unwrap();
@@ -2937,22 +3265,22 @@ mod tests {
         let store = test_store();
 
         // First call creates thread
-        let t1 = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let t1 = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
 
         // Second call with same context_type + context_ref returns same thread
-        let t2 = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "Different title", Some("BACK"),
-        ).unwrap();
+        let t2 = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "Different title", Some("BACK"))
+            .unwrap();
 
         assert_eq!(t1.id, t2.id);
         assert_eq!(t1.title, "BACK-42: Fix auth"); // Title from first creation
 
         // Different context_ref creates new thread
-        let t3 = store.get_or_create_inbox_thread(
-            "issue", "BACK-43", "BACK-43: New feature", Some("BACK"),
-        ).unwrap();
+        let t3 = store
+            .get_or_create_inbox_thread("issue", "BACK-43", "BACK-43: New feature", Some("BACK"))
+            .unwrap();
         assert_ne!(t1.id, t3.id);
 
         // Two messages with same context join same thread
@@ -2969,9 +3297,9 @@ mod tests {
     fn test_inbox_thread_pending_count() {
         let store = test_store();
 
-        let thread = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
 
         // Create 3 messages
         for i in 1..=3 {
@@ -3033,9 +3361,9 @@ mod tests {
     fn test_inbox_stats() {
         let store = test_store();
 
-        let thread = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
 
         // Create messages with different urgencies and kinds
         let mut msg1 = make_inbox_message("msg-1", &thread.id, "critical");
@@ -3061,12 +3389,12 @@ mod tests {
     fn test_inbox_list_threads() {
         let store = test_store();
 
-        let t1 = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
-        let t2 = store.get_or_create_inbox_thread(
-            "issue", "FRONT-10", "FRONT-10: Dashboard", Some("FRONT"),
-        ).unwrap();
+        let t1 = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
+        let t2 = store
+            .get_or_create_inbox_thread("issue", "FRONT-10", "FRONT-10: Dashboard", Some("FRONT"))
+            .unwrap();
 
         // Add a pending message to t1 only
         let msg = make_inbox_message("msg-1", &t1.id, "high");
@@ -3096,9 +3424,9 @@ mod tests {
     fn test_inbox_list_actions() {
         let store = test_store();
 
-        let thread = store.get_or_create_inbox_thread(
-            "issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("issue", "BACK-42", "BACK-42: Fix auth", Some("BACK"))
+            .unwrap();
 
         let msg = make_inbox_message("msg-1", &thread.id, "high");
         store.create_inbox_message(&msg).unwrap();
@@ -3117,21 +3445,27 @@ mod tests {
         store.create_inbox_action(&action).unwrap();
 
         // List all actions
-        let actions = store.list_inbox_actions(&InboxActionFilter::default()).unwrap();
+        let actions = store
+            .list_inbox_actions(&InboxActionFilter::default())
+            .unwrap();
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].action_type, "approve");
 
         // Filter by actor
-        let by_actor = store.list_inbox_actions(&InboxActionFilter {
-            actor_id: Some("user-1".into()),
-            ..Default::default()
-        }).unwrap();
+        let by_actor = store
+            .list_inbox_actions(&InboxActionFilter {
+                actor_id: Some("user-1".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(by_actor.len(), 1);
 
-        let by_other = store.list_inbox_actions(&InboxActionFilter {
-            actor_id: Some("user-999".into()),
-            ..Default::default()
-        }).unwrap();
+        let by_other = store
+            .list_inbox_actions(&InboxActionFilter {
+                actor_id: Some("user-999".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(by_other.len(), 0);
     }
 }

--- a/kernel/crates/gctrl-storage/src/schema.rs
+++ b/kernel/crates/gctrl-storage/src/schema.rs
@@ -197,7 +197,25 @@ CREATE TABLE IF NOT EXISTS board_issues (
     github_issue_number INTEGER,
     github_url      VARCHAR,
     start_date      VARCHAR,
-    due_date        VARCHAR
+    due_date        VARCHAR,
+    acceptance_criteria VARCHAR
+)
+"#;
+
+pub const CREATE_BOARD_ACCEPTANCE_CHECKS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS board_acceptance_checks (
+    id                VARCHAR PRIMARY KEY,
+    issue_id          VARCHAR NOT NULL,
+    check_idx         INTEGER NOT NULL,
+    kind              VARCHAR NOT NULL,
+    command           VARCHAR NOT NULL,
+    status            VARCHAR NOT NULL DEFAULT 'pending',
+    last_session_id   VARCHAR,
+    last_run_at       VARCHAR,
+    output            VARCHAR,
+    created_at        VARCHAR NOT NULL,
+    updated_at        VARCHAR NOT NULL,
+    UNIQUE(issue_id, check_idx)
 )
 "#;
 
@@ -339,6 +357,8 @@ pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_board_issues_parent ON board_issues(parent_id)",
     "CREATE INDEX IF NOT EXISTS idx_board_events_issue ON board_events(issue_id)",
     "CREATE INDEX IF NOT EXISTS idx_board_comments_issue ON board_comments(issue_id)",
+    "CREATE INDEX IF NOT EXISTS idx_board_acceptance_checks_issue ON board_acceptance_checks(issue_id)",
+    "CREATE INDEX IF NOT EXISTS idx_board_acceptance_checks_status ON board_acceptance_checks(status)",
     // Persona indexes
     "CREATE INDEX IF NOT EXISTS idx_persona_definitions_name ON persona_definitions(name)",
     "CREATE INDEX IF NOT EXISTS idx_persona_review_rules_type ON persona_review_rules(pr_type)",
@@ -370,6 +390,7 @@ pub fn all_migrations() -> Vec<&'static str> {
         CREATE_CONTEXT_ENTRIES_TABLE,
         CREATE_BOARD_PROJECTS_TABLE,
         CREATE_BOARD_ISSUES_TABLE,
+        CREATE_BOARD_ACCEPTANCE_CHECKS_TABLE,
         CREATE_BOARD_EVENTS_TABLE,
         CREATE_BOARD_COMMENTS_TABLE,
         CREATE_PERSONA_DEFINITIONS_TABLE,

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -8,14 +8,14 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use rusqlite::{params, Connection};
 use gctrl_core::{
-    GctlError, Result, Task, VaultMount, VaultMountKind,
-    InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
-    PersonaDefinition, PersonaReviewRule,
     context::{ContextEntry, ContextEntryId, ContextFilter, ContextKind, ContextSource},
     memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
+    AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
+    GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
+    PersonaDefinition, PersonaReviewRule, Result, Task, VaultMount, VaultMountKind,
 };
+use rusqlite::{params, Connection};
 
 // ═══════════════════════════════════════════════════════════════
 // Schema (SQLite-compatible DDL)
@@ -66,8 +66,30 @@ CREATE TABLE IF NOT EXISTS board_issues (
     github_url      TEXT,
     start_date      TEXT,
     due_date        TEXT,
+    acceptance_criteria TEXT,
     device_id       TEXT NOT NULL DEFAULT '',
     synced          INTEGER NOT NULL DEFAULT 0
+)
+"#;
+
+// Checks parsed from an issue's `acceptance_criteria` markdown, one row per
+// `- [ ] kind: command` line. `check_idx` is the 0-based position in the list
+// and forms the natural key alongside `issue_id` — agents call back with
+// `(issue_id, check_idx)` when reporting results.
+const CREATE_BOARD_ACCEPTANCE_CHECKS: &str = r#"
+CREATE TABLE IF NOT EXISTS board_acceptance_checks (
+    id                TEXT PRIMARY KEY,
+    issue_id          TEXT NOT NULL,
+    check_idx         INTEGER NOT NULL,
+    kind              TEXT NOT NULL,
+    command           TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'pending',
+    last_session_id   TEXT,
+    last_run_at       TEXT,
+    output            TEXT,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    UNIQUE(issue_id, check_idx)
 )
 "#;
 
@@ -272,6 +294,8 @@ const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_board_issues_due_date ON board_issues(due_date)",
     "CREATE INDEX IF NOT EXISTS idx_board_events_issue ON board_events(issue_id)",
     "CREATE INDEX IF NOT EXISTS idx_board_comments_issue ON board_comments(issue_id)",
+    "CREATE INDEX IF NOT EXISTS idx_board_acceptance_checks_issue ON board_acceptance_checks(issue_id)",
+    "CREATE INDEX IF NOT EXISTS idx_board_acceptance_checks_status ON board_acceptance_checks(status)",
     // Board sync indexes
     "CREATE INDEX IF NOT EXISTS idx_board_projects_synced ON board_projects(synced)",
     "CREATE INDEX IF NOT EXISTS idx_board_projects_updated ON board_projects(updated_at)",
@@ -355,6 +379,7 @@ impl SqliteStore {
         let tables = [
             CREATE_BOARD_PROJECTS,
             CREATE_BOARD_ISSUES,
+            CREATE_BOARD_ACCEPTANCE_CHECKS,
             CREATE_BOARD_EVENTS,
             CREATE_BOARD_COMMENTS,
             CREATE_TASKS,
@@ -381,6 +406,7 @@ impl SqliteStore {
             "ALTER TABLE board_projects ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE board_issues ADD COLUMN device_id TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE board_issues ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE board_issues ADD COLUMN acceptance_criteria TEXT",
             "ALTER TABLE board_events ADD COLUMN device_id TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE board_events ADD COLUMN updated_at TEXT NOT NULL DEFAULT (datetime('now'))",
             "ALTER TABLE board_events ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",
@@ -431,22 +457,28 @@ impl SqliteStore {
                     github_repo: row.get(4)?,
                 })
             },
-        ).ok().map(Ok).transpose()
+        )
+        .ok()
+        .map(Ok)
+        .transpose()
     }
 
     pub fn list_board_projects(&self) -> Result<Vec<gctrl_core::BoardProject>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT id, name, key, counter, github_repo FROM board_projects ORDER BY name")
+        let mut stmt = conn
+            .prepare("SELECT id, name, key, counter, github_repo FROM board_projects ORDER BY name")
             .map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([], |row| {
-            Ok(gctrl_core::BoardProject {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                key: row.get(2)?,
-                counter: row.get(3)?,
-                github_repo: row.get(4)?,
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(gctrl_core::BoardProject {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    key: row.get(2)?,
+                    counter: row.get(3)?,
+                    github_repo: row.get(4)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -467,19 +499,21 @@ impl SqliteStore {
             "UPDATE board_projects SET counter = counter + 1, device_id = ?1, updated_at = ?2, synced = 0 WHERE id = ?3",
             params![self.device_id, now, project_id],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let counter: i32 = conn.query_row(
-            "SELECT counter FROM board_projects WHERE id = ?1",
-            [project_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let counter: i32 = conn
+            .query_row(
+                "SELECT counter FROM board_projects WHERE id = ?1",
+                [project_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(counter)
     }
 
     pub fn insert_board_issue(&self, issue: &gctrl_core::BoardIssue) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, device_id, synced)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria, device_id, synced)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
             params![
                 issue.id,
                 issue.project_id,
@@ -509,6 +543,7 @@ impl SqliteStore {
                 issue.github_url,
                 issue.start_date,
                 issue.due_date,
+                issue.acceptance_criteria,
                 self.device_id,
             ],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -529,8 +564,9 @@ impl SqliteStore {
                 "UPDATE board_issues SET title = ?1, description = ?2, status = ?3, priority = ?4,
                  assignee_id = ?5, assignee_name = ?6, assignee_type = ?7,
                  labels = ?8, parent_id = ?9, updated_at = ?10,
-                 content_hash = ?11, source_path = ?12, device_id = ?13, synced = 0
-                 WHERE id = ?14",
+                 content_hash = ?11, source_path = ?12, acceptance_criteria = ?13,
+                 device_id = ?14, synced = 0
+                 WHERE id = ?15",
                 params![
                     issue.title,
                     issue.description,
@@ -544,10 +580,12 @@ impl SqliteStore {
                     chrono::Utc::now().to_rfc3339(),
                     issue.content_hash,
                     issue.source_path,
+                    issue.acceptance_criteria,
                     self.device_id,
                     issue.id,
                 ],
-            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
             Ok(true)
         } else {
             self.insert_board_issue(issue)?;
@@ -558,16 +596,19 @@ impl SqliteStore {
     pub fn get_board_issue(&self, id: &str) -> Result<Option<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE id = ?1",
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria FROM board_issues WHERE id = ?1",
             [id],
             row_to_board_issue,
         ).ok().map(Ok).transpose()
     }
 
-    pub fn list_board_issues(&self, filter: &gctrl_core::BoardIssueFilter) -> Result<Vec<gctrl_core::BoardIssue>> {
+    pub fn list_board_issues(
+        &self,
+        filter: &gctrl_core::BoardIssueFilter,
+    ) -> Result<Vec<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         let mut sql = String::from(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE 1=1"
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria FROM board_issues WHERE 1=1"
         );
         let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         let mut idx = 1;
@@ -593,24 +634,37 @@ impl SqliteStore {
             params_vec.push(Box::new(limit as i64));
         }
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_board_issue)
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_board_issue)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn update_board_issue_status(&self, id: &str, status: &str, actor_id: &str, actor_name: &str, actor_type: &str) -> Result<()> {
+    pub fn update_board_issue_status(
+        &self,
+        id: &str,
+        status: &str,
+        actor_id: &str,
+        actor_name: &str,
+        actor_type: &str,
+    ) -> Result<()> {
         let target = gctrl_core::IssueStatus::from_str(status)
             .ok_or_else(|| GctlError::Storage(format!("invalid status: {}", status)))?;
 
         // Get current status
         let conn = self.conn.lock().unwrap();
-        let current_str: String = conn.query_row(
-            "SELECT status FROM board_issues WHERE id = ?1",
-            [id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(format!("issue not found: {} ({})", id, e)))?;
+        let current_str: String = conn
+            .query_row(
+                "SELECT status FROM board_issues WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("issue not found: {} ({})", id, e)))?;
 
         let current = gctrl_core::IssueStatus::from_str(&current_str)
             .unwrap_or(gctrl_core::IssueStatus::Backlog);
@@ -625,7 +679,12 @@ impl SqliteStore {
                 "invalid transition: {} -> {} (allowed: {})",
                 current.as_str(),
                 target.as_str(),
-                current.valid_transitions().iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "),
+                current
+                    .valid_transitions()
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
             )));
         };
 
@@ -671,13 +730,24 @@ impl SqliteStore {
         actor_type: &str,
     ) -> Result<Option<Task>> {
         self.update_board_issue_status(id, status, actor_id, actor_name, actor_type)?;
-        if status == gctrl_core::IssueStatus::InProgress.as_str() {
-            let conn = self.conn.lock().unwrap();
-            let task = Self::promote_issue_to_task_inner(&conn, id, agent_kind)?;
-            Ok(Some(task))
-        } else {
-            Ok(None)
+        if status != gctrl_core::IssueStatus::InProgress.as_str() {
+            return Ok(None);
         }
+        let task = {
+            let conn = self.conn.lock().unwrap();
+            Self::promote_issue_to_task_inner(&conn, id, agent_kind)?
+        };
+        // Sync acceptance_checks with the issue's acceptance_criteria so the
+        // agent has rows to POST results against. seed_acceptance_checks
+        // preserves status for unchanged (kind, command) pairs — idempotent on
+        // re-promotion.
+        let checks = self
+            .get_board_issue(id)?
+            .and_then(|i| i.acceptance_criteria)
+            .map(|s| gctrl_core::parse_acceptance_criteria(&s))
+            .unwrap_or_default();
+        self.seed_acceptance_checks(id, &checks)?;
+        Ok(Some(task))
     }
 
     /// Promote an Issue to a Task. Idempotent while the Task is non-terminal —
@@ -689,7 +759,11 @@ impl SqliteStore {
         Self::promote_issue_to_task_inner(&conn, issue_id, agent_kind)
     }
 
-    fn promote_issue_to_task_inner(conn: &Connection, issue_id: &str, agent_kind: &str) -> Result<Task> {
+    fn promote_issue_to_task_inner(
+        conn: &Connection,
+        issue_id: &str,
+        agent_kind: &str,
+    ) -> Result<Task> {
         // Reuse the existing Task if one is still non-terminal.
         let existing = Self::find_nonterminal_task_for_issue(conn, issue_id)?;
         if let Some(task) = existing {
@@ -973,22 +1047,24 @@ impl SqliteStore {
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, type, actor_id, actor_name, actor_type, timestamp, data FROM board_events WHERE issue_id = ?1 ORDER BY timestamp"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([issue_id], |row| {
-            let ts: String = row.get(6)?;
-            let data_str: String = row.get(7)?;
-            Ok(gctrl_core::BoardEvent {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                event_type: row.get(2)?,
-                actor_id: row.get(3)?,
-                actor_name: row.get(4)?,
-                actor_type: row.get(5)?,
-                timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                data: serde_json::from_str(&data_str).unwrap_or(serde_json::Value::Null),
+        let rows = stmt
+            .query_map([issue_id], |row| {
+                let ts: String = row.get(6)?;
+                let data_str: String = row.get(7)?;
+                Ok(gctrl_core::BoardEvent {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    event_type: row.get(2)?,
+                    actor_id: row.get(3)?,
+                    actor_name: row.get(4)?,
+                    actor_type: row.get(5)?,
+                    timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    data: serde_json::from_str(&data_str).unwrap_or(serde_json::Value::Null),
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -1012,34 +1088,44 @@ impl SqliteStore {
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, author_id, author_name, author_type, body, created_at, session_id FROM board_comments WHERE issue_id = ?1 ORDER BY created_at"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([issue_id], |row| {
-            let ts: String = row.get(6)?;
-            Ok(gctrl_core::BoardComment {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                author_id: row.get(2)?,
-                author_name: row.get(3)?,
-                author_type: row.get(4)?,
-                body: row.get(5)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                session_id: row.get(7)?,
+        let rows = stmt
+            .query_map([issue_id], |row| {
+                let ts: String = row.get(6)?;
+                Ok(gctrl_core::BoardComment {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    author_id: row.get(2)?,
+                    author_name: row.get(3)?,
+                    author_type: row.get(4)?,
+                    body: row.get(5)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    session_id: row.get(7)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn link_session_to_issue(&self, issue_id: &str, session_id: &str, cost: f64, tokens: u64) -> Result<()> {
+    pub fn link_session_to_issue(
+        &self,
+        issue_id: &str,
+        session_id: &str,
+        cost: f64,
+        tokens: u64,
+    ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let now = chrono::Utc::now().to_rfc3339();
 
         // Read current session_ids, append, write back
-        let current: String = conn.query_row(
-            "SELECT session_ids FROM board_issues WHERE id = ?1",
-            [issue_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let current: String = conn
+            .query_row(
+                "SELECT session_ids FROM board_issues WHERE id = ?1",
+                [issue_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut ids: Vec<String> = serde_json::from_str(&current).unwrap_or_default();
         if !ids.contains(&session_id.to_string()) {
@@ -1057,7 +1143,8 @@ impl SqliteStore {
                 synced = 0
              WHERE id = ?6",
             params![ids_json, cost, tokens as i64, now, self.device_id, issue_id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
 
@@ -1065,77 +1152,98 @@ impl SqliteStore {
     // Board sync helpers (D1)
     // ═══════════════════════════════════════════════════════════════
 
-    pub fn list_unsynced_board_projects(&self, batch_size: usize) -> Result<Vec<gctrl_core::BoardProject>> {
+    pub fn list_unsynced_board_projects(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<gctrl_core::BoardProject>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, key, counter, github_repo FROM board_projects WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([batch_size as i64], |row| {
-            Ok(gctrl_core::BoardProject {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                key: row.get(2)?,
-                counter: row.get(3)?,
-                github_repo: row.get(4)?,
+        let rows = stmt
+            .query_map([batch_size as i64], |row| {
+                Ok(gctrl_core::BoardProject {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    key: row.get(2)?,
+                    counter: row.get(3)?,
+                    github_repo: row.get(4)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
-        Ok(rows.filter_map(|r| r.ok()).collect())
-    }
-
-    pub fn list_unsynced_board_issues(&self, batch_size: usize) -> Result<Vec<gctrl_core::BoardIssue>> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([batch_size as i64], row_to_board_issue)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn list_unsynced_board_events(&self, batch_size: usize) -> Result<Vec<gctrl_core::BoardEvent>> {
+    pub fn list_unsynced_board_issues(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<gctrl_core::BoardIssue>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, acceptance_criteria FROM board_issues WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([batch_size as i64], row_to_board_issue)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    pub fn list_unsynced_board_events(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<gctrl_core::BoardEvent>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, type, actor_id, actor_name, actor_type, timestamp, data FROM board_events WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([batch_size as i64], |row| {
-            let ts: String = row.get(6)?;
-            let data_str: Option<String> = row.get(7)?;
-            Ok(gctrl_core::BoardEvent {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                event_type: row.get(2)?,
-                actor_id: row.get(3)?,
-                actor_name: row.get(4)?,
-                actor_type: row.get(5)?,
-                timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                data: data_str.and_then(|s| serde_json::from_str(&s).ok()).unwrap_or(serde_json::Value::Null),
+        let rows = stmt
+            .query_map([batch_size as i64], |row| {
+                let ts: String = row.get(6)?;
+                let data_str: Option<String> = row.get(7)?;
+                Ok(gctrl_core::BoardEvent {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    event_type: row.get(2)?,
+                    actor_id: row.get(3)?,
+                    actor_name: row.get(4)?,
+                    actor_type: row.get(5)?,
+                    timestamp: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    data: data_str
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or(serde_json::Value::Null),
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn list_unsynced_board_comments(&self, batch_size: usize) -> Result<Vec<gctrl_core::BoardComment>> {
+    pub fn list_unsynced_board_comments(
+        &self,
+        batch_size: usize,
+    ) -> Result<Vec<gctrl_core::BoardComment>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, issue_id, author_id, author_name, author_type, body, created_at, session_id FROM board_comments WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map([batch_size as i64], |row| {
-            let ts: String = row.get(6)?;
-            Ok(gctrl_core::BoardComment {
-                id: row.get(0)?,
-                issue_id: row.get(1)?,
-                author_id: row.get(2)?,
-                author_name: row.get(3)?,
-                author_type: row.get(4)?,
-                body: row.get(5)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&ts)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now()),
-                session_id: row.get(7)?,
+        let rows = stmt
+            .query_map([batch_size as i64], |row| {
+                let ts: String = row.get(6)?;
+                Ok(gctrl_core::BoardComment {
+                    id: row.get(0)?,
+                    issue_id: row.get(1)?,
+                    author_id: row.get(2)?,
+                    author_name: row.get(3)?,
+                    author_type: row.get(4)?,
+                    body: row.get(5)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&ts)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .unwrap_or_else(|_| chrono::Utc::now()),
+                    session_id: row.get(7)?,
+                })
             })
-        }).map_err(|e| GctlError::Storage(e.to_string()))?;
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
@@ -1146,8 +1254,10 @@ impl SqliteStore {
         let conn = self.conn.lock().unwrap();
         let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
         let sql = format!("UPDATE {table} SET synced = 1 WHERE id IN ({placeholders})");
-        let params_vec: Vec<&dyn rusqlite::types::ToSql> =
-            ids.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        let params_vec: Vec<&dyn rusqlite::types::ToSql> = ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
         conn.execute(&sql, params_vec.as_slice())
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
@@ -1174,7 +1284,8 @@ impl SqliteStore {
         let conn = self.conn.lock().unwrap();
         let count = |table: &str| -> u64 {
             let sql = format!("SELECT COUNT(*) FROM {table} WHERE synced = 0");
-            conn.query_row(&sql, [], |row| row.get::<_, i64>(0)).unwrap_or(0) as u64
+            conn.query_row(&sql, [], |row| row.get::<_, i64>(0))
+                .unwrap_or(0) as u64
         };
         Ok((
             count("board_projects"),
@@ -1182,6 +1293,106 @@ impl SqliteStore {
             count("board_comments"),
             count("board_events"),
         ))
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Acceptance checks
+    // ═══════════════════════════════════════════════════════════════
+
+    /// Synchronize `board_acceptance_checks` for an issue with the given parsed
+    /// checks. Idempotent on re-promotion: rows whose `(kind, command)` is
+    /// unchanged keep their existing status/output so agent results survive
+    /// re-runs. Rows whose content changed reset to `pending`. Rows whose
+    /// `check_idx` is beyond the new list are deleted (checklist shrank).
+    pub fn seed_acceptance_checks(&self, issue_id: &str, checks: &[AcceptanceCheck]) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        for check in checks {
+            let existing: Option<(String, String)> = conn
+                .query_row(
+                    "SELECT kind, command FROM board_acceptance_checks WHERE issue_id = ?1 AND check_idx = ?2",
+                    params![issue_id, check.idx as i64],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .ok();
+            let kind_str = check.kind.as_str();
+            match existing {
+                Some((ek, ec)) if ek == kind_str && ec == check.command => {
+                    // Unchanged — preserve runtime status.
+                }
+                Some(_) => {
+                    conn.execute(
+                        "UPDATE board_acceptance_checks SET kind = ?1, command = ?2, status = 'pending', output = NULL, last_session_id = NULL, last_run_at = NULL, updated_at = ?3 WHERE issue_id = ?4 AND check_idx = ?5",
+                        params![kind_str, check.command, now, issue_id, check.idx as i64],
+                    ).map_err(|e| GctlError::Storage(e.to_string()))?;
+                }
+                None => {
+                    let id = format!("acc-{}", uuid::Uuid::new_v4());
+                    conn.execute(
+                        "INSERT INTO board_acceptance_checks (id, issue_id, check_idx, kind, command, status, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', ?6, ?6)",
+                        params![id, issue_id, check.idx as i64, kind_str, check.command, now],
+                    ).map_err(|e| GctlError::Storage(e.to_string()))?;
+                }
+            }
+        }
+        conn.execute(
+            "DELETE FROM board_acceptance_checks WHERE issue_id = ?1 AND check_idx >= ?2",
+            params![issue_id, checks.len() as i64],
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Record an agent's result for one check. Returns `true` if the row
+    /// existed (and was updated). Agent POSTs land here.
+    pub fn upsert_acceptance_result(
+        &self,
+        issue_id: &str,
+        check_idx: i64,
+        status: AcceptanceStatus,
+        output: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = conn
+            .execute(
+                "UPDATE board_acceptance_checks SET status = ?1, output = ?2, last_session_id = ?3, last_run_at = ?4, updated_at = ?4 WHERE issue_id = ?5 AND check_idx = ?6",
+                params![status.as_str(), output, session_id, now, issue_id, check_idx],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows > 0)
+    }
+
+    pub fn list_acceptance_checks(&self, issue_id: &str) -> Result<Vec<AcceptanceCheckRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, issue_id, check_idx, kind, command, status, last_session_id, last_run_at, output, created_at, updated_at FROM board_acceptance_checks WHERE issue_id = ?1 ORDER BY check_idx ASC",
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([issue_id], row_to_acceptance_check)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    pub fn acceptance_rollup(&self, issue_id: &str) -> Result<AcceptanceRollup> {
+        let checks = self.list_acceptance_checks(issue_id)?;
+        let mut rollup = AcceptanceRollup {
+            total: checks.len() as u64,
+            ..AcceptanceRollup::default()
+        };
+        for c in &checks {
+            match c.status {
+                AcceptanceStatus::Pass => rollup.passed += 1,
+                AcceptanceStatus::Fail => rollup.failed += 1,
+                AcceptanceStatus::Pending => rollup.pending += 1,
+                AcceptanceStatus::Running => rollup.running += 1,
+            }
+        }
+        rollup.checks = checks;
+        Ok(rollup)
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1195,11 +1406,13 @@ impl SqliteStore {
         let specs_json = serde_json::to_string(&persona.key_specs).unwrap_or_else(|_| "[]".into());
 
         // Check if exists
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM persona_definitions WHERE id = ?1",
-            [&persona.id],
-            |row| row.get(0),
-        ).unwrap_or(false);
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM persona_definitions WHERE id = ?1",
+                [&persona.id],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
 
         if exists {
             conn.execute(
@@ -1245,7 +1458,9 @@ impl SqliteStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, focus, prompt_prefix, owns, review_focus, pushes_back, tools, key_specs, source_hash FROM persona_definitions ORDER BY name"
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut personas = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let tools_str: String = row.get(7).unwrap_or_default();
@@ -1268,7 +1483,8 @@ impl SqliteStore {
 
     pub fn delete_persona(&self, id: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let affected = conn.execute("DELETE FROM persona_definitions WHERE id = ?1", [id])
+        let affected = conn
+            .execute("DELETE FROM persona_definitions WHERE id = ?1", [id])
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(affected > 0)
     }
@@ -1279,11 +1495,13 @@ impl SqliteStore {
         let ids_json = serde_json::to_string(&rule.persona_ids).unwrap_or_else(|_| "[]".into());
 
         // Check if exists by id
-        let exists: bool = conn.query_row(
-            "SELECT COUNT(*) > 0 FROM persona_review_rules WHERE id = ?1",
-            [&rule.id],
-            |row| row.get(0),
-        ).unwrap_or(false);
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM persona_review_rules WHERE id = ?1",
+                [&rule.id],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
 
         if exists {
             conn.execute(
@@ -1302,10 +1520,12 @@ impl SqliteStore {
 
     pub fn list_review_rules(&self) -> Result<Vec<PersonaReviewRule>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT id, pr_type, persona_ids FROM persona_review_rules ORDER BY pr_type"
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT id, pr_type, persona_ids FROM persona_review_rules ORDER BY pr_type")
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let mut rules = Vec::new();
         while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
             let ids_str: String = row.get(2).unwrap_or_default();
@@ -1331,7 +1551,10 @@ impl SqliteStore {
                     persona_ids: serde_json::from_str(&ids_str).unwrap_or_default(),
                 })
             },
-        ).ok().map(Ok).transpose()
+        )
+        .ok()
+        .map(Ok)
+        .transpose()
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1424,7 +1647,11 @@ impl SqliteStore {
         let conn = self.conn.lock().unwrap();
         let needs_join = filter.project.is_some();
         let col = |name: &str| -> String {
-            if needs_join { format!("m.{}", name) } else { name.to_string() }
+            if needs_join {
+                format!("m.{}", name)
+            } else {
+                name.to_string()
+            }
         };
 
         let base = if needs_join {
@@ -1475,9 +1702,13 @@ impl SqliteStore {
             params_vec.push(Box::new(limit as i64));
         }
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_message)
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_message)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1522,9 +1753,13 @@ impl SqliteStore {
             params_vec.push(Box::new(limit as i64));
         }
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_thread)
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_thread)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1533,11 +1768,13 @@ impl SqliteStore {
         let conn = self.conn.lock().unwrap();
 
         // Validate message is pending
-        let status: String = conn.query_row(
-            "SELECT status FROM inbox_messages WHERE id = ?1",
-            [&action.message_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(format!("message not found: {}", e)))?;
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM inbox_messages WHERE id = ?1",
+                [&action.message_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("message not found: {}", e)))?;
 
         if status != "pending" {
             return Err(GctlError::Storage(format!(
@@ -1568,7 +1805,8 @@ impl SqliteStore {
         conn.execute(
             "UPDATE inbox_messages SET status = 'acted', updated_at = ?1 WHERE id = ?2",
             params![now, action.message_id],
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         // Recalc thread counts
         self.recalc_thread_counts_with_conn(&conn, &action.thread_id)?;
@@ -1606,9 +1844,13 @@ impl SqliteStore {
             params_vec.push(Box::new(limit as i64));
         }
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
-        let rows = stmt.query_map(param_refs.as_slice(), row_to_inbox_action)
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), row_to_inbox_action)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
@@ -1618,16 +1860,14 @@ impl SqliteStore {
         self.recalc_thread_counts_with_conn(&conn, thread_id)
     }
 
-    fn recalc_thread_counts_with_conn(
-        &self,
-        conn: &Connection,
-        thread_id: &str,
-    ) -> Result<()> {
-        let pending_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'",
-            [thread_id],
-            |row| row.get(0),
-        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+    fn recalc_thread_counts_with_conn(&self, conn: &Connection, thread_id: &str) -> Result<()> {
+        let pending_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'",
+                [thread_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         // Compute latest_urgency as the highest urgency among pending messages
         let urgency_order = ["critical", "high", "medium", "low", "info"];
@@ -1636,7 +1876,9 @@ impl SqliteStore {
             let mut stmt = conn.prepare(
                 "SELECT DISTINCT urgency FROM inbox_messages WHERE thread_id = ?1 AND status = 'pending'"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([thread_id]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([thread_id])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let u: String = row.get(0).unwrap_or_default();
                 let u_pos = urgency_order.iter().position(|&x| x == u).unwrap_or(4);
@@ -1662,17 +1904,25 @@ impl SqliteStore {
     pub fn get_inbox_stats(&self) -> Result<serde_json::Value> {
         let conn = self.conn.lock().unwrap();
 
-        let total: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM inbox_messages", [], |row| row.get(0))
+            .unwrap_or(0);
 
-        let pending: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE status = 'pending'", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE status = 'pending'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
 
-        let acted: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM inbox_messages WHERE status = 'acted'", [], |row| row.get(0),
-        ).unwrap_or(0);
+        let acted: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM inbox_messages WHERE status = 'acted'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
 
         // By urgency (pending only)
         let mut by_urgency = serde_json::Map::new();
@@ -1680,7 +1930,9 @@ impl SqliteStore {
             let mut stmt = conn.prepare(
                 "SELECT urgency, COUNT(*) FROM inbox_messages WHERE status = 'pending' GROUP BY urgency"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let urgency: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1694,7 +1946,9 @@ impl SqliteStore {
             let mut stmt = conn.prepare(
                 "SELECT kind, COUNT(*) FROM inbox_messages WHERE status = 'pending' GROUP BY kind"
             ).map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let kind: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1803,8 +2057,11 @@ impl SqliteStore {
             params_vec.push(Box::new(limit as i64));
         }
 
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let entries = stmt
             .query_map(param_refs.as_slice(), row_to_context_entry)
             .map_err(|e| GctlError::Storage(e.to_string()))?
@@ -1813,7 +2070,10 @@ impl SqliteStore {
 
         // Post-filter by tag (SQLite JSON array filtering is simpler in Rust)
         let entries = if let Some(ref tag) = filter.tag {
-            entries.into_iter().filter(|e| e.tags.contains(tag)).collect()
+            entries
+                .into_iter()
+                .filter(|e| e.tags.contains(tag))
+                .collect()
         } else {
             entries
         };
@@ -1823,7 +2083,8 @@ impl SqliteStore {
 
     pub fn remove_context_entry(&self, id: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let affected = conn.execute("DELETE FROM context_entries WHERE id = ?1", [id])
+        let affected = conn
+            .execute("DELETE FROM context_entries WHERE id = ?1", [id])
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(affected > 0)
     }
@@ -1845,9 +2106,12 @@ impl SqliteStore {
 
         let mut by_kind = serde_json::Map::new();
         {
-            let mut stmt = conn.prepare("SELECT kind, COUNT(*) FROM context_entries GROUP BY kind ORDER BY kind")
+            let mut stmt = conn
+                .prepare("SELECT kind, COUNT(*) FROM context_entries GROUP BY kind ORDER BY kind")
                 .map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let kind: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1859,7 +2123,9 @@ impl SqliteStore {
         {
             let mut stmt = conn.prepare("SELECT source_type, COUNT(*) FROM context_entries GROUP BY source_type ORDER BY source_type")
                 .map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let source: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -1907,7 +2173,8 @@ impl SqliteStore {
                     entry.device_id,
                     entry.name,
                 ],
-            ).map_err(|e| GctlError::Storage(e.to_string()))?;
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
             Ok(false)
         } else {
             conn.execute(
@@ -1970,7 +2237,9 @@ impl SqliteStore {
 
         let param_refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
         let entries = stmt
             .query_map(param_refs.as_slice(), row_to_memory_entry)
             .map_err(|e| GctlError::Storage(e.to_string()))?
@@ -1978,7 +2247,10 @@ impl SqliteStore {
             .collect::<Vec<_>>();
 
         let entries = if let Some(ref tag) = filter.tag {
-            entries.into_iter().filter(|e| e.tags.contains(tag)).collect()
+            entries
+                .into_iter()
+                .filter(|e| e.tags.contains(tag))
+                .collect()
         } else {
             entries
         };
@@ -2002,7 +2274,11 @@ impl SqliteStore {
             .unwrap_or(0);
 
         let unsynced: i64 = conn
-            .query_row("SELECT COUNT(*) FROM memory_entries WHERE synced = 0", [], |row| row.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM memory_entries WHERE synced = 0",
+                [],
+                |row| row.get(0),
+            )
             .unwrap_or(0);
 
         let mut by_type = Vec::new();
@@ -2010,7 +2286,9 @@ impl SqliteStore {
             let mut stmt = conn
                 .prepare("SELECT type, COUNT(*) FROM memory_entries GROUP BY type ORDER BY type")
                 .map_err(|e| GctlError::Storage(e.to_string()))?;
-            let mut rows = stmt.query([]).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query([])
+                .map_err(|e| GctlError::Storage(e.to_string()))?;
             while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
                 let ty: String = row.get(0).unwrap_or_default();
                 let count: i64 = row.get(1).unwrap_or(0);
@@ -2047,8 +2325,10 @@ impl SqliteStore {
         let conn = self.conn.lock().unwrap();
         let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
         let sql = format!("UPDATE memory_entries SET synced = 1 WHERE id IN ({placeholders})");
-        let params_vec: Vec<&dyn rusqlite::types::ToSql> =
-            ids.iter().map(|s| s as &dyn rusqlite::types::ToSql).collect();
+        let params_vec: Vec<&dyn rusqlite::types::ToSql> = ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
         conn.execute(&sql, params_vec.as_slice())
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
@@ -2196,7 +2476,8 @@ fn row_to_board_issue(row: &rusqlite::Row<'_>) -> rusqlite::Result<gctrl_core::B
         project_id: row.get(1)?,
         title: row.get(2)?,
         description: row.get(3)?,
-        status: gctrl_core::IssueStatus::from_str(&status_str).unwrap_or(gctrl_core::IssueStatus::Backlog),
+        status: gctrl_core::IssueStatus::from_str(&status_str)
+            .unwrap_or(gctrl_core::IssueStatus::Backlog),
         priority: row.get(5)?,
         assignee_id: row.get(6)?,
         assignee_name: row.get(7)?,
@@ -2216,14 +2497,48 @@ fn row_to_board_issue(row: &rusqlite::Row<'_>) -> rusqlite::Result<gctrl_core::B
         blocking: serde_json::from_str(&blocking_str).unwrap_or_default(),
         session_ids: serde_json::from_str(&session_ids_str).unwrap_or_default(),
         total_cost_usd: row.get(19)?,
-        total_tokens: { let v: i64 = row.get(20)?; v as u64 },
+        total_tokens: {
+            let v: i64 = row.get(20)?;
+            v as u64
+        },
         pr_numbers: serde_json::from_str(&pr_numbers_str).unwrap_or_default(),
         content_hash: row.get(22)?,
         source_path: row.get(23)?,
-        github_issue_number: { let v: Option<i32> = row.get(24)?; v.map(|n| n as u32) },
+        github_issue_number: {
+            let v: Option<i32> = row.get(24)?;
+            v.map(|n| n as u32)
+        },
         github_url: row.get(25)?,
         start_date: row.get(26)?,
         due_date: row.get(27)?,
+        acceptance_criteria: row.get(28)?,
+    })
+}
+
+fn row_to_acceptance_check(row: &rusqlite::Row<'_>) -> rusqlite::Result<AcceptanceCheckRow> {
+    let kind_str: String = row.get(3)?;
+    let status_str: String = row.get(5)?;
+    let last_run_at_str: Option<String> = row.get(7)?;
+    let created_at_str: String = row.get(9)?;
+    let updated_at_str: String = row.get(10)?;
+    Ok(AcceptanceCheckRow {
+        id: row.get(0)?,
+        issue_id: row.get(1)?,
+        check_idx: row.get(2)?,
+        kind: AcceptanceKind::from_str(&kind_str).unwrap_or(AcceptanceKind::Shell),
+        command: row.get(4)?,
+        status: AcceptanceStatus::from_str(&status_str).unwrap_or(AcceptanceStatus::Pending),
+        last_session_id: row.get(6)?,
+        last_run_at: last_run_at_str
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc)),
+        output: row.get(8)?,
+        created_at: chrono::DateTime::parse_from_rfc3339(&created_at_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
+        updated_at: chrono::DateTime::parse_from_rfc3339(&updated_at_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
     })
 }
 
@@ -2242,7 +2557,10 @@ fn row_to_inbox_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<InboxMessag
         status: row.get(8)?,
         requires_action: row.get(9)?,
         payload: payload_str.and_then(|s| serde_json::from_str(&s).ok()),
-        duplicate_count: { let v: i32 = row.get(11)?; v as u32 },
+        duplicate_count: {
+            let v: i32 = row.get(11)?;
+            v as u32
+        },
         snoozed_until: row.get(12)?,
         expires_at: row.get(13)?,
         created_at: row.get(14)?,
@@ -2455,6 +2773,7 @@ mod tests {
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         };
         store.insert_board_issue(&issue).unwrap();
 
@@ -2474,7 +2793,9 @@ mod tests {
         assert_eq!(issues.len(), 1);
 
         // Update status
-        store.update_board_issue_status("TEST-1", "todo", "user-1", "Alice", "human").unwrap();
+        store
+            .update_board_issue_status("TEST-1", "todo", "user-1", "Alice", "human")
+            .unwrap();
         let updated = store.get_board_issue("TEST-1").unwrap().unwrap();
         assert_eq!(updated.status, IssueStatus::Todo);
     }
@@ -2483,9 +2804,9 @@ mod tests {
     fn test_create_and_list_inbox_messages() {
         let store = test_store();
 
-        let thread = store.get_or_create_inbox_thread(
-            "pr", "org/repo#42", "PR #42: Fix stuff", Some("BOARD"),
-        ).unwrap();
+        let thread = store
+            .get_or_create_inbox_thread("pr", "org/repo#42", "PR #42: Fix stuff", Some("BOARD"))
+            .unwrap();
         assert_eq!(thread.context_type, "pr");
         assert_eq!(thread.pending_count, 0);
 
@@ -2581,11 +2902,21 @@ mod tests {
         let now = Utc::now().to_rfc3339();
 
         // Create
-        let created = store.upsert_context_entry(
-            "ctx-1", "document", "notes/test.md", "Test Note",
-            "human", None, 42, "hash123",
-            &["test".into()], &now, &now,
-        ).unwrap();
+        let created = store
+            .upsert_context_entry(
+                "ctx-1",
+                "document",
+                "notes/test.md",
+                "Test Note",
+                "human",
+                None,
+                42,
+                "hash123",
+                &["test".into()],
+                &now,
+                &now,
+            )
+            .unwrap();
         assert!(created);
 
         // Get
@@ -2598,11 +2929,21 @@ mod tests {
         assert_eq!(fetched.tags, vec!["test".to_string()]);
 
         // Upsert (update by path)
-        let updated = store.upsert_context_entry(
-            "ctx-1", "document", "notes/test.md", "Updated Title",
-            "human", None, 50, "hash456",
-            &["test".into(), "updated".into()], &now, &now,
-        ).unwrap();
+        let updated = store
+            .upsert_context_entry(
+                "ctx-1",
+                "document",
+                "notes/test.md",
+                "Updated Title",
+                "human",
+                None,
+                50,
+                "hash456",
+                &["test".into(), "updated".into()],
+                &now,
+                &now,
+            )
+            .unwrap();
         assert!(!updated); // was update, not create
 
         let fetched = store.get_context_entry("ctx-1").unwrap().unwrap();
@@ -2610,7 +2951,9 @@ mod tests {
         assert_eq!(fetched.word_count, 50);
 
         // List
-        let all = store.list_context_entries(&ContextFilter::default()).unwrap();
+        let all = store
+            .list_context_entries(&ContextFilter::default())
+            .unwrap();
         assert_eq!(all.len(), 1);
 
         // Remove
@@ -2624,12 +2967,36 @@ mod tests {
         let store = test_store();
         let now = Utc::now().to_rfc3339();
 
-        store.upsert_context_entry(
-            "ctx-1", "document", "a.md", "A", "human", None, 10, "h1", &[], &now, &now,
-        ).unwrap();
-        store.upsert_context_entry(
-            "ctx-2", "config", "b.md", "B", "system", Some("board"), 20, "h2", &[], &now, &now,
-        ).unwrap();
+        store
+            .upsert_context_entry(
+                "ctx-1",
+                "document",
+                "a.md",
+                "A",
+                "human",
+                None,
+                10,
+                "h1",
+                &[],
+                &now,
+                &now,
+            )
+            .unwrap();
+        store
+            .upsert_context_entry(
+                "ctx-2",
+                "config",
+                "b.md",
+                "B",
+                "system",
+                Some("board"),
+                20,
+                "h2",
+                &[],
+                &now,
+                &now,
+            )
+            .unwrap();
 
         let stats = store.get_context_stats().unwrap();
         assert_eq!(stats["total_entries"], 2);
@@ -2683,24 +3050,34 @@ mod tests {
     #[test]
     fn test_memory_list_and_filter() {
         let store = test_store();
-        store.upsert_memory(&make_memory("m_user", MemoryType::User, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("m_fb", MemoryType::Feedback, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("m_ref", MemoryType::Reference, "dev-a")).unwrap();
+        store
+            .upsert_memory(&make_memory("m_user", MemoryType::User, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("m_fb", MemoryType::Feedback, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("m_ref", MemoryType::Reference, "dev-a"))
+            .unwrap();
 
         let all = store.list_memories(&MemoryFilter::default()).unwrap();
         assert_eq!(all.len(), 3);
 
-        let fb_only = store.list_memories(&MemoryFilter {
-            memory_type: Some(MemoryType::Feedback),
-            ..Default::default()
-        }).unwrap();
+        let fb_only = store
+            .list_memories(&MemoryFilter {
+                memory_type: Some(MemoryType::Feedback),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(fb_only.len(), 1);
         assert_eq!(fb_only[0].name, "m_fb");
 
-        let searched = store.list_memories(&MemoryFilter {
-            search: Some("user".into()),
-            ..Default::default()
-        }).unwrap();
+        let searched = store
+            .list_memories(&MemoryFilter {
+                search: Some("user".into()),
+                ..Default::default()
+            })
+            .unwrap();
         assert_eq!(searched.len(), 1);
         assert_eq!(searched[0].name, "m_user");
     }
@@ -2708,8 +3085,12 @@ mod tests {
     #[test]
     fn test_memory_unique_per_device() {
         let store = test_store();
-        store.upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-b")).unwrap();
+        store
+            .upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("shared_name", MemoryType::Project, "dev-b"))
+            .unwrap();
 
         let all = store.list_memories(&MemoryFilter::default()).unwrap();
         assert_eq!(all.len(), 2, "same name on different devices must coexist");
@@ -2718,8 +3099,12 @@ mod tests {
     #[test]
     fn test_memory_sync_roundtrip() {
         let store = test_store();
-        store.upsert_memory(&make_memory("a", MemoryType::User, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("b", MemoryType::User, "dev-a")).unwrap();
+        store
+            .upsert_memory(&make_memory("a", MemoryType::User, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("b", MemoryType::User, "dev-a"))
+            .unwrap();
 
         let pending = store.list_unsynced_memories(100).unwrap();
         assert_eq!(pending.len(), 2);
@@ -2741,14 +3126,24 @@ mod tests {
     #[test]
     fn test_memory_stats() {
         let store = test_store();
-        store.upsert_memory(&make_memory("u1", MemoryType::User, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("u2", MemoryType::User, "dev-a")).unwrap();
-        store.upsert_memory(&make_memory("f1", MemoryType::Feedback, "dev-a")).unwrap();
+        store
+            .upsert_memory(&make_memory("u1", MemoryType::User, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("u2", MemoryType::User, "dev-a"))
+            .unwrap();
+        store
+            .upsert_memory(&make_memory("f1", MemoryType::Feedback, "dev-a"))
+            .unwrap();
 
         let stats = store.get_memory_stats().unwrap();
         assert_eq!(stats.total_entries, 3);
         assert_eq!(stats.unsynced, 3);
-        let user_count = stats.by_type.iter().find(|(k, _)| k == "user").map(|(_, v)| *v);
+        let user_count = stats
+            .by_type
+            .iter()
+            .find(|(k, _)| k == "user")
+            .map(|(_, v)| *v);
         assert_eq!(user_count, Some(2));
     }
 
@@ -2783,19 +3178,22 @@ mod tests {
             github_url: None,
             start_date: None,
             due_date: None,
+            acceptance_criteria: None,
         }
     }
 
     #[test]
     fn board_writes_stamp_device_and_unsynced() {
         let store = SqliteStore::open_with_device(":memory:", "dev-1").unwrap();
-        store.create_board_project(&BoardProject {
-            id: "p1".into(),
-            name: "P".into(),
-            key: "P".into(),
-            counter: 0,
-            github_repo: None,
-        }).unwrap();
+        store
+            .create_board_project(&BoardProject {
+                id: "p1".into(),
+                name: "P".into(),
+                key: "P".into(),
+                counter: 0,
+                github_repo: None,
+            })
+            .unwrap();
         store.insert_board_issue(&make_issue("P-1", "p1")).unwrap();
 
         let projects = store.list_unsynced_board_projects(10).unwrap();
@@ -2812,17 +3210,21 @@ mod tests {
     #[test]
     fn board_round_trip_mark_synced() {
         let store = SqliteStore::open_with_device(":memory:", "dev-1").unwrap();
-        store.create_board_project(&BoardProject {
-            id: "p1".into(),
-            name: "P".into(),
-            key: "P".into(),
-            counter: 0,
-            github_repo: None,
-        }).unwrap();
+        store
+            .create_board_project(&BoardProject {
+                id: "p1".into(),
+                name: "P".into(),
+                key: "P".into(),
+                counter: 0,
+                github_repo: None,
+            })
+            .unwrap();
         store.insert_board_issue(&make_issue("P-1", "p1")).unwrap();
 
         // Status change emits an event AND bumps issue updated_at.
-        store.update_board_issue_status("P-1", "todo", "u", "u", "human").unwrap();
+        store
+            .update_board_issue_status("P-1", "todo", "u", "u", "human")
+            .unwrap();
 
         let comment = BoardComment {
             id: "c1".into(),
@@ -2837,14 +3239,30 @@ mod tests {
         store.insert_board_comment(&comment).unwrap();
 
         // Fetch unsynced, mark them, expect zero unsynced after.
-        let projects: Vec<String> = store.list_unsynced_board_projects(10).unwrap()
-            .into_iter().map(|p| p.id).collect();
-        let issues: Vec<String> = store.list_unsynced_board_issues(10).unwrap()
-            .into_iter().map(|i| i.id).collect();
-        let events: Vec<String> = store.list_unsynced_board_events(10).unwrap()
-            .into_iter().map(|e| e.id).collect();
-        let comments: Vec<String> = store.list_unsynced_board_comments(10).unwrap()
-            .into_iter().map(|c| c.id).collect();
+        let projects: Vec<String> = store
+            .list_unsynced_board_projects(10)
+            .unwrap()
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        let issues: Vec<String> = store
+            .list_unsynced_board_issues(10)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.id)
+            .collect();
+        let events: Vec<String> = store
+            .list_unsynced_board_events(10)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+        let comments: Vec<String> = store
+            .list_unsynced_board_comments(10)
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
 
         assert!(!projects.is_empty());
         assert!(!issues.is_empty());
@@ -2863,22 +3281,30 @@ mod tests {
     #[test]
     fn board_update_resets_synced_flag() {
         let store = SqliteStore::open_with_device(":memory:", "dev-1").unwrap();
-        store.create_board_project(&BoardProject {
-            id: "p1".into(),
-            name: "P".into(),
-            key: "P".into(),
-            counter: 0,
-            github_repo: None,
-        }).unwrap();
+        store
+            .create_board_project(&BoardProject {
+                id: "p1".into(),
+                name: "P".into(),
+                key: "P".into(),
+                counter: 0,
+                github_repo: None,
+            })
+            .unwrap();
         store.insert_board_issue(&make_issue("P-1", "p1")).unwrap();
 
-        let issues: Vec<String> = store.list_unsynced_board_issues(10).unwrap()
-            .into_iter().map(|i| i.id).collect();
+        let issues: Vec<String> = store
+            .list_unsynced_board_issues(10)
+            .unwrap()
+            .into_iter()
+            .map(|i| i.id)
+            .collect();
         store.mark_board_issues_synced(&issues).unwrap();
         assert_eq!(store.list_unsynced_board_issues(10).unwrap().len(), 0);
 
         // A subsequent local edit must mark the row unsynced again.
-        store.assign_board_issue("P-1", "u2", "User 2", "human").unwrap();
+        store
+            .assign_board_issue("P-1", "u2", "User 2", "human")
+            .unwrap();
         assert_eq!(store.list_unsynced_board_issues(10).unwrap().len(), 1);
     }
 
@@ -2895,6 +3321,27 @@ mod tests {
             last_synced_at: None,
             created_at: now,
             updated_at: now,
+        }
+    }
+
+    fn setup_issue_for_acceptance(store: &SqliteStore) {
+        store
+            .create_board_project(&BoardProject {
+                id: "p1".into(),
+                name: "P".into(),
+                key: "P".into(),
+                counter: 0,
+                github_repo: None,
+            })
+            .unwrap();
+        store.insert_board_issue(&make_issue("P-1", "p1")).unwrap();
+    }
+
+    fn shell(idx: usize, cmd: &str) -> AcceptanceCheck {
+        AcceptanceCheck {
+            idx,
+            kind: AcceptanceKind::Shell,
+            command: cmd.into(),
         }
     }
 
@@ -2955,5 +3402,108 @@ mod tests {
         let m = store.get_vault_mount("ext").unwrap().unwrap();
         assert_eq!(m.last_commit_sha.as_deref(), Some("abc123def"));
         assert!(m.last_synced_at.is_some());
+    }
+
+    #[test]
+    fn seed_inserts_pending_rows_in_index_order() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        let checks = vec![shell(0, "curl a"), shell(1, "curl b")];
+        store.seed_acceptance_checks("P-1", &checks).unwrap();
+
+        let rows = store.list_acceptance_checks("P-1").unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].check_idx, 0);
+        assert_eq!(rows[1].check_idx, 1);
+        assert_eq!(rows[0].status, AcceptanceStatus::Pending);
+        assert_eq!(rows[0].command, "curl a");
+    }
+
+    #[test]
+    fn seed_preserves_status_for_unchanged_checks() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        let checks = vec![shell(0, "curl a")];
+        store.seed_acceptance_checks("P-1", &checks).unwrap();
+        store
+            .upsert_acceptance_result("P-1", 0, AcceptanceStatus::Pass, Some("ok"), Some("sess1"))
+            .unwrap();
+
+        store.seed_acceptance_checks("P-1", &checks).unwrap();
+        let rows = store.list_acceptance_checks("P-1").unwrap();
+        assert_eq!(rows[0].status, AcceptanceStatus::Pass);
+        assert_eq!(rows[0].output.as_deref(), Some("ok"));
+        assert_eq!(rows[0].last_session_id.as_deref(), Some("sess1"));
+    }
+
+    #[test]
+    fn seed_resets_status_when_check_content_changes() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        store
+            .seed_acceptance_checks("P-1", &[shell(0, "curl a")])
+            .unwrap();
+        store
+            .upsert_acceptance_result("P-1", 0, AcceptanceStatus::Pass, Some("ok"), None)
+            .unwrap();
+
+        store
+            .seed_acceptance_checks("P-1", &[shell(0, "curl DIFFERENT")])
+            .unwrap();
+        let rows = store.list_acceptance_checks("P-1").unwrap();
+        assert_eq!(rows[0].command, "curl DIFFERENT");
+        assert_eq!(rows[0].status, AcceptanceStatus::Pending);
+        assert_eq!(rows[0].output, None);
+        assert_eq!(rows[0].last_session_id, None);
+    }
+
+    #[test]
+    fn seed_deletes_trailing_rows_when_list_shrinks() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        store
+            .seed_acceptance_checks("P-1", &[shell(0, "a"), shell(1, "b"), shell(2, "c")])
+            .unwrap();
+        store
+            .seed_acceptance_checks("P-1", &[shell(0, "a")])
+            .unwrap();
+
+        let rows = store.list_acceptance_checks("P-1").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].command, "a");
+    }
+
+    #[test]
+    fn upsert_result_returns_false_when_row_missing() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        let updated = store
+            .upsert_acceptance_result("P-1", 99, AcceptanceStatus::Pass, None, None)
+            .unwrap();
+        assert!(!updated);
+    }
+
+    #[test]
+    fn rollup_counts_by_status() {
+        let store = test_store();
+        setup_issue_for_acceptance(&store);
+        store
+            .seed_acceptance_checks("P-1", &[shell(0, "a"), shell(1, "b"), shell(2, "c")])
+            .unwrap();
+        store
+            .upsert_acceptance_result("P-1", 0, AcceptanceStatus::Pass, None, None)
+            .unwrap();
+        store
+            .upsert_acceptance_result("P-1", 1, AcceptanceStatus::Fail, Some("boom"), None)
+            .unwrap();
+
+        let rollup = store.acceptance_rollup("P-1").unwrap();
+        assert_eq!(rollup.total, 3);
+        assert_eq!(rollup.passed, 1);
+        assert_eq!(rollup.failed, 1);
+        assert_eq!(rollup.pending, 1);
+        assert_eq!(rollup.running, 0);
+        assert_eq!(rollup.checks.len(), 3);
+        assert_eq!(rollup.checks[1].output.as_deref(), Some("boom"));
     }
 }

--- a/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
+++ b/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
@@ -62,6 +62,7 @@ fn seed_issue(
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     };
     store.insert_board_issue(&issue).expect("insert issue");
 }

--- a/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
+++ b/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
@@ -54,6 +54,7 @@ fn seed_project_and_issue(store: &SqliteStore, key: &str, issue_id: &str) {
         github_url: None,
         start_date: None,
         due_date: None,
+        acceptance_criteria: None,
     };
     store.insert_board_issue(&issue).expect("insert issue");
 }

--- a/kernel/crates/gctrl-sync/src/engine.rs
+++ b/kernel/crates/gctrl-sync/src/engine.rs
@@ -988,6 +988,7 @@ mod tests {
                 content_hash: None, source_path: None,
                 github_issue_number: None, github_url: None,
                 start_date: None, due_date: None,
+                acceptance_criteria: None,
             }).unwrap();
         }
 


### PR DESCRIPTION
## Summary

Add structured **acceptance checks** to board Issues. Checks are parsed from an Issue's `acceptance_criteria` markdown (`- [ ] kind: command` with kind ∈ {shell, test, http}) and persisted as one row per check in `board_acceptance_checks` (natural key: `issue_id` + `check_idx`). Agents POST results back to the kernel; the Issue card shows a pass/fail badge.

End-to-end flow:

```mermaid
sequenceDiagram
  participant UI as Board UI
  participant W as Worker (facade)
  participant K as Kernel (truth)
  participant O as Orch
  participant A as Agent

  O->>K: GET issue + acceptance checks
  O->>A: brief incl. `## Acceptance Tests` + callback URL
  A->>K: POST /api/board/issues/:id/acceptance/checks/:idx {status,output}
  UI->>W: GET /api/board/issues/:id/acceptance
  W->>K: GET /api/board/issues/:id/acceptance
  K-->>W: rollup
  W-->>UI: rollup (→ AcceptanceBadge)
```

Composes with the `## Agent: <name>` handoff convention codified in #60: `prompt::build_prompt` layers an `## Acceptance Tests` section onto whatever the latest dispatch comment said, with a callback URL injected from `OrchConfig.kernel_base_url` (defaulting to `GCTL_KERNEL_BASE_URL` env var or `http://127.0.0.1:4318`).

## Changes

**Kernel**
- `gctrl-core::acceptance` — domain types (`AcceptanceKind`, `AcceptanceStatus`, `AcceptanceCheck`, `AcceptanceCheckRow`, `AcceptanceRollup`) + markdown parser (11 unit tests).
- `board_acceptance_checks` table on SQLite + DuckDB; `acceptance_criteria` column added to `board_issues` (alongside the gantt `start_date`/`due_date` columns from #56).
- `gctrl-storage`: SQLite + DuckDB CRUD — `seed_acceptance_checks` (idempotent, resets status only when command content changes, deletes trailing rows when list shrinks), `upsert_acceptance_result`, `acceptance_rollup` (6 unit tests).
- `gctrl-otel` routes (5 integration tests in `tests/acceptance_routes.rs`):
  - `GET  /api/board/issues/:id/acceptance` → `AcceptanceRollup`
  - `POST /api/board/issues/:id/acceptance/checks/:idx` → agent callback `{status: pass|fail, output, session_id?}`
- `gctrl-orch::prompt` — appends a `## Acceptance Tests` section to the agent brief (only when checks are non-empty) with the per-check callback URL.

**Apps**
- `apps/gctrl-board/src/worker.ts` — proxies rollup GETs to the kernel (kernel = source of truth, Worker = read facade; graceful empty-rollup fallback when kernel is unreachable).
- `apps/gctrl-board/web/src/components/AcceptanceBadge.tsx` — `AC n/m ✓/✗` badge on each `IssueCard`, tone driven by pass/fail/pending counts.
- `apps/gctrl-board/web/src/api/client.ts` — `api.issues.acceptance(id)`; `AcceptanceRollup` + related types in `web/src/types.ts`.

## Test plan

- [x] `cargo test -p gctrl-core` — 11 acceptance unit tests pass.
- [x] `cargo test -p gctrl-otel --test acceptance_routes` — 5 route tests pass.
- [x] `cargo test -p gctrl-storage --lib` — 96 tests pass (incl. 6 acceptance + 5 vault_mount tests preserved through rebase).
- [ ] Manual: start kernel + Worker, open a Todo with `acceptance_criteria` markdown, drag to In-Progress, verify agent brief has the checklist + callback URL, POST a pass + fail, watch the badge update.

## Known follow-ups

- **Markdown round-trip is incomplete.** `parse_issue_markdown` / `issue_to_markdown` (`board_markdown.rs`) don't yet read or emit an `acceptance_criteria` section, so vault import sets it to `None`. Once the vault watcher becomes the canonical write path, criteria entered in vault `.md` files won't reach `board_acceptance_checks` until this is wired up. ~30-line follow-up.
- **Execution model.** This PR ships the verification protocol (parse → seed → callback → rollup) but assumes the agent runs the shell/test/http commands and self-reports. Server-side execution would be a separate driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
