### PR TITLE
fix(ci): switch from Depot to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   # ──────────────────────────────────────────────
   rust:
     name: Rust (build + test)
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -80,7 +80,7 @@ jobs:
   # ──────────────────────────────────────────────
   typescript:
     name: TypeScript (lint + test + build)
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -132,7 +132,7 @@ jobs:
   # ──────────────────────────────────────────────
   playwright:
     name: Playwright acceptance tests
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: [changes, rust, typescript]
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
   # ── Preview deploy (PR) ──
   preview:
     name: Deploy preview
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
     permissions:
@@ -101,7 +101,7 @@ jobs:
   #    idle gaps between test files.
   acceptance:
     name: Acceptance (preview Worker)
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: [preview]
     if: github.event_name == 'pull_request'
@@ -170,7 +170,7 @@ jobs:
   # ── Production deploy (main) ──
   deploy:
     name: Deploy to Cloudflare Workers
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     # Skip deploy if CI failed (workflow_run triggers on both success and failure)
     if: >-


### PR DESCRIPTION
## Summary

- Depot runners have been consistently dropping with `The self-hosted runner lost communication with the server` at the 10-min mark since `2026-04-23T07:35Z`. This blocks all full-build CI on `main` and every PR (doc-only runs mask the outage by skipping code jobs).
- Last green full build: run [24789993739](https://github.com/OpenHackersClub/gctrl/actions/runs/24789993739) (2026-04-22 16:27 UTC).
- Every full-build run since has failed the same way — reruns reproduce it.
- Swap `depot-ubuntu-24.04` → `ubuntu-24.04` (GitHub-hosted) across `ci.yml` + `deploy.yml` so builds can proceed. Revert when Depot is healthy.

## Test plan

- [ ] This PR's own CI run completes (Rust + TypeScript + Playwright all green on GitHub-hosted runners)
- [ ] Preview deploy job in `deploy.yml` also succeeds on GitHub-hosted runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)