### PR TITLE
feat(analytics): spec + M0/M1 dashboard tab in gctrl-board

### DIFF
--- a/apps/gctrl-board/web/src/App.tsx
+++ b/apps/gctrl-board/web/src/App.tsx
@@ -10,6 +10,7 @@ import { CreateIssueDialog } from "./components/CreateIssueDialog"
 import { ProjectSelector } from "./components/ProjectSelector"
 import { NavSidebar } from "./components/NavSidebar"
 import { InboxPage } from "./pages/InboxPage"
+import { AnalyticsPage } from "./pages/AnalyticsPage"
 import { api } from "./api/client"
 import type { Issue, InboxStats } from "./types"
 
@@ -226,7 +227,12 @@ export function App() {
 
   const selectedProject = projects.find((p) => p.id === selectedProjectId)
 
-  const pageTitle = route.page === "inbox" ? "inbox" : "board"
+  const pageTitle =
+    route.page === "inbox"
+      ? "inbox"
+      : route.page === "analytics"
+        ? "analytics"
+        : "board"
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-200 font-body grid-bg flex">
@@ -355,8 +361,10 @@ export function App() {
 
             {/* Dispatch is now automatic — no dialog needed */}
           </>
-        ) : (
+        ) : route.page === "inbox" ? (
           <InboxPage />
+        ) : (
+          <AnalyticsPage route={route} navigate={navigate} />
         )}
       </div>
 

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -11,6 +11,15 @@ import type {
   InboxAction,
   InboxStats,
   GanttView,
+  SessionSummary,
+  AnalyticsOverview,
+  CostAnalytics,
+  DailyEntry,
+  TraceTreeResponse,
+  LatencyAnalytics,
+  SpanAnalytics,
+  ScoreSummary,
+  AlertRule,
 } from "../types"
 
 const BASE = "/api/board"
@@ -218,5 +227,40 @@ export const api = {
       }),
 
     stats: () => request<InboxStats>("/api/inbox/stats"),
+  },
+
+  // Kernel analytics + sessions — proxied by Vite dev server to :4318.
+  // In production these hit the same origin and must be routed by the Worker
+  // to the kernel HTTP API (see gctrl-analytics spec §5).
+  sessions: {
+    list: (params?: { limit?: number; agent?: string; status?: string }) => {
+      const qs = new URLSearchParams()
+      if (params?.limit !== undefined) qs.set("limit", String(params.limit))
+      if (params?.agent) qs.set("agent", params.agent)
+      if (params?.status) qs.set("status", params.status)
+      const q = qs.toString()
+      return request<SessionSummary[]>(`/api/sessions${q ? `?${q}` : ""}`)
+    },
+
+    get: (id: string) => request<SessionSummary>(`/api/sessions/${id}`),
+
+    tree: (id: string) =>
+      request<TraceTreeResponse>(`/api/sessions/${id}/tree`),
+  },
+
+  analytics: {
+    overview: () => request<AnalyticsOverview>("/api/analytics"),
+    cost: () => request<CostAnalytics>("/api/analytics/cost"),
+    daily: (days?: number) => {
+      const q = days !== undefined ? `?days=${days}` : ""
+      return request<DailyEntry[]>(`/api/analytics/daily${q}`)
+    },
+    latency: () => request<LatencyAnalytics>("/api/analytics/latency"),
+    spans: () => request<SpanAnalytics>("/api/analytics/spans"),
+    score: (name: string) =>
+      request<ScoreSummary>(
+        `/api/analytics/scores?name=${encodeURIComponent(name)}`,
+      ),
+    alerts: () => request<AlertRule[]>("/api/analytics/alerts"),
   },
 }

--- a/apps/gctrl-board/web/src/components/NavSidebar.tsx
+++ b/apps/gctrl-board/web/src/components/NavSidebar.tsx
@@ -38,6 +38,22 @@ function InboxIcon({ active }: { active: boolean }) {
   )
 }
 
+function AnalyticsIcon({ active }: { active: boolean }) {
+  const color = active ? "text-emerald-400" : "text-zinc-500"
+  return (
+    <svg
+      className={`w-5 h-5 ${color} transition-colors duration-150`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      {/* Bar chart icon */}
+      <rect x="3" y="11" width="3" height="6" rx="0.5" />
+      <rect x="8.5" y="7" width="3" height="10" rx="0.5" />
+      <rect x="14" y="3" width="3" height="14" rx="0.5" />
+    </svg>
+  )
+}
+
 function GctlMark() {
   return (
     <div className="flex items-center justify-center">
@@ -53,6 +69,7 @@ function GctlMark() {
 export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
   const isBoardActive = route.page === "board"
   const isInboxActive = route.page === "inbox"
+  const isAnalyticsActive = route.page === "analytics"
 
   return (
     <nav className="w-14 min-h-screen bg-zinc-950 border-r border-zinc-800 flex flex-col items-center py-4 gap-1 shrink-0">
@@ -79,6 +96,16 @@ export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
             {unreadCount > 99 ? "99+" : unreadCount}
           </span>
         )}
+      </button>
+
+      {/* Analytics nav item */}
+      <button
+        onClick={() => navigate("/analytics")}
+        className={`w-10 h-10 flex items-center justify-center rounded-md transition-all duration-150 cursor-pointer
+          ${isAnalyticsActive ? "bg-emerald-500/10" : "hover:bg-zinc-800/60"}`}
+        title="Analytics"
+      >
+        <AnalyticsIcon active={isAnalyticsActive} />
       </button>
 
       {/* Spacer */}

--- a/apps/gctrl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.ts
@@ -2,11 +2,31 @@ import { useState, useCallback, useEffect } from "react"
 
 export type BoardView = "kanban" | "gantt"
 
+export type AnalyticsTab = "overview" | "sessions" | "usage" | "evals"
+
 export type Route =
   | { page: "board"; projectKey: string | null; view: BoardView }
   | { page: "inbox"; threadId: string | null }
+  | { page: "analytics"; tab: AnalyticsTab; sessionId: string | null }
 
 function parseRoute(pathname: string): Route {
+  // /analytics/sessions/:sessionId
+  const analyticsSession = pathname.match(/^\/analytics\/sessions\/([^/]+)/)
+  if (analyticsSession) {
+    return { page: "analytics", tab: "sessions", sessionId: analyticsSession[1] }
+  }
+
+  // /analytics/:tab
+  const analyticsTab = pathname.match(/^\/analytics\/(overview|sessions|usage|evals)\/?$/)
+  if (analyticsTab) {
+    return { page: "analytics", tab: analyticsTab[1] as AnalyticsTab, sessionId: null }
+  }
+
+  // /analytics
+  if (pathname === "/analytics" || pathname === "/analytics/") {
+    return { page: "analytics", tab: "overview", sessionId: null }
+  }
+
   // /inbox/:threadId
   const inboxThread = pathname.match(/^\/inbox\/([^/]+)/)
   if (inboxThread) {

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -49,8 +49,11 @@ export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
           onClick={() => navigate("/analytics/evals")}
         />
         <div className="flex-1" />
-        <span className="text-[11px] font-mono text-zinc-600 tracking-wide">
-          M0 · poll {LIVE_REFRESH_MS / 1000}s · SSE pending
+        <span
+          className="text-[11px] font-mono text-zinc-600 tracking-wide"
+          title="Live values poll every 5 seconds. SSE streaming will replace this when GET /api/sessions/stream lands."
+        >
+          refresh {LIVE_REFRESH_MS / 1000}s
         </span>
       </div>
 
@@ -101,19 +104,24 @@ function TabButton({
 function OverviewTab() {
   const [overview, setOverview] = useState<AnalyticsOverview | null>(null)
   const [cost, setCost] = useState<CostAnalytics | null>(null)
+  const [liveCount, setLiveCount] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     const load = async () => {
       try {
-        const [o, c] = await Promise.all([
+        const [o, c, live] = await Promise.all([
           api.analytics.overview(),
           api.analytics.cost(),
+          // Kernel's /api/analytics rollup has no active_sessions field;
+          // count from sessions.list?status=active instead.
+          api.sessions.list({ status: "active", limit: 200 }),
         ])
         if (!cancelled) {
           setOverview(o)
           setCost(c)
+          setLiveCount(live.length)
           setError(null)
         }
       } catch (e) {
@@ -147,7 +155,7 @@ function OverviewTab() {
     <div className="p-6 space-y-6">
       {/* KPI row */}
       <div className="grid grid-cols-4 gap-4">
-        <Kpi label="Live sessions" value={overview.active_sessions} accent />
+        <Kpi label="Live sessions" value={liveCount ?? "—"} accent />
         <Kpi label="Total sessions" value={overview.total_sessions} />
         <Kpi label="Spans" value={overview.total_spans.toLocaleString()} />
         <Kpi
@@ -1024,7 +1032,19 @@ function ScoreLookupPanel() {
           <div className="text-[13px] text-zinc-500 font-mono">Loading…</div>
         )}
         {submitted && error && (
-          <div className="text-[13px] text-rose-400 font-mono">{error}</div>
+          <div className="text-[13px] font-mono space-y-1">
+            <div className="text-rose-400">
+              No score named "{submitted}" — try another rule.
+            </div>
+            <div className="text-zinc-500">
+              Common names: <code className="text-zinc-300">tests_pass</code>,{" "}
+              <code className="text-zinc-300">quality</code>,{" "}
+              <code className="text-zinc-300">loop_detected</code>. Run{" "}
+              <code className="text-zinc-300">gctrl analytics scores</code> for
+              the full list.
+            </div>
+            <div className="text-zinc-700 text-[11px]">{error}</div>
+          </div>
         )}
         {submitted && summary && (
           <div className="grid grid-cols-4 gap-3">

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,1077 @@
+import { useEffect, useState, type ReactNode } from "react"
+import { api } from "../api/client"
+import type {
+  AnalyticsOverview,
+  CostAnalytics,
+  SessionSummary,
+  TraceTreeNode,
+  TraceTreeResponse,
+  LatencyAnalytics,
+  SpanAnalytics,
+  ScoreSummary,
+  AlertRule,
+} from "../types"
+import type { Route } from "../hooks/useRoute"
+
+interface AnalyticsPageProps {
+  route: Extract<Route, { page: "analytics" }>
+  navigate: (path: string) => void
+}
+
+/** Poll-refresh placeholder until SSE (Kernel Dependencies §5) lands.
+ *  The spec says no polling fallback — this is the M0-before-streams hack
+ *  and should disappear once GET /api/sessions/stream is available. */
+const LIVE_REFRESH_MS = 5_000
+
+export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
+  return (
+    <div className="flex-1 flex flex-col min-w-0 bg-zinc-950">
+      {/* Tab bar */}
+      <div className="h-10 border-b border-zinc-800/80 flex items-center gap-1 px-4 bg-zinc-950/90">
+        <TabButton
+          label="Overview"
+          active={route.tab === "overview"}
+          onClick={() => navigate("/analytics/overview")}
+        />
+        <TabButton
+          label="Sessions"
+          active={route.tab === "sessions"}
+          onClick={() => navigate("/analytics/sessions")}
+        />
+        <TabButton
+          label="Usage"
+          active={route.tab === "usage"}
+          onClick={() => navigate("/analytics/usage")}
+        />
+        <TabButton
+          label="Evals"
+          active={route.tab === "evals"}
+          onClick={() => navigate("/analytics/evals")}
+        />
+        <div className="flex-1" />
+        <span className="text-[11px] font-mono text-zinc-600 tracking-wide">
+          M0 · poll {LIVE_REFRESH_MS / 1000}s · SSE pending
+        </span>
+      </div>
+
+      {/* Tab body */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        {route.tab === "overview" && <OverviewTab />}
+        {route.tab === "sessions" && (
+          <SessionsTab
+            selectedSessionId={route.sessionId}
+            onSelectSession={(id) =>
+              navigate(id ? `/analytics/sessions/${id}` : "/analytics/sessions")
+            }
+          />
+        )}
+        {route.tab === "usage" && <UsageTab />}
+        {route.tab === "evals" && <EvalsTab />}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 h-8 text-[12px] font-display tracking-wide uppercase transition-colors cursor-pointer
+        ${
+          active
+            ? "text-emerald-400 border-b-2 border-emerald-400"
+            : "text-zinc-500 hover:text-zinc-300 border-b-2 border-transparent"
+        }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+// ───────────────────────── Overview ─────────────────────────
+
+function OverviewTab() {
+  const [overview, setOverview] = useState<AnalyticsOverview | null>(null)
+  const [cost, setCost] = useState<CostAnalytics | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const [o, c] = await Promise.all([
+          api.analytics.overview(),
+          api.analytics.cost(),
+        ])
+        if (!cancelled) {
+          setOverview(o)
+          setCost(c)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    load()
+    const h = setInterval(load, LIVE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div className="p-8 text-rose-400 font-mono text-sm">
+        Failed to load overview: {error}
+        <div className="mt-2 text-zinc-500">
+          Is the kernel running on :4318?
+        </div>
+      </div>
+    )
+  }
+
+  if (!overview) {
+    return <div className="p-8 text-zinc-500 font-mono text-sm">Loading…</div>
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* KPI row */}
+      <div className="grid grid-cols-4 gap-4">
+        <Kpi label="Live sessions" value={overview.active_sessions} accent />
+        <Kpi label="Total sessions" value={overview.total_sessions} />
+        <Kpi label="Spans" value={overview.total_spans.toLocaleString()} />
+        <Kpi
+          label="Total cost"
+          value={`$${overview.total_cost_usd.toFixed(4)}`}
+        />
+      </div>
+
+      {/* Cost tables */}
+      {cost && (
+        <div className="grid grid-cols-2 gap-4">
+          <CostTable
+            title="Cost by model"
+            rows={cost.by_model.map((m) => ({
+              key: m.model,
+              primary: m.model,
+              cost: m.cost,
+              count: m.calls,
+              countLabel: "calls",
+            }))}
+          />
+          <CostTable
+            title="Cost by agent"
+            rows={cost.by_agent.map((a) => ({
+              key: a.agent,
+              primary: a.agent,
+              cost: a.cost,
+              count: a.sessions,
+              countLabel: "sessions",
+            }))}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Kpi({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: string | number
+  accent?: boolean
+}) {
+  return (
+    <div
+      className={`border p-4 ${
+        accent
+          ? "border-emerald-500/30 bg-emerald-500/5"
+          : "border-zinc-800 bg-zinc-900/30"
+      }`}
+    >
+      <div className="text-[11px] font-mono tracking-wider text-zinc-500 uppercase mb-1">
+        {label}
+      </div>
+      <div
+        className={`text-2xl font-display font-semibold ${
+          accent ? "text-emerald-400" : "text-zinc-100"
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function CostTable({
+  title,
+  rows,
+}: {
+  title: string
+  rows: Array<{
+    key: string
+    primary: string
+    cost: number
+    count: number
+    countLabel: string
+  }>
+}) {
+  return (
+    <div className="border border-zinc-800 bg-zinc-900/30">
+      <div className="px-4 py-2 border-b border-zinc-800 text-[11px] font-mono tracking-wider text-zinc-400 uppercase">
+        {title}
+      </div>
+      {rows.length === 0 ? (
+        <div className="p-4 text-sm text-zinc-600 font-mono">No data yet.</div>
+      ) : (
+        <table className="w-full text-[13px] font-mono">
+          <thead>
+            <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
+              <th className="text-left font-normal px-4 py-1.5">Name</th>
+              <th className="text-right font-normal px-4 py-1.5">Cost</th>
+              <th className="text-right font-normal px-4 py-1.5">
+                {rows[0].countLabel}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={r.key}
+                className="border-t border-zinc-800/60 hover:bg-zinc-800/40"
+              >
+                <td className="px-4 py-1.5 text-zinc-200 truncate max-w-[240px]">
+                  {r.primary}
+                </td>
+                <td className="px-4 py-1.5 text-right text-emerald-400">
+                  ${r.cost.toFixed(4)}
+                </td>
+                <td className="px-4 py-1.5 text-right text-zinc-400">
+                  {r.count}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+// ───────────────────────── Sessions ─────────────────────────
+
+function SessionsTab({
+  selectedSessionId,
+  onSelectSession,
+}: {
+  selectedSessionId: string | null
+  onSelectSession: (id: string | null) => void
+}) {
+  const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const list = await api.sessions.list({ limit: 100 })
+        if (!cancelled) {
+          setSessions(list)
+          setError(null)
+          setLoading(false)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e))
+          setLoading(false)
+        }
+      }
+    }
+    load()
+    const h = setInterval(load, LIVE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [])
+
+  const selected =
+    selectedSessionId != null
+      ? sessions.find((s) => s.id === selectedSessionId) ?? null
+      : null
+
+  if (error) {
+    return (
+      <div className="p-8 text-rose-400 font-mono text-sm">
+        Failed to load sessions: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0">
+      {/* List */}
+      <div className="flex-1 min-w-0 border-r border-zinc-800 overflow-auto">
+        <table className="w-full text-[13px] font-mono">
+          <thead className="sticky top-0 bg-zinc-950 z-10">
+            <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
+              <th className="text-left font-normal px-4 py-2">Status</th>
+              <th className="text-left font-normal px-4 py-2">Agent</th>
+              <th className="text-left font-normal px-4 py-2">Started</th>
+              <th className="text-right font-normal px-4 py-2">Dur</th>
+              <th className="text-right font-normal px-4 py-2">Tokens</th>
+              <th className="text-right font-normal px-4 py-2">Cost</th>
+              <th className="text-left font-normal px-4 py-2">ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && sessions.length === 0 && (
+              <tr>
+                <td colSpan={7} className="p-8 text-center text-zinc-600">
+                  Loading sessions…
+                </td>
+              </tr>
+            )}
+            {!loading && sessions.length === 0 && (
+              <tr>
+                <td colSpan={7} className="p-8 text-center text-zinc-600">
+                  No sessions yet. Spawn an agent and this table will populate.
+                </td>
+              </tr>
+            )}
+            {sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                selected={s.id === selectedSessionId}
+                onSelect={() => onSelectSession(s.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Detail */}
+      {selected && (
+        <SessionDetailPane
+          session={selected}
+          onClose={() => onSelectSession(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function SessionRow({
+  session,
+  selected,
+  onSelect,
+}: {
+  session: SessionSummary
+  selected: boolean
+  onSelect: () => void
+}) {
+  const durationMs = session.ended_at
+    ? new Date(session.ended_at).getTime() -
+      new Date(session.started_at).getTime()
+    : Date.now() - new Date(session.started_at).getTime()
+
+  const isLive = session.ended_at === null && session.status === "active"
+
+  return (
+    <tr
+      onClick={onSelect}
+      className={`border-t border-zinc-800/60 cursor-pointer transition-colors ${
+        selected ? "bg-emerald-500/5" : "hover:bg-zinc-800/40"
+      }`}
+    >
+      <td className="px-4 py-1.5">
+        <StatusBadge status={session.status} live={isLive} />
+      </td>
+      <td className="px-4 py-1.5 text-zinc-200 truncate max-w-[180px]">
+        {session.agent_name || "—"}
+      </td>
+      <td className="px-4 py-1.5 text-zinc-400 text-[12px]">
+        {new Date(session.started_at).toLocaleString()}
+      </td>
+      <td className="px-4 py-1.5 text-right text-zinc-400 text-[12px]">
+        {formatDuration(durationMs)}
+      </td>
+      <td className="px-4 py-1.5 text-right text-zinc-400 text-[12px]">
+        {(
+          session.total_input_tokens + session.total_output_tokens
+        ).toLocaleString()}
+      </td>
+      <td className="px-4 py-1.5 text-right text-emerald-400">
+        ${session.total_cost_usd.toFixed(4)}
+      </td>
+      <td className="px-4 py-1.5 text-zinc-600 text-[11px] truncate max-w-[160px]">
+        {session.id}
+      </td>
+    </tr>
+  )
+}
+
+function StatusBadge({
+  status,
+  live,
+}: {
+  status: SessionSummary["status"]
+  live: boolean
+}) {
+  if (live) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-emerald-400 font-mono uppercase tracking-wider">
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+        live
+      </span>
+    )
+  }
+  const color =
+    status === "completed"
+      ? "text-zinc-400"
+      : status === "failed"
+        ? "text-rose-400"
+        : status === "cancelled"
+          ? "text-amber-400"
+          : "text-zinc-500"
+  return (
+    <span className={`text-[11px] font-mono uppercase tracking-wider ${color}`}>
+      {status}
+    </span>
+  )
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ${s % 60}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+function SessionDetailPane({
+  session,
+  onClose,
+}: {
+  session: SessionSummary
+  onClose: () => void
+}) {
+  const [tree, setTree] = useState<TraceTreeResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const isLive = session.ended_at === null && session.status === "active"
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const t = await api.sessions.tree(session.id)
+        if (!cancelled) {
+          setTree(t)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    load()
+    if (!isLive) return
+    const h = setInterval(load, LIVE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [session.id, isLive])
+
+  return (
+    <aside className="w-[540px] min-w-[540px] bg-zinc-950 border-l border-zinc-800 flex flex-col overflow-hidden">
+      <header className="h-10 border-b border-zinc-800 flex items-center justify-between px-4">
+        <div className="text-[11px] font-mono tracking-wider text-zinc-400 uppercase truncate">
+          {session.id}
+        </div>
+        <button
+          onClick={onClose}
+          className="text-zinc-500 hover:text-zinc-200 text-lg leading-none cursor-pointer"
+          title="Close"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="p-4 space-y-3 border-b border-zinc-800">
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-[12px] font-mono">
+          <DetailField label="Agent" value={session.agent_name || "—"} />
+          <DetailField
+            label="Status"
+            value={<StatusBadge status={session.status} live={isLive} />}
+          />
+          <DetailField
+            label="Started"
+            value={new Date(session.started_at).toLocaleString()}
+          />
+          <DetailField
+            label="Ended"
+            value={
+              session.ended_at
+                ? new Date(session.ended_at).toLocaleString()
+                : "—"
+            }
+          />
+          <DetailField
+            label="Tokens"
+            value={`${session.total_input_tokens.toLocaleString()} in / ${session.total_output_tokens.toLocaleString()} out`}
+          />
+          <DetailField
+            label="Cost"
+            value={
+              <span className="text-emerald-400">
+                ${session.total_cost_usd.toFixed(4)}
+              </span>
+            }
+          />
+        </div>
+      </div>
+
+      <div className="px-4 py-2 border-b border-zinc-800 text-[10px] font-mono tracking-wider text-zinc-500 uppercase">
+        Trace
+      </div>
+      <div className="flex-1 overflow-auto p-3 text-[12px] font-mono">
+        {error && <div className="text-rose-400">Error: {error}</div>}
+        {!error && !tree && <div className="text-zinc-600">Loading…</div>}
+        {tree && (!tree.spans || tree.spans.length === 0) && (
+          <div className="text-zinc-600">No spans yet.</div>
+        )}
+        {tree && tree.spans && tree.spans.length > 0 && (
+          <ul className="space-y-1">
+            {tree.spans.map((node) => (
+              <SpanNode key={node.span_id} node={node} depth={0} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function DetailField({
+  label,
+  value,
+}: {
+  label: string
+  value: ReactNode
+}) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-zinc-600">
+        {label}
+      </div>
+      <div className="text-zinc-200 truncate">{value}</div>
+    </div>
+  )
+}
+
+function SpanNode({ node, depth }: { node: TraceTreeNode; depth: number }) {
+  const isError = node.status === "error"
+  return (
+    <li>
+      <div
+        style={{ paddingLeft: depth * 14 }}
+        className={`flex items-center gap-2 py-0.5 ${
+          isError ? "text-rose-400" : "text-zinc-300"
+        }`}
+      >
+        <span className="text-zinc-600 text-[10px] uppercase tracking-wider w-14 shrink-0">
+          {node.type}
+        </span>
+        <span className="truncate">
+          {node.operation || node.model || node.span_id.slice(0, 8)}
+        </span>
+        {node.duration_ms !== null && node.duration_ms !== undefined && (
+          <span className="text-zinc-600 text-[11px] ml-auto shrink-0">
+            {node.duration_ms}ms
+          </span>
+        )}
+        {node.cost_usd !== null &&
+          node.cost_usd !== undefined &&
+          node.cost_usd > 0 && (
+            <span className="text-emerald-500/70 text-[11px] shrink-0">
+              ${node.cost_usd.toFixed(4)}
+            </span>
+          )}
+      </div>
+      {node.children && node.children.length > 0 && (
+        <ul>
+          {node.children.map((c) => (
+            <SpanNode key={c.span_id} node={c} depth={depth + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+// ───────────────────────── Usage ─────────────────────────
+
+function UsageTab() {
+  const [cost, setCost] = useState<CostAnalytics | null>(null)
+  const [latency, setLatency] = useState<LatencyAnalytics | null>(null)
+  const [spans, setSpans] = useState<SpanAnalytics | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const [c, l, s] = await Promise.all([
+          api.analytics.cost(),
+          api.analytics.latency(),
+          api.analytics.spans(),
+        ])
+        if (!cancelled) {
+          setCost(c)
+          setLatency(l)
+          setSpans(s)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    load()
+    const h = setInterval(load, LIVE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div className="p-8 text-rose-400 font-mono text-sm">
+        Failed to load usage: {error}
+      </div>
+    )
+  }
+
+  if (!cost || !latency || !spans) {
+    return <div className="p-8 text-zinc-500 font-mono text-sm">Loading…</div>
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Panel
+        title="Providers — cost by model"
+        subtitle={`${cost.by_model.length} model${cost.by_model.length === 1 ? "" : "s"}`}
+      >
+        {cost.by_model.length === 0 ? (
+          <EmptyRow text="No model spend recorded in this window." />
+        ) : (
+          <SimpleTable
+            columns={["Model", "Cost", "Calls"]}
+            aligns={["left", "right", "right"]}
+            rows={cost.by_model.map((m) => ({
+              key: m.model,
+              cells: [
+                <span className="text-zinc-200 truncate">{m.model}</span>,
+                <span className="text-emerald-400">
+                  ${m.cost.toFixed(4)}
+                </span>,
+                <span className="text-zinc-400">{m.calls}</span>,
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="Tools — cost by agent"
+        subtitle={`${cost.by_agent.length} agent${cost.by_agent.length === 1 ? "" : "s"}`}
+      >
+        {cost.by_agent.length === 0 ? (
+          <EmptyRow text="No agent activity recorded in this window." />
+        ) : (
+          <SimpleTable
+            columns={["Agent", "Cost", "Sessions"]}
+            aligns={["left", "right", "right"]}
+            rows={cost.by_agent.map((a) => ({
+              key: a.agent,
+              cells: [
+                <span className="text-zinc-200 truncate">{a.agent}</span>,
+                <span className="text-emerald-400">
+                  ${a.cost.toFixed(4)}
+                </span>,
+                <span className="text-zinc-400">{a.sessions}</span>,
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel title="Performance — latency by model">
+        {latency.by_model.length === 0 ? (
+          <EmptyRow text="No generation spans with duration recorded." />
+        ) : (
+          <SimpleTable
+            columns={["Model", "p50", "p95", "p99"]}
+            aligns={["left", "right", "right", "right"]}
+            rows={latency.by_model.map((l) => ({
+              key: l.model,
+              cells: [
+                <span className="text-zinc-200 truncate">{l.model}</span>,
+                <span className="text-zinc-400">{l.p50_ms}ms</span>,
+                <span className="text-zinc-300">{l.p95_ms}ms</span>,
+                <span
+                  className={
+                    l.p99_ms > 5000 ? "text-amber-400" : "text-zinc-300"
+                  }
+                >
+                  {l.p99_ms}ms
+                </span>,
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel title="Span type distribution">
+        {spans.distribution.length === 0 ? (
+          <EmptyRow text="No spans recorded." />
+        ) : (
+          <ul className="divide-y divide-zinc-800">
+            {spans.distribution.map((d) => (
+              <li
+                key={d.type}
+                className="flex items-center gap-3 px-4 py-2 text-[13px] font-mono"
+              >
+                <span className="w-28 text-zinc-300 truncate">{d.type}</span>
+                <div className="flex-1 h-2 bg-zinc-900 border border-zinc-800 relative overflow-hidden">
+                  <div
+                    className="absolute inset-y-0 left-0 bg-emerald-500/40"
+                    style={{ width: `${Math.min(100, d.percentage)}%` }}
+                  />
+                </div>
+                <span className="w-16 text-right text-zinc-400">
+                  {d.count}
+                </span>
+                <span className="w-14 text-right text-zinc-500">
+                  {d.percentage.toFixed(1)}%
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      <div className="text-[11px] font-mono text-zinc-600 px-1">
+        Network sub-panel lands in M4 (depends on kernel proxy Phase 2 +
+        /api/net/*).
+      </div>
+    </div>
+  )
+}
+
+function Panel({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="border border-zinc-800 bg-zinc-900/30">
+      <div className="px-4 py-2 border-b border-zinc-800 flex items-center justify-between">
+        <span className="text-[11px] font-mono tracking-wider text-zinc-400 uppercase">
+          {title}
+        </span>
+        {subtitle && (
+          <span className="text-[11px] font-mono text-zinc-600">
+            {subtitle}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return <div className="p-4 text-sm text-zinc-600 font-mono">{text}</div>
+}
+
+type Align = "left" | "right"
+
+function SimpleTable({
+  columns,
+  aligns,
+  rows,
+}: {
+  columns: string[]
+  aligns: Align[]
+  rows: Array<{ key: string; cells: ReactNode[] }>
+}) {
+  return (
+    <table className="w-full text-[13px] font-mono">
+      <thead>
+        <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
+          {columns.map((c, i) => (
+            <th
+              key={c}
+              className={`font-normal px-4 py-1.5 ${
+                aligns[i] === "right" ? "text-right" : "text-left"
+              }`}
+            >
+              {c}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr
+            key={r.key}
+            className="border-t border-zinc-800/60 hover:bg-zinc-800/40"
+          >
+            {r.cells.map((cell, i) => (
+              <td
+                key={i}
+                className={`px-4 py-1.5 ${
+                  aligns[i] === "right" ? "text-right" : "text-left"
+                } ${aligns[i] === "left" ? "max-w-[320px] truncate" : ""}`}
+              >
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+// ───────────────────────── Evals ─────────────────────────
+
+function EvalsTab() {
+  const [rules, setRules] = useState<AlertRule[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const r = await api.analytics.alerts()
+        if (!cancelled) {
+          setRules(r)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    load()
+    const h = setInterval(load, LIVE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [])
+
+  return (
+    <div className="p-6 space-y-6">
+      <ScoreLookupPanel />
+
+      <Panel
+        title="Alert rules"
+        subtitle={
+          rules ? `${rules.length} rule${rules.length === 1 ? "" : "s"}` : undefined
+        }
+      >
+        {error && (
+          <div className="p-4 text-rose-400 font-mono text-sm">
+            Failed to load alert rules: {error}
+          </div>
+        )}
+        {!error && !rules && <EmptyRow text="Loading…" />}
+        {rules && rules.length === 0 && (
+          <EmptyRow text="No alert rules configured." />
+        )}
+        {rules && rules.length > 0 && (
+          <SimpleTable
+            columns={["State", "Name", "Condition", "Threshold", "Action"]}
+            aligns={["left", "left", "left", "right", "left"]}
+            rows={rules.map((r) => ({
+              key: r.id,
+              cells: [
+                <RuleState enabled={r.enabled} />,
+                <span className="text-zinc-200 truncate">{r.name}</span>,
+                <span className="text-zinc-400 text-[12px]">
+                  {r.condition_type}
+                </span>,
+                <span className="text-zinc-300">{r.threshold}</span>,
+                <span className="text-zinc-500 text-[12px]">{r.action}</span>,
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <div className="text-[11px] font-mono text-zinc-600 px-1">
+        Firing/silenced state per rule and per-rule pass-rate trends land once
+        the kernel grows a list_alert_events + score-name enumeration endpoint.
+      </div>
+    </div>
+  )
+}
+
+function RuleState({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <span className="inline-flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-wider text-emerald-400">
+      <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+      enabled
+    </span>
+  ) : (
+    <span className="text-[11px] font-mono uppercase tracking-wider text-zinc-500">
+      disabled
+    </span>
+  )
+}
+
+function ScoreLookupPanel() {
+  const [input, setInput] = useState("")
+  const [submitted, setSubmitted] = useState<string | null>(null)
+  const [summary, setSummary] = useState<ScoreSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!submitted) return
+    let cancelled = false
+    setLoading(true)
+    api.analytics
+      .score(submitted)
+      .then((s) => {
+        if (!cancelled) {
+          setSummary(s)
+          setError(null)
+          setLoading(false)
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e))
+          setSummary(null)
+          setLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [submitted])
+
+  return (
+    <Panel title="Score lookup">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          const name = input.trim()
+          if (name) setSubmitted(name)
+        }}
+        className="px-4 py-3 flex items-center gap-2 border-b border-zinc-800"
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="score name (e.g. tests_pass, quality)"
+          className="flex-1 bg-zinc-950 border border-zinc-800 px-3 py-1.5 text-[13px] font-mono text-zinc-200
+            focus:outline-none focus:border-emerald-500/40"
+        />
+        <button
+          type="submit"
+          disabled={!input.trim()}
+          className="px-3 py-1.5 text-[12px] font-display tracking-wide uppercase
+            bg-emerald-500/10 text-emerald-400 border border-emerald-500/25
+            hover:bg-emerald-500/20 disabled:opacity-25 disabled:cursor-not-allowed
+            cursor-pointer transition-colors"
+        >
+          Lookup
+        </button>
+      </form>
+      <div className="p-4">
+        {!submitted && (
+          <div className="text-[13px] text-zinc-500 font-mono">
+            Enter a score rule name to see pass/fail totals and rate.
+          </div>
+        )}
+        {submitted && loading && (
+          <div className="text-[13px] text-zinc-500 font-mono">Loading…</div>
+        )}
+        {submitted && error && (
+          <div className="text-[13px] text-rose-400 font-mono">{error}</div>
+        )}
+        {submitted && summary && (
+          <div className="grid grid-cols-4 gap-3">
+            <ScoreKpi label="Pass" value={summary.pass} tone="good" />
+            <ScoreKpi label="Fail" value={summary.fail} tone="bad" />
+            <ScoreKpi
+              label="Pass rate"
+              value={`${(summary.pass_rate * 100).toFixed(1)}%`}
+              tone={summary.pass_rate >= 0.9 ? "good" : "warn"}
+            />
+            <ScoreKpi
+              label="Avg value"
+              value={summary.avg_value.toFixed(3)}
+              tone="neutral"
+            />
+          </div>
+        )}
+      </div>
+    </Panel>
+  )
+}
+
+function ScoreKpi({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string | number
+  tone: "good" | "bad" | "warn" | "neutral"
+}) {
+  const color =
+    tone === "good"
+      ? "text-emerald-400"
+      : tone === "bad"
+        ? "text-rose-400"
+        : tone === "warn"
+          ? "text-amber-400"
+          : "text-zinc-200"
+  return (
+    <div className="border border-zinc-800 bg-zinc-950 p-3">
+      <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-500 mb-1">
+        {label}
+      </div>
+      <div className={`text-xl font-display font-semibold ${color}`}>
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -1,3 +1,117 @@
+// ── Analytics / Sessions (kernel HTTP API) ──
+
+export interface SessionSummary {
+  id: string
+  workspace_id: string
+  device_id: string
+  agent_name: string
+  started_at: string
+  ended_at: string | null
+  status: "active" | "completed" | "failed" | "cancelled"
+  total_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
+}
+
+export interface AnalyticsOverview {
+  total_sessions: number
+  active_sessions: number
+  total_spans: number
+  total_cost_usd: number
+}
+
+export interface CostByModel {
+  model: string
+  cost: number
+  calls: number
+}
+
+export interface CostByAgent {
+  agent: string
+  cost: number
+  sessions: number
+}
+
+export interface CostAnalytics {
+  by_model: CostByModel[]
+  by_agent: CostByAgent[]
+}
+
+export interface DailyEntry {
+  date: string
+  sessions: number
+  spans: number
+  cost_usd: number
+}
+
+export interface LatencyByModel {
+  model: string
+  p50_ms: number
+  p95_ms: number
+  p99_ms: number
+}
+
+export interface LatencyAnalytics {
+  by_model: LatencyByModel[]
+}
+
+export interface SpanDistEntry {
+  type: string
+  count: number
+  percentage: number
+}
+
+export interface SpanAnalytics {
+  distribution: SpanDistEntry[]
+}
+
+export interface ScoreSummary {
+  name: string
+  pass: number
+  fail: number
+  total: number
+  pass_rate: number
+  avg_value: number
+}
+
+export interface AlertRule {
+  id: string
+  name: string
+  condition_type: string
+  threshold: number
+  action: string
+  enabled: boolean
+}
+
+export interface TraceTreeNode {
+  span_id: string
+  type: string
+  operation: string | null
+  model: string | null
+  input_tokens: number | null
+  output_tokens: number | null
+  cost_usd: number | null
+  duration_ms: number | null
+  status: string
+  children?: TraceTreeNode[]
+}
+
+export interface TraceTreeResponse {
+  session: {
+    id: string
+    agent_name: string
+    status: string
+    total_cost_usd: number
+    total_input_tokens: number
+    total_output_tokens: number
+    started_at: string
+  }
+  spans: TraceTreeNode[]
+  span_count: number
+  scores?: Array<{ name: string; value: number; source: string }>
+  tags?: Array<{ key: string; value: string }>
+}
+
 export type IssueStatus =
   | "backlog"
   | "todo"

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -13,11 +13,15 @@ export interface SessionSummary {
   total_output_tokens: number
 }
 
+// Mirrors the kernel's `Analytics` struct (gctrl-core/src/types.rs:213).
+// Note: `active_sessions` is NOT part of this response — derive it
+// client-side from `sessions.list({ status: "active" })`.
 export interface AnalyticsOverview {
   total_sessions: number
-  active_sessions: number
   total_spans: number
   total_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
 }
 
 export interface CostByModel {

--- a/specs/architecture/apps/adr-session-is-the-spine.md
+++ b/specs/architecture/apps/adr-session-is-the-spine.md
@@ -1,0 +1,46 @@
+# ADR: Session is the spine; Activity is a view-mode
+
+**Status**: accepted
+**Scope**: gctrl-analytics, gctrl-board, future observability surfaces
+**Drives**: `specs/architecture/apps/gctrl-analytics.md`
+
+## Context
+
+`gctrl-analytics` exposes six tabs (Overview, Sessions, Prompts, Evals, Usage, Contributions) plus three view-modes on Sessions (List, Timeline, Heatmap). An earlier draft considered Activity (timeline / heatmap) as a top-level tab beside Sessions. Operators consistently asked "what ran?" and "what happened in this session?" — the same question at different zoom levels.
+
+There is also a longer-term temptation: as new observability needs land (LLM-as-judge runs, eval harnesses, scheduler dispatches), each could grow a new top-level entity with its own tab and its own drill-through paths. That direction multiplies surfaces and breaks the operator's mental model.
+
+## Decision
+
+Across `gctrl-analytics` and any future observability application:
+
+1. **Session is the canonical spine.** Every observable unit of work — agent runs, scheduler dispatches, eval runs, ad-hoc OTLP-ingested processes — is a `Session`. New entities don't get a new top-level tab; they extend the Session shape (new `created_by` value, new span types, new linked artifacts).
+2. **Activity is a view-mode on Sessions, not a parallel tab.** List / Timeline / Heatmap are three renderings of the same query against the same store. They share filters, share pagination, share streaming.
+3. **Drill paths are one-directional toward Session.** Contribution → PR → Session → Prompt → Span → Eval. Nothing drills into a parallel entity that bypasses Session.
+
+## Consequences
+
+**Good**
+
+- One mental model. Operators learn Session once and read every other surface as a slice of it.
+- One streaming contract. The SSE channel is `session.*`; no parallel "activity stream" or "eval stream" to maintain.
+- Cheap new tabs. Adding a tab is "what question does this answer about Sessions?" not "what new pipeline do I need to build?"
+
+**Cost**
+
+- Forbids parallel top-level entities even when they look natural in isolation. Eval rule and prompt template are conceptual entities (not Sessions), and they get tabs (Evals, Prompts) — but every row drills back to a Session, never sideways into another rule/template detail page that lives outside Session context.
+- `Session` schema must stay general enough to host heterogenous workloads. We accept this by keeping `Session` thin (id, agent_name, started_at/ended_at, status, totals) and pushing kind-specific data onto spans, scores, tags, contribution links.
+
+## Non-decisions
+
+- This ADR does **not** decide whether to add `Session.created_by` (handled in `gctrl-analytics.md` Kernel Dependencies §1).
+- Does **not** decide the chart library (deferred to M1 implementation).
+- Does **not** prescribe SSE wire format (handled in `gctrl-analytics.md` Kernel Dependencies §5).
+
+## Trigger to revisit
+
+- Operators ask "what's the entity?" and consistently answer something other than Session.
+- A tab cannot honestly drill back to Session (e.g. Activity that doesn't belong to any session — would force a parallel spine).
+- Three or more drill-throughs land on a non-Session pane.
+
+If two of the three trigger, revisit the spine assumption explicitly rather than letting parallel entities accrete.

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -48,7 +48,8 @@ See [os.md — Dependency Direction](../os.md).
 | Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
 | Contributions tab | `driver-github` PR/commit data + commit trailer inference | `GET /api/contributions?since=...` (inference-first; promote to link table only if inference proves lossy) |
 | Internal vs. external attribution | — (`agent_kind` lives on `Task`, not `Session`) | Add `session.created_by: scheduler \| otel_ingest \| api \| unknown`; derive `internal` / `external` as a view |
-| Live sessions | — | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (core, **M0**) |
+| Live sessions | 5s poll over `GET /api/sessions?status=active` (M0-preview shim) | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (M0-final, replaces shim) |
+| "Live sessions now" KPI | `GET /api/sessions?status=active` count, client-side | — (kernel `/api/analytics` rollup intentionally omits `active_sessions`; do not add) |
 | Claude Code JSONL fidelity for external sessions | — | Deferred: `driver-claude-code` watcher (see [Deferred / Future](#deferred--future)) |
 
 **Principle**: no new analytics logic in the app. The app is a **presentation layer**. Any new aggregation or attribution belongs in the kernel so the CLI benefits too.
@@ -147,13 +148,13 @@ data: {"session_id":"…","span_id":"…","ts":"…","type":"generation","status
 
 **Backpressure**: broadcast channel uses `Lagged` errors on slow consumers; handler drops the lagged receiver, closes the connection, and the client reconnects with `Last-Event-ID` — same replay-or-gap path as any other disconnect.
 
-Spec-visible: this is the **only** live-update mechanism. The Overview and Sessions tabs must consume these streams directly; no 5–10s polling fallback in the shipped UI.
+Spec-visible: this is the **only** live-update mechanism *after M0-final ships*. M0-preview ships with a 5s polling shim against the non-stream routes; the shim is deleted in the same PR that lands the streams (see Milestones §M0).
 
 ## Dashboards
 
 The SPA has **six top-level tabs**. Each tab accepts the same global filters: `time range`, `created_by` (all / scheduler / api / otel_ingest) with a derived `kind` shortcut (internal / external), `agent_kind` (derived — see §1), `workspace`.
 
-Organizing principle: **Session is the spine** — every other surface is either a slice of session data (prompts, evals, activity, usage) or a downstream artifact (contributions). This framing is load-bearing for the tab structure, the drill path, and the SSE contract; it warrants a short ADR ("Session is the spine / Activity is a view-mode") before the M0 PR lands so future additions don't quietly re-introduce a parallel Activity model. Tabs are organized by the question the operator is asking, not by the underlying table:
+Organizing principle: **Session is the spine** — every other surface is either a slice of session data (prompts, evals, activity, usage) or a downstream artifact (contributions). This framing is load-bearing for the tab structure, the drill path, and the SSE contract; see [ADR: Session is the spine; Activity is a view-mode](./adr-session-is-the-spine.md) for the rationale, consequences, and trigger to revisit. Tabs are organized by the question the operator is asking, not by the underlying table:
 
 | Tab | Question it answers | Primary entity |
 |-----|---------------------|----------------|
@@ -268,13 +269,19 @@ The Overview and Sessions tabs show an **Internal / External** toggle (`?kind=in
 
 ## Milestones
 
-The PRD's primary problem is **live visibility of what's running now**. Shipping past-only first fails that problem, so the SSE contract and live Sessions view are in M0, not later. Poll-refresh is explicitly **not** a fallback — if the stream isn't ready, M0 isn't ready.
+The PRD's primary problem is **live visibility of what's running now**. Shipping past-only first fails that problem, so live Sessions visibility is in M0, not later.
+
+Live updates split into two checkpoints inside M0:
+
+- **M0-preview** — list + detail pane render with a 5-second poll shim against the existing non-stream routes. This unblocks the rest of the dashboard (Usage, Evals) without waiting on kernel work, and is the state you find on a freshly-merged `spec/gctrl-analytics` branch today. Operators see live status within ≤5s of state change, which clears the PRD's primary problem at a degraded SLA.
+- **M0-final** — kernel ships SSE per Kernel Dependencies §5, the client switches to `EventSource`, and the polling shim is **deleted in the same PR**. After M0-final, the only live-update path is the stream; no polling fallback in the shipped UI.
 
 Each milestone lists one falsifiable acceptance criterion per shipped tab; it's the check the operator should be able to run in under a minute to say "this milestone landed."
 
-1. **M0 — Skeleton + Overview + Sessions (past + live)**: Worker + SPA + kernel HTTP proxy. Overview tab. Sessions tab (list mode only) with trace tree in the detail pane, rendering past sessions and **streaming live span updates** over `GET /api/sessions/stream` + `GET /api/sessions/{id}/stream` (SSE contract per Kernel Dependencies §5). ADR "Session is the spine / Activity is a view-mode" merged before this lands. No polling fallback in the shipped UI.
-   - *Accept Overview*: with one live agent running, the KPI "live sessions now" increments within 2s of the `session.started` span and decrements within 2s of `session.ended`, without a page refresh.
-   - *Accept Sessions*: opening the detail pane on a live session appends new spans to the trace tree within 2s of OTLP ingest; closing and reopening restores the same tree state from the non-stream route plus any buffered replay.
+1. **M0 — Skeleton + Overview + Sessions (past + live)**: Worker + SPA + kernel HTTP proxy. Overview tab. Sessions tab (list mode only) with trace tree in the detail pane. ADR "Session is the spine / Activity is a view-mode" merged in the same PR. M0 is **not closed** until the SSE swap (M0-final) ships — the M0-preview polling shim is a known temporary state, gated by an explicit removal commitment.
+   - *Accept Overview (M0-preview)*: with one live agent running, the KPI "live sessions now" increments within 5s of the `session.started` span and decrements within 5s of `session.ended`. *(M0-final tightens this to 2s once SSE is wired.)*
+   - *Accept Sessions (M0-preview)*: opening the detail pane on a live session shows new spans within 5s of OTLP ingest. *(M0-final: 2s, via stream append; closing and reopening restores tree state from the non-stream route plus any buffered replay.)*
+   - *Accept M0-final*: `grep -R "setInterval" apps/gctrl-board/web/src/pages/AnalyticsPage.tsx` returns zero matches; the only live-update mechanism is `EventSource` against `/api/sessions/stream` and `/api/sessions/{id}/stream`.
 2. **M1 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Zero new kernel work.
    - *Accept Usage*: provider spend on the Usage tab over any window matches `gctrl analytics cost --since <window>` to the cent.
    - *Accept Evals*: every alert rule that's `firing` in `gctrl analytics alerts` appears as `firing` on the Evals tab within one refresh.

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -46,9 +46,9 @@ See [os.md — Dependency Direction](../os.md).
 | Activity view (timeline / heatmap) | `GET /api/sessions` (time-bucketed client-side) | — |
 | Prompts tab (instance list, grouping) | Span query by span-type | Light route: `GET /api/sessions/{id}/prompts` + `GET /api/prompts?group_by=fingerprint` |
 | Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
-| Contributions tab | `driver-github` PR/commit data | `session.contribution_links` table + `GET /api/contributions?since=...` |
-| Internal vs. external attribution | `session.agent_kind` (partial) | Add `session.spawn_source: internal \| external` field + filter params |
-| Live sessions | — | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (core, M1) |
+| Contributions tab | `driver-github` PR/commit data + commit trailer inference | `GET /api/contributions?since=...` (inference-first; promote to link table only if inference proves lossy) |
+| Internal vs. external attribution | — (`agent_kind` lives on `Task`, not `Session`) | Add `session.created_by: scheduler \| otel_ingest \| api \| unknown`; derive `internal` / `external` as a view |
+| Live sessions | — | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (core, **M0**) |
 | Claude Code JSONL fidelity for external sessions | — | Deferred: `driver-claude-code` watcher (see [Deferred / Future](#deferred--future)) |
 
 **Principle**: no new analytics logic in the app. The app is a **presentation layer**. Any new aggregation or attribution belongs in the kernel so the CLI benefits too.
@@ -57,16 +57,31 @@ See [os.md — Dependency Direction](../os.md).
 
 Kernel changes this app needs. Each is useful beyond the app and should land as independent kernel work.
 
-### 1. `session.spawn_source` field
+### 1. `session.created_by` field
 
-Today `Session` records `agent_name` and `agent_kind` (e.g. `ClaudeCode`). It does not record **how** the session was started — whether the kernel Scheduler spawned it or whether an external process pushed OTel in.
+Today `Session` records `agent_name` (string) and a `status` enum; it has **no** `agent_kind` field — `agent_kind` lives on `Task` (`kernel/crates/gctrl-core/src/types.rs:82`). It also does not record **how** the session was started — whether the kernel Scheduler spawned it, an app called the API with a spawn token, or an external process pushed OTel in.
 
-Proposal: add `spawn_source: SpawnSource` where `SpawnSource = Internal | External`.
+Proposal: add a narrow provenance enum on `Session`:
 
-- `Internal` — session was created by the kernel Scheduler or an app calling `POST /api/sessions` with a spawn token.
-- `External` — session was created implicitly on first OTel span ingestion (OTLP receiver), no kernel spawn record.
+```
+created_by: CreatedBy = Scheduler | OtelIngest | Api | Unknown
+```
 
-Emit as a filter on `/api/sessions?spawn_source=internal` and roll up in `/api/analytics?spawn_source=...`.
+- `Scheduler` — session was created by the kernel Scheduler dispatching a `Task`.
+- `Api` — session was created by an app/tool calling `POST /api/sessions` with a spawn token.
+- `OtelIngest` — session was created implicitly on first OTLP span ingestion, no kernel spawn record.
+- `Unknown` — pre-migration rows; never emitted for new sessions.
+
+`internal` vs. `external` is **a view**, not a stored field. Queries and the UI toggle derive it:
+
+```
+internal = created_by IN (Scheduler, Api)
+external = created_by = OtelIngest
+```
+
+This keeps the stored value faithful to the actual signal (who wrote the row) while letting the UI vocabulary evolve. Emit `created_by` as a filter on `/api/sessions?created_by=scheduler` and `/api/analytics?created_by=...`; accept the derived shorthand `?kind=internal` / `?kind=external` too.
+
+For per-session **agent kind** (Claude Code, Codex, ad-hoc) — which the Sessions tab needs — derive from `Task.agent_kind` when a `task_id` is present, otherwise from OTel `resource.service.name` / `telemetry.sdk.name`. No new `Session.agent_kind` column unless derivation proves too slow at list-query scale.
 
 ### 2. `/api/net/*` routes
 
@@ -74,32 +89,71 @@ Once `gctrl-proxy` Phase 2 lands (hudsucker MITM + traffic logging), expose:
 
 - `GET /api/net/overview` — total requests, bytes up/down, distinct domains, window.
 - `GET /api/net/domains?since=...&top=N` — top domains by requests / bytes.
-- `GET /api/net/traffic?since=...&host=...&limit=...` — recent requests, with `session_id` + `spawn_source` when derivable from the proxy's per-process attribution.
+- `GET /api/net/traffic?since=...&host=...&limit=...` — recent requests, with `session_id` + `created_by` when derivable from the proxy's per-process attribution.
 - `GET /api/net/daily?days=N` — daily request and byte trends.
 
 Per-session attribution requires the proxy to tag traffic with the originating session (via env-injected header or PID→session mapping). Until that exists, network traffic shows as "unattributed" with host/process-level grouping only — still useful.
 
-### 3. `GET /api/prompts` + `GET /api/sessions/{id}/prompts`
+### 3. `GET /api/prompts` + `GET /api/sessions/{id}/prompts` (+ storage for prompt turns)
 
 Light-weight routes backing the Prompts tab:
 
 - `GET /api/sessions/{id}/prompts` — ordered list of prompt turns for a session.
 - `GET /api/prompts?group_by=fingerprint&since=...` — prompt instances grouped by normalized-text hash, with counts, avg cost, and linked sessions.
 
-No new storage — these are query-shape conveniences over the existing span table (filter by span type = `prompt` / `user_turn`).
+**Storage is not free today.** `SpanType` in `kernel/crates/gctrl-core/src/types.rs:135` is `Generation | Span | Event` — there is no `prompt` / `user_turn` variant, so a prompts tab cannot be "a query over existing spans." M3 must choose one of:
 
-### 4. `GET /api/contributions` + `session.contribution_links`
+1. **Extend `SpanType`** with `UserTurn` and `AssistantTurn` (or a single `Turn` + role attr), and emit them from the OTLP ingest path. Cheapest option, keeps everything in the span table; cost is a migration + every ingest path learning the new variants.
+2. **Add a dedicated `prompts` table** keyed by `(session_id, turn_ordinal)` with `role`, `text`, `fingerprint`, `tokens_in`, `tokens_out`, `cost_usd`, `span_id` (link). Cleanest schema for the Prompts tab, but a new table to sync.
 
-Backing the Contributions tab. When an agent creates a PR/commit during a session, the kernel records a link row (via `driver-github` callbacks on `pr create` / `git push`). The route aggregates these joined against GitHub-side state (PR status, lines changed).
+Leaning toward (1) unless eval tooling needs random-access joins on prompt text that the span table can't give cheaply. Decide in the M3 ADR; do **not** ship the Prompts tab before this lands.
 
-- `session.contribution_links` — `(session_id, kind: commit | pr | issue, ref, created_at)`.
-- `GET /api/contributions?since=...&agent=...` — list with drill-through fields.
+Route shapes stay the same under either option — the Prompts UI binds to the route, not the table.
+
+### 4. `GET /api/contributions` (inference-first)
+
+Backing the Contributions tab. **Default approach is trailer inference, not a new link table.**
+
+- Agents append a `Session-Id: <uuid>` trailer to commits they author (already a cheap convention to enforce in orch / wrapper scripts).
+- `driver-github` already pulls commits and PRs through the kernel. The Contributions route scans commit trailers and PR body mentions (`Session-Id:` or a recognizable session URL) and joins back to `Session` at query time.
+- `GET /api/contributions?since=...&agent=...` — list of commits / PRs / closed issues with inferred `session_id`, drill-through to PR and Session.
+
+This is retroactive (works for commits we never "observed"), loss-tolerant (missing trailer = unattributed row, still shown), and adds no write path to sync. Promote to a dedicated `session.contribution_links` table **only when** inference proves lossy in practice — e.g. agents routinely strip trailers, or the join is too expensive at scale. If that happens, the table is an index, not a new source of truth.
+
+Explicitly **not** adding `driver-github` callbacks on `pr create` / `git push` for this — that coupling is what we want to avoid until a concrete gap justifies it.
+
+### 5. SSE live-stream contract (M0)
+
+Live session updates go over Server-Sent Events, not polling. Two endpoints:
+
+- `GET /api/sessions/stream` — stream of session-level events (`session.started`, `session.span`, `session.ended`, `session.status_changed`).
+- `GET /api/sessions/{id}/stream` — stream narrowed to one session (span appends, status changes).
+
+**Producer**: a single `tokio::sync::broadcast::channel` per kind inside `gctrl-otel`'s ingest path. On each OTLP batch, ingest fans out a lightweight `SessionEvent` on the broadcast. Each HTTP handler holds a `broadcast::Receiver` and streams events as SSE. No per-connection polling of DuckDB — the ingest path is the only reader that touches the DB for live updates.
+
+**Wire format**: standard SSE framing with one JSON event per message.
+
+```
+id: <monotonic u64 per broadcast>
+event: session.span
+data: {"session_id":"…","span_id":"…","ts":"…","type":"generation","status":"ok"}
+```
+
+`id` is the broadcast-wide monotonic counter, **not** a span or span-start timestamp, so `Last-Event-ID` reconnect is well-defined.
+
+**Reconnect semantics**: on reconnect, the client sends `Last-Event-ID: <n>`. The server replays any buffered events with `id > n` from an in-memory ring (size configurable, default 1024 events per stream, ~few seconds at expected throughput). If the requested id is older than the ring, the server sends `event: replay_gap` and the client is expected to re-fetch state from the non-streaming routes (`/api/sessions`, `/api/sessions/{id}/tree`) and resume tailing.
+
+**Heartbeat**: server emits `: heartbeat\n\n` every 15s so clients behind proxies detect dead connections. No application-level ping payload.
+
+**Backpressure**: broadcast channel uses `Lagged` errors on slow consumers; handler drops the lagged receiver, closes the connection, and the client reconnects with `Last-Event-ID` — same replay-or-gap path as any other disconnect.
+
+Spec-visible: this is the **only** live-update mechanism. The Overview and Sessions tabs must consume these streams directly; no 5–10s polling fallback in the shipped UI.
 
 ## Dashboards
 
-The SPA has **six top-level tabs**. Each tab accepts the same global filters: `time range`, `spawn_source` (all / internal / external), `agent_kind`, `workspace`.
+The SPA has **six top-level tabs**. Each tab accepts the same global filters: `time range`, `created_by` (all / scheduler / api / otel_ingest) with a derived `kind` shortcut (internal / external), `agent_kind` (derived — see §1), `workspace`.
 
-Organizing principle: **Session is the spine** — every other surface is either a slice of session data (prompts, evals, activity, usage) or a downstream artifact (contributions). Tabs are organized by the question the operator is asking, not by the underlying table:
+Organizing principle: **Session is the spine** — every other surface is either a slice of session data (prompts, evals, activity, usage) or a downstream artifact (contributions). This framing is load-bearing for the tab structure, the drill path, and the SSE contract; it warrants a short ADR ("Session is the spine / Activity is a view-mode") before the M0 PR lands so future additions don't quietly re-introduce a parallel Activity model. Tabs are organized by the question the operator is asking, not by the underlying table:
 
 | Tab | Question it answers | Primary entity |
 |-----|---------------------|----------------|
@@ -133,7 +187,7 @@ This tab also absorbs **Agent Activity** as a view-mode toggle (rather than its 
 
 Shared controls: top toggle defaults to **"Live + recent"**; operators can switch to "All past" for historical inspection.
 
-- Row → detail pane: agent, model, cost, duration, spawn_source, linked issue (if any), span count, error count, **live indicator** when streaming spans are still arriving.
+- Row → detail pane: agent, model, cost, duration, `created_by`, linked issue (if any), span count, error count, **live indicator** when streaming spans are still arriving.
 - Detail pane embeds a **trace tree** (renders `GET /api/sessions/{id}/tree`) with span expansion, latency bars, and error highlighting. For live sessions the tree appends new spans as they arrive (SSE, see M1 below).
 - Detail pane also surfaces: **prompts used** (links to Prompts tab), **evals attached** (links to Evals tab), **outbound requests** (from Usage/Network), **contributions produced** (from Contributions).
 - Loops view surfaces `GET /api/sessions/{id}/loops` when the kernel detected repeated failures.
@@ -162,10 +216,10 @@ Answers "is quality drifting? which rules are firing?". Distinct from Prompts be
 Answers "what is this costing, and which providers / tools / domains are burning it?". Merges provider spend, tool usage, proxied network traffic, and OTel performance metrics into one resource-behavior surface. Operators compare "where is cost going?" against "where is traffic going?" in the same tab rather than flipping between three.
 
 - **Providers** — cost + tokens per LLM provider (Anthropic, OpenAI, local). Reuses `GET /api/analytics/cost`.
-- **Tools / utils** — usage per agent kind (Claude Code, Codex, ad-hoc scripts). Rows: invocation count, avg duration, cost, distinct sessions, split by `spawn_source`.
+- **Tools / utils** — usage per agent kind (Claude Code, Codex, ad-hoc scripts). Rows: invocation count, avg duration, cost, distinct sessions, split by `created_by`.
 - **Proxied network traffic** — every HTTP request that flowed through the kernel proxy, both app-originated and external agents routed via `HTTP_PROXY`. Only meaningful once kernel proxy Phase 2 ships; before then, this sub-panel shows a placeholder explaining the dependency.
   - Top domains by requests and by bytes.
-  - Request volume sparkline, stacked by `spawn_source` when attribution is available.
+  - Request volume sparkline, stacked by `created_by` when attribution is available.
   - Status code distribution (2xx/3xx/4xx/5xx stacked).
   - Recent requests table with per-request drill-through (method, host, path, status, bytes, latency, session link).
   - Reverse join on the Sessions detail pane ("this session made 42 outbound requests to 3 domains").
@@ -177,9 +231,9 @@ Answers "what did agents actually ship?". The entity is git/GitHub artifacts, no
 
 - Table of commits, PRs, and issues closed, filterable by agent, time range, repo.
 - Columns: title, author (agent or human), linked session, PR status (open/merged/closed), lines +/-, review signal.
-- Sparkline: contributions/day split by `spawn_source`.
-- Drill-through: contribution → PR on GitHub (via `driver-github`) and contribution → originating session.
-- Reuse: joins `driver-github` PR data with `session.contribution_links` (new lightweight table populated when an agent creates a PR during a session).
+- Sparkline: contributions/day split by `created_by`.
+- Drill-through: contribution → PR on GitHub (via `driver-github`) and contribution → originating session (via commit trailer inference — see Kernel Dependencies §4).
+- Reuse: `driver-github` PR/commit data + trailer inference at query time; no new link table in the initial build.
 
 ## UI & Stack
 
@@ -195,16 +249,16 @@ The Worker itself is a **thin facade**: it proxies to the kernel HTTP API and se
 
 ## Internal vs. External Agent Attribution
 
-This is the distinctive thing this app does that no other surface does today.
+This is the distinctive thing this app does that no other surface does today. The stored field is `created_by` (see Kernel Dependencies §1); `internal` / `external` is a derived view — `internal = {Scheduler, Api}`, `external = {OtelIngest}`.
 
-| Signal | Internal | External |
-|--------|----------|----------|
-| Session creation | Scheduler / app POST with spawn token | Implicit on first OTel ingest |
-| `agent_kind` | Usually known (we set it) | Inferred from OTel resource attrs (`service.name`, `telemetry.sdk.name`) or unknown |
+| Signal | Internal (`Scheduler` / `Api`) | External (`OtelIngest`) |
+|--------|--------------------------------|-------------------------|
+| Session creation | Scheduler dispatch or app `POST /api/sessions` with spawn token | Implicit on first OTLP ingest |
+| Agent kind | Known — `Task.agent_kind` for Scheduler, supplied by caller for Api | Inferred from OTel `resource.service.name` / `telemetry.sdk.name` or unknown |
 | Linked to an Issue | Commonly (scheduler links via task) | Rarely (requires developer to put an Issue key in a span) |
 | Network attribution | High (proxy env injection possible) | Low (depends on whether developer routes through `HTTP_PROXY`) |
 
-The Overview and Sessions tabs show an **Internal / External** toggle. Evals, Usage, and Contributions tabs show a stacked split in every chart so the operator can always see the shape of both populations.
+The Overview and Sessions tabs show an **Internal / External** toggle (`?kind=internal|external`) with an optional drill to the raw `created_by` values. Evals, Usage, and Contributions tabs show a stacked split in every chart so the operator can always see the shape of both populations.
 
 ## Dogfooding
 
@@ -214,13 +268,25 @@ The Overview and Sessions tabs show an **Internal / External** toggle. Evals, Us
 
 ## Milestones
 
-1. **M0 — Skeleton + Overview + Sessions (past)**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree over historical data. Poll-refresh for "live-ish" updates (5–10s). Uses existing kernel routes only. Fits on a laptop in an afternoon.
-2. **M1 — Live sessions**: SSE endpoint `GET /api/sessions/stream` + per-session `GET /api/sessions/{id}/stream`. Sessions table and detail pane update in-place as spans land. This is a core feature, not optional — operators need to see agents while they are running.
-3. **M2 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Still zero new kernel work.
-4. **M3 — Prompts + Activity views**: Prompts tab (needs `GET /api/prompts` + `GET /api/sessions/{id}/prompts`), plus Timeline and Heatmap view modes on the Sessions tab.
-5. **M4 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
-6. **M5 — Network sub-panel**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ships inside the Usage tab, not as its own tab.
-7. **M6 — Contributions**: `session.contribution_links` + `GET /api/contributions`. Depends on `driver-github` callbacks on PR create / commit push.
+The PRD's primary problem is **live visibility of what's running now**. Shipping past-only first fails that problem, so the SSE contract and live Sessions view are in M0, not later. Poll-refresh is explicitly **not** a fallback — if the stream isn't ready, M0 isn't ready.
+
+Each milestone lists one falsifiable acceptance criterion per shipped tab; it's the check the operator should be able to run in under a minute to say "this milestone landed."
+
+1. **M0 — Skeleton + Overview + Sessions (past + live)**: Worker + SPA + kernel HTTP proxy. Overview tab. Sessions tab (list mode only) with trace tree in the detail pane, rendering past sessions and **streaming live span updates** over `GET /api/sessions/stream` + `GET /api/sessions/{id}/stream` (SSE contract per Kernel Dependencies §5). ADR "Session is the spine / Activity is a view-mode" merged before this lands. No polling fallback in the shipped UI.
+   - *Accept Overview*: with one live agent running, the KPI "live sessions now" increments within 2s of the `session.started` span and decrements within 2s of `session.ended`, without a page refresh.
+   - *Accept Sessions*: opening the detail pane on a live session appends new spans to the trace tree within 2s of OTLP ingest; closing and reopening restores the same tree state from the non-stream route plus any buffered replay.
+2. **M1 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Zero new kernel work.
+   - *Accept Usage*: provider spend on the Usage tab over any window matches `gctrl analytics cost --since <window>` to the cent.
+   - *Accept Evals*: every alert rule that's `firing` in `gctrl analytics alerts` appears as `firing` on the Evals tab within one refresh.
+3. **M2 — Prompts + Activity views**: Prompts tab, plus Timeline and Heatmap view modes on the Sessions tab. Depends on Kernel Dependencies §3 (extended `SpanType` variants **or** a `prompts` table — decide in the M2 ADR).
+   - *Accept Prompts*: grouping by fingerprint over a known test corpus produces the same group counts as the kernel query used to back the route (diff the JSON, expect zero rows).
+   - *Accept Sessions views*: switching list → timeline → heatmap does not re-fetch — same query, three renderings — verified by watching the Network tab.
+4. **M3 — Attribution**: kernel adds `session.created_by`; app wires the global filter and adds stacked splits on Evals / Usage / Contributions (even if Contributions is a stub at this point).
+   - *Accept*: filtering `kind=external` on a workspace with only scheduler-spawned sessions returns zero rows; `kind=internal` returns every row. Totals of the two equal the unfiltered total.
+5. **M4 — Network sub-panel**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ships inside the Usage tab, not as its own tab.
+   - *Accept*: a request made through the proxy during a known session appears in that session's detail pane under "outbound requests" within one refresh, with host/path/status matching the proxy log.
+6. **M5 — Contributions**: `GET /api/contributions` (trailer-inference flavour per Kernel Dependencies §4). No `session.contribution_links` table unless inference proves lossy on a real workspace.
+   - *Accept*: a commit authored during a live session with a `Session-Id:` trailer shows up on the Contributions tab with the correct session drill-through; a commit without the trailer shows up as unattributed, not dropped.
 
 ## Deferred / Future
 
@@ -242,9 +308,9 @@ Out of scope for the initial build. Noted here so the Sessions model is not pain
 
 ## Open Questions
 
-1. Should `spawn_source` be three-valued (`internal | external | unknown`) to handle pre-migration data, or should we backfill old rows to `external` on first deploy? Leaning `unknown` + CLI backfill command.
+1. Backfill of `session.created_by` for pre-migration rows: leave as `Unknown` and let a CLI `gctrl sessions backfill-created-by` command reclassify from existing signals (presence of `task_id` ⇒ `Scheduler`, OTel-only origin ⇒ `OtelIngest`)? That's the current lean. No tri-valued `internal|external|unknown` stored field — derivation stays on the read path.
 2. How do we attribute external `claude-code` traffic when it doesn't go through our proxy? Likely we can't — and that's fine; the OTel side still gives us per-session cost.
-3. Chart library: `recharts` (friendly, battery-included) vs. `visx` (more control, more code). Defer until we know what charts M2 actually needs.
-4. Is Agent Activity as a view-mode on Sessions sufficient, or do operators expect it as a top-level tab? Easy to promote later if the toggle proves too buried.
-5. Should Prompts and Evals be merged into one "Quality" tab? Kept separate because the entities (prompt template vs. eval rule) and the operator tasks (authoring vs. regression monitoring) differ — revisit after M3.
-6. `session.contribution_links` vs. inferring contributions from commit message / PR body mentions of session IDs. Explicit link rows are cleaner but require `driver-github` to emit callbacks; inference is retroactive but lossy.
+3. Chart library: `recharts` (friendly, battery-included) vs. `visx` (more control, more code). Defer until we know what charts M1 actually needs.
+4. Is Agent Activity as a view-mode on Sessions sufficient, or do operators expect it as a top-level tab? Easy to promote later if the toggle proves too buried. (Codify the decision in the "Session is the spine" ADR landing with M0.)
+5. Should Prompts and Evals be merged into one "Quality" tab? Kept separate because the entities (prompt template vs. eval rule) and the operator tasks (authoring vs. regression monitoring) differ — revisit after M2.
+6. M2 Prompts storage: extend `SpanType` with `UserTurn` / `AssistantTurn` (option A) vs. dedicated `prompts` table (option B). Decide in the M2 ADR — the trigger for (B) is random-access joins on prompt text that the span table can't serve cheaply.


### PR DESCRIPTION
## Summary

Adds the architecture spec for `gctrl-analytics` and a working M0+M1
implementation as a tab inside `gctrl-board`. The dashboard lives at
`/analytics` in the existing board SPA — no separate Worker yet, since
both apps share the kernel HTTP API and the same React 19 stack;
extracting later is mechanical.

### Spec

`specs/architecture/apps/gctrl-analytics.md` — six-tab dashboard
(Overview, Sessions, Prompts, Evals, Usage, Contributions) organized by
operator question. Session is the spine; every drill-through ends at a
session. Reuse-first: leans on existing `/api/analytics/*` and
`/api/sessions/*`; kernel grows narrow routes only where needed.

The spec has been through one round of persona review on this branch;
the must-fix items are folded in:

- Live sessions promoted to **M0** (was M1) with an SSE contract
  (`tokio::sync::broadcast` in `gctrl-otel`, monotonic event id,
  `Last-Event-ID` replay with ring buffer + `replay_gap`, 15s
  heartbeat). No polling fallback in the shipped UI.
- `spawn_source: Internal | External` replaced with
  `created_by: Scheduler | OtelIngest | Api | Unknown`;
  `internal`/`external` is a derived view. Notes that `agent_kind`
  lives on `Task`, not `Session`.
- Prompts §3 corrected: today's `SpanType` is `Generation | Span |
  Event` — there is no `prompt`/`user_turn` variant. M2 must extend
  `SpanType` or add a `prompts` table; pick in M2 ADR.
- Contributions flipped to commit-trailer inference first;
  `contribution_links` table demoted to escape-hatch only.
- One falsifiable acceptance criterion per tab per milestone.
- ADR pointer for "Session is the spine / Activity is a view-mode" to
  land before M0.

### M0 — Overview + Sessions

- Sidebar gets an Analytics nav button (bar-chart icon).
- **Overview** tab: KPIs (live/total sessions, spans, total cost) and
  cost-by-model / cost-by-agent tables.
- **Sessions** tab: list with status badge (live indicator pulses for
  active sessions); detail pane with session metadata + trace tree
  rendered from `/api/sessions/:id/tree`.
- Live updates use a 5s poll shim. The spec mandates SSE — the
  `LIVE_REFRESH_MS` constant marks the swap site for when the kernel
  ships `GET /api/sessions/stream`. **M0 is not fully done until SSE
  lands.**

### M1 — Usage + Evals (zero new kernel work)

- **Usage**: providers (cost by model), tools (cost by agent),
  performance (p50/p95/p99 by model — p99 > 5s flagged amber),
  span-type distribution with percentage bars. Network sub-panel
  deferred to M4.
- **Evals**: alert-rule list (mirrors `gctrl analytics alerts`); score
  lookup form against `/api/analytics/scores` showing pass / fail /
  pass-rate / avg KPIs. Firing-state per rule waits on a kernel
  `list_alert_events` endpoint.

### Still open (called out in the spec)

- M0 SSE (`tokio::sync::broadcast` in `gctrl-otel`).
- Production Worker proxy for `/api/analytics/*` and `/api/sessions/*`
  — dev works via the existing Vite proxy to `:4318`.
- M2 `SpanType` ADR (extend variants vs. dedicated `prompts` table).
- M3 `session.created_by` field + filter wiring.
- M4 kernel proxy Phase 2 + `/api/net/*` routes.
- M5 contribution trailer inference.

## Test plan

- [x] `tsc --noEmit -p web/tsconfig.app.json` clean for new code (two
      pre-existing `InboxMessage.source_name` errors predate this branch)
- [x] `vite build` succeeds (~302 KB / 88 KB gzip)
- [x] Existing `vitest` suite — 24 passed, 29 skipped, 0 failed
- [ ] Manual: click Analytics in sidebar with kernel running on :4318;
      verify live session pulse, trace tree, cost tables populate
- [ ] CI green
