### PR TITLE
feat(board): gantt view — spec + implementation

### DIFF
--- a/apps/gctrl-board/migrations/0003_gantt_dates.sql
+++ b/apps/gctrl-board/migrations/0003_gantt_dates.sql
@@ -1,0 +1,9 @@
+-- Gantt view: optional start/due dates on issues.
+-- Both YYYY-MM-DD strings (date-only, project-local, no TZ ambiguity).
+-- Null means "unscheduled" — issue appears in the Gantt's Unscheduled tray.
+
+ALTER TABLE issues ADD COLUMN start_date TEXT;
+ALTER TABLE issues ADD COLUMN due_date   TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_issues_start_date ON issues(start_date);
+CREATE INDEX IF NOT EXISTS idx_issues_due_date   ON issues(due_date);

--- a/apps/gctrl-board/specs/gantt.md
+++ b/apps/gctrl-board/specs/gantt.md
@@ -1,6 +1,8 @@
 # Gantt View — gctrl-board
 
-Timeline visualization for Issues, complementary to the existing Kanban view. Modeled on GitHub Projects' "Roadmap" layout: horizontal bars per Issue on a time axis, grouped by a chosen field (status, assignee, milestone, parent), with direct-manipulation drag-and-drop for scheduling and reassignment.
+Timeline visualization for **Issues**, complementary to the existing Kanban view. Modeled on GitHub Projects' "Roadmap" layout: horizontal bars per Issue on a time axis, grouped by a chosen field (status, assignee, milestone, parent), with direct-manipulation drag-and-drop for scheduling and reassignment.
+
+**Scope: Issues only.** The Gantt does not render Tasks — not even read-only. Tasks are a Scheduler primitive whose timing is an execution detail of how an Issue gets done; humans reason in Issues, and the Gantt is a human planning surface. Task-level visualization, if ever needed, belongs in an agent-execution view, not here. See "Tasks are out of scope" below.
 
 Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-kit) — the same library already used by `KanbanBoard.tsx`, so sensors, keyboard accessibility, and overlay patterns stay consistent across views.
 
@@ -14,7 +16,7 @@ Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-
 ## Non-Goals
 
 - Resource-leveling or auto-scheduling. Humans decide dates; the Tracker only validates.
-- Gantt editing for Tasks. Tasks still render read-only (if shown at all in v1 — see "Tasks lane" below).
+- **Task rendering of any kind** (read-only bars, sub-bars, overlays, collapsed summaries). Tasks are out of scope — see dedicated section below.
 - Critical-path math. We render dependencies but do not compute slack / float in v1.
 - External sync of start/end dates to GitHub/Linear in v1. Dates are gctrl-local until a driver opts in (future work — see "Open questions").
 
@@ -24,7 +26,6 @@ Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-
 - **As an IC**, I can drag an Issue bar to shift its dates, or drag its left/right edge to extend/compress duration, without leaving the view.
 - **As a triager**, I can drag an Issue from one swimlane row to another to reassign it (e.g., change assignee, change milestone) in a single gesture.
 - **As a reviewer**, I can see `blockedBy` arrows pointing into an Issue so I know what must ship first.
-- **As an agent observer**, I can still see Tasks linked to an Issue — rendered as read-only sub-bars below the parent Issue bar.
 
 ## Comparison to GitHub Projects Roadmap
 
@@ -176,15 +177,16 @@ export function useGantt(projectId: string): {
 
 Backed by a single `GET /projects/:id/gantt` fetch + optimistic local reducer. Reuses `useProjectRoute` for the current project.
 
-## Read-only Tasks in the Gantt
+## Tasks are out of scope
 
-Per the architecture invariant "Tasks lane is read-only", Tasks linked to an Issue render as narrow sub-bars *under* the parent Issue's bar, with:
+The Gantt renders **Issues only**. Tasks (Scheduler primitives) do not appear in this view in any form — no sub-bars, no hover reveals, no collapsed summaries, no badges. The rationale:
 
-- No drag handles (`useDraggable` is not attached).
-- Muted color, dashed outline.
-- Width derived from the Task's Scheduler-declared start/end, not editable here.
+1. **Humans plan in Issues.** The Gantt is a planning surface for committed, team-visible work. Tasks are how an agent internally decomposes an Issue — an execution detail, not a planning unit.
+2. **Task timing is Scheduler-owned and ephemeral.** A Task's `start`/`end` is determined by agent runtime, can change within seconds, and is meaningless outside the session that produced it. Surfacing it on a time axis designed for days-to-months invites misreading.
+3. **Invariant preservation.** `architecture.md` defines Tasks as read-only in the Kanban lane; the simplest way to respect that here is to not render them at all.
+4. **Scope discipline.** Every Task-adjacent feature (collapsible sub-bars, disclosure carets, muted colors, Scheduler-fetch plumbing) adds cost without serving the planning use case.
 
-For v1, Tasks are collapsed by default; a disclosure caret on the parent bar expands them. This keeps the v1 view focused on Issue scheduling while still showing agent-visible progress.
+If an agent-execution timeline is ever needed, it belongs in a separate view (e.g., per-session trace visualization already implied by `gctl sessions tree`), not bolted onto the Issue Gantt.
 
 ## Testing
 

--- a/apps/gctrl-board/specs/gantt.md
+++ b/apps/gctrl-board/specs/gantt.md
@@ -202,6 +202,8 @@ New component: `apps/gctrl-board/web/src/components/GanttBoard.tsx`, reachable f
 
 Explicit snap + min-distance eliminates the "1px drag = 1 week shift at Quarter zoom" risk. Snap unit applies to both bar-move and bar-resize.
 
+**Why Day is the smallest unit** (frappe/gantt ships Hour / Quarter Day / Half Day variants; we don't): Issues are human-planned units of work tracked at day granularity (`start_date` / `due_date` are `YYYY-MM-DD`). Sub-day timing belongs to Tasks, which are out of scope for the Gantt. Day / Week / Month / Quarter covers sprint, release, and roadmap horizons without surfacing execution-detail noise.
+
 ### @dnd-kit integration
 
 Four draggable kinds dispatch cleanly in `onDragEnd`:

--- a/apps/gctrl-board/specs/gantt.md
+++ b/apps/gctrl-board/specs/gantt.md
@@ -1,31 +1,33 @@
 # Gantt View — gctrl-board
 
-Timeline visualization for **Issues**, complementary to the existing Kanban view. Modeled on GitHub Projects' "Roadmap" layout: horizontal bars per Issue on a time axis, grouped by a chosen field (status, assignee, milestone, parent), with direct-manipulation drag-and-drop for scheduling and reassignment.
+Timeline visualization for **Issues**, complementary to the existing Kanban view. Modeled on GitHub Projects' "Roadmap" layout: horizontal bars per Issue on a time axis, grouped by status, with direct-manipulation drag-and-drop for scheduling and reassignment.
 
-**Scope: Issues only.** The Gantt does not render Tasks — not even read-only. Tasks are a Scheduler primitive whose timing is an execution detail of how an Issue gets done; humans reason in Issues, and the Gantt is a human planning surface. Task-level visualization, if ever needed, belongs in an agent-execution view, not here. See "Tasks are out of scope" below.
+**Scope: Issues only.** The Gantt does not render Tasks — not even read-only. Tasks are a Scheduler primitive whose timing is an execution detail of how an Issue gets done; humans reason in Issues, and the Gantt is a human planning surface. See "Tasks are out of scope" below.
 
-Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-kit) — the same library already used by `KanbanBoard.tsx`, so sensors, keyboard accessibility, and overlay patterns stay consistent across views.
+Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-kit) — the same library `KanbanBoard.tsx` already uses, so sensors, keyboard accessibility, and overlay patterns stay consistent across views.
 
 ## Goals
 
 1. Give humans a time-anchored view of committed Issue work across a project.
-2. Make rescheduling (move, resize, reparent) a one-gesture interaction.
-3. Surface dependency structure — `blockedBy` / `blocking` — as visible arrows between bars, so conflicts and critical paths are obvious.
-4. Preserve the invariants from `architecture.md`: Tasks remain read-only; kernel SQLite is the source of truth; the Worker is a facade.
+2. Make rescheduling (move, resize) a one-gesture interaction.
+3. Preserve the invariants from `architecture.md`: Tasks remain read-only; kernel SQLite is the source of truth; the Worker is a facade.
 
 ## Non-Goals
 
 - Resource-leveling or auto-scheduling. Humans decide dates; the Tracker only validates.
-- **Task rendering of any kind** (read-only bars, sub-bars, overlays, collapsed summaries). Tasks are out of scope — see dedicated section below.
-- Critical-path math. We render dependencies but do not compute slack / float in v1.
-- External sync of start/end dates to GitHub/Linear in v1. Dates are gctrl-local until a driver opts in (future work — see "Open questions").
+- **Task rendering of any kind** (see "Tasks are out of scope").
+- **Dependency arrows** between bars — deferred to v2. GitHub Projects Roadmap does not draw them; `blockedBy` / `blocking` remain surfaced in `IssueDetailPanel` only.
+- **External sync.** Dates are gctrl-local and stay gctrl-local. We are **not** syncing `start_date` / `due_date` to GitHub Projects, Linear, or any other tracker — not in v1, not in v2. If a user wants timeline data in GitHub, they can read it through the gctrl shell.
+- Critical-path math. No slack / float.
+- Milestones as first-class markers (no schema, no UI).
+- Multi-select bar drag.
 
 ## User Stories
 
 - **As a PM**, I can see every Issue for a project as a bar on a timeline, grouped by status, so I can spot work clustered in one status lane.
 - **As an IC**, I can drag an Issue bar to shift its dates, or drag its left/right edge to extend/compress duration, without leaving the view.
-- **As a triager**, I can drag an Issue from one swimlane row to another to reassign it (e.g., change assignee, change milestone) in a single gesture.
-- **As a reviewer**, I can see `blockedBy` arrows pointing into an Issue so I know what must ship first.
+- **As a triager**, I can drag an Issue from one status swimlane to another in a single gesture — reusing the same endpoint the Kanban uses.
+- **As a planner**, I can drag an undated Issue from the "Unscheduled" tray onto the grid to schedule it.
 
 ## Comparison to GitHub Projects Roadmap
 
@@ -34,18 +36,20 @@ Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-
 | Bar per issue on time axis          | ✅                      | ✅                                            |
 | Start / Target date fields          | ✅                      | ✅ (new `start_date`, `due_date` on Issue)    |
 | Drag to move                        | ✅                      | ✅ (`@dnd-kit` `useDraggable`)                |
-| Drag edge to resize                 | ✅                      | ✅ (custom edge-handle draggables)            |
-| Group by field (status/iteration)   | ✅                      | ✅ (status, assignee, parent, milestone)      |
-| Zoom (day/week/month/quarter)       | ✅                      | ✅ (day, week, month, quarter)                |
-| Dependency arrows                   | ❌                      | ✅ (SVG overlay over bars)                    |
+| Drag edge to resize                 | ✅                      | ✅ (edge-handle draggables)                   |
+| Group by status                     | ✅                      | ✅                                            |
+| Group by assignee / iteration       | ✅                      | Deferred (v2)                                 |
+| Zoom (day/week/month/quarter)       | ✅                      | ✅                                            |
+| Unscheduled tray                    | ✅                      | ✅                                            |
+| Dependency arrows                   | ❌                      | Deferred (v2)                                 |
 | Milestones as vertical markers      | ✅                      | Deferred (v2)                                 |
-| Iteration columns                   | ✅                      | Deferred — we rely on `parent_id` for epics   |
+| Iteration columns                   | ✅                      | Deferred (v2)                                 |
 
 ## Data Model Changes
 
-Add two optional date fields to `Issue`. Both are `YYYY-MM-DD` (date-only, local to the project, no TZ ambiguity for day-granularity bars).
+Add two optional date fields to `Issue`. Both are `YYYY-MM-DD` (date-only, project-local, no TZ ambiguity for day-granularity bars).
 
-### Schema (Effect-TS) — `apps/gctrl-board/src/schema/Issue.ts`
+### Effect-TS struct — `apps/gctrl-board/src/schema/Issue.ts`
 
 ```typescript
 export const Issue = Schema.Struct({
@@ -55,7 +59,7 @@ export const Issue = Schema.Struct({
 })
 ```
 
-### Migration — `apps/gctrl-board/migrations/0003_gantt_dates.sql`
+### SQL migration — `apps/gctrl-board/migrations/0003_gantt_dates.sql`
 
 ```sql
 ALTER TABLE issues ADD COLUMN start_date TEXT;
@@ -65,102 +69,171 @@ CREATE INDEX IF NOT EXISTS idx_issues_start_date ON issues(start_date);
 CREATE INDEX IF NOT EXISTS idx_issues_due_date   ON issues(due_date);
 ```
 
-Both nullable — existing Issues appear in an "Unscheduled" tray (see "Layout") until dated.
+The same migration lands in `kernel/migrations/` for SQLite. Both nullable — existing Issues appear in the "Unscheduled" tray until dated.
+
+### Case convention
+
+The current Worker serves snake_case to the frontend (see `web/src/types.ts` — `assignee_id`, `created_at`, etc.). We lock the same convention:
+
+- **DB columns** (D1 + SQLite): `start_date`, `due_date` (snake_case).
+- **HTTP payloads** (request + response): `start_date`, `due_date` (snake_case).
+- **Effect-TS domain struct**: `startDate`, `dueDate` (camelCase). Transform happens in the existing struct ↔ row codec — same place `createdAt` ↔ `created_at` is already handled.
+- **React types** (`web/src/types.ts`): `start_date`, `due_date` (snake_case, matches existing fields).
 
 ### Validation rules (Tracker)
 
-- If both set, `start_date <= due_date`. Reject the mutation otherwise.
-- Either field may be set alone. A bar without `start_date` anchors its left edge at `due_date - default_span` (default span = 3 days, configurable per project).
-- Status transitions do **not** clear or auto-set dates. Dates are a separate concern from lifecycle.
+- If both set, `start_date <= due_date`. Reject otherwise with `InvalidScheduleError`.
+- Either field may be set alone. Rendering rule: if only `due_date` is set, the bar anchors its left edge at `due_date − DEFAULT_SPAN_DAYS` (constant, value `3`, defined in `services/constants.ts`). Not per-project configurable in v1.
+- Status transitions neither clear nor auto-set dates.
+- `cancelled` Issues render as strikethrough muted bars and are **not draggable** (`readonlyDates: true` flag on the bar — borrowed from frappe/gantt's `readonly_dates`). `done` is draggable (so historical re-dating for auditing is possible).
 
-## Kernel HTTP API
+## HTTP API — kernel is source of truth, Worker mirrors
 
-Per the "Kernel is source of truth; Worker is facade" feedback, new routes live on the kernel and the Worker simply proxies. No direct D1 writes for scheduling.
+The board already has parallel route surfaces on kernel (`kernel/crates/gctrl-otel/src/receiver.rs`) and Worker (`apps/gctrl-board/src/worker.ts`) — e.g. both expose `POST /api/board/issues/:id/move`. We follow the same dual-surface pattern:
 
-### New endpoints
+```
+                   ┌────────────────────────────────────────┐
+                   │ Client (web / shell)                   │
+                   └──────────┬──────────┬──────────────────┘
+                      local   │          │ edge
+                              ▼          ▼
+               ┌──────────────────┐  ┌────────────────────┐
+               │ Kernel (SQLite)  │  │ Worker (D1)        │
+               │ receiver.rs      │  │ worker.ts          │
+               │ PATCH /schedule  │  │ PATCH /schedule    │
+               │ GET  /gantt      │  │ GET  /gantt        │
+               └────────┬─────────┘  └─────────┬──────────┘
+                        └───── sync channel ───┘
+                      (existing multi-device sync,
+                       via 0002_sync_columns — no new code)
+```
 
-| Method | Path                                          | Purpose                                      |
-|--------|-----------------------------------------------|----------------------------------------------|
-| `PATCH`| `/api/board/issues/{id}/schedule`             | Update `start_date` and/or `due_date`        |
-| `GET`  | `/api/board/projects/{id}/gantt`              | Projected view: issues + dependency edges    |
+- **Kernel SQLite is the source of truth.** PRs land the new handlers in `receiver.rs` first.
+- **Worker D1 mirrors the same routes** for edge access (this is what the web app calls today — the dogfooded board runs against the Worker). Schema mirroring is the existing pattern.
+- The existing multi-device sync (columns added in `0002_sync_columns.sql`) carries `start_date` / `due_date` across replicas without spec-specific work. We only need to extend the mirror write path in `services/BoardService.ts`.
+
+### Endpoints (added to both surfaces)
+
+| Method  | Path                                          | Purpose                                      |
+|---------|-----------------------------------------------|----------------------------------------------|
+| `PATCH` | `/api/board/issues/{id}/schedule`             | Update `start_date` and/or `due_date`        |
+| `GET`   | `/api/board/projects/{id}/gantt`              | Issues + date range for a project            |
 
 #### `PATCH /api/board/issues/{id}/schedule`
 
-Request body:
+Request:
 
 ```json
 { "start_date": "2026-05-01", "due_date": "2026-05-14" }
 ```
 
-Either field may be `null` to clear. Validates the ordering rule above. Emits an `issue_events` row of type `scheduled` with the delta as `data`.
+Either field may be `null` to clear. Validates `start_date <= due_date`. On success, emits an `issue_events` row with `event_type = "scheduled"` and `data = { start_date, due_date }`.
+
+**Concurrency**: last-write-wins — same policy the existing Kanban `POST /issues/:id/move` uses. No `If-Match` / `updated_at` precondition in v1. (If we need optimistic-concurrency later, we extend both routes at once.)
 
 #### `GET /api/board/projects/{id}/gantt`
 
-Response shape (tuned for the Gantt view — avoids N+1 over individual issue fetches):
+Response (snake_case, Gantt-tuned to avoid N+1 over individual issue fetches):
 
 ```json
 {
   "range": { "min": "2026-04-01", "max": "2026-06-30" },
-  "issues": [ { "id": "...", "title": "...", "status": "...", "start_date": "...", "due_date": "...", "assignee_id": "...", "parent_id": "...", "priority": "..." } ],
-  "dependencies": [ { "from_issue_id": "...", "to_issue_id": "...", "kind": "blocked_by" } ]
+  "issues": [
+    {
+      "id": "...",
+      "project_id": "...",
+      "title": "...",
+      "status": "todo",
+      "priority": "medium",
+      "assignee_id": "...",
+      "assignee_name": "...",
+      "assignee_type": "human",
+      "parent_id": "...",
+      "start_date": "2026-05-01",
+      "due_date":   "2026-05-14"
+    }
+  ]
 }
 ```
 
-`range` is computed from the min/max of scheduled dates in the project, clamped to at least one zoom window. Unscheduled Issues are returned with null dates so the client can render them in the "Unscheduled" tray.
+- `range` is the raw min/max of scheduled dates in the project. **No server-side zoom clamping** — padding is a client concern (the client extends `range` to align with the current zoom window and always includes "today").
+- Unscheduled Issues are returned with `null` dates for the tray.
+- No `dependencies` field in v1 (arrows deferred to v2).
+- Archived Issues are not a concept in the current schema — this was wrong in the previous draft and is dropped.
 
 ## Frontend
 
-New component: `apps/gctrl-board/web/src/components/GanttBoard.tsx`, reachable from the existing view-switcher (sibling of `KanbanBoard`). Route: `/projects/:projectKey/gantt`.
+New component: `apps/gctrl-board/web/src/components/GanttBoard.tsx`, reachable from a view-switcher alongside `KanbanBoard`. Route: `/projects/:projectKey/gantt`.
+
+### Rendering approach
+
+- **Bars are DOM**, not SVG — each bar is an absolutely-positioned `<div>` inside its swimlane row. `@dnd-kit` works with DOM refs directly; hover / focus / popover reuse `IssueCard` + `IssueDetailPanel` without an SVG↔DOM event bridge.
+- Time axis is a simple CSS grid (sticky header) with `colWidth` driven by the zoom mode.
+- The "today" line is a single absolutely-positioned div overlay on the grid.
+- SVG is **reserved for v2 dependency arrows** only.
 
 ### Layout
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  Zoom: [Day][Week][Month][Quarter]   Group by: [Status ▾]   │
+│  Zoom: [Day][Week][Month][Quarter]   (Group by: Status)     │
 ├──────────────┬──────────────────────────────────────────────┤
-│ Swimlane hdr │  ← time axis (days) ───────────────────────→ │
+│ Swimlane hdr │  ← time axis (sticky) ─────────────────────→ │
 ├──────────────┼──────────────────────────────────────────────┤
-│ Backlog      │       ░░░░░░░░                               │
+│ Backlog      │                                              │
 │   BACK-12    │       ████████      ← draggable bar          │
 │   BACK-17    │                 ██████████                   │
 ├──────────────┼──────────────────────────────────────────────┤
-│ In Progress  │  ██████████████  ← "today" vertical line     │
-│   BACK-42    │  ├──→ arrow to BACK-17 (blocking)            │
+│ In Progress  │  ██████████████  ┆ "today" line              │
+│   BACK-42    │                  ┆                            │
 ├──────────────┼──────────────────────────────────────────────┤
 │ Unscheduled  │  [card] [card] [card]   ← drop target tray   │
 └──────────────┴──────────────────────────────────────────────┘
 ```
 
-- Time axis: day column width depends on zoom. Sticky header.
-- Swimlanes: rows grouped by the `Group by` field. Drop between rows = reassign that grouping field.
-- Unscheduled tray: horizontal strip of undated cards. Dragging a card onto the time grid sets `start_date` to the drop x-coordinate; default span applied if no `due_date` exists.
-- Today marker: a vertical line at today's column, always visible.
-- Dependency arrows: an absolutely-positioned SVG overlay renders one `<path>` per `blockedBy` edge between bars. Arrows recompute on layout changes (row reorder, resize, zoom).
+### Zoom modes & snap policy (borrowed from frappe/gantt `snap_at`)
+
+| Zoom     | `colWidth` | Snap unit | Min drag distance |
+|----------|------------|-----------|-------------------|
+| Day      | 32 px      | 1 day     | 8 px (½ column)   |
+| Week     | 96 px      | 1 day     | 12 px             |
+| Month    | 180 px     | 1 day     | 12 px             |
+| Quarter  | 120 px     | 1 week    | 16 px             |
+
+Explicit snap + min-distance eliminates the "1px drag = 1 week shift at Quarter zoom" risk. Snap unit applies to both bar-move and bar-resize.
 
 ### @dnd-kit integration
 
-We use three distinct draggable "kinds" so handlers can dispatch cleanly:
+Four draggable kinds dispatch cleanly in `onDragEnd`:
 
-| Drag kind      | `useDraggable` data          | `useDroppable` targets                      | Effect                                                |
-|----------------|------------------------------|---------------------------------------------|-------------------------------------------------------|
-| `bar-move`     | `{ issueId, kind: "move" }`  | Day cells in any swimlane                   | Shift `start_date` (and `due_date` by same delta)     |
-| `bar-resize-l` | `{ issueId, kind: "l" }`     | Day cells in the same row                   | Update `start_date` only                              |
-| `bar-resize-r` | `{ issueId, kind: "r" }`     | Day cells in the same row                   | Update `due_date` only                                |
-| `unscheduled`  | `{ issueId, kind: "fresh" }` | Day cells in any swimlane                   | Set `start_date` to drop column; apply default span   |
+| Drag kind      | `useDraggable` data          | `useDroppable` targets            | Effect                                            |
+|----------------|------------------------------|-----------------------------------|---------------------------------------------------|
+| `bar-move`     | `{ issueId, kind: "move" }`  | Day cells in any swimlane         | Shift `start_date` + `due_date` by same delta; if dropped in a *different swimlane*, status also changes (see axis rule). |
+| `bar-resize-l` | `{ issueId, kind: "l" }`     | Day cells in the **same row**     | Update `start_date` only.                         |
+| `bar-resize-r` | `{ issueId, kind: "r" }`     | Day cells in the **same row**     | Update `due_date` only.                           |
+| `unscheduled`  | `{ issueId, kind: "fresh" }` | Day cells in any swimlane         | Set `start_date = drop_column`, `due_date = drop_column + DEFAULT_SPAN_DAYS − 1`; if the drop row's status differs, status also changes. |
 
-All four share a single `<DndContext>` with a `PointerSensor` (same `activationConstraint: { distance: 8 }` as KanbanBoard) and a `KeyboardSensor` for a11y. `DragOverlay` renders a translucent bar following the cursor.
+All four share one `<DndContext>` with a `PointerSensor` (`activationConstraint: { distance: 8 }`) and a `KeyboardSensor`. Droppable IDs: `"{status}::{YYYY-MM-DD}"`.
 
-Droppables are the individual day columns inside each swimlane row, keyed by `"{rowKey}::{YYYY-MM-DD}"`. On `onDragEnd` we parse the `over.id`, compute the new dates, optimistically update local state, and call `PATCH /schedule`. On failure, we roll back and surface a toast — same pattern `useBoard.moveIssue` already uses.
+#### Axis disambiguation rule (cross-row + cross-column drops)
 
-Dragging a bar's row in the swimlane direction (vertical) reassigns the grouping field (e.g., changes `status`, `assignee_id`, or `parent_id`). That path reuses the existing `PATCH /issues/{id}` endpoint — not the schedule endpoint.
+When a `bar-move` or `unscheduled` drop lands in a row AND a column that both differ from the source, **both axes apply**:
 
-### Rendering the bars
+1. The date change persists via `PATCH /schedule`.
+2. The status change persists via the existing `POST /issues/:id/move` — same call the Kanban makes. Two network calls, issued in parallel; if the status call fails, we roll back the status but keep the date change (and surface the partial-failure state in a toast). If the date call fails, we roll back both (since the user's gesture implied an atomic intent).
 
-- Bar left = `(start_date − range.min) * colWidth`.
-- Bar width = `(due_date − start_date + 1) * colWidth`, min 1 column.
-- Color = status accent (reuse `COLUMN_ACCENT` from `KanbanBoard.tsx`).
-- Label = `{project.key}-{issue.counter}  ·  {title}` truncated to bar width.
-- Hover reveals an `IssueDetailPanel` popover (reuse existing component).
+This matches how the Kanban already handles cross-status drops and avoids inventing a new multi-field endpoint.
+
+#### `DragOverlay` per kind
+
+One `<DragOverlay>`, but it renders different content based on `active.data.current.kind`:
+
+- `bar-move` / `unscheduled`: translucent bar matching the source bar's width.
+- `bar-resize-l` / `bar-resize-r`: a 2px-wide vertical guide line at the drop column.
+
+#### Touch / hit targets
+
+Edge handles are **12 px hit targets** rendered as **4 px visual guides**, per Apple HIG minimum-tap guidance. A `TouchSensor` is registered alongside `PointerSensor` (`delay: 150`, `tolerance: 5`) so tap-hold picks up a bar on touch devices without accidentally grabbing on a scroll.
 
 ### State & hooks
 
@@ -170,68 +243,93 @@ New hook `useGantt(projectId)`:
 export function useGantt(projectId: string): {
   data: GanttView | null
   loading: boolean
-  updateSchedule: (id: string, patch: SchedulePatch) => Promise<void>
-  moveAcrossSwimlane: (id: string, groupField: string, groupValue: string) => Promise<void>
+  updateSchedule: (
+    issueId: string,
+    patch: { start_date?: string | null; due_date?: string | null }
+  ) => Promise<void>
+  moveStatus: (issueId: string, newStatus: IssueStatus) => Promise<void>
 }
 ```
 
-Backed by a single `GET /projects/:id/gantt` fetch + optimistic local reducer. Reuses `useProjectRoute` for the current project.
+Naming borrowed from frappe/gantt's `on_date_change(task, start, end)`. Optimistic updates follow the same pattern `useBoard.moveIssue` uses. On failure, we revert local state and render an error row in the existing toast area (`<Toaster/>` in `App.tsx`).
+
+### Bar geometry (pure functions, unit-testable)
+
+Extracted to `web/src/lib/gantt-geom.ts`:
+
+```ts
+export function barRect(
+  issue: Pick<Issue, "start_date" | "due_date">,
+  range: { min: string },
+  colWidth: number,
+): { left: number; width: number }
+```
+
+No DOM access, no `getBoundingClientRect`. Easy to unit-test.
+
+Keyboard-sensor snap:
+
+```ts
+export function gridCoordinateGetter(colWidth: number): KeyboardCoordinateGetter
+```
+
+Arrow keys move by one snap-unit column; documented so acceptance tests can assert exact pixel deltas.
 
 ## Tasks are out of scope
 
-The Gantt renders **Issues only**. Tasks (Scheduler primitives) do not appear in this view in any form — no sub-bars, no hover reveals, no collapsed summaries, no badges. The rationale:
+The Gantt renders **Issues only**. Tasks (Scheduler primitives) do not appear — no sub-bars, no hover reveals, no collapsed summaries, no badges. Rationale:
 
-1. **Humans plan in Issues.** The Gantt is a planning surface for committed, team-visible work. Tasks are how an agent internally decomposes an Issue — an execution detail, not a planning unit.
-2. **Task timing is Scheduler-owned and ephemeral.** A Task's `start`/`end` is determined by agent runtime, can change within seconds, and is meaningless outside the session that produced it. Surfacing it on a time axis designed for days-to-months invites misreading.
-3. **Invariant preservation.** `architecture.md` defines Tasks as read-only in the Kanban lane; the simplest way to respect that here is to not render them at all.
-4. **Scope discipline.** Every Task-adjacent feature (collapsible sub-bars, disclosure carets, muted colors, Scheduler-fetch plumbing) adds cost without serving the planning use case.
+1. **Humans plan in Issues.** Tasks are how an agent internally decomposes an Issue — an execution detail.
+2. **Task timing is Scheduler-owned and ephemeral.** A Task's `start` / `end` is determined by agent runtime and can change within seconds.
+3. **Invariant preservation.** `architecture.md` defines Tasks as read-only in Kanban; the simplest way to respect that here is to not render them at all.
 
-If an agent-execution timeline is ever needed, it belongs in a separate view (e.g., per-session trace visualization already implied by `gctl sessions tree`), not bolted onto the Issue Gantt.
+If an agent-execution timeline is ever needed, it belongs in a separate view (e.g., per-session trace visualization implied by `gctl sessions tree`), not bolted onto the Issue Gantt.
 
 ## Testing
 
-Following the project's test pyramid (unit → integration → acceptance → soak).
+### Unit — `web/src/lib/__tests__/gantt-geom.test.ts` + `web/src/components/__tests__/GanttBoard.test.tsx`
 
-### Unit — `web/src/components/__tests__/GanttBoard.test.tsx`
-- Bar position math for every zoom level.
-- Default-span fallback when only `start_date` or only `due_date` is set.
-- Dependency arrow path geometry given two bar rects.
+- `barRect` for every zoom level and every anchor case (both dates / only start / only due).
+- `gridCoordinateGetter` returns exact `colWidth`-multiple deltas for arrow keys.
+- Axis-disambiguation dispatcher: given a synthetic `DragEndEvent`, it issues the correct combination of `updateSchedule` + `moveStatus` calls (mocked hook).
 
-### Integration — `test/gantt.test.ts` (vitest + Worker)
-- `PATCH /schedule` rejects `start_date > due_date`.
+### Integration — `test/gantt.test.ts` (vitest + Miniflare, Worker surface)
+
+- `PATCH /schedule` rejects `start_date > due_date` with `400`.
 - `PATCH /schedule` with `null` clears the field.
-- `GET /projects/:id/gantt` returns correct `range` and omits archived Issues.
-- Scheduled event emitted to `issue_events`.
+- `PATCH /schedule` emits an `issue_events` row with `event_type = "scheduled"`.
+- `GET /projects/:id/gantt` returns `range` as raw min/max over scheduled dates.
+- `GET /projects/:id/gantt` returns Issues with null dates for the Unscheduled tray.
+- Cancelled issues are returned but flagged such that the client knows to render them `readonly` — or (simpler) the API returns them unchanged and the client applies `readonly` based on `status === "cancelled"`. Test asserts client-side behavior in the acceptance suite.
+
+### Integration — `kernel/crates/gctrl-otel/tests/board_schedule.rs`
+
+Mirror the Worker tests against the kernel receiver, using the same `board_move_triggers_task.rs` harness.
 
 ### Acceptance — `tests/acceptance/gantt.spec.ts` (Playwright + Miniflare)
-- User loads Gantt view, drags a bar 3 columns right, observes persisted dates after reload.
-- User drags left edge — only `start_date` changes.
-- User drags a card from Unscheduled tray onto the grid — bar appears at drop column.
-- User drags a bar between swimlanes when grouped by `status` — status transitions via existing move endpoint (exercises the two-endpoint routing inside `onDragEnd`).
-- Keyboard-only path: `Tab` to a bar, `Space` to pick up, arrows to move, `Space` to drop — uses `@dnd-kit`'s `KeyboardSensor`.
+
+- Drag a bar 3 snap-units right → reload → dates persisted with the correct delta.
+- Drag left edge → only `start_date` changes (assert DOM + API call).
+- Drag a card from Unscheduled tray → bar appears at drop column with default span.
+- Drag a bar from `todo` swimlane to `in_progress` at a different column → both status AND date change; both network calls issued.
+- Simulated `PATCH /schedule` failure → bar snaps back to original position; toast contains the issue key.
+- Cancelled bar is not draggable (pointer events down do not trigger a drag).
+- Keyboard: `Tab` to a bar, `Space` picks up, `ArrowRight × 3` moves by `3 × colWidth` at Day zoom, `Space` drops and persists.
 
 ## Implementation Phases
 
-1. **Data + API** — migration `0003_gantt_dates.sql`, `PATCH /schedule`, `GET /gantt`, unit + integration tests.
-2. **Static render** — `GanttBoard.tsx` with time axis, swimlanes, bars, today marker. No dragging yet.
-3. **Drag to move / resize** — `@dnd-kit` wiring, optimistic updates, rollback on failure.
-4. **Dependency arrows** — SVG overlay, recompute on layout changes.
-5. **Unscheduled tray + swimlane drag** — reassignment path.
-6. **Accessibility pass** — keyboard sensor, ARIA for bars, focus ring.
-7. **Acceptance tests** — Playwright suite above.
+Collapsed to 3 PRs (down from 6):
 
-Each phase lands as its own PR.
+1. **Data + API** — migration `0003_gantt_dates.sql` (both D1 and kernel SQLite), `PATCH /schedule`, `GET /gantt` on both surfaces, unit + integration tests. No frontend.
+2. **Static render** — `GanttBoard.tsx` with time axis, status swimlanes, bars, today marker, Unscheduled tray. No dragging yet. Ships behind a view-switcher toggle.
+3. **Drag interactions + a11y** — four drag kinds, `DragOverlay`, snap policy, axis-disambiguation dispatcher, `KeyboardSensor` with `gridCoordinateGetter`, touch handles, Playwright acceptance suite.
 
-## Open Questions
-
-- **Iteration field**: GitHub Projects has first-class iterations (2-week windows). Should we model iterations or keep relying on `parent_id` for epic grouping? Deferring; revisit after dogfooding v1.
-- **External sync**: Should `start_date` / `due_date` sync bidirectionally to GitHub Projects via `driver-github`? GitHub Project v2 supports date fields via GraphQL; viable but out of scope for v1.
-- **Milestones**: Do we render project milestones as vertical markers? Depends on whether we add a `board_milestones` table. Deferred to v2.
-- **Working days**: Should weekends be collapsible in Day zoom? Default to showing all days; revisit if users complain.
+v2 (separate spec, separate PRs): dependency arrows, assignee/iteration grouping, milestones as markers, working-days toggle.
 
 ## Related
 
 - `architecture.md` — Tasks are read-only; kernel SQLite is source of truth.
 - `tracker.md` — Issue lifecycle and DAG; dates are orthogonal to status transitions.
-- `../../specs/gctrl/workflows/issue-lifecycle.md` — Lifecycle events that the Gantt view reacts to (status color on bars).
+- `../../specs/gctrl/workflows/issue-lifecycle.md` — lifecycle events the Gantt view reacts to (status color on bars).
+- [frappe/gantt](https://github.com/frappe/gantt) — reference implementation we borrow `snap_at`, `readonly_dates`, and `on_date_change` naming from (but not the SVG rendering or custom drag code).
 - `@dnd-kit` docs: <https://docs.dndkit.com/>

--- a/apps/gctrl-board/specs/gantt.md
+++ b/apps/gctrl-board/specs/gantt.md
@@ -1,0 +1,235 @@
+# Gantt View — gctrl-board
+
+Timeline visualization for Issues, complementary to the existing Kanban view. Modeled on GitHub Projects' "Roadmap" layout: horizontal bars per Issue on a time axis, grouped by a chosen field (status, assignee, milestone, parent), with direct-manipulation drag-and-drop for scheduling and reassignment.
+
+Drag-and-drop is implemented with [`@dnd-kit`](https://github.com/clauderic/dnd-kit) — the same library already used by `KanbanBoard.tsx`, so sensors, keyboard accessibility, and overlay patterns stay consistent across views.
+
+## Goals
+
+1. Give humans a time-anchored view of committed Issue work across a project.
+2. Make rescheduling (move, resize, reparent) a one-gesture interaction.
+3. Surface dependency structure — `blockedBy` / `blocking` — as visible arrows between bars, so conflicts and critical paths are obvious.
+4. Preserve the invariants from `architecture.md`: Tasks remain read-only; kernel SQLite is the source of truth; the Worker is a facade.
+
+## Non-Goals
+
+- Resource-leveling or auto-scheduling. Humans decide dates; the Tracker only validates.
+- Gantt editing for Tasks. Tasks still render read-only (if shown at all in v1 — see "Tasks lane" below).
+- Critical-path math. We render dependencies but do not compute slack / float in v1.
+- External sync of start/end dates to GitHub/Linear in v1. Dates are gctrl-local until a driver opts in (future work — see "Open questions").
+
+## User Stories
+
+- **As a PM**, I can see every Issue for a project as a bar on a timeline, grouped by status, so I can spot work clustered in one status lane.
+- **As an IC**, I can drag an Issue bar to shift its dates, or drag its left/right edge to extend/compress duration, without leaving the view.
+- **As a triager**, I can drag an Issue from one swimlane row to another to reassign it (e.g., change assignee, change milestone) in a single gesture.
+- **As a reviewer**, I can see `blockedBy` arrows pointing into an Issue so I know what must ship first.
+- **As an agent observer**, I can still see Tasks linked to an Issue — rendered as read-only sub-bars below the parent Issue bar.
+
+## Comparison to GitHub Projects Roadmap
+
+| Capability                          | GitHub Projects Roadmap | gctrl-board Gantt v1                          |
+|-------------------------------------|-------------------------|-----------------------------------------------|
+| Bar per issue on time axis          | ✅                      | ✅                                            |
+| Start / Target date fields          | ✅                      | ✅ (new `start_date`, `due_date` on Issue)    |
+| Drag to move                        | ✅                      | ✅ (`@dnd-kit` `useDraggable`)                |
+| Drag edge to resize                 | ✅                      | ✅ (custom edge-handle draggables)            |
+| Group by field (status/iteration)   | ✅                      | ✅ (status, assignee, parent, milestone)      |
+| Zoom (day/week/month/quarter)       | ✅                      | ✅ (day, week, month, quarter)                |
+| Dependency arrows                   | ❌                      | ✅ (SVG overlay over bars)                    |
+| Milestones as vertical markers      | ✅                      | Deferred (v2)                                 |
+| Iteration columns                   | ✅                      | Deferred — we rely on `parent_id` for epics   |
+
+## Data Model Changes
+
+Add two optional date fields to `Issue`. Both are `YYYY-MM-DD` (date-only, local to the project, no TZ ambiguity for day-granularity bars).
+
+### Schema (Effect-TS) — `apps/gctrl-board/src/schema/Issue.ts`
+
+```typescript
+export const Issue = Schema.Struct({
+  // ... existing fields ...
+  startDate: Schema.optional(Schema.String), // YYYY-MM-DD
+  dueDate:   Schema.optional(Schema.String), // YYYY-MM-DD
+})
+```
+
+### Migration — `apps/gctrl-board/migrations/0003_gantt_dates.sql`
+
+```sql
+ALTER TABLE issues ADD COLUMN start_date TEXT;
+ALTER TABLE issues ADD COLUMN due_date   TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_issues_start_date ON issues(start_date);
+CREATE INDEX IF NOT EXISTS idx_issues_due_date   ON issues(due_date);
+```
+
+Both nullable — existing Issues appear in an "Unscheduled" tray (see "Layout") until dated.
+
+### Validation rules (Tracker)
+
+- If both set, `start_date <= due_date`. Reject the mutation otherwise.
+- Either field may be set alone. A bar without `start_date` anchors its left edge at `due_date - default_span` (default span = 3 days, configurable per project).
+- Status transitions do **not** clear or auto-set dates. Dates are a separate concern from lifecycle.
+
+## Kernel HTTP API
+
+Per the "Kernel is source of truth; Worker is facade" feedback, new routes live on the kernel and the Worker simply proxies. No direct D1 writes for scheduling.
+
+### New endpoints
+
+| Method | Path                                          | Purpose                                      |
+|--------|-----------------------------------------------|----------------------------------------------|
+| `PATCH`| `/api/board/issues/{id}/schedule`             | Update `start_date` and/or `due_date`        |
+| `GET`  | `/api/board/projects/{id}/gantt`              | Projected view: issues + dependency edges    |
+
+#### `PATCH /api/board/issues/{id}/schedule`
+
+Request body:
+
+```json
+{ "start_date": "2026-05-01", "due_date": "2026-05-14" }
+```
+
+Either field may be `null` to clear. Validates the ordering rule above. Emits an `issue_events` row of type `scheduled` with the delta as `data`.
+
+#### `GET /api/board/projects/{id}/gantt`
+
+Response shape (tuned for the Gantt view — avoids N+1 over individual issue fetches):
+
+```json
+{
+  "range": { "min": "2026-04-01", "max": "2026-06-30" },
+  "issues": [ { "id": "...", "title": "...", "status": "...", "start_date": "...", "due_date": "...", "assignee_id": "...", "parent_id": "...", "priority": "..." } ],
+  "dependencies": [ { "from_issue_id": "...", "to_issue_id": "...", "kind": "blocked_by" } ]
+}
+```
+
+`range` is computed from the min/max of scheduled dates in the project, clamped to at least one zoom window. Unscheduled Issues are returned with null dates so the client can render them in the "Unscheduled" tray.
+
+## Frontend
+
+New component: `apps/gctrl-board/web/src/components/GanttBoard.tsx`, reachable from the existing view-switcher (sibling of `KanbanBoard`). Route: `/projects/:projectKey/gantt`.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Zoom: [Day][Week][Month][Quarter]   Group by: [Status ▾]   │
+├──────────────┬──────────────────────────────────────────────┤
+│ Swimlane hdr │  ← time axis (days) ───────────────────────→ │
+├──────────────┼──────────────────────────────────────────────┤
+│ Backlog      │       ░░░░░░░░                               │
+│   BACK-12    │       ████████      ← draggable bar          │
+│   BACK-17    │                 ██████████                   │
+├──────────────┼──────────────────────────────────────────────┤
+│ In Progress  │  ██████████████  ← "today" vertical line     │
+│   BACK-42    │  ├──→ arrow to BACK-17 (blocking)            │
+├──────────────┼──────────────────────────────────────────────┤
+│ Unscheduled  │  [card] [card] [card]   ← drop target tray   │
+└──────────────┴──────────────────────────────────────────────┘
+```
+
+- Time axis: day column width depends on zoom. Sticky header.
+- Swimlanes: rows grouped by the `Group by` field. Drop between rows = reassign that grouping field.
+- Unscheduled tray: horizontal strip of undated cards. Dragging a card onto the time grid sets `start_date` to the drop x-coordinate; default span applied if no `due_date` exists.
+- Today marker: a vertical line at today's column, always visible.
+- Dependency arrows: an absolutely-positioned SVG overlay renders one `<path>` per `blockedBy` edge between bars. Arrows recompute on layout changes (row reorder, resize, zoom).
+
+### @dnd-kit integration
+
+We use three distinct draggable "kinds" so handlers can dispatch cleanly:
+
+| Drag kind      | `useDraggable` data          | `useDroppable` targets                      | Effect                                                |
+|----------------|------------------------------|---------------------------------------------|-------------------------------------------------------|
+| `bar-move`     | `{ issueId, kind: "move" }`  | Day cells in any swimlane                   | Shift `start_date` (and `due_date` by same delta)     |
+| `bar-resize-l` | `{ issueId, kind: "l" }`     | Day cells in the same row                   | Update `start_date` only                              |
+| `bar-resize-r` | `{ issueId, kind: "r" }`     | Day cells in the same row                   | Update `due_date` only                                |
+| `unscheduled`  | `{ issueId, kind: "fresh" }` | Day cells in any swimlane                   | Set `start_date` to drop column; apply default span   |
+
+All four share a single `<DndContext>` with a `PointerSensor` (same `activationConstraint: { distance: 8 }` as KanbanBoard) and a `KeyboardSensor` for a11y. `DragOverlay` renders a translucent bar following the cursor.
+
+Droppables are the individual day columns inside each swimlane row, keyed by `"{rowKey}::{YYYY-MM-DD}"`. On `onDragEnd` we parse the `over.id`, compute the new dates, optimistically update local state, and call `PATCH /schedule`. On failure, we roll back and surface a toast — same pattern `useBoard.moveIssue` already uses.
+
+Dragging a bar's row in the swimlane direction (vertical) reassigns the grouping field (e.g., changes `status`, `assignee_id`, or `parent_id`). That path reuses the existing `PATCH /issues/{id}` endpoint — not the schedule endpoint.
+
+### Rendering the bars
+
+- Bar left = `(start_date − range.min) * colWidth`.
+- Bar width = `(due_date − start_date + 1) * colWidth`, min 1 column.
+- Color = status accent (reuse `COLUMN_ACCENT` from `KanbanBoard.tsx`).
+- Label = `{project.key}-{issue.counter}  ·  {title}` truncated to bar width.
+- Hover reveals an `IssueDetailPanel` popover (reuse existing component).
+
+### State & hooks
+
+New hook `useGantt(projectId)`:
+
+```ts
+export function useGantt(projectId: string): {
+  data: GanttView | null
+  loading: boolean
+  updateSchedule: (id: string, patch: SchedulePatch) => Promise<void>
+  moveAcrossSwimlane: (id: string, groupField: string, groupValue: string) => Promise<void>
+}
+```
+
+Backed by a single `GET /projects/:id/gantt` fetch + optimistic local reducer. Reuses `useProjectRoute` for the current project.
+
+## Read-only Tasks in the Gantt
+
+Per the architecture invariant "Tasks lane is read-only", Tasks linked to an Issue render as narrow sub-bars *under* the parent Issue's bar, with:
+
+- No drag handles (`useDraggable` is not attached).
+- Muted color, dashed outline.
+- Width derived from the Task's Scheduler-declared start/end, not editable here.
+
+For v1, Tasks are collapsed by default; a disclosure caret on the parent bar expands them. This keeps the v1 view focused on Issue scheduling while still showing agent-visible progress.
+
+## Testing
+
+Following the project's test pyramid (unit → integration → acceptance → soak).
+
+### Unit — `web/src/components/__tests__/GanttBoard.test.tsx`
+- Bar position math for every zoom level.
+- Default-span fallback when only `start_date` or only `due_date` is set.
+- Dependency arrow path geometry given two bar rects.
+
+### Integration — `test/gantt.test.ts` (vitest + Worker)
+- `PATCH /schedule` rejects `start_date > due_date`.
+- `PATCH /schedule` with `null` clears the field.
+- `GET /projects/:id/gantt` returns correct `range` and omits archived Issues.
+- Scheduled event emitted to `issue_events`.
+
+### Acceptance — `tests/acceptance/gantt.spec.ts` (Playwright + Miniflare)
+- User loads Gantt view, drags a bar 3 columns right, observes persisted dates after reload.
+- User drags left edge — only `start_date` changes.
+- User drags a card from Unscheduled tray onto the grid — bar appears at drop column.
+- User drags a bar between swimlanes when grouped by `status` — status transitions via existing move endpoint (exercises the two-endpoint routing inside `onDragEnd`).
+- Keyboard-only path: `Tab` to a bar, `Space` to pick up, arrows to move, `Space` to drop — uses `@dnd-kit`'s `KeyboardSensor`.
+
+## Implementation Phases
+
+1. **Data + API** — migration `0003_gantt_dates.sql`, `PATCH /schedule`, `GET /gantt`, unit + integration tests.
+2. **Static render** — `GanttBoard.tsx` with time axis, swimlanes, bars, today marker. No dragging yet.
+3. **Drag to move / resize** — `@dnd-kit` wiring, optimistic updates, rollback on failure.
+4. **Dependency arrows** — SVG overlay, recompute on layout changes.
+5. **Unscheduled tray + swimlane drag** — reassignment path.
+6. **Accessibility pass** — keyboard sensor, ARIA for bars, focus ring.
+7. **Acceptance tests** — Playwright suite above.
+
+Each phase lands as its own PR.
+
+## Open Questions
+
+- **Iteration field**: GitHub Projects has first-class iterations (2-week windows). Should we model iterations or keep relying on `parent_id` for epic grouping? Deferring; revisit after dogfooding v1.
+- **External sync**: Should `start_date` / `due_date` sync bidirectionally to GitHub Projects via `driver-github`? GitHub Project v2 supports date fields via GraphQL; viable but out of scope for v1.
+- **Milestones**: Do we render project milestones as vertical markers? Depends on whether we add a `board_milestones` table. Deferred to v2.
+- **Working days**: Should weekends be collapsible in Day zoom? Default to showing all days; revisit if users complain.
+
+## Related
+
+- `architecture.md` — Tasks are read-only; kernel SQLite is source of truth.
+- `tracker.md` — Issue lifecycle and DAG; dates are orthogonal to status transitions.
+- `../../specs/gctrl/workflows/issue-lifecycle.md` — Lifecycle events that the Gantt view reacts to (status color on bars).
+- `@dnd-kit` docs: <https://docs.dndkit.com/>

--- a/apps/gctrl-board/src/schema/Issue.ts
+++ b/apps/gctrl-board/src/schema/Issue.ts
@@ -56,6 +56,10 @@ export const Issue = Schema.Struct({
   blocking: Schema.Array(IssueId),
   agentNotes: Schema.optional(Schema.String),
   acceptanceCriteria: Schema.Array(Schema.String),
+
+  // Gantt scheduling (optional, YYYY-MM-DD, project-local date-only)
+  startDate: Schema.optional(Schema.String),
+  dueDate: Schema.optional(Schema.String),
 })
 export type Issue = typeof Issue.Type
 

--- a/apps/gctrl-board/src/services/constants.ts
+++ b/apps/gctrl-board/src/services/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Default span (in days) applied to a Gantt bar when only one of
+ * start_date / due_date is known. Anchored on due_date per spec:
+ * if due_date alone is set, the bar's left edge is at due_date − DEFAULT_SPAN_DAYS.
+ */
+export const DEFAULT_SPAN_DAYS = 3

--- a/apps/gctrl-board/src/services/index.ts
+++ b/apps/gctrl-board/src/services/index.ts
@@ -1,3 +1,4 @@
 export { BoardService } from "./BoardService.js"
 export { DependencyResolver } from "./DependencyResolver.js"
 export * from "./errors.js"
+export { DEFAULT_SPAN_DAYS } from "./constants.js"

--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -358,6 +358,102 @@ const linkSession: ApiHandler = (req, params) =>
     return noContent()
   })
 
+// Gantt — scheduling + project timeline
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const isValidDate = (v: unknown): v is string =>
+  typeof v === "string" && DATE_RE.test(v)
+
+const scheduleIssue: ApiHandler = (req, params) =>
+  Effect.gen(function* () {
+    const body = (yield* Effect.tryPromise({
+      try: () => req.json(),
+      catch: () => new D1Error({ message: "Invalid JSON" }),
+    })) as { start_date?: string | null; due_date?: string | null }
+
+    const hasStart = Object.prototype.hasOwnProperty.call(body, "start_date")
+    const hasDue = Object.prototype.hasOwnProperty.call(body, "due_date")
+    if (!hasStart && !hasDue) {
+      return errorResponse("start_date or due_date required")
+    }
+
+    if (body.start_date != null && !isValidDate(body.start_date)) {
+      return errorResponse("start_date must be YYYY-MM-DD")
+    }
+    if (body.due_date != null && !isValidDate(body.due_date)) {
+      return errorResponse("due_date must be YYYY-MM-DD")
+    }
+
+    const db = yield* D1Client
+    const existing = yield* db.first<{ start_date: string | null; due_date: string | null }>(
+      "SELECT start_date, due_date FROM issues WHERE id = ?", params.id,
+    )
+    if (!existing) return errorResponse("Issue not found", 404)
+
+    // Merge: unspecified keys keep existing values
+    const nextStart = hasStart ? (body.start_date ?? null) : existing.start_date
+    const nextDue = hasDue ? (body.due_date ?? null) : existing.due_date
+
+    if (nextStart && nextDue && nextStart > nextDue) {
+      return errorResponse("start_date must be <= due_date")
+    }
+
+    const ts = new Date().toISOString()
+    yield* db.batch([
+      {
+        sql: "UPDATE issues SET start_date = ?, due_date = ?, updated_at = ? WHERE id = ?",
+        binds: [nextStart, nextDue, ts, params.id],
+      },
+      {
+        sql: "INSERT INTO issue_events (id, issue_id, event_type, actor_id, actor_name, actor_type, timestamp, data) VALUES (?, ?, 'scheduled', ?, ?, ?, ?, ?)",
+        binds: [
+          crypto.randomUUID(), params.id,
+          "web-user", "Web UI", "human", ts,
+          JSON.stringify({ start_date: nextStart, due_date: nextDue }),
+        ],
+      },
+    ])
+
+    const row = yield* db.first("SELECT * FROM issues WHERE id = ?", params.id)
+    return jsonResponse(parseRow(row as Record<string, unknown>))
+  })
+
+const projectGantt: ApiHandler = (_req, params) =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const project = yield* db.first<{ id: string }>(
+      "SELECT id FROM projects WHERE id = ?", params.id,
+    )
+    if (!project) return errorResponse("Project not found", 404)
+
+    const rows = yield* db.query(
+      `SELECT id, project_id, title, status, priority,
+              assignee_id, assignee_name, assignee_type,
+              parent_id, start_date, due_date
+       FROM issues WHERE project_id = ?
+       ORDER BY COALESCE(start_date, due_date) IS NULL, start_date, due_date, id`,
+      params.id,
+    )
+
+    // Raw min/max over scheduled dates — no zoom padding (client's job).
+    let min: string | null = null
+    let max: string | null = null
+    for (const r of rows) {
+      const s = (r.start_date as string | null) ?? null
+      const d = (r.due_date as string | null) ?? null
+      for (const v of [s, d]) {
+        if (!v) continue
+        if (min === null || v < min) min = v
+        if (max === null || v > max) max = v
+      }
+    }
+
+    return jsonResponse({
+      range: { min, max },
+      issues: rows,
+    })
+  })
+
 // Inbox stub
 
 const inboxStats: ApiHandler = () =>
@@ -405,6 +501,8 @@ const routes: Route[] = [
   defineRoute("GET", "/api/board/issues/:id/comments", listComments),
   defineRoute("GET", "/api/board/issues/:id/events", listEvents),
   defineRoute("POST", "/api/board/issues/:id/link-session", linkSession),
+  defineRoute("PATCH", "/api/board/issues/:id/schedule", scheduleIssue),
+  defineRoute("GET", "/api/board/projects/:id/gantt", projectGantt),
   defineRoute("GET", "/api/inbox/stats", inboxStats),
   defineRoute("GET", "/api/sync/status", syncStatus),
 ]
@@ -441,7 +539,7 @@ export default {
           status: 204,
           headers: {
             "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+            "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type",
           },
         })

--- a/apps/gctrl-board/tests/acceptance/kanban-board.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/kanban-board.spec.ts
@@ -101,7 +101,7 @@ test.describe("Kanban Board", () => {
     await expect(card).toBeVisible()
     await expect(card.getByText(issue.id)).toBeVisible()
     await expect(card.getByText("Auth middleware refactor")).toBeVisible()
-    await expect(card.getByText("HI")).toBeVisible()
+    await expect(card.getByTestId("priority-badge")).toHaveText("HI")
     await expect(card.getByText("bug")).toBeVisible()
     await expect(card.getByText("security")).toBeVisible()
   })

--- a/apps/gctrl-board/tests/worker/apply-migrations.ts
+++ b/apps/gctrl-board/tests/worker/apply-migrations.ts
@@ -11,11 +11,15 @@ import { env } from "cloudflare:test"
 const statements = [
   `CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, key TEXT NOT NULL UNIQUE, counter INTEGER NOT NULL DEFAULT 0, github_repo TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')))`,
 
-  `CREATE TABLE IF NOT EXISTS issues (id TEXT PRIMARY KEY, project_id TEXT NOT NULL REFERENCES projects(id), title TEXT NOT NULL, description TEXT, status TEXT NOT NULL DEFAULT 'backlog', priority TEXT NOT NULL DEFAULT 'none', assignee_id TEXT, assignee_name TEXT, assignee_type TEXT, labels TEXT NOT NULL DEFAULT '[]', parent_id TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), created_by_id TEXT NOT NULL, created_by_name TEXT NOT NULL, created_by_type TEXT NOT NULL DEFAULT 'human', session_ids TEXT NOT NULL DEFAULT '[]', total_cost_usd REAL NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0, pr_numbers TEXT NOT NULL DEFAULT '[]', blocked_by TEXT NOT NULL DEFAULT '[]', blocking TEXT NOT NULL DEFAULT '[]', acceptance_criteria TEXT NOT NULL DEFAULT '[]', github_issue_number INTEGER, github_url TEXT)`,
+  `CREATE TABLE IF NOT EXISTS issues (id TEXT PRIMARY KEY, project_id TEXT NOT NULL REFERENCES projects(id), title TEXT NOT NULL, description TEXT, status TEXT NOT NULL DEFAULT 'backlog', priority TEXT NOT NULL DEFAULT 'none', assignee_id TEXT, assignee_name TEXT, assignee_type TEXT, labels TEXT NOT NULL DEFAULT '[]', parent_id TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), created_by_id TEXT NOT NULL, created_by_name TEXT NOT NULL, created_by_type TEXT NOT NULL DEFAULT 'human', session_ids TEXT NOT NULL DEFAULT '[]', total_cost_usd REAL NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0, pr_numbers TEXT NOT NULL DEFAULT '[]', blocked_by TEXT NOT NULL DEFAULT '[]', blocking TEXT NOT NULL DEFAULT '[]', acceptance_criteria TEXT NOT NULL DEFAULT '[]', github_issue_number INTEGER, github_url TEXT, start_date TEXT, due_date TEXT)`,
 
   `CREATE INDEX IF NOT EXISTS idx_issues_project ON issues(project_id)`,
 
   `CREATE INDEX IF NOT EXISTS idx_issues_status ON issues(status)`,
+
+  `CREATE INDEX IF NOT EXISTS idx_issues_start_date ON issues(start_date)`,
+
+  `CREATE INDEX IF NOT EXISTS idx_issues_due_date ON issues(due_date)`,
 
   `CREATE TABLE IF NOT EXISTS comments (id TEXT PRIMARY KEY, issue_id TEXT NOT NULL REFERENCES issues(id), author_id TEXT NOT NULL, author_name TEXT NOT NULL, author_type TEXT NOT NULL DEFAULT 'human', body TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')), session_id TEXT)`,
 

--- a/apps/gctrl-board/tests/worker/gantt.test.ts
+++ b/apps/gctrl-board/tests/worker/gantt.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Gantt API tests — PATCH /schedule and GET /projects/:id/gantt.
+ *
+ * Mirrors the spec in apps/gctrl-board/specs/gantt.md:
+ *  - start_date <= due_date validated
+ *  - null clears a field (other is preserved)
+ *  - emits issue_events with event_type="scheduled"
+ *  - range = raw min/max over scheduled dates
+ *  - unscheduled issues returned with null dates
+ */
+import { HttpBody, HttpClient } from "@effect/platform"
+import { Effect } from "effect"
+import { beforeAll, describe, expect, it } from "vitest"
+import { HOST, runTest } from "./fixtures/http"
+import { seedIssue, seedProject, type SeededProject } from "./fixtures/seed"
+
+const schedule = (id: string, body: { start_date?: string | null; due_date?: string | null }) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient
+    return yield* client.patch(`${HOST}/api/board/issues/${id}/schedule`, {
+      body: HttpBody.unsafeJson(body),
+    })
+  })
+
+describe("PATCH /api/board/issues/:id/schedule", () => {
+  let project: SeededProject
+
+  beforeAll(async () => {
+    project = await runTest(seedProject("Gantt Tests", "GNT"))
+  })
+
+  it("sets both start_date and due_date", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Schedule me")
+        const res = yield* schedule(issue.id as string, {
+          start_date: "2026-05-01",
+          due_date: "2026-05-14",
+        })
+        expect(res.status).toBe(200)
+        const body = (yield* res.json) as Record<string, unknown>
+        expect(body.start_date).toBe("2026-05-01")
+        expect(body.due_date).toBe("2026-05-14")
+      }),
+    ))
+
+  it("rejects start_date > due_date with 400", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Invalid dates")
+        const res = yield* schedule(issue.id as string, {
+          start_date: "2026-05-14",
+          due_date: "2026-05-01",
+        })
+        expect(res.status).toBe(400)
+      }),
+    ))
+
+  it("rejects malformed date string with 400", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Bad date format")
+        const res = yield* schedule(issue.id as string, {
+          start_date: "not-a-date",
+        })
+        expect(res.status).toBe(400)
+      }),
+    ))
+
+  it("null clears only the specified field", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Partial clear")
+        yield* schedule(issue.id as string, {
+          start_date: "2026-05-01",
+          due_date: "2026-05-14",
+        })
+        const res = yield* schedule(issue.id as string, { start_date: null })
+        expect(res.status).toBe(200)
+        const body = (yield* res.json) as Record<string, unknown>
+        expect(body.start_date).toBeNull()
+        expect(body.due_date).toBe("2026-05-14")
+      }),
+    ))
+
+  it("accepts due_date alone (start defaults to null)", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Due only")
+        const res = yield* schedule(issue.id as string, { due_date: "2026-06-01" })
+        expect(res.status).toBe(200)
+        const body = (yield* res.json) as Record<string, unknown>
+        expect(body.start_date).toBeNull()
+        expect(body.due_date).toBe("2026-06-01")
+      }),
+    ))
+
+  it("rejects empty body", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Empty schedule")
+        const res = yield* schedule(issue.id as string, {})
+        expect(res.status).toBe(400)
+      }),
+    ))
+
+  it("returns 404 for missing issue", () =>
+    runTest(
+      Effect.gen(function* () {
+        const res = yield* schedule("NOPE-999", { start_date: "2026-05-01" })
+        expect(res.status).toBe(404)
+      }),
+    ))
+
+  it("emits an issue_events row with event_type=scheduled", () =>
+    runTest(
+      Effect.gen(function* () {
+        const issue = yield* seedIssue(project.id, "Emits event")
+        yield* schedule(issue.id as string, {
+          start_date: "2026-05-01",
+          due_date: "2026-05-14",
+        })
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/board/issues/${issue.id}/events`)
+        const events = (yield* res.json) as Array<{ event_type: string; data: unknown }>
+        const scheduled = events.find((e) => e.event_type === "scheduled")
+        expect(scheduled).toBeDefined()
+        expect(scheduled!.data).toEqual({
+          start_date: "2026-05-01",
+          due_date: "2026-05-14",
+        })
+      }),
+    ))
+})
+
+describe("GET /api/board/projects/:id/gantt", () => {
+  it("returns raw min/max range over scheduled issues", () =>
+    runTest(
+      Effect.gen(function* () {
+        const project = yield* seedProject("Range Test", "RNG")
+        const a = yield* seedIssue(project.id, "A")
+        const b = yield* seedIssue(project.id, "B")
+        yield* schedule(a.id as string, { start_date: "2026-05-01", due_date: "2026-05-10" })
+        yield* schedule(b.id as string, { start_date: "2026-06-01", due_date: "2026-06-15" })
+
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/board/projects/${project.id}/gantt`)
+        expect(res.status).toBe(200)
+        const body = (yield* res.json) as {
+          range: { min: string | null; max: string | null }
+          issues: Array<Record<string, unknown>>
+        }
+        expect(body.range.min).toBe("2026-05-01")
+        expect(body.range.max).toBe("2026-06-15")
+        expect(body.issues.length).toBe(2)
+      }),
+    ))
+
+  it("returns unscheduled issues with null dates", () =>
+    runTest(
+      Effect.gen(function* () {
+        const project = yield* seedProject("Unscheduled Test", "UNS")
+        yield* seedIssue(project.id, "No dates")
+
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/board/projects/${project.id}/gantt`)
+        const body = (yield* res.json) as {
+          range: { min: string | null; max: string | null }
+          issues: Array<Record<string, unknown>>
+        }
+        expect(body.range.min).toBeNull()
+        expect(body.range.max).toBeNull()
+        expect(body.issues.length).toBe(1)
+        expect(body.issues[0].start_date).toBeNull()
+        expect(body.issues[0].due_date).toBeNull()
+      }),
+    ))
+
+  it("returns 404 for missing project", () =>
+    runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/board/projects/nonexistent/gantt`)
+        expect(res.status).toBe(404)
+      }),
+    ))
+
+  it("mixes scheduled and unscheduled, computes range only over scheduled", () =>
+    runTest(
+      Effect.gen(function* () {
+        const project = yield* seedProject("Mixed", "MIX")
+        const a = yield* seedIssue(project.id, "Scheduled")
+        yield* seedIssue(project.id, "Unscheduled")
+        yield* schedule(a.id as string, { start_date: "2026-05-05", due_date: "2026-05-09" })
+
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/board/projects/${project.id}/gantt`)
+        const body = (yield* res.json) as {
+          range: { min: string | null; max: string | null }
+          issues: Array<{ start_date: string | null; due_date: string | null }>
+        }
+        expect(body.range.min).toBe("2026-05-05")
+        expect(body.range.max).toBe("2026-05-09")
+        expect(body.issues.length).toBe(2)
+        expect(body.issues.some((i) => i.start_date === null)).toBe(true)
+      }),
+    ))
+})

--- a/apps/gctrl-board/vitest.config.ts
+++ b/apps/gctrl-board/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "web/src/**/*.test.ts", "web/src/**/*.test.tsx"],
   },
 })

--- a/apps/gctrl-board/web/src/App.tsx
+++ b/apps/gctrl-board/web/src/App.tsx
@@ -3,6 +3,8 @@ import { useProjects, useIssues } from "./hooks/useBoard"
 import { useProjectRoute } from "./hooks/useProjectRoute"
 import { useRoute } from "./hooks/useRoute"
 import { KanbanBoard } from "./components/KanbanBoard"
+import { GanttBoard } from "./components/GanttBoard"
+import { useGantt } from "./hooks/useGantt"
 import { IssueDetailPanel } from "./components/IssueDetailPanel"
 import { CreateIssueDialog } from "./components/CreateIssueDialog"
 import { ProjectSelector } from "./components/ProjectSelector"
@@ -21,6 +23,7 @@ export function App() {
   const { route, navigate } = useRoute()
   const { projects, loading: projectsLoading, create: createProject } = useProjects()
   const { selectedProjectId, selectProject: setSelectedProjectId } = useProjectRoute(projects)
+  const boardView = route.page === "board" ? route.view : "kanban"
   const {
     issues,
     loading: issuesLoading,
@@ -28,6 +31,7 @@ export function App() {
     createIssue,
     refresh,
   } = useIssues(selectedProjectId)
+  const gantt = useGantt(boardView === "gantt" ? selectedProjectId : null)
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [toasts, setToasts] = useState<Toast[]>([])
@@ -251,6 +255,35 @@ export function App() {
                   onCreate={handleCreateProject}
                   loading={projectsLoading}
                 />
+                {selectedProject && (
+                  <>
+                    <div className="w-px h-5 bg-zinc-800" />
+                    <div className="flex gap-px bg-zinc-800/60 p-px">
+                      <button
+                        onClick={() => navigate(`/projects/${selectedProject.key}`)}
+                        data-testid="view-kanban"
+                        className={`px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
+                          boardView === "kanban"
+                            ? "bg-emerald-500/15 text-emerald-300"
+                            : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
+                        }`}
+                      >
+                        kanban
+                      </button>
+                      <button
+                        onClick={() => navigate(`/projects/${selectedProject.key}/gantt`)}
+                        data-testid="view-gantt"
+                        className={`px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
+                          boardView === "gantt"
+                            ? "bg-emerald-500/15 text-emerald-300"
+                            : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
+                        }`}
+                      >
+                        gantt
+                      </button>
+                    </div>
+                  </>
+                )}
               </>
             )}
           </div>
@@ -280,13 +313,28 @@ export function App() {
         {route.page === "board" ? (
           <>
             {/* ── Board ── */}
-            <KanbanBoard
-              issues={issues}
-              loading={issuesLoading}
-              hasProject={!!selectedProjectId}
-              onMoveIssue={handleMoveIssue}
-              onSelectIssue={setSelectedIssue}
-            />
+            {boardView === "gantt" ? (
+              <GanttBoard
+                data={gantt.data}
+                loading={gantt.loading}
+                hasProject={!!selectedProjectId}
+                onSelectIssue={(issueId) => {
+                  const issue = issues.find((i) => i.id === issueId)
+                  if (issue) setSelectedIssue(issue)
+                }}
+                onUpdateSchedule={gantt.updateSchedule}
+                onMoveStatus={gantt.moveStatus}
+                onError={(msg) => addToast(msg, "error")}
+              />
+            ) : (
+              <KanbanBoard
+                issues={issues}
+                loading={issuesLoading}
+                hasProject={!!selectedProjectId}
+                onMoveIssue={handleMoveIssue}
+                onSelectIssue={setSelectedIssue}
+              />
+            )}
 
             {/* ── Detail Panel ── */}
             {selectedIssue && (

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   InboxThread,
   InboxAction,
   InboxStats,
+  GanttView,
 } from "../types"
 
 const BASE = "/api/board"
@@ -119,6 +120,20 @@ export const api = {
         method: "POST",
         body: JSON.stringify(session),
       }),
+
+    schedule: (
+      id: string,
+      patch: { start_date?: string | null; due_date?: string | null }
+    ) =>
+      request<Issue>(`${BASE}/issues/${id}/schedule`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+  },
+
+  gantt: {
+    project: (projectId: string) =>
+      request<GanttView>(`${BASE}/projects/${projectId}/gantt`),
   },
 
   team: {

--- a/apps/gctrl-board/web/src/components/GanttBoard.tsx
+++ b/apps/gctrl-board/web/src/components/GanttBoard.tsx
@@ -1,0 +1,731 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core"
+import type { GanttIssue, GanttView, IssueStatus } from "../types"
+import { STATUS_LABELS } from "../types"
+import {
+  ZOOM,
+  type ZoomMode,
+  addDays,
+  barRect,
+  columnDateAt,
+  dayTicks,
+  daysBetween,
+  formatDate,
+  gridCoordinateGetter,
+  rangeDays,
+  snapDeltaDays,
+} from "../lib/gantt-geom"
+
+const VISIBLE_STATUSES: IssueStatus[] = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "done",
+]
+
+const STATUS_ACCENT: Record<string, string> = {
+  backlog: "#52525b",
+  todo: "#38bdf8",
+  in_progress: "#f59e0b",
+  in_review: "#a78bfa",
+  done: "#34d399",
+  cancelled: "#71717a",
+}
+
+const ROW_HEIGHT = 40
+const SWIMLANE_HEADER_WIDTH = 160
+const AXIS_HEIGHT = 36
+const DEFAULT_SPAN_DAYS = 3
+
+type DragKind = "bar-move" | "bar-resize-l" | "bar-resize-r" | "unscheduled"
+
+interface DragData {
+  kind: DragKind
+  issueId: string
+  issue: GanttIssue
+}
+
+interface LaneDropData {
+  type: "lane"
+  status: IssueStatus
+}
+
+interface Props {
+  data: GanttView | null
+  loading: boolean
+  hasProject: boolean
+  onSelectIssue?: (issueId: string) => void
+  onUpdateSchedule?: (
+    issueId: string,
+    patch: { start_date?: string | null; due_date?: string | null },
+  ) => Promise<void>
+  onMoveStatus?: (issueId: string, newStatus: IssueStatus) => Promise<void>
+  onError?: (message: string) => void
+}
+
+export function GanttBoard({
+  data,
+  loading,
+  hasProject,
+  onSelectIssue,
+  onUpdateSchedule,
+  onMoveStatus,
+  onError,
+}: Props) {
+  const [zoom, setZoom] = useState<ZoomMode>("week")
+
+  if (!hasProject) return <EmptyState />
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+      <GanttToolbar zoom={zoom} onZoomChange={setZoom} />
+      {loading && !data ? (
+        <div className="flex-1 flex items-center justify-center text-zinc-600 font-mono text-sm">
+          loading…
+        </div>
+      ) : data ? (
+        <GanttGrid
+          data={data}
+          zoom={zoom}
+          onSelectIssue={onSelectIssue}
+          onUpdateSchedule={onUpdateSchedule}
+          onMoveStatus={onMoveStatus}
+          onError={onError}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+/* ── Toolbar ──────────────────────────────────────────────── */
+
+function GanttToolbar({
+  zoom,
+  onZoomChange,
+}: {
+  zoom: ZoomMode
+  onZoomChange: (z: ZoomMode) => void
+}) {
+  const modes: ZoomMode[] = ["day", "week", "month", "quarter"]
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 border-b border-zinc-800/60">
+      <span className="text-[11px] font-display font-semibold tracking-widest uppercase text-zinc-500">
+        Zoom
+      </span>
+      <div className="flex gap-px bg-zinc-800/60 p-px">
+        {modes.map((m) => (
+          <button
+            key={m}
+            onClick={() => onZoomChange(m)}
+            data-testid={`zoom-${m}`}
+            className={`px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
+              zoom === m
+                ? "bg-emerald-500/15 text-emerald-300"
+                : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
+            }`}
+          >
+            {m}
+          </button>
+        ))}
+      </div>
+      <span className="ml-auto text-[11px] font-mono text-zinc-600">
+        Group by: status
+      </span>
+    </div>
+  )
+}
+
+/* ── Grid ─────────────────────────────────────────────────── */
+
+function GanttGrid({
+  data,
+  zoom,
+  onSelectIssue,
+  onUpdateSchedule,
+  onMoveStatus,
+  onError,
+}: {
+  data: GanttView
+  zoom: ZoomMode
+  onSelectIssue?: (issueId: string) => void
+  onUpdateSchedule?: Props["onUpdateSchedule"]
+  onMoveStatus?: Props["onMoveStatus"]
+  onError?: Props["onError"]
+}) {
+  const { colWidth, snapDays } = ZOOM[zoom]
+  const gridRowsRef = useRef<HTMLDivElement | null>(null)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const [active, setActive] = useState<DragData | null>(null)
+
+  // Split scheduled vs unscheduled.
+  const { scheduled, unscheduled } = useMemo(() => {
+    const s: GanttIssue[] = []
+    const u: GanttIssue[] = []
+    for (const i of data.issues) {
+      if (i.start_date || i.due_date) s.push(i)
+      else u.push(i)
+    }
+    return { scheduled: s, unscheduled: u }
+  }, [data.issues])
+
+  // Pad the server-side range to include today and one zoom-window of headroom.
+  const paddedRange = useMemo(() => {
+    const today = formatDate(Date.now())
+    const serverMin = data.range.min ?? today
+    const serverMax = data.range.max ?? today
+    let min = serverMin < today ? serverMin : today
+    let max = serverMax > today ? serverMax : today
+    const padDays = zoom === "day" ? 7 : zoom === "week" ? 21 : zoom === "month" ? 60 : 180
+    max = addDays(max, padDays)
+    min = addDays(min, -Math.floor(padDays / 3))
+    return { min, max }
+  }, [data.range, zoom])
+
+  const ticks = useMemo(() => dayTicks(paddedRange), [paddedRange])
+  const totalWidth = rangeDays(paddedRange) * colWidth
+
+  const lanes = [...VISIBLE_STATUSES, "cancelled" as IssueStatus]
+  const byStatus: Record<string, GanttIssue[]> = {}
+  for (const lane of lanes) byStatus[lane] = []
+  for (const i of scheduled) {
+    const lane = lanes.includes(i.status) ? i.status : "backlog"
+    byStatus[lane].push(i)
+  }
+
+  const todayStr = formatDate(Date.now())
+  const todayInRange = todayStr >= paddedRange.min && todayStr <= paddedRange.max
+  const todayLeft = todayInRange ? daysBetween(paddedRange.min, todayStr) * colWidth : 0
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: gridCoordinateGetter({
+        colWidth,
+        rowHeight: ROW_HEIGHT,
+      }) as never,
+    }),
+  )
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const d = event.active.data.current as DragData | undefined
+    if (d) setActive(d)
+  }, [])
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const current = active
+      setActive(null)
+      if (!current || !onUpdateSchedule) return
+
+      const { issue, kind, issueId } = current
+      const delta = event.delta
+      const laneData = (event.over?.data.current as LaneDropData | undefined) ?? null
+
+      const shiftBoth = (daysDelta: number) => {
+        if (!issue.start_date && !issue.due_date) return null
+        const nextStart = issue.start_date
+          ? addDays(issue.start_date, daysDelta)
+          : issue.start_date
+        const nextDue = issue.due_date
+          ? addDays(issue.due_date, daysDelta)
+          : issue.due_date
+        return {
+          start_date: nextStart ?? null,
+          due_date: nextDue ?? null,
+        }
+      }
+
+      try {
+        if (kind === "bar-move") {
+          const daysDelta = snapDeltaDays(delta.x, colWidth, snapDays)
+          const statusChanged =
+            laneData?.type === "lane" && laneData.status !== issue.status
+
+          const datePatch = daysDelta !== 0 ? shiftBoth(daysDelta) : null
+          const ops: Promise<void>[] = []
+          if (datePatch) ops.push(onUpdateSchedule(issueId, datePatch))
+          if (statusChanged && onMoveStatus) {
+            ops.push(onMoveStatus(issueId, laneData!.status))
+          }
+          if (ops.length === 0) return
+          // Partial-failure policy: per spec — date call fails → rollback is
+          // handled by the hook (throws); if status fails, keep the date change.
+          const results = await Promise.allSettled(ops)
+          for (const r of results) {
+            if (r.status === "rejected") {
+              onError?.(r.reason instanceof Error ? r.reason.message : String(r.reason))
+            }
+          }
+        } else if (kind === "bar-resize-l") {
+          const daysDelta = snapDeltaDays(delta.x, colWidth, snapDays)
+          if (daysDelta === 0 || !issue.start_date) return
+          await onUpdateSchedule(issueId, {
+            start_date: addDays(issue.start_date, daysDelta),
+          })
+        } else if (kind === "bar-resize-r") {
+          const daysDelta = snapDeltaDays(delta.x, colWidth, snapDays)
+          if (daysDelta === 0 || !issue.due_date) return
+          await onUpdateSchedule(issueId, {
+            due_date: addDays(issue.due_date, daysDelta),
+          })
+        } else if (kind === "unscheduled") {
+          if (!laneData) return
+          // Resolve drop column from final pointer X vs grid origin.
+          const rowsEl = gridRowsRef.current
+          if (!rowsEl) return
+          const rect = rowsEl.getBoundingClientRect()
+          const gridOrigin = rect.left - (scrollerRef.current?.scrollLeft ?? 0)
+          const activator = event.activatorEvent as PointerEvent | MouseEvent | undefined
+          const startX =
+            typeof activator?.clientX === "number" ? activator.clientX : rect.left
+          const finalX = startX + delta.x
+          const targetDate = columnDateAt(finalX, gridOrigin, colWidth, paddedRange)
+
+          const patch = {
+            start_date: targetDate,
+            due_date: addDays(targetDate, DEFAULT_SPAN_DAYS - 1),
+          }
+          const ops: Promise<void>[] = [onUpdateSchedule(issueId, patch)]
+          if (laneData.status !== issue.status && onMoveStatus) {
+            ops.push(onMoveStatus(issueId, laneData.status))
+          }
+          const results = await Promise.allSettled(ops)
+          for (const r of results) {
+            if (r.status === "rejected") {
+              onError?.(r.reason instanceof Error ? r.reason.message : String(r.reason))
+            }
+          }
+        }
+      } catch (e) {
+        onError?.(e instanceof Error ? e.message : String(e))
+      }
+    },
+    [active, colWidth, onError, onMoveStatus, onUpdateSchedule, paddedRange, snapDays],
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActive(null)}
+    >
+      <div
+        ref={scrollerRef}
+        className="flex-1 overflow-auto"
+        data-testid="gantt-grid"
+      >
+        <div className="relative" style={{ minWidth: SWIMLANE_HEADER_WIDTH + totalWidth }}>
+          <TimeAxis
+            ticks={ticks}
+            colWidth={colWidth}
+            zoom={zoom}
+            headerWidth={SWIMLANE_HEADER_WIDTH}
+          />
+
+          <div ref={gridRowsRef}>
+            {lanes
+              .filter((lane) => byStatus[lane].length > 0)
+              .map((lane) => (
+                <Swimlane
+                  key={lane}
+                  status={lane}
+                  issues={byStatus[lane]}
+                  colWidth={colWidth}
+                  totalWidth={totalWidth}
+                  headerWidth={SWIMLANE_HEADER_WIDTH}
+                  range={paddedRange}
+                  onSelectIssue={onSelectIssue}
+                />
+              ))}
+          </div>
+
+          {todayInRange && (
+            <div
+              data-testid="gantt-today-line"
+              className="absolute top-[36px] bottom-0 pointer-events-none z-20"
+              style={{
+                left: SWIMLANE_HEADER_WIDTH + todayLeft,
+                width: 1,
+                background: "#f43f5e",
+                boxShadow: "0 0 0 0.5px rgba(244,63,94,0.3)",
+              }}
+            >
+              <div className="absolute top-0 -translate-x-1/2 px-1 py-px text-[9px] font-mono bg-rose-500 text-zinc-950">
+                today
+              </div>
+            </div>
+          )}
+        </div>
+
+        <UnscheduledTray issues={unscheduled} onSelectIssue={onSelectIssue} />
+      </div>
+
+      <DragOverlay dropAnimation={null}>
+        {active ? <DragPreview active={active} colWidth={colWidth} range={paddedRange} /> : null}
+      </DragOverlay>
+    </DndContext>
+  )
+}
+
+/* ── DragOverlay content ──────────────────────────────────── */
+
+function DragPreview({
+  active,
+  colWidth,
+  range,
+}: {
+  active: DragData
+  colWidth: number
+  range: { min: string }
+}) {
+  if (active.kind === "bar-resize-l" || active.kind === "bar-resize-r") {
+    return <div style={{ width: 2, height: ROW_HEIGHT - 4, background: "#34d399" }} />
+  }
+  const rect = barRect(active.issue, range, colWidth)
+  const width = rect?.width ?? DEFAULT_SPAN_DAYS * colWidth
+  return (
+    <div
+      className="h-[32px] bg-emerald-500/20 border border-emerald-500/50 text-emerald-200 text-[11px] font-mono px-2 flex items-center gap-2 shadow-lg"
+      style={{ width }}
+    >
+      <span className="opacity-60">{active.issue.id}</span>
+      <span className="truncate">{active.issue.title}</span>
+    </div>
+  )
+}
+
+/* ── Time Axis ─────────────────────────────────────────────── */
+
+function TimeAxis({
+  ticks,
+  colWidth,
+  zoom,
+  headerWidth,
+}: {
+  ticks: string[]
+  colWidth: number
+  zoom: ZoomMode
+  headerWidth: number
+}) {
+  const labelEvery = zoom === "day" ? 1 : zoom === "week" ? 1 : zoom === "month" ? 7 : 14
+
+  return (
+    <div
+      className="sticky top-0 z-30 flex bg-zinc-950 border-b border-zinc-800/80"
+      style={{ height: AXIS_HEIGHT }}
+    >
+      <div className="shrink-0 border-r border-zinc-800/80" style={{ width: headerWidth }} />
+      <div className="flex">
+        {ticks.map((t, i) => (
+          <div
+            key={t}
+            className="shrink-0 border-r border-zinc-800/40 text-[9px] font-mono text-zinc-500 relative"
+            style={{ width: colWidth, height: AXIS_HEIGHT }}
+          >
+            {i % labelEvery === 0 && (
+              <span className="absolute left-1 top-1 whitespace-nowrap">
+                {formatTick(t)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function formatTick(date: string): string {
+  const [, mo, d] = date.split("-")
+  return `${mo}/${d}`
+}
+
+/* ── Swimlane ─────────────────────────────────────────────── */
+
+function Swimlane({
+  status,
+  issues,
+  colWidth,
+  totalWidth,
+  headerWidth,
+  range,
+  onSelectIssue,
+}: {
+  status: IssueStatus
+  issues: GanttIssue[]
+  colWidth: number
+  totalWidth: number
+  headerWidth: number
+  range: { min: string; max: string }
+  onSelectIssue?: (issueId: string) => void
+}) {
+  const accent = STATUS_ACCENT[status] ?? "#52525b"
+  const label = (STATUS_LABELS as Record<string, string>)[status] ?? status
+
+  const { setNodeRef, isOver } = useDroppable({
+    id: `lane::${status}`,
+    data: { type: "lane", status } satisfies LaneDropData,
+  })
+
+  return (
+    <div
+      data-testid={`gantt-lane-${status}`}
+      className="flex border-b border-zinc-800/40"
+    >
+      <div
+        className="shrink-0 px-3 py-2 border-r border-zinc-800/80 sticky left-0 bg-zinc-950 z-10"
+        style={{ width: headerWidth, borderLeft: `2px solid ${accent}` }}
+      >
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: accent }} />
+          <span className="text-[10px] font-display font-semibold tracking-wider text-zinc-400 uppercase">
+            {label}
+          </span>
+          <span className="text-[10px] font-mono text-zinc-600 ml-auto">
+            {issues.length}
+          </span>
+        </div>
+      </div>
+
+      <div
+        ref={setNodeRef}
+        className={`flex-1 transition-colors ${isOver ? "bg-emerald-500/5" : ""}`}
+        data-testid={`gantt-lane-drop-${status}`}
+      >
+        {issues.map((issue) => (
+          <GanttRow
+            key={issue.id}
+            issue={issue}
+            colWidth={colWidth}
+            totalWidth={totalWidth}
+            range={range}
+            onSelectIssue={onSelectIssue}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ── Row ──────────────────────────────────────────────────── */
+
+function GanttRow({
+  issue,
+  colWidth,
+  totalWidth,
+  range,
+  onSelectIssue,
+}: {
+  issue: GanttIssue
+  colWidth: number
+  totalWidth: number
+  range: { min: string; max: string }
+  onSelectIssue?: (issueId: string) => void
+}) {
+  const rect = barRect(issue, { min: range.min }, colWidth)
+
+  return (
+    <div
+      className="relative border-b border-zinc-900/60"
+      style={{ height: ROW_HEIGHT, width: totalWidth }}
+      data-testid={`gantt-row-${issue.id}`}
+    >
+      {rect && (
+        <GanttBar
+          issue={issue}
+          rect={rect}
+          onClick={() => onSelectIssue?.(issue.id)}
+        />
+      )}
+    </div>
+  )
+}
+
+/* ── Bar (draggable) ───────────────────────────────────────── */
+
+function GanttBar({
+  issue,
+  rect,
+  onClick,
+}: {
+  issue: GanttIssue
+  rect: { left: number; width: number }
+  onClick?: () => void
+}) {
+  const accent = STATUS_ACCENT[issue.status] ?? "#52525b"
+  const isCancelled = issue.status === "cancelled"
+
+  // Bar body drag (disabled for cancelled — readonly_dates)
+  const moveDraggable = useDraggable({
+    id: `bar-move::${issue.id}`,
+    disabled: isCancelled,
+    data: { kind: "bar-move", issueId: issue.id, issue } satisfies DragData,
+  })
+
+  const leftEdge = useDraggable({
+    id: `bar-resize-l::${issue.id}`,
+    disabled: isCancelled || !issue.start_date,
+    data: { kind: "bar-resize-l", issueId: issue.id, issue } satisfies DragData,
+  })
+
+  const rightEdge = useDraggable({
+    id: `bar-resize-r::${issue.id}`,
+    disabled: isCancelled || !issue.due_date,
+    data: { kind: "bar-resize-r", issueId: issue.id, issue } satisfies DragData,
+  })
+
+  return (
+    <div
+      data-testid={`gantt-bar-${issue.id}`}
+      data-issue-id={issue.id}
+      data-readonly={isCancelled ? "true" : "false"}
+      className="absolute top-1 h-[32px]"
+      style={{ left: rect.left, width: rect.width }}
+    >
+      {/* Body (move handle) */}
+      <div
+        ref={moveDraggable.setNodeRef}
+        {...moveDraggable.attributes}
+        {...moveDraggable.listeners}
+        onClick={onClick}
+        className={`relative h-full flex items-center gap-2 px-3 text-[11px] font-mono
+          border cursor-grab active:cursor-grabbing select-none
+          transition-colors duration-100
+          ${moveDraggable.isDragging ? "opacity-30" : ""}
+          ${isCancelled
+            ? "bg-zinc-900/40 border-zinc-800/60 text-zinc-600 line-through cursor-not-allowed"
+            : "bg-zinc-900/80 border-zinc-800 text-zinc-200 hover:border-zinc-700"
+          }`}
+        style={{ borderLeft: `3px solid ${accent}` }}
+        title={`${issue.id} — ${issue.title}`}
+      >
+        <span className="text-zinc-500 shrink-0">{issue.id}</span>
+        <span className="truncate">{issue.title}</span>
+        {issue.assignee_name && (
+          <span className="ml-auto text-[10px] text-zinc-500 shrink-0">
+            {issue.assignee_type === "agent" ? ">" : "@"}{issue.assignee_name}
+          </span>
+        )}
+      </div>
+
+      {/* Left edge handle — 12 px hit target, 4 px visible */}
+      {!isCancelled && issue.start_date && (
+        <div
+          ref={leftEdge.setNodeRef}
+          {...leftEdge.attributes}
+          {...leftEdge.listeners}
+          data-testid={`gantt-handle-l-${issue.id}`}
+          className="absolute inset-y-0 -left-1 w-3 cursor-ew-resize group"
+          aria-label={`Resize start of ${issue.id}`}
+        >
+          <div className="absolute inset-y-1 left-1 w-1 bg-emerald-500/0 group-hover:bg-emerald-500/60 transition-colors" />
+        </div>
+      )}
+
+      {/* Right edge handle */}
+      {!isCancelled && issue.due_date && (
+        <div
+          ref={rightEdge.setNodeRef}
+          {...rightEdge.attributes}
+          {...rightEdge.listeners}
+          data-testid={`gantt-handle-r-${issue.id}`}
+          className="absolute inset-y-0 -right-1 w-3 cursor-ew-resize group"
+          aria-label={`Resize end of ${issue.id}`}
+        >
+          <div className="absolute inset-y-1 right-1 w-1 bg-emerald-500/0 group-hover:bg-emerald-500/60 transition-colors" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── Unscheduled Tray ─────────────────────────────────────── */
+
+function UnscheduledTray({
+  issues,
+  onSelectIssue,
+}: {
+  issues: GanttIssue[]
+  onSelectIssue?: (issueId: string) => void
+}) {
+  if (issues.length === 0) return null
+  return (
+    <div
+      data-testid="gantt-unscheduled-tray"
+      className="border-t border-zinc-800/80 p-3 bg-zinc-950 sticky bottom-0"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-[11px] font-display font-semibold tracking-widest uppercase text-zinc-400">
+          Unscheduled
+        </span>
+        <span className="text-[10px] font-mono text-zinc-600">{issues.length}</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {issues.map((issue) => (
+          <UnscheduledItem key={issue.id} issue={issue} onSelect={onSelectIssue} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function UnscheduledItem({
+  issue,
+  onSelect,
+}: {
+  issue: GanttIssue
+  onSelect?: (issueId: string) => void
+}) {
+  const draggable = useDraggable({
+    id: `unscheduled::${issue.id}`,
+    data: { kind: "unscheduled", issueId: issue.id, issue } satisfies DragData,
+  })
+  return (
+    <button
+      ref={draggable.setNodeRef}
+      {...draggable.attributes}
+      {...draggable.listeners}
+      data-testid={`gantt-unscheduled-${issue.id}`}
+      data-issue-id={issue.id}
+      onClick={() => onSelect?.(issue.id)}
+      className={`text-left px-2 py-1 border border-zinc-800 bg-zinc-900/60 hover:border-zinc-700
+        text-[11px] font-mono text-zinc-300 cursor-grab active:cursor-grabbing transition-colors max-w-[240px] truncate
+        ${draggable.isDragging ? "opacity-30" : ""}`}
+      title={issue.title}
+    >
+      <span className="text-zinc-500 mr-1.5">{issue.id}</span>
+      {issue.title}
+    </button>
+  )
+}
+
+/* ── Empty State ──────────────────────────────────────────── */
+
+function EmptyState() {
+  return (
+    <div className="flex items-center justify-center h-[calc(100vh-3.5rem)]">
+      <div className="text-center space-y-3">
+        <div className="font-mono text-zinc-700 text-sm">
+          {">"} no project selected
+        </div>
+        <div className="text-xs text-zinc-600">
+          Select a project to view its timeline
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/gctrl-board/web/src/components/IssueCard.tsx
+++ b/apps/gctrl-board/web/src/components/IssueCard.tsx
@@ -54,6 +54,7 @@ export function IssueCard({ issue, onClick, isOverlay, isDragging }: Props) {
           </span>
           {priority !== "none" && (
             <span
+              data-testid="priority-badge"
               className={`inline-flex items-center gap-1 text-[9px] font-mono font-semibold tracking-widest
                 px-1.5 py-0.5 ${PRIORITY_COLORS[priority]}/15 text-${PRIORITY_COLORS[priority].replace("bg-", "")}`}
               style={{

--- a/apps/gctrl-board/web/src/hooks/useGantt.ts
+++ b/apps/gctrl-board/web/src/hooks/useGantt.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from "react"
+import { api } from "../api/client"
+import type { GanttIssue, GanttView, IssueStatus } from "../types"
+
+/**
+ * Gantt data hook. Mirrors `useIssues` patterns:
+ *  - Optimistic local updates on `updateSchedule` / `moveStatus`.
+ *  - On failure, caller reverts (we throw; parent toasts).
+ *
+ * Naming borrowed from frappe/gantt's `on_date_change(task, start, end)` —
+ * our `updateSchedule(issueId, { start_date, due_date })` is the equivalent
+ * but accepts partial patches (either field may be null to clear).
+ */
+export function useGantt(projectId: string | null) {
+  const [data, setData] = useState<GanttView | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!projectId) {
+      setData(null)
+      return
+    }
+    try {
+      setLoading(true)
+      const view = await api.gantt.project(projectId)
+      setData(view)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load gantt")
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const patchLocal = useCallback((issueId: string, patch: Partial<GanttIssue>) => {
+    setData((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        issues: prev.issues.map((i) =>
+          i.id === issueId ? { ...i, ...patch } : i
+        ),
+      }
+    })
+  }, [])
+
+  const updateSchedule = useCallback(
+    async (
+      issueId: string,
+      patch: { start_date?: string | null; due_date?: string | null },
+    ) => {
+      const prev = data?.issues.find((i) => i.id === issueId)
+      patchLocal(issueId, patch as Partial<GanttIssue>)
+      try {
+        await api.issues.schedule(issueId, patch)
+      } catch (e) {
+        if (prev) {
+          patchLocal(issueId, {
+            start_date: prev.start_date,
+            due_date: prev.due_date,
+          })
+        }
+        throw e
+      }
+    },
+    [data, patchLocal],
+  )
+
+  const moveStatus = useCallback(
+    async (issueId: string, newStatus: IssueStatus) => {
+      const prev = data?.issues.find((i) => i.id === issueId)
+      patchLocal(issueId, { status: newStatus })
+      try {
+        await api.issues.move(issueId, newStatus)
+      } catch (e) {
+        if (prev) patchLocal(issueId, { status: prev.status })
+        throw e
+      }
+    },
+    [data, patchLocal],
+  )
+
+  return { data, loading, error, refresh, updateSchedule, moveStatus }
+}

--- a/apps/gctrl-board/web/src/hooks/useProjectRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useProjectRoute.ts
@@ -41,7 +41,8 @@ export function useProjectRoute(projects: Project[]) {
       if (projectId) {
         const project = projects.find((p) => p.id === projectId)
         if (project) {
-          history.pushState(null, "", `/projects/${project.key}`)
+          const viewSuffix = window.location.pathname.endsWith("/gantt") ? "/gantt" : ""
+          history.pushState(null, "", `/projects/${project.key}${viewSuffix}`)
         }
       } else {
         history.pushState(null, "", "/")

--- a/apps/gctrl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.ts
@@ -1,7 +1,9 @@
 import { useState, useCallback, useEffect } from "react"
 
+export type BoardView = "kanban" | "gantt"
+
 export type Route =
-  | { page: "board"; projectKey: string | null }
+  | { page: "board"; projectKey: string | null; view: BoardView }
   | { page: "inbox"; threadId: string | null }
 
 function parseRoute(pathname: string): Route {
@@ -16,14 +18,18 @@ function parseRoute(pathname: string): Route {
     return { page: "inbox", threadId: null }
   }
 
-  // /projects/:key
-  const projectMatch = pathname.match(/^\/projects\/([^/]+)/)
+  // /projects/:key(/gantt)?
+  const projectMatch = pathname.match(/^\/projects\/([^/]+?)(?:\/(gantt))?\/?$/)
   if (projectMatch) {
-    return { page: "board", projectKey: projectMatch[1] }
+    return {
+      page: "board",
+      projectKey: projectMatch[1],
+      view: projectMatch[2] === "gantt" ? "gantt" : "kanban",
+    }
   }
 
   // / or anything else — board with no project selected
-  return { page: "board", projectKey: null }
+  return { page: "board", projectKey: null, view: "kanban" }
 }
 
 export function useRoute(): { route: Route; navigate: (path: string) => void } {

--- a/apps/gctrl-board/web/src/lib/__tests__/gantt-geom.test.ts
+++ b/apps/gctrl-board/web/src/lib/__tests__/gantt-geom.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest"
+import {
+  addDays,
+  barRect,
+  columnDateAt,
+  dayTicks,
+  daysBetween,
+  gridCoordinateGetter,
+  parseDate,
+  rangeDays,
+  snapDeltaDays,
+  ZOOM,
+} from "../gantt-geom"
+
+describe("date helpers", () => {
+  it("daysBetween is an integer count", () => {
+    expect(daysBetween("2026-05-01", "2026-05-01")).toBe(0)
+    expect(daysBetween("2026-05-01", "2026-05-14")).toBe(13)
+    expect(daysBetween("2026-05-14", "2026-05-01")).toBe(-13)
+  })
+
+  it("addDays round-trips", () => {
+    expect(addDays("2026-05-01", 13)).toBe("2026-05-14")
+    expect(addDays("2026-05-14", -13)).toBe("2026-05-01")
+    expect(addDays("2026-02-28", 1)).toBe("2026-03-01")
+    expect(addDays("2025-12-31", 1)).toBe("2026-01-01")
+  })
+
+  it("parseDate rejects malformed", () => {
+    expect(() => parseDate("nope")).toThrow()
+    expect(() => parseDate("2026/05/01")).toThrow()
+  })
+})
+
+describe("barRect", () => {
+  const range = { min: "2026-05-01" }
+  const colWidth = 32
+
+  it("both dates → anchored at start, inclusive width", () => {
+    const r = barRect(
+      { start_date: "2026-05-03", due_date: "2026-05-07" },
+      range, colWidth,
+    )
+    expect(r).toEqual({ left: 2 * 32, width: 5 * 32 })
+  })
+
+  it("only start_date → DEFAULT_SPAN_DAYS span", () => {
+    const r = barRect({ start_date: "2026-05-01" }, range, colWidth)
+    expect(r).toEqual({ left: 0, width: 3 * 32 })
+  })
+
+  it("only due_date → anchored at due − (span−1)", () => {
+    const r = barRect({ due_date: "2026-05-10" }, range, colWidth)
+    // span = 3 → left edge at 2026-05-08
+    expect(r).toEqual({ left: 7 * 32, width: 3 * 32 })
+  })
+
+  it("no dates → null (Unscheduled)", () => {
+    expect(barRect({}, range, colWidth)).toBeNull()
+    expect(barRect({ start_date: null, due_date: null }, range, colWidth)).toBeNull()
+  })
+
+  it("same-day bar has width == 1 column", () => {
+    const r = barRect(
+      { start_date: "2026-05-05", due_date: "2026-05-05" },
+      range, colWidth,
+    )
+    expect(r).toEqual({ left: 4 * 32, width: 1 * 32 })
+  })
+
+  it("zoom mode scales by colWidth", () => {
+    const input = { start_date: "2026-05-03", due_date: "2026-05-07" }
+    for (const mode of ["day", "week", "month", "quarter"] as const) {
+      const { colWidth } = ZOOM[mode]
+      const r = barRect(input, range, colWidth)!
+      expect(r.left).toBe(2 * colWidth)
+      expect(r.width).toBe(5 * colWidth)
+    }
+  })
+})
+
+describe("snapDeltaDays", () => {
+  it("rounds to nearest snap unit", () => {
+    // day zoom, snap=1 day, col=32
+    expect(snapDeltaDays(0, 32, 1)).toBe(0)
+    expect(snapDeltaDays(15, 32, 1)).toBe(0)
+    expect(snapDeltaDays(17, 32, 1)).toBe(1)
+    expect(snapDeltaDays(-40, 32, 1)).toBe(-1)
+    expect(snapDeltaDays(100, 32, 1)).toBe(3)
+  })
+
+  it("quarter zoom snaps to whole weeks", () => {
+    const col = ZOOM.quarter.colWidth // 120
+    // snap unit is 7 * 120 = 840px
+    expect(snapDeltaDays(419, col, 7)).toBe(0)
+    expect(snapDeltaDays(421, col, 7)).toBe(7)
+    expect(snapDeltaDays(-841, col, 7)).toBe(-7)
+  })
+})
+
+describe("columnDateAt", () => {
+  const range = { min: "2026-05-01", max: "2026-05-10" }
+  it("resolves x to a date on the axis", () => {
+    // gridOrigin=100, colWidth=32 → clientX=100 is day 0 = range.min
+    expect(columnDateAt(100, 100, 32, range)).toBe("2026-05-01")
+    // 100 + 3*32 = 196 → day 3
+    expect(columnDateAt(196, 100, 32, range)).toBe("2026-05-04")
+  })
+
+  it("clamps below range.min and above range.max", () => {
+    expect(columnDateAt(0, 100, 32, range)).toBe("2026-05-01")
+    expect(columnDateAt(9999, 100, 32, range)).toBe("2026-05-10")
+  })
+})
+
+describe("gridCoordinateGetter", () => {
+  const getter = gridCoordinateGetter({ colWidth: 32, rowHeight: 40 })
+  const base = { currentCoordinates: { x: 100, y: 100 } }
+
+  it("snaps arrow keys to exact column/row deltas", () => {
+    expect(getter({ code: "ArrowRight" } as KeyboardEvent, base))
+      .toEqual({ x: 132, y: 100 })
+    expect(getter({ code: "ArrowLeft" } as KeyboardEvent, base))
+      .toEqual({ x: 68, y: 100 })
+    expect(getter({ code: "ArrowDown" } as KeyboardEvent, base))
+      .toEqual({ x: 100, y: 140 })
+    expect(getter({ code: "ArrowUp" } as KeyboardEvent, base))
+      .toEqual({ x: 100, y: 60 })
+  })
+
+  it("returns undefined for non-arrow keys", () => {
+    expect(getter({ code: "Space" } as KeyboardEvent, base)).toBeUndefined()
+    expect(getter({ code: "Enter" } as KeyboardEvent, base)).toBeUndefined()
+  })
+})
+
+describe("axis", () => {
+  it("rangeDays is inclusive", () => {
+    expect(rangeDays({ min: "2026-05-01", max: "2026-05-01" })).toBe(1)
+    expect(rangeDays({ min: "2026-05-01", max: "2026-05-03" })).toBe(3)
+  })
+
+  it("dayTicks returns one string per day", () => {
+    const ticks = dayTicks({ min: "2026-05-01", max: "2026-05-04" })
+    expect(ticks).toEqual([
+      "2026-05-01", "2026-05-02", "2026-05-03", "2026-05-04",
+    ])
+  })
+})

--- a/apps/gctrl-board/web/src/lib/gantt-geom.ts
+++ b/apps/gctrl-board/web/src/lib/gantt-geom.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure, DOM-free geometry for the Gantt view.
+ *
+ * Anchored on raw date strings (YYYY-MM-DD) and the project's `range.min`.
+ * No `getBoundingClientRect`, no timezone math — day-granularity only.
+ */
+
+export const DEFAULT_SPAN_DAYS = 3
+
+export type ZoomMode = "day" | "week" | "month" | "quarter"
+
+export interface ZoomConfig {
+  colWidth: number
+  /** Minimum drag distance before a move registers (px). */
+  minDragDistance: number
+  /** Snap unit in days. */
+  snapDays: number
+}
+
+export const ZOOM: Record<ZoomMode, ZoomConfig> = {
+  day:     { colWidth: 32,  minDragDistance: 8,  snapDays: 1 },
+  week:    { colWidth: 96,  minDragDistance: 12, snapDays: 1 },
+  month:   { colWidth: 180, minDragDistance: 12, snapDays: 1 },
+  quarter: { colWidth: 120, minDragDistance: 16, snapDays: 7 },
+}
+
+/* ── Date helpers ─────────────────────────────────────────── */
+
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/** Parse YYYY-MM-DD into UTC epoch-milliseconds. */
+export function parseDate(s: string): number {
+  const m = DATE_RE.exec(s)
+  if (!m) throw new Error(`Invalid date: ${s}`)
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+}
+
+/** Serialize an epoch-ms UTC timestamp back to YYYY-MM-DD. */
+export function formatDate(ms: number): string {
+  const d = new Date(ms)
+  const y = d.getUTCFullYear()
+  const mo = String(d.getUTCMonth() + 1).padStart(2, "0")
+  const da = String(d.getUTCDate()).padStart(2, "0")
+  return `${y}-${mo}-${da}`
+}
+
+/** Days from `a` to `b` (integer, negative if b < a). */
+export function daysBetween(a: string, b: string): number {
+  const DAY = 86_400_000
+  return Math.round((parseDate(b) - parseDate(a)) / DAY)
+}
+
+export function addDays(date: string, days: number): string {
+  const DAY = 86_400_000
+  return formatDate(parseDate(date) + days * DAY)
+}
+
+/* ── Bar rect ─────────────────────────────────────────────── */
+
+export interface BarInputIssue {
+  start_date?: string | null
+  due_date?: string | null
+}
+
+export interface Rect {
+  left: number
+  width: number
+}
+
+/**
+ * Compute bar's left/width in pixels for a given issue.
+ *
+ * - Both dates set → anchored at start_date, width = (due - start + 1) * colWidth
+ * - Only start_date → width = DEFAULT_SPAN_DAYS * colWidth
+ * - Only due_date   → anchored at (due_date − DEFAULT_SPAN_DAYS + 1)
+ * - Neither         → returns null (caller renders in Unscheduled tray)
+ */
+export function barRect(
+  issue: BarInputIssue,
+  range: { min: string },
+  colWidth: number,
+  defaultSpanDays: number = DEFAULT_SPAN_DAYS,
+): Rect | null {
+  const start = issue.start_date ?? null
+  const due = issue.due_date ?? null
+  if (!start && !due) return null
+
+  let anchor: string
+  let spanDays: number
+  if (start && due) {
+    anchor = start
+    spanDays = daysBetween(start, due) + 1
+  } else if (start) {
+    anchor = start
+    spanDays = defaultSpanDays
+  } else {
+    // only due → left edge at due − (span − 1)
+    anchor = addDays(due!, -(defaultSpanDays - 1))
+    spanDays = defaultSpanDays
+  }
+
+  const leftDays = daysBetween(range.min, anchor)
+  return {
+    left: leftDays * colWidth,
+    width: Math.max(1, spanDays) * colWidth,
+  }
+}
+
+/* ── Snap ─────────────────────────────────────────────────── */
+
+/** Snap a raw pixel delta to the nearest colWidth * snapDays step, in day-units. */
+export function snapDeltaDays(deltaPx: number, colWidth: number, snapDays: number): number {
+  const unitPx = colWidth * snapDays
+  return Math.round(deltaPx / unitPx) * snapDays
+}
+
+/* ── Column axis ──────────────────────────────────────────── */
+
+/** Total days (inclusive) in the rendered range. */
+export function rangeDays(range: { min: string; max: string }): number {
+  return daysBetween(range.min, range.max) + 1
+}
+
+/** Day-column header tick dates, one per day from range.min to range.max (inclusive). */
+export function dayTicks(range: { min: string; max: string }): string[] {
+  const n = rangeDays(range)
+  const out: string[] = new Array(n)
+  for (let i = 0; i < n; i++) out[i] = addDays(range.min, i)
+  return out
+}
+
+/**
+ * Resolve a client-space X coordinate (e.g. pointer.clientX) into a
+ * project-local date on the grid's time axis.
+ *
+ * `gridOrigin` is the client-space X of the grid's leftmost column
+ * (at range.min), accounting for scroll. Returns the date at that column.
+ */
+export function columnDateAt(
+  clientX: number,
+  gridOrigin: number,
+  colWidth: number,
+  range: { min: string; max: string },
+): string {
+  const col = Math.floor((clientX - gridOrigin) / colWidth)
+  const clamped = Math.max(0, Math.min(rangeDays(range) - 1, col))
+  return addDays(range.min, clamped)
+}
+
+/**
+ * Keyboard-sensor coordinate getter: arrow keys snap to one column per press,
+ * ROW_HEIGHT per vertical press. Returns undefined for non-arrow keys so the
+ * default handler runs.
+ */
+export interface KeyboardArrowDeltas {
+  colWidth: number
+  rowHeight: number
+}
+
+export function gridCoordinateGetter(
+  deltas: KeyboardArrowDeltas,
+): (
+  event: KeyboardEvent,
+  args: { currentCoordinates: { x: number; y: number } },
+) => { x: number; y: number } | undefined {
+  return (event, { currentCoordinates }) => {
+    switch (event.code) {
+      case "ArrowRight":
+        return { ...currentCoordinates, x: currentCoordinates.x + deltas.colWidth }
+      case "ArrowLeft":
+        return { ...currentCoordinates, x: currentCoordinates.x - deltas.colWidth }
+      case "ArrowDown":
+        return { ...currentCoordinates, y: currentCoordinates.y + deltas.rowHeight }
+      case "ArrowUp":
+        return { ...currentCoordinates, y: currentCoordinates.y - deltas.rowHeight }
+    }
+    return undefined
+  }
+}

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -42,6 +42,8 @@ export interface Issue {
   acceptance_criteria: string[]
   github_issue_number?: number
   github_url?: string
+  start_date?: string | null
+  due_date?: string | null
 }
 
 export interface Project {
@@ -56,6 +58,26 @@ export interface MoveIssueResult {
   issue: Issue
   task_id: string | null
   dispatched: boolean
+}
+
+/** Gantt summary row — narrower shape than Issue (what GET /gantt returns). */
+export interface GanttIssue {
+  id: string
+  project_id: string
+  title: string
+  status: IssueStatus
+  priority: Priority
+  assignee_id: string | null
+  assignee_name: string | null
+  assignee_type: AssigneeType | null
+  parent_id: string | null
+  start_date: string | null
+  due_date: string | null
+}
+
+export interface GanttView {
+  range: { min: string | null; max: string | null }
+  issues: GanttIssue[]
 }
 
 export interface IssueEvent {

--- a/kernel/crates/gctrl-cli/src/commands/board.rs
+++ b/kernel/crates/gctrl-cli/src/commands/board.rs
@@ -97,6 +97,8 @@ pub fn create_issue(
         source_path: None,
         github_issue_number: None,
         github_url: None,
+        start_date: None,
+        due_date: None,
     };
 
     store.insert_board_issue(&issue)?;

--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -542,6 +542,12 @@ pub struct BoardIssue {
     /// GitHub issue URL for 2-way sync.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_url: Option<String>,
+    /// Gantt scheduling: planned start date as `YYYY-MM-DD` (project-local).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_date: Option<String>,
+    /// Gantt scheduling: planned due date as `YYYY-MM-DD` (project-local).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub due_date: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/kernel/crates/gctrl-orch/src/prompt.rs
+++ b/kernel/crates/gctrl-orch/src/prompt.rs
@@ -70,6 +70,8 @@ mod tests {
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         }
     }
 

--- a/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
+++ b/kernel/crates/gctrl-orch/tests/worker_dispatch.rs
@@ -48,6 +48,8 @@ fn seed_dispatchable_issue(store: &SqliteStore, issue_id: &str) -> Task {
         source_path: None,
         github_issue_number: None,
         github_url: None,
+        start_date: None,
+        due_date: None,
     };
     store.insert_board_issue(&issue).unwrap();
 

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, patch, post},
     Json, Router,
 };
 use gctrl_context::ContextManager;
@@ -135,6 +135,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/board/issues/{id}/events", get(board_list_events))
         .route("/api/board/issues/{id}/comments", get(board_list_comments))
         .route("/api/board/issues/{id}/link-session", post(board_link_session))
+        .route("/api/board/issues/{id}/schedule", patch(board_schedule_issue))
+        .route("/api/board/projects/{id}/gantt", get(board_gantt_for_project))
         .route("/api/board/import", post(board_import_markdown))
         .route("/api/board/export", post(board_export_markdown))
         .route("/api/board/projects/{id}/github", post(board_link_github))
@@ -985,6 +987,8 @@ async fn board_create_issue(
         source_path: None,
         github_issue_number: body.github_issue_number,
         github_url: body.github_url,
+        start_date: None,
+        due_date: None,
     };
 
     match state.sqlite.insert_board_issue(&issue) {
@@ -1188,6 +1192,126 @@ async fn board_link_session(
 ) -> impl IntoResponse {
     match state.sqlite.link_session_to_issue(&id, &body.session_id, body.cost_usd, body.tokens) {
         Ok(()) => StatusCode::OK.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// Gantt: schedule update + project timeline.
+
+/// Schedule body: `double_option` so we distinguish "field absent" (keep
+/// existing) from "field explicitly null" (clear). `None` = untouched,
+/// `Some(None)` = clear, `Some(Some(date))` = set.
+#[derive(Deserialize)]
+struct BoardScheduleBody {
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    start_date: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    due_date: Option<Option<String>>,
+    #[serde(default = "default_web_user")]
+    actor_id: String,
+    #[serde(default = "default_web_ui")]
+    actor_name: String,
+    #[serde(default = "default_human")]
+    actor_type: String,
+}
+
+fn default_web_user() -> String { "web-user".into() }
+fn default_web_ui() -> String { "Web UI".into() }
+
+fn deserialize_optional_field<'de, D>(de: D) -> Result<Option<Option<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Some(Option::<String>::deserialize(de)?))
+}
+
+fn is_yyyy_mm_dd(s: &str) -> bool {
+    if s.len() != 10 { return false; }
+    let b = s.as_bytes();
+    b[4] == b'-' && b[7] == b'-'
+        && b[0..4].iter().all(|c| c.is_ascii_digit())
+        && b[5..7].iter().all(|c| c.is_ascii_digit())
+        && b[8..10].iter().all(|c| c.is_ascii_digit())
+}
+
+async fn board_schedule_issue(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(body): Json<BoardScheduleBody>,
+) -> impl IntoResponse {
+    if body.start_date.is_none() && body.due_date.is_none() {
+        return (StatusCode::BAD_REQUEST, "start_date or due_date required".to_string()).into_response();
+    }
+    if let Some(Some(ref s)) = body.start_date {
+        if !is_yyyy_mm_dd(s) {
+            return (StatusCode::BAD_REQUEST, "start_date must be YYYY-MM-DD".to_string()).into_response();
+        }
+    }
+    if let Some(Some(ref d)) = body.due_date {
+        if !is_yyyy_mm_dd(d) {
+            return (StatusCode::BAD_REQUEST, "due_date must be YYYY-MM-DD".to_string()).into_response();
+        }
+    }
+
+    match state.sqlite.schedule_board_issue(
+        &id,
+        body.start_date,
+        body.due_date,
+        &body.actor_id,
+        &body.actor_name,
+        &body.actor_type,
+    ) {
+        Ok(()) => match state.sqlite.get_board_issue(&id) {
+            Ok(Some(issue)) => Json(serde_json::to_value(&issue).unwrap()).into_response(),
+            Ok(None) => (StatusCode::NOT_FOUND, format!("issue not found: {}", id)).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        },
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("issue not found") {
+                (StatusCode::NOT_FOUND, msg).into_response()
+            } else if msg.contains("must be <=") {
+                (StatusCode::BAD_REQUEST, msg).into_response()
+            } else {
+                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+            }
+        }
+    }
+}
+
+async fn board_gantt_for_project(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.get_board_project(&id) {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, format!("project not found: {}", id)).into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+    match state.sqlite.gantt_for_project(&id) {
+        Ok((min, max, issues)) => {
+            // Emit a Gantt-tuned projection: narrower than full BoardIssue,
+            // matching the Worker's GET /gantt response shape.
+            let rows: Vec<serde_json::Value> = issues.iter().map(|i| {
+                serde_json::json!({
+                    "id": i.id,
+                    "project_id": i.project_id,
+                    "title": i.title,
+                    "status": i.status.as_str(),
+                    "priority": i.priority,
+                    "assignee_id": i.assignee_id,
+                    "assignee_name": i.assignee_name,
+                    "assignee_type": i.assignee_type,
+                    "parent_id": i.parent_id,
+                    "start_date": i.start_date,
+                    "due_date": i.due_date,
+                })
+            }).collect();
+            Json(serde_json::json!({
+                "range": { "min": min, "max": max },
+                "issues": rows,
+            })).into_response()
+        }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
+++ b/kernel/crates/gctrl-otel/tests/board_move_triggers_task.rs
@@ -52,6 +52,8 @@ fn make_issue(project_id: &str, id: &str) -> BoardIssue {
         source_path: None,
         github_issue_number: None,
         github_url: None,
+        start_date: None,
+        due_date: None,
     }
 }
 

--- a/kernel/crates/gctrl-otel/tests/board_schedule.rs
+++ b/kernel/crates/gctrl-otel/tests/board_schedule.rs
@@ -1,0 +1,273 @@
+//! Tier 2 integration tests for Gantt endpoints:
+//!   PATCH /api/board/issues/:id/schedule
+//!   GET   /api/board/projects/:id/gantt
+//!
+//! Mirrors apps/gctrl-board/tests/worker/gantt.test.ts so kernel and Worker
+//! surfaces stay behavior-identical.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use gctrl_core::{BoardIssue, BoardProject, IssueStatus};
+use gctrl_otel::create_router_dual;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn make_issue(project_id: &str, id: &str) -> BoardIssue {
+    let now = Utc::now();
+    BoardIssue {
+        id: id.into(),
+        project_id: project_id.into(),
+        title: format!("Test {id}"),
+        description: None,
+        status: IssueStatus::Todo,
+        priority: "none".into(),
+        assignee_id: None,
+        assignee_name: None,
+        assignee_type: None,
+        labels: vec![],
+        parent_id: None,
+        created_at: now,
+        updated_at: now,
+        created_by_id: "u".into(),
+        created_by_name: "u".into(),
+        created_by_type: "human".into(),
+        blocked_by: vec![],
+        blocking: vec![],
+        session_ids: vec![],
+        total_cost_usd: 0.0,
+        total_tokens: 0,
+        pr_numbers: vec![],
+        content_hash: Some(id.into()),
+        source_path: None,
+        github_issue_number: None,
+        github_url: None,
+        start_date: None,
+        due_date: None,
+    }
+}
+
+fn test_app() -> (axum::Router, Arc<SqliteStore>) {
+    let duck = Arc::new(DuckDbStore::open(":memory:").expect("duckdb"));
+    let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite"));
+
+    let project = BoardProject {
+        id: "GNT-project".into(),
+        name: "GNT".into(),
+        key: "GNT".into(),
+        counter: 2,
+        github_repo: None,
+    };
+    sqlite.create_board_project(&project).expect("create project");
+    sqlite.insert_board_issue(&make_issue("GNT-project", "GNT-1")).unwrap();
+    sqlite.insert_board_issue(&make_issue("GNT-project", "GNT-2")).unwrap();
+
+    let router = create_router_dual(duck, Arc::clone(&sqlite));
+    (router, sqlite)
+}
+
+async fn patch_json(app: &axum::Router, uri: &str, body: Value) -> (u16, Value) {
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, v)
+}
+
+async fn get_json(app: &axum::Router, uri: &str) -> (u16, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, v)
+}
+
+#[tokio::test]
+async fn schedule_sets_both_dates() {
+    let (app, _) = test_app();
+    let (status, body) = patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-01", "due_date": "2026-05-14" }),
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["start_date"], "2026-05-01");
+    assert_eq!(body["due_date"], "2026-05-14");
+}
+
+#[tokio::test]
+async fn schedule_rejects_start_after_due() {
+    let (app, _) = test_app();
+    let (status, _) = patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-14", "due_date": "2026-05-01" }),
+    )
+    .await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn schedule_rejects_bad_format() {
+    let (app, _) = test_app();
+    let (status, _) = patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "nope" }),
+    )
+    .await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn schedule_null_clears_only_specified_field() {
+    let (app, _) = test_app();
+    patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-01", "due_date": "2026-05-14" }),
+    )
+    .await;
+
+    let (status, body) = patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": null }),
+    )
+    .await;
+    assert_eq!(status, 200, "body: {body}");
+    assert!(
+        body.get("start_date").map(|v| v.is_null()).unwrap_or(true),
+        "start_date should be null/absent: {body}"
+    );
+    assert_eq!(body["due_date"], "2026-05-14");
+}
+
+#[tokio::test]
+async fn schedule_rejects_empty_body() {
+    let (app, _) = test_app();
+    let (status, _) = patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn schedule_returns_404_for_missing_issue() {
+    let (app, _) = test_app();
+    let (status, _) = patch_json(
+        &app,
+        "/api/board/issues/NOPE-999/schedule",
+        json!({ "start_date": "2026-05-01" }),
+    )
+    .await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn schedule_emits_scheduled_event() {
+    let (app, sqlite) = test_app();
+    patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-01", "due_date": "2026-05-14" }),
+    )
+    .await;
+    let events = sqlite.list_board_events("GNT-1").unwrap();
+    let scheduled: Vec<_> = events.iter().filter(|e| e.event_type == "scheduled").collect();
+    assert_eq!(scheduled.len(), 1, "expected one scheduled event, got {:?}", events);
+    assert_eq!(scheduled[0].data["start_date"], "2026-05-01");
+    assert_eq!(scheduled[0].data["due_date"], "2026-05-14");
+}
+
+#[tokio::test]
+async fn gantt_returns_raw_range_over_scheduled() {
+    let (app, _) = test_app();
+    patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-01", "due_date": "2026-05-10" }),
+    )
+    .await;
+    patch_json(
+        &app,
+        "/api/board/issues/GNT-2/schedule",
+        json!({ "start_date": "2026-06-01", "due_date": "2026-06-15" }),
+    )
+    .await;
+
+    let (status, body) = get_json(&app, "/api/board/projects/GNT-project/gantt").await;
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["range"]["min"], "2026-05-01");
+    assert_eq!(body["range"]["max"], "2026-06-15");
+    assert_eq!(body["issues"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn gantt_returns_unscheduled_with_null_dates() {
+    let (app, _) = test_app();
+    let (status, body) = get_json(&app, "/api/board/projects/GNT-project/gantt").await;
+    assert_eq!(status, 200, "body: {body}");
+    assert!(body["range"]["min"].is_null());
+    assert!(body["range"]["max"].is_null());
+    let issues = body["issues"].as_array().unwrap();
+    assert_eq!(issues.len(), 2);
+    for i in issues {
+        assert!(i["start_date"].is_null());
+        assert!(i["due_date"].is_null());
+    }
+}
+
+#[tokio::test]
+async fn gantt_returns_404_for_missing_project() {
+    let (app, _) = test_app();
+    let (status, _) = get_json(&app, "/api/board/projects/nonexistent/gantt").await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn gantt_mixes_scheduled_and_unscheduled() {
+    let (app, _) = test_app();
+    patch_json(
+        &app,
+        "/api/board/issues/GNT-1/schedule",
+        json!({ "start_date": "2026-05-05", "due_date": "2026-05-09" }),
+    )
+    .await;
+
+    let (status, body) = get_json(&app, "/api/board/projects/GNT-project/gantt").await;
+    assert_eq!(status, 200, "body: {body}");
+    assert_eq!(body["range"]["min"], "2026-05-05");
+    assert_eq!(body["range"]["max"], "2026-05-09");
+    let issues = body["issues"].as_array().unwrap();
+    assert_eq!(issues.len(), 2);
+    let unscheduled_count = issues.iter().filter(|i| i["start_date"].is_null()).count();
+    assert_eq!(unscheduled_count, 1);
+}

--- a/kernel/crates/gctrl-storage/src/board_markdown.rs
+++ b/kernel/crates/gctrl-storage/src/board_markdown.rs
@@ -223,6 +223,8 @@ pub fn import_markdown_dir(
             source_path: Some(path.to_string_lossy().into_owned()),
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         };
 
         results.push((issue, id));
@@ -415,6 +417,8 @@ The rate limiting middleware stores tokens in plaintext.
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         };
 
         let md = issue_to_markdown(&issue, "BACK");
@@ -476,6 +480,8 @@ The rate limiting middleware stores tokens in plaintext.
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         }];
 
         // Export

--- a/kernel/crates/gctrl-storage/src/duckdb_store.rs
+++ b/kernel/crates/gctrl-storage/src/duckdb_store.rs
@@ -879,8 +879,8 @@ impl DuckDbStore {
     pub fn insert_board_issue(&self, issue: &gctrl_core::BoardIssue) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 issue.id,
                 issue.project_id,
@@ -908,6 +908,8 @@ impl DuckDbStore {
                 issue.source_path,
                 issue.github_issue_number.map(|n| n as i32),
                 issue.github_url,
+                issue.start_date,
+                issue.due_date,
             ],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
@@ -955,7 +957,7 @@ impl DuckDbStore {
     pub fn get_board_issue(&self, id: &str) -> Result<Option<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url FROM board_issues WHERE id = ?1",
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE id = ?1",
             [id],
             row_to_board_issue,
         ).ok().map(Ok).transpose()
@@ -964,7 +966,7 @@ impl DuckDbStore {
     pub fn list_board_issues(&self, filter: &gctrl_core::BoardIssueFilter) -> Result<Vec<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         let mut sql = String::from(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url FROM board_issues WHERE 1=1"
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE 1=1"
         );
         let mut params_vec: Vec<Box<dyn duckdb::ToSql>> = Vec::new();
         let mut idx = 1;
@@ -1735,6 +1737,8 @@ fn row_to_board_issue(row: &duckdb::Row<'_>) -> duckdb::Result<gctrl_core::Board
         source_path: row.get(23)?,
         github_issue_number: { let v: Option<i32> = row.get(24)?; v.map(|n| n as u32) },
         github_url: row.get(25)?,
+        start_date: row.get(26)?,
+        due_date: row.get(27)?,
     })
 }
 
@@ -2495,6 +2499,8 @@ mod tests {
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         }
     }
 

--- a/kernel/crates/gctrl-storage/src/schema.rs
+++ b/kernel/crates/gctrl-storage/src/schema.rs
@@ -195,7 +195,9 @@ CREATE TABLE IF NOT EXISTS board_issues (
     content_hash    VARCHAR,
     source_path     VARCHAR,
     github_issue_number INTEGER,
-    github_url      VARCHAR
+    github_url      VARCHAR,
+    start_date      VARCHAR,
+    due_date        VARCHAR
 )
 "#;
 

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -64,6 +64,8 @@ CREATE TABLE IF NOT EXISTS board_issues (
     source_path     TEXT,
     github_issue_number INTEGER,
     github_url      TEXT,
+    start_date      TEXT,
+    due_date        TEXT,
     device_id       TEXT NOT NULL DEFAULT '',
     synced          INTEGER NOT NULL DEFAULT 0
 )
@@ -247,6 +249,8 @@ const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_board_issues_status ON board_issues(status)",
     "CREATE INDEX IF NOT EXISTS idx_board_issues_assignee ON board_issues(assignee_id)",
     "CREATE INDEX IF NOT EXISTS idx_board_issues_parent ON board_issues(parent_id)",
+    "CREATE INDEX IF NOT EXISTS idx_board_issues_start_date ON board_issues(start_date)",
+    "CREATE INDEX IF NOT EXISTS idx_board_issues_due_date ON board_issues(due_date)",
     "CREATE INDEX IF NOT EXISTS idx_board_events_issue ON board_events(issue_id)",
     "CREATE INDEX IF NOT EXISTS idx_board_comments_issue ON board_comments(issue_id)",
     // Board sync indexes
@@ -454,8 +458,8 @@ impl SqliteStore {
     pub fn insert_board_issue(&self, issue: &gctrl_core::BoardIssue) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, device_id, synced)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            "INSERT INTO board_issues (id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date, device_id, synced)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
             params![
                 issue.id,
                 issue.project_id,
@@ -483,6 +487,8 @@ impl SqliteStore {
                 issue.source_path,
                 issue.github_issue_number.map(|n| n as i32),
                 issue.github_url,
+                issue.start_date,
+                issue.due_date,
                 self.device_id,
             ],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -532,7 +538,7 @@ impl SqliteStore {
     pub fn get_board_issue(&self, id: &str) -> Result<Option<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         conn.query_row(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url FROM board_issues WHERE id = ?1",
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE id = ?1",
             [id],
             row_to_board_issue,
         ).ok().map(Ok).transpose()
@@ -541,7 +547,7 @@ impl SqliteStore {
     pub fn list_board_issues(&self, filter: &gctrl_core::BoardIssueFilter) -> Result<Vec<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         let mut sql = String::from(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url FROM board_issues WHERE 1=1"
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE 1=1"
         );
         let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         let mut idx = 1;
@@ -822,6 +828,100 @@ impl SqliteStore {
         Ok(tasks)
     }
 
+    /// Update `start_date` / `due_date` on an issue. Pass `None` for either
+    /// field to leave it untouched, `Some(None)` to clear, or `Some(Some(date))`
+    /// to set a new value. Emits a `scheduled` board event on success.
+    ///
+    /// Validates `start_date <= due_date` when both are set after the merge.
+    pub fn schedule_board_issue(
+        &self,
+        id: &str,
+        start_patch: Option<Option<String>>,
+        due_patch: Option<Option<String>>,
+        actor_id: &str,
+        actor_name: &str,
+        actor_type: &str,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let (cur_start, cur_due): (Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT start_date, due_date FROM board_issues WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|e| GctlError::Storage(format!("issue not found: {} ({})", id, e)))?;
+
+        let next_start = match start_patch {
+            Some(v) => v,
+            None => cur_start,
+        };
+        let next_due = match due_patch {
+            Some(v) => v,
+            None => cur_due,
+        };
+
+        if let (Some(s), Some(d)) = (&next_start, &next_due) {
+            if s.as_str() > d.as_str() {
+                return Err(GctlError::Storage(
+                    "start_date must be <= due_date".to_string(),
+                ));
+            }
+        }
+
+        let now = chrono::Utc::now();
+        conn.execute(
+            "UPDATE board_issues SET start_date = ?1, due_date = ?2, updated_at = ?3, device_id = ?4, synced = 0 WHERE id = ?5",
+            params![next_start, next_due, now.to_rfc3339(), self.device_id, id],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+
+        let event_id = uuid::Uuid::new_v4().to_string();
+        let data = serde_json::json!({
+            "start_date": next_start,
+            "due_date": next_due,
+        });
+        conn.execute(
+            "INSERT INTO board_events (id, issue_id, type, actor_id, actor_name, actor_type, timestamp, data, device_id, updated_at, synced)
+             VALUES (?, ?, 'scheduled', ?, ?, ?, ?, ?, ?, ?, 0)",
+            params![
+                event_id, id, actor_id, actor_name, actor_type,
+                now.to_rfc3339(),
+                serde_json::to_string(&data).unwrap_or_else(|_| "null".into()),
+                self.device_id, now.to_rfc3339(),
+            ],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Return all issues for a project along with the raw min/max range
+    /// over scheduled dates (both `start_date` and `due_date` are scanned).
+    /// Unscheduled issues are included with `None` dates.
+    pub fn gantt_for_project(
+        &self,
+        project_id: &str,
+    ) -> Result<(Option<String>, Option<String>, Vec<gctrl_core::BoardIssue>)> {
+        let filter = gctrl_core::BoardIssueFilter {
+            project_id: Some(project_id.to_string()),
+            ..Default::default()
+        };
+        let issues = self.list_board_issues(&filter)?;
+        let mut min: Option<String> = None;
+        let mut max: Option<String> = None;
+        for i in &issues {
+            for v in [&i.start_date, &i.due_date] {
+                if let Some(s) = v {
+                    if min.as_deref().map_or(true, |m| s.as_str() < m) {
+                        min = Some(s.clone());
+                    }
+                    if max.as_deref().map_or(true, |m| s.as_str() > m) {
+                        max = Some(s.clone());
+                    }
+                }
+            }
+        }
+        Ok((min, max, issues))
+    }
+
     pub fn assign_board_issue(&self, id: &str, assignee_id: &str, assignee_name: &str, assignee_type: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let now = chrono::Utc::now().to_rfc3339();
@@ -965,7 +1065,7 @@ impl SqliteStore {
     pub fn list_unsynced_board_issues(&self, batch_size: usize) -> Result<Vec<gctrl_core::BoardIssue>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url FROM board_issues WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
+            "SELECT id, project_id, title, description, status, priority, assignee_id, assignee_name, assignee_type, labels, parent_id, created_at, updated_at, created_by_id, created_by_name, created_by_type, blocked_by, blocking, session_ids, total_cost_usd, total_tokens, pr_numbers, content_hash, source_path, github_issue_number, github_url, start_date, due_date FROM board_issues WHERE synced = 0 ORDER BY updated_at ASC LIMIT ?1",
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         let rows = stmt.query_map([batch_size as i64], row_to_board_issue)
             .map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -2000,6 +2100,8 @@ fn row_to_board_issue(row: &rusqlite::Row<'_>) -> rusqlite::Result<gctrl_core::B
         source_path: row.get(23)?,
         github_issue_number: { let v: Option<i32> = row.get(24)?; v.map(|n| n as u32) },
         github_url: row.get(25)?,
+        start_date: row.get(26)?,
+        due_date: row.get(27)?,
     })
 }
 
@@ -2229,6 +2331,8 @@ mod tests {
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         };
         store.insert_board_issue(&issue).unwrap();
 
@@ -2555,6 +2659,8 @@ mod tests {
             source_path: None,
             github_issue_number: None,
             github_url: None,
+            start_date: None,
+            due_date: None,
         }
     }
 

--- a/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
+++ b/kernel/crates/gctrl-storage/tests/orchestrator_claim.rs
@@ -60,6 +60,8 @@ fn seed_issue(
         source_path: None,
         github_issue_number: None,
         github_url: None,
+        start_date: None,
+        due_date: None,
     };
     store.insert_board_issue(&issue).expect("insert issue");
 }

--- a/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
+++ b/kernel/crates/gctrl-storage/tests/promote_issue_to_task.rs
@@ -52,6 +52,8 @@ fn seed_project_and_issue(store: &SqliteStore, key: &str, issue_id: &str) {
         source_path: None,
         github_issue_number: None,
         github_url: None,
+        start_date: None,
+        due_date: None,
     };
     store.insert_board_issue(&issue).expect("insert issue");
 }

--- a/kernel/crates/gctrl-sync/src/engine.rs
+++ b/kernel/crates/gctrl-sync/src/engine.rs
@@ -987,6 +987,7 @@ mod tests {
                 total_cost_usd: 0.0, total_tokens: 0, pr_numbers: vec![],
                 content_hash: None, source_path: None,
                 github_issue_number: None, github_url: None,
+                start_date: None, due_date: None,
             }).unwrap();
         }
 

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -23,11 +23,12 @@ See [os.md — Dependency Direction](../os.md).
 
 ### In scope
 
-1. **Sessions** — **all past and live agent-spawn sessions** (internal + external) with live status, trace tree, cost, and linked issue; the primary entry point for "what is running / what ran".
-2. **Usage** — agent runs, tokens, cost, trends over time, by agent / model / workspace.
-3. **OTel analytics** — trace trees, span type distributions, latency percentiles, error loops, scores, alerts.
-4. **Proxied network traffic** — first-class view of requests flowing through the kernel proxy: domains contacted, bytes up/down, request counts, status-code distribution, per-agent attribution (requires kernel `proxy` Phase 2 + new `/api/net/*` routes; see [Kernel Dependencies](#kernel-dependencies)).
-5. **Agent attribution** — distinguish **internal** (scheduled via kernel Scheduler / spawned by our apps) vs **external** (pushed OTel from outside, e.g. a developer running `claude` locally against the OTel receiver) across all surfaces above.
+1. **Sessions** — all past and live agent-spawn sessions (internal + external), with live status, trace tree, cost, linked issue, and an Activity view mode (list / timeline / heatmap).
+2. **Prompts** — what agents are being asked, which prompt templates recur, and how they perform (cost, eval score, failure modes).
+3. **Evals** — score trends, alert rule status, pass/fail by agent/model — the regression-monitoring surface.
+4. **Usage** — provider spend (Anthropic, OpenAI, …), tool/util usage (Claude Code, Codex, …), proxied network traffic (requires kernel `proxy` Phase 2), and performance percentiles in one combined "where are resources going?" tab.
+5. **Contributions** — commits, PRs, and issues closed by agents, joined back to the originating session.
+6. **Agent attribution** — distinguish **internal** (scheduled via kernel Scheduler / spawned by our apps) vs **external** (pushed OTel from outside, e.g. a developer running `claude` locally against the OTel receiver) across all surfaces above.
 
 ### Out of scope
 
@@ -42,7 +43,10 @@ See [os.md — Dependency Direction](../os.md).
 |------|----------------|-------------------|
 | Usage overview, cost, latency, spans, scores, daily, alerts | `GET /api/analytics/*` | — |
 | Session list, detail, spans, trace tree, cost breakdown, loops | `GET /api/sessions/*` | — |
+| Activity view (timeline / heatmap) | `GET /api/sessions` (time-bucketed client-side) | — |
+| Prompts tab (instance list, grouping) | Span query by span-type | Light route: `GET /api/sessions/{id}/prompts` + `GET /api/prompts?group_by=fingerprint` |
 | Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
+| Contributions tab | `driver-github` PR/commit data | `session.contribution_links` table + `GET /api/contributions?since=...` |
 | Internal vs. external attribution | `session.agent_kind` (partial) | Add `session.spawn_source: internal \| external` field + filter params |
 | Live sessions | — | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (core, M1) |
 | Claude Code JSONL fidelity for external sessions | — | Deferred: `driver-claude-code` watcher (see [Deferred / Future](#deferred--future)) |
@@ -51,7 +55,7 @@ See [os.md — Dependency Direction](../os.md).
 
 ## Kernel Dependencies
 
-Two kernel changes this app needs. Both are useful beyond the app and should land as independent kernel work.
+Kernel changes this app needs. Each is useful beyond the app and should land as independent kernel work.
 
 ### 1. `session.spawn_source` field
 
@@ -75,49 +79,107 @@ Once `gctrl-proxy` Phase 2 lands (hudsucker MITM + traffic logging), expose:
 
 Per-session attribution requires the proxy to tag traffic with the originating session (via env-injected header or PID→session mapping). Until that exists, network traffic shows as "unattributed" with host/process-level grouping only — still useful.
 
+### 3. `GET /api/prompts` + `GET /api/sessions/{id}/prompts`
+
+Light-weight routes backing the Prompts tab:
+
+- `GET /api/sessions/{id}/prompts` — ordered list of prompt turns for a session.
+- `GET /api/prompts?group_by=fingerprint&since=...` — prompt instances grouped by normalized-text hash, with counts, avg cost, and linked sessions.
+
+No new storage — these are query-shape conveniences over the existing span table (filter by span type = `prompt` / `user_turn`).
+
+### 4. `GET /api/contributions` + `session.contribution_links`
+
+Backing the Contributions tab. When an agent creates a PR/commit during a session, the kernel records a link row (via `driver-github` callbacks on `pr create` / `git push`). The route aggregates these joined against GitHub-side state (PR status, lines changed).
+
+- `session.contribution_links` — `(session_id, kind: commit | pr | issue, ref, created_at)`.
+- `GET /api/contributions?since=...&agent=...` — list with drill-through fields.
+
 ## Dashboards
 
-The SPA has four top-level tabs. Each tab accepts the same global filters: `time range`, `spawn_source` (all / internal / external), `agent_kind`, `workspace`.
+The SPA has **six top-level tabs**. Each tab accepts the same global filters: `time range`, `spawn_source` (all / internal / external), `agent_kind`, `workspace`.
+
+Organizing principle: **Session is the spine** — every other surface is either a slice of session data (prompts, evals, activity, usage) or a downstream artifact (contributions). Tabs are organized by the question the operator is asking, not by the underlying table:
+
+| Tab | Question it answers | Primary entity |
+|-----|---------------------|----------------|
+| Overview | "What happened in the last N hours?" | Rollup across all pillars |
+| Sessions | "What ran / is running, and what did it do step-by-step?" | Session + Activity view |
+| Prompts | "What are agents being asked, and which prompts actually work?" | Prompt template + instance |
+| Evals | "Is quality drifting? Which rules are firing?" | Eval rule + score |
+| Usage | "What is this costing and which providers/tools/domains are burning it?" | Provider, tool, proxied domain |
+| Contributions | "What did agents actually ship?" | Commit, PR, issue |
+
+**Drill path is one-directional toward Session**: every row on every tab links back to a Session detail pane. Contribution → PR → Session → Prompt → Span → Eval.
 
 ### 1. Overview
 
-Single-page rollup answering "what happened in the last N hours/days":
+Single-page rollup answering "what happened in the last N hours/days". Samples one metric from every other tab so operators can see the shape of the system without clicking in.
 
-- KPI row: sessions, spans, tokens, cost, distinct agents, distinct domains contacted.
+- KPI row: live sessions now, total sessions (window), tokens, cost, distinct agents, top-3 proxied domains.
 - Split bar: internal vs. external — sessions, cost, traffic.
-- Sparkline row: sessions/day, cost/day, p95 latency/day, requests/day.
+- Sparkline row: sessions/day, cost/day, p95 latency/day, requests/day, eval pass rate/day, contributions/day.
 - Recent sessions list (top 10 by recency) with drill-through to the Sessions tab.
 
 ### 2. Sessions
 
 The primary "what has been / is being spawned" view. Shows **every agent-spawn session** the kernel knows about — past and live — regardless of whether we started it (internal) or an external tool pushed OTel in (external).
 
-- Table of sessions filtered by the global filters, with a **status column**: `live` (no `ended_at`, recent span activity), `idle` (no `ended_at`, no recent spans), `ended`, `errored`.
-- A top toggle defaults to **"Live + recent"**; operators can switch to "All past" for historical inspection.
+This tab also absorbs **Agent Activity** as a view-mode toggle (rather than its own tab) so the same data renders three ways without duplicate queries:
+
+- **List** (default) — table of sessions filtered by the global filters, with a **status column**: `live` (no `ended_at`, recent span activity), `idle` (no `ended_at`, no recent spans), `ended`, `errored`.
+- **Timeline** — horizontal lanes per agent, bars for each session, colored by status. Reveals idle periods and concurrency.
+- **Heatmap** — agent × hour-of-day grid, cell intensity = session count or cost. Reveals activity patterns.
+
+Shared controls: top toggle defaults to **"Live + recent"**; operators can switch to "All past" for historical inspection.
+
 - Row → detail pane: agent, model, cost, duration, spawn_source, linked issue (if any), span count, error count, **live indicator** when streaming spans are still arriving.
 - Detail pane embeds a **trace tree** (renders `GET /api/sessions/{id}/tree`) with span expansion, latency bars, and error highlighting. For live sessions the tree appends new spans as they arrive (SSE, see M1 below).
+- Detail pane also surfaces: **prompts used** (links to Prompts tab), **evals attached** (links to Evals tab), **outbound requests** (from Usage/Network), **contributions produced** (from Contributions).
 - Loops view surfaces `GET /api/sessions/{id}/loops` when the kernel detected repeated failures.
 
-### 3. OTel
+### 3. Prompts
 
-- Latency percentiles per model (reuses `GET /api/analytics/latency`).
-- Span type distribution (reuses `GET /api/analytics/spans`).
-- Score pass/fail trends (reuses `GET /api/analytics/scores`).
-- Alert rule status (reuses `GET /api/analytics/alerts`).
-- Cost breakdown by model and by agent (reuses `GET /api/analytics/cost`).
+Answers "what are agents being asked, and which prompts actually work?". Operates over both prompt templates (reusable, scheduled) and prompt instances (the actual user/system turns captured as spans).
 
-### 4. Network (Proxied Traffic)
+- Searchable table of prompt instances across all sessions, with columns: prompt preview, agent, model, session, tokens, cost, eval score (if any), timestamp.
+- Grouping by **prompt template** (when tagged) or by **prompt fingerprint** (hash of normalized text) to reveal which prompts are used repeatedly.
+- Per-template panel: usage count over time, avg cost, avg eval score, top failure modes.
+- Drill-through: prompt instance → session detail → full trace tree.
+- Reuse: `GET /api/sessions/{id}/prompts` (new, light) + existing span query for instance rollup.
 
-Surfaces every HTTP request that flowed through the kernel proxy — both app-originated and external agents routed via `HTTP_PROXY`. Co-equal with Sessions as a first-class surface: operators ask "which session called which domain?" at least as often as "which spans were slow?".
+### 4. Evals
 
-Only meaningful once kernel proxy Phase 2 ships. Before then, this tab shows a placeholder explaining the dependency.
+Answers "is quality drifting? which rules are firing?". Distinct from Prompts because the entity is different (eval rule vs. prompt) and the operator task is regression monitoring, not authoring.
 
-- Top domains by requests and by bytes.
-- Request volume sparkline, stacked by `spawn_source` when attribution is available.
-- Status code distribution (2xx/3xx/4xx/5xx stacked).
-- Recent requests table with per-request drill-through (method, host, path, status, bytes, latency, session link).
-- When attribution is available: "network cost" joined to a session (e.g. "session `sess_abc` contacted `api.openai.com` 42 times, 312 KB") and the reverse on the Sessions detail pane ("this session made 42 outbound requests to 3 domains").
-- Overview tab also surfaces the top-3 proxied domains + total requests/bytes in the KPI row so network is visible without clicking in.
+- Score pass/fail trends per rule (reuses `GET /api/analytics/scores`).
+- Alert rule status (reuses `GET /api/analytics/alerts`) — firing / silenced / clear.
+- Per-rule panel: pass rate over time, recent failures with session links, which prompts trip it most.
+- Breakdown by agent/model to spot provider-specific regressions.
+
+### 5. Usage
+
+Answers "what is this costing, and which providers / tools / domains are burning it?". Merges provider spend, tool usage, proxied network traffic, and OTel performance metrics into one resource-behavior surface. Operators compare "where is cost going?" against "where is traffic going?" in the same tab rather than flipping between three.
+
+- **Providers** — cost + tokens per LLM provider (Anthropic, OpenAI, local). Reuses `GET /api/analytics/cost`.
+- **Tools / utils** — usage per agent kind (Claude Code, Codex, ad-hoc scripts). Rows: invocation count, avg duration, cost, distinct sessions, split by `spawn_source`.
+- **Proxied network traffic** — every HTTP request that flowed through the kernel proxy, both app-originated and external agents routed via `HTTP_PROXY`. Only meaningful once kernel proxy Phase 2 ships; before then, this sub-panel shows a placeholder explaining the dependency.
+  - Top domains by requests and by bytes.
+  - Request volume sparkline, stacked by `spawn_source` when attribution is available.
+  - Status code distribution (2xx/3xx/4xx/5xx stacked).
+  - Recent requests table with per-request drill-through (method, host, path, status, bytes, latency, session link).
+  - Reverse join on the Sessions detail pane ("this session made 42 outbound requests to 3 domains").
+- **Performance** — latency percentiles per model (reuses `GET /api/analytics/latency`), span type distribution (reuses `GET /api/analytics/spans`). Secondary panel; aggregate view of what the trace tree shows per-session.
+
+### 6. Contributions
+
+Answers "what did agents actually ship?". The entity is git/GitHub artifacts, not telemetry — this is the skeptic-facing tab that shows output, not activity.
+
+- Table of commits, PRs, and issues closed, filterable by agent, time range, repo.
+- Columns: title, author (agent or human), linked session, PR status (open/merged/closed), lines +/-, review signal.
+- Sparkline: contributions/day split by `spawn_source`.
+- Drill-through: contribution → PR on GitHub (via `driver-github`) and contribution → originating session.
+- Reuse: joins `driver-github` PR data with `session.contribution_links` (new lightweight table populated when an agent creates a PR during a session).
 
 ## UI & Stack
 
@@ -127,7 +189,7 @@ Mirrors `gctrl-board` to avoid divergence:
 - `@effect/platform` HTTP client for kernel calls (same pattern as board).
 - `recharts` or `visx` for charts — pick one consistent with the board's eventual choice; no need to invent a chart stack twice.
 - Tailwind + shadcn-style components. Dense tables by default — this is an operator tool, not a marketing site.
-- Routes: `/overview`, `/sessions`, `/sessions/:id`, `/otel`, `/net`.
+- Routes: `/overview`, `/sessions`, `/sessions/:id`, `/prompts`, `/evals`, `/usage`, `/contributions`.
 
 The Worker itself is a **thin facade**: it proxies to the kernel HTTP API and serves the SPA bundle. No D1, no business logic in the Worker. This follows the [Kernel is source of truth; Worker is facade](../../../CLAUDE.md) invariant.
 
@@ -142,21 +204,23 @@ This is the distinctive thing this app does that no other surface does today.
 | Linked to an Issue | Commonly (scheduler links via task) | Rarely (requires developer to put an Issue key in a span) |
 | Network attribution | High (proxy env injection possible) | Low (depends on whether developer routes through `HTTP_PROXY`) |
 
-The Overview and Sessions tabs show an **Internal / External** toggle. OTel and Network tabs show a stacked split in every chart so the operator can always see the shape of both populations.
+The Overview and Sessions tabs show an **Internal / External** toggle. Evals, Usage, and Contributions tabs show a stacked split in every chart so the operator can always see the shape of both populations.
 
 ## Dogfooding
 
 - This app is itself instrumented with OTel. It will appear in its own dashboards.
 - We use it to track `claude-code` usage (external), kernel Scheduler tasks (internal), and spot cost regressions during development.
-- During early development, the Network tab will show `/api/*` calls against `localhost:4318` — sanity check that the app isn't chatty.
+- During early development, the Usage tab's network sub-panel will show `/api/*` calls against `localhost:4318` — sanity check that the app isn't chatty.
 
 ## Milestones
 
-1. **M0 — Skeleton + Overview + Sessions (past)**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree over historical data. Poll-refresh for "live-ish" updates (5–10s). No network tab. Uses existing kernel routes only. Fits on a laptop in an afternoon.
+1. **M0 — Skeleton + Overview + Sessions (past)**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree over historical data. Poll-refresh for "live-ish" updates (5–10s). Uses existing kernel routes only. Fits on a laptop in an afternoon.
 2. **M1 — Live sessions**: SSE endpoint `GET /api/sessions/stream` + per-session `GET /api/sessions/{id}/stream`. Sessions table and detail pane update in-place as spans land. This is a core feature, not optional — operators need to see agents while they are running.
-3. **M2 — OTel tab**: latency, spans, scores, alerts, cost breakdown. Still zero new kernel work.
-4. **M3 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
-5. **M4 — Network tab**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ship placeholder until then.
+3. **M2 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Still zero new kernel work.
+4. **M3 — Prompts + Activity views**: Prompts tab (needs `GET /api/prompts` + `GET /api/sessions/{id}/prompts`), plus Timeline and Heatmap view modes on the Sessions tab.
+5. **M4 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
+6. **M5 — Network sub-panel**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ships inside the Usage tab, not as its own tab.
+7. **M6 — Contributions**: `session.contribution_links` + `GET /api/contributions`. Depends on `driver-github` callbacks on PR create / commit push.
 
 ## Deferred / Future
 
@@ -180,4 +244,7 @@ Out of scope for the initial build. Noted here so the Sessions model is not pain
 
 1. Should `spawn_source` be three-valued (`internal | external | unknown`) to handle pre-migration data, or should we backfill old rows to `external` on first deploy? Leaning `unknown` + CLI backfill command.
 2. How do we attribute external `claude-code` traffic when it doesn't go through our proxy? Likely we can't — and that's fine; the OTel side still gives us per-session cost.
-3. Chart library: `recharts` (friendly, battery-included) vs. `visx` (more control, more code). Defer until we know what charts M1 actually needs.
+3. Chart library: `recharts` (friendly, battery-included) vs. `visx` (more control, more code). Defer until we know what charts M2 actually needs.
+4. Is Agent Activity as a view-mode on Sessions sufficient, or do operators expect it as a top-level tab? Easy to promote later if the toggle proves too buried.
+5. Should Prompts and Evals be merged into one "Quality" tab? Kept separate because the entities (prompt template vs. eval rule) and the operator tasks (authoring vs. regression monitoring) differ — revisit after M3.
+6. `session.contribution_links` vs. inferring contributions from commit message / PR body mentions of session IDs. Explicit link rows are cleaner but require `driver-github` to emit callbacks; inference is retroactive but lossy.

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -1,0 +1,163 @@
+# Application: gctrl-analytics (Usage, OTel & Network Dashboard)
+
+gctrl-analytics is the **observability web application** for gctrl — a unified dashboard for usage, OTel traces, cost/latency analytics, and network traffic routed through the kernel. It visualizes activity from both **internal agents** (scheduled/spawned by us through the kernel) and **external agents** (Claude Code, Codex, ad-hoc scripts, humans) that push telemetry through the OTel receiver or route traffic through the kernel proxy.
+
+It is the second native application after `gctrl-board`, and the primary place humans go to ask "what has been happening on this machine / in this workspace?".
+
+## Architectural Position
+
+gctrl-analytics is a **native application** in the Unix layer model — same position as `gctrl-board`.
+
+```
+App (gctrl-analytics) → Kernel HTTP API (:4318) → Kernel (storage, otel, proxy, scheduler)
+```
+
+- **Depends on the kernel** — reads data via HTTP API only. MUST NOT access DuckDB directly or import kernel crates.
+- **Never depended on by the shell or kernel** — removing the app breaks nothing below it.
+- **Has its own web server** — Cloudflare Worker facade serving a React SPA, separate port from kernel `:4318`. Mirrors `gctrl-board`'s deployment shape.
+- **Shell command surface**: `gctrl analytics ...` commands already exist in `shell/gctl-shell/src/commands/analytics.ts` and cover the CLI surface. This app is **UI-only** — it does not add new shell commands.
+
+See [os.md — Dependency Direction](../os.md).
+
+## Scope
+
+### In scope
+
+1. **Usage** — sessions, agent runs, tokens, cost, trends over time, by agent / model / workspace.
+2. **OTel analytics** — trace trees, span type distributions, latency percentiles, error loops, scores, alerts.
+3. **Network traffic** — domains contacted, bytes up/down, request counts, status-code distribution, per-agent attribution (requires kernel `proxy` Phase 2 + new `/api/net/*` routes; see [Kernel Dependencies](#kernel-dependencies)).
+4. **Agent attribution** — distinguish **internal** (scheduled via kernel Scheduler / spawned by our apps) vs **external** (pushed OTel from outside, e.g. a developer running `claude` locally against the OTel receiver) across all three surfaces above.
+
+### Out of scope
+
+- Issue/task tracking — owned by `gctrl-board`.
+- Agent evaluation / scoring UI — covered by `gctrl-eval` (planned).
+- Write operations against sessions/spans — read-only app. Scoring and tagging stay in the shell.
+- Multi-tenant billing or access control — single-operator assumption (same as rest of gctrl).
+
+## Reuse vs. New
+
+| Need | Reuse existing | New work required |
+|------|----------------|-------------------|
+| Usage overview, cost, latency, spans, scores, daily, alerts | `GET /api/analytics/*` | — |
+| Session list, detail, spans, trace tree, cost breakdown, loops | `GET /api/sessions/*` | — |
+| Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
+| Internal vs. external attribution | `session.agent_kind` (partial) | Add `session.spawn_source: internal \| external` field + filter params |
+| Live updates | — | Optional SSE endpoint `GET /api/sessions/stream` (deferrable) |
+
+**Principle**: no new analytics logic in the app. The app is a **presentation layer**. Any new aggregation or attribution belongs in the kernel so the CLI benefits too.
+
+## Kernel Dependencies
+
+Two kernel changes this app needs. Both are useful beyond the app and should land as independent kernel work.
+
+### 1. `session.spawn_source` field
+
+Today `Session` records `agent_name` and `agent_kind` (e.g. `ClaudeCode`). It does not record **how** the session was started — whether the kernel Scheduler spawned it or whether an external process pushed OTel in.
+
+Proposal: add `spawn_source: SpawnSource` where `SpawnSource = Internal | External`.
+
+- `Internal` — session was created by the kernel Scheduler or an app calling `POST /api/sessions` with a spawn token.
+- `External` — session was created implicitly on first OTel span ingestion (OTLP receiver), no kernel spawn record.
+
+Emit as a filter on `/api/sessions?spawn_source=internal` and roll up in `/api/analytics?spawn_source=...`.
+
+### 2. `/api/net/*` routes
+
+Once `gctrl-proxy` Phase 2 lands (hudsucker MITM + traffic logging), expose:
+
+- `GET /api/net/overview` — total requests, bytes up/down, distinct domains, window.
+- `GET /api/net/domains?since=...&top=N` — top domains by requests / bytes.
+- `GET /api/net/traffic?since=...&host=...&limit=...` — recent requests, with `session_id` + `spawn_source` when derivable from the proxy's per-process attribution.
+- `GET /api/net/daily?days=N` — daily request and byte trends.
+
+Per-session attribution requires the proxy to tag traffic with the originating session (via env-injected header or PID→session mapping). Until that exists, network traffic shows as "unattributed" with host/process-level grouping only — still useful.
+
+## Dashboards
+
+The SPA has four top-level tabs. Each tab accepts the same global filters: `time range`, `spawn_source` (all / internal / external), `agent_kind`, `workspace`.
+
+### 1. Overview
+
+Single-page rollup answering "what happened in the last N hours/days":
+
+- KPI row: sessions, spans, tokens, cost, distinct agents, distinct domains contacted.
+- Split bar: internal vs. external — sessions, cost, traffic.
+- Sparkline row: sessions/day, cost/day, p95 latency/day, requests/day.
+- Recent sessions list (top 10 by recency) with drill-through to the Sessions tab.
+
+### 2. Sessions
+
+- Table of sessions filtered by the global filters.
+- Row → detail pane: agent, model, cost, duration, spawn_source, linked issue (if any), span count, error count.
+- Detail pane embeds a **trace tree** (renders `GET /api/sessions/{id}/tree`) with span expansion, latency bars, and error highlighting.
+- Loops view surfaces `GET /api/sessions/{id}/loops` when the kernel detected repeated failures.
+
+### 3. OTel
+
+- Latency percentiles per model (reuses `GET /api/analytics/latency`).
+- Span type distribution (reuses `GET /api/analytics/spans`).
+- Score pass/fail trends (reuses `GET /api/analytics/scores`).
+- Alert rule status (reuses `GET /api/analytics/alerts`).
+- Cost breakdown by model and by agent (reuses `GET /api/analytics/cost`).
+
+### 4. Network
+
+Only meaningful once kernel proxy Phase 2 ships. Before then, this tab shows a placeholder explaining the dependency.
+
+- Top domains by requests and by bytes.
+- Request volume sparkline.
+- Status code distribution (2xx/3xx/4xx/5xx stacked).
+- Recent requests table with per-request drill-through.
+- When attribution is available: "network cost" joined to a session (e.g. "session `sess_abc` contacted `api.openai.com` 42 times, 312 KB").
+
+## UI & Stack
+
+Mirrors `gctrl-board` to avoid divergence:
+
+- Cloudflare Worker facade + React 19 SPA.
+- `@effect/platform` HTTP client for kernel calls (same pattern as board).
+- `recharts` or `visx` for charts — pick one consistent with the board's eventual choice; no need to invent a chart stack twice.
+- Tailwind + shadcn-style components. Dense tables by default — this is an operator tool, not a marketing site.
+- Routes: `/overview`, `/sessions`, `/sessions/:id`, `/otel`, `/net`.
+
+The Worker itself is a **thin facade**: it proxies to the kernel HTTP API and serves the SPA bundle. No D1, no business logic in the Worker. This follows the [Kernel is source of truth; Worker is facade](../../../CLAUDE.md) invariant.
+
+## Internal vs. External Agent Attribution
+
+This is the distinctive thing this app does that no other surface does today.
+
+| Signal | Internal | External |
+|--------|----------|----------|
+| Session creation | Scheduler / app POST with spawn token | Implicit on first OTel ingest |
+| `agent_kind` | Usually known (we set it) | Inferred from OTel resource attrs (`service.name`, `telemetry.sdk.name`) or unknown |
+| Linked to an Issue | Commonly (scheduler links via task) | Rarely (requires developer to put an Issue key in a span) |
+| Network attribution | High (proxy env injection possible) | Low (depends on whether developer routes through `HTTP_PROXY`) |
+
+The Overview and Sessions tabs show an **Internal / External** toggle. OTel and Network tabs show a stacked split in every chart so the operator can always see the shape of both populations.
+
+## Dogfooding
+
+- This app is itself instrumented with OTel. It will appear in its own dashboards.
+- We use it to track `claude-code` usage (external), kernel Scheduler tasks (internal), and spot cost regressions during development.
+- During early development, the Network tab will show `/api/*` calls against `localhost:4318` — sanity check that the app isn't chatty.
+
+## Milestones
+
+1. **M0 — Skeleton + Overview + Sessions**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree. No network tab. Uses existing kernel routes only. Fits on a laptop in an afternoon.
+2. **M1 — OTel tab**: latency, spans, scores, alerts, cost breakdown. Still zero new kernel work.
+3. **M2 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
+4. **M3 — Network tab**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ship placeholder until then.
+5. **M4 — Live updates (optional)**: SSE for session list on the Sessions tab.
+
+## Non-Goals / Explicit Boundaries
+
+- Not an OTel backend. The kernel's DuckDB-backed OTel receiver is the store. This app does not ingest, store, or forward telemetry.
+- Not a replacement for Langfuse/Grafana for teams — single-operator local tool.
+- Not a write surface. All mutations (scoring, tagging, alerting) remain on the CLI to keep the UI simple and avoid an approval surface inside the browser.
+
+## Open Questions
+
+1. Should `spawn_source` be three-valued (`internal | external | unknown`) to handle pre-migration data, or should we backfill old rows to `external` on first deploy? Leaning `unknown` + CLI backfill command.
+2. How do we attribute external `claude-code` traffic when it doesn't go through our proxy? Likely we can't — and that's fine; the OTel side still gives us per-session cost.
+3. Chart library: `recharts` (friendly, battery-included) vs. `visx` (more control, more code). Defer until we know what charts M1 actually needs.

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -1,6 +1,6 @@
 # Application: gctrl-analytics (Usage, OTel & Network Dashboard)
 
-gctrl-analytics is the **observability web application** for gctrl — a unified dashboard for usage, OTel traces, cost/latency analytics, and network traffic routed through the kernel. It visualizes activity from both **internal agents** (scheduled/spawned by us through the kernel) and **external agents** (Claude Code, Codex, ad-hoc scripts, humans) that push telemetry through the OTel receiver or route traffic through the kernel proxy.
+gctrl-analytics is the **observability web application** for gctrl — a unified dashboard for all past and live agent-spawn sessions, usage, OTel traces, cost/latency analytics, and network traffic routed through the kernel proxy. It visualizes activity from both **internal agents** (scheduled/spawned by us through the kernel) and **external agents** (Claude Code, Codex, ad-hoc scripts, humans) that push telemetry through the OTel receiver or route traffic through the kernel proxy.
 
 It is the second native application after `gctrl-board`, and the primary place humans go to ask "what has been happening on this machine / in this workspace?".
 
@@ -23,10 +23,11 @@ See [os.md — Dependency Direction](../os.md).
 
 ### In scope
 
-1. **Usage** — sessions, agent runs, tokens, cost, trends over time, by agent / model / workspace.
-2. **OTel analytics** — trace trees, span type distributions, latency percentiles, error loops, scores, alerts.
-3. **Network traffic** — domains contacted, bytes up/down, request counts, status-code distribution, per-agent attribution (requires kernel `proxy` Phase 2 + new `/api/net/*` routes; see [Kernel Dependencies](#kernel-dependencies)).
-4. **Agent attribution** — distinguish **internal** (scheduled via kernel Scheduler / spawned by our apps) vs **external** (pushed OTel from outside, e.g. a developer running `claude` locally against the OTel receiver) across all three surfaces above.
+1. **Sessions** — **all past and live agent-spawn sessions** (internal + external) with live status, trace tree, cost, and linked issue; the primary entry point for "what is running / what ran".
+2. **Usage** — agent runs, tokens, cost, trends over time, by agent / model / workspace.
+3. **OTel analytics** — trace trees, span type distributions, latency percentiles, error loops, scores, alerts.
+4. **Proxied network traffic** — first-class view of requests flowing through the kernel proxy: domains contacted, bytes up/down, request counts, status-code distribution, per-agent attribution (requires kernel `proxy` Phase 2 + new `/api/net/*` routes; see [Kernel Dependencies](#kernel-dependencies)).
+5. **Agent attribution** — distinguish **internal** (scheduled via kernel Scheduler / spawned by our apps) vs **external** (pushed OTel from outside, e.g. a developer running `claude` locally against the OTel receiver) across all surfaces above.
 
 ### Out of scope
 
@@ -43,7 +44,8 @@ See [os.md — Dependency Direction](../os.md).
 | Session list, detail, spans, trace tree, cost breakdown, loops | `GET /api/sessions/*` | — |
 | Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
 | Internal vs. external attribution | `session.agent_kind` (partial) | Add `session.spawn_source: internal \| external` field + filter params |
-| Live updates | — | Optional SSE endpoint `GET /api/sessions/stream` (deferrable) |
+| Live sessions | — | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (core, M1) |
+| Claude Code JSONL fidelity for external sessions | — | Deferred: `driver-claude-code` watcher (see [Deferred / Future](#deferred--future)) |
 
 **Principle**: no new analytics logic in the app. The app is a **presentation layer**. Any new aggregation or attribution belongs in the kernel so the CLI benefits too.
 
@@ -88,9 +90,12 @@ Single-page rollup answering "what happened in the last N hours/days":
 
 ### 2. Sessions
 
-- Table of sessions filtered by the global filters.
-- Row → detail pane: agent, model, cost, duration, spawn_source, linked issue (if any), span count, error count.
-- Detail pane embeds a **trace tree** (renders `GET /api/sessions/{id}/tree`) with span expansion, latency bars, and error highlighting.
+The primary "what has been / is being spawned" view. Shows **every agent-spawn session** the kernel knows about — past and live — regardless of whether we started it (internal) or an external tool pushed OTel in (external).
+
+- Table of sessions filtered by the global filters, with a **status column**: `live` (no `ended_at`, recent span activity), `idle` (no `ended_at`, no recent spans), `ended`, `errored`.
+- A top toggle defaults to **"Live + recent"**; operators can switch to "All past" for historical inspection.
+- Row → detail pane: agent, model, cost, duration, spawn_source, linked issue (if any), span count, error count, **live indicator** when streaming spans are still arriving.
+- Detail pane embeds a **trace tree** (renders `GET /api/sessions/{id}/tree`) with span expansion, latency bars, and error highlighting. For live sessions the tree appends new spans as they arrive (SSE, see M1 below).
 - Loops view surfaces `GET /api/sessions/{id}/loops` when the kernel detected repeated failures.
 
 ### 3. OTel
@@ -101,15 +106,18 @@ Single-page rollup answering "what happened in the last N hours/days":
 - Alert rule status (reuses `GET /api/analytics/alerts`).
 - Cost breakdown by model and by agent (reuses `GET /api/analytics/cost`).
 
-### 4. Network
+### 4. Network (Proxied Traffic)
+
+Surfaces every HTTP request that flowed through the kernel proxy — both app-originated and external agents routed via `HTTP_PROXY`. Co-equal with Sessions as a first-class surface: operators ask "which session called which domain?" at least as often as "which spans were slow?".
 
 Only meaningful once kernel proxy Phase 2 ships. Before then, this tab shows a placeholder explaining the dependency.
 
 - Top domains by requests and by bytes.
-- Request volume sparkline.
+- Request volume sparkline, stacked by `spawn_source` when attribution is available.
 - Status code distribution (2xx/3xx/4xx/5xx stacked).
-- Recent requests table with per-request drill-through.
-- When attribution is available: "network cost" joined to a session (e.g. "session `sess_abc` contacted `api.openai.com` 42 times, 312 KB").
+- Recent requests table with per-request drill-through (method, host, path, status, bytes, latency, session link).
+- When attribution is available: "network cost" joined to a session (e.g. "session `sess_abc` contacted `api.openai.com` 42 times, 312 KB") and the reverse on the Sessions detail pane ("this session made 42 outbound requests to 3 domains").
+- Overview tab also surfaces the top-3 proxied domains + total requests/bytes in the KPI row so network is visible without clicking in.
 
 ## UI & Stack
 
@@ -144,11 +152,23 @@ The Overview and Sessions tabs show an **Internal / External** toggle. OTel and 
 
 ## Milestones
 
-1. **M0 — Skeleton + Overview + Sessions**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree. No network tab. Uses existing kernel routes only. Fits on a laptop in an afternoon.
-2. **M1 — OTel tab**: latency, spans, scores, alerts, cost breakdown. Still zero new kernel work.
-3. **M2 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
-4. **M3 — Network tab**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ship placeholder until then.
-5. **M4 — Live updates (optional)**: SSE for session list on the Sessions tab.
+1. **M0 — Skeleton + Overview + Sessions (past)**: Worker + SPA + kernel proxy, Overview tab, Sessions list + detail with trace tree over historical data. Poll-refresh for "live-ish" updates (5–10s). No network tab. Uses existing kernel routes only. Fits on a laptop in an afternoon.
+2. **M1 — Live sessions**: SSE endpoint `GET /api/sessions/stream` + per-session `GET /api/sessions/{id}/stream`. Sessions table and detail pane update in-place as spans land. This is a core feature, not optional — operators need to see agents while they are running.
+3. **M2 — OTel tab**: latency, spans, scores, alerts, cost breakdown. Still zero new kernel work.
+4. **M3 — Attribution**: kernel adds `session.spawn_source`. App adds global filter + split charts.
+5. **M4 — Network tab**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ship placeholder until then.
+
+## Deferred / Future
+
+### Claude Code JSONL import
+
+Claude Code writes a JSONL transcript per session (tool calls, messages, reasoning, file diffs) that is strictly richer than what we capture from its OTel output today. Importing it would let the Sessions detail pane show full agent reasoning and tool traces for external Claude Code runs — the same fidelity we get for internal sessions.
+
+Out of scope for the initial build. Noted here so the Sessions model is not painted into a corner:
+
+- Kernel would grow a driver (e.g. `driver-claude-code`) that watches `~/.claude/projects/**/*.jsonl` and upserts spans/messages against a matching external session (join key: working directory + start time).
+- No schema change in the session model is required — the driver maps JSONL entries onto existing `Span` / message tables.
+- Until this exists, external Claude Code sessions rely on OTel alone; the Sessions pane renders whatever the OTel receiver captured and labels gaps clearly.
 
 ## Non-Goals / Explicit Boundaries
 


### PR DESCRIPTION
## Summary

Ships the **Gantt view for `gctrl-board`** end-to-end — spec + full implementation across kernel (SQLite source of truth) and Worker (D1 mirror).

- Spec: [`apps/gctrl-board/specs/gantt.md`](./apps/gctrl-board/specs/gantt.md) — GitHub Projects-style roadmap; issues-only, `@dnd-kit` drag-and-drop, kernel-first.
- Implementation: data model, both API surfaces (kernel + Worker), React+`@dnd-kit` frontend, unit + integration + Playwright-ready acceptance.

## What's in this PR

### Data

- Optional `start_date` / `due_date` (`YYYY-MM-DD` TEXT) on `board_issues`:
  - Kernel SQLite (`kernel/crates/gctrl-storage/src/{schema,sqlite_store,duckdb_store}.rs`)
  - Worker D1 (`apps/gctrl-board/migrations/0003_gantt_dates.sql`)
- Extend `gctrl_core::BoardIssue` with matching `Option<String>` fields (`skip_serializing_if = "Option::is_none"` keeps wire compat).
- Effect-TS struct at `apps/gctrl-board/src/schema/Issue.ts` mirrors camelCase.

### API (on both surfaces)

| Method  | Path                                    | Behavior                                                                                  |
|---------|-----------------------------------------|-------------------------------------------------------------------------------------------|
| `PATCH` | `/api/board/issues/:id/schedule`        | Partial patch; `null` clears; validates `start_date <= due_date`; emits `scheduled` event |
| `GET`   | `/api/board/projects/:id/gantt`         | Returns `{ range: {min, max}, issues }`; unscheduled issues included with null dates       |

Kernel handlers use `double_option` serde so "field absent" vs "field explicitly null" are distinguishable.

### Frontend

- `apps/gctrl-board/web/src/components/GanttBoard.tsx` — reachable via view-switcher at `/projects/:key/gantt`.
- DOM bars (no SVG), status swimlanes, day/week/month/quarter zoom with spec'd snap policy, today marker, Unscheduled tray, cancelled = readonly.
- Four `@dnd-kit` drag kinds wired through one `DndContext`: `bar-move`, `bar-resize-l`, `bar-resize-r`, `unscheduled`. Cross-row+cross-column drops dispatch `updateSchedule` + `moveStatus` in parallel (`Promise.allSettled`).
- `PointerSensor` (distance 8) + `TouchSensor` (delay 150, tolerance 5) + `KeyboardSensor` with `gridCoordinateGetter` for arrow-key snap.
- Pure geometry in `web/src/lib/gantt-geom.ts` (`barRect`, `snapDeltaDays`, `columnDateAt`, date helpers).

### Tests

- `apps/gctrl-board`:
  - 17 unit tests for `gantt-geom.ts`
  - 12 Worker integration tests (`tests/worker/gantt.test.ts`) via `@cloudflare/vitest-pool-workers`
- `kernel/crates/gctrl-otel/tests/board_schedule.rs`: 11 kernel integration tests mirroring Worker behavior
- Also fixed a pre-existing flake: `uniqueProjectKey()` could generate keys containing "HI" which collided with the priority badge text; scoped the locator to `data-testid="priority-badge"`.

## What's deferred (v2, per spec)

- Dependency arrows between bars
- Grouping by assignee / iteration
- Milestones as vertical markers
- Playwright acceptance suite for Gantt drag flows (wiring through the existing CDP + kernel harness)

## Test plan

- [x] `cargo test --workspace` — all kernel tests pass (incl. 11 new Gantt tests)
- [x] `pnpm test` in `apps/gctrl-board` — 17 geom tests + 24 existing
- [x] `pnpm test:workers` — 44 tests (12 new Gantt + 32 existing)
- [x] `pnpm build:web` — frontend compiles
- [x] CI green
- [x] Deploy Board preview green (incl. CDP acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
