### PR TITLE
feat(uebermensch): process vault prompts/ folder as user research queries

### DIFF
--- a/apps/uebermensch/PRD.md
+++ b/apps/uebermensch/PRD.md
@@ -17,7 +17,7 @@ flowchart TB
   end
   subgraph Vault["$UBER_VAULT_DIR (Obsidian-mountable)"]
     direction LR
-    Authored["Authored tier\nprofile.md · theses/ · prompts/"]
+    Authored["Authored tier\nprofile.md · theses/ · personas/ · prompts/ (queries)"]
     Generated["Generated tier\nwiki/ · briefs/ · sources/"]
   end
   subgraph Shell["Shell (HTTP :4318)"]
@@ -79,7 +79,7 @@ The non-obvious bets:
 
 ## Principles
 
-1. **Vault is portable and Obsidian-mountable.** `$UBER_VAULT_DIR` is a git-versioned Obsidian vault outside the gctrl repo, readable without Uebermensch running. Every file is CommonMark markdown with YAML frontmatter; wikilinks use plain `[[slug]]` form (typed prefixes like `[[thesis:slug]]` are forbidden — they break Obsidian's resolver). The app MUST NOT write to the authored tier (profile.md, theses/, prompts/) without explicit user confirmation.
+1. **Vault is portable and Obsidian-mountable.** `$UBER_VAULT_DIR` is a git-versioned Obsidian vault outside the gctrl repo, readable without Uebermensch running. Every file is CommonMark markdown with YAML frontmatter; wikilinks use plain `[[slug]]` form (typed prefixes like `[[thesis:slug]]` are forbidden — they break Obsidian's resolver). The app MUST NOT write to the authored tier (profile.md, theses/, personas/, prompts/) without explicit user confirmation. The single exception: `prompts/<slug>.md` frontmatter is updated in-place by the prompts processor (`gctrl uber prompts process`) to record `status`/`output`/`processed_at`; the body is never touched.
 2. **Markdown is the source of truth.** Briefs, wiki pages, sources, and theses live on disk as markdown files. SQLite tables (`uber_briefs`, `uber_brief_items`, …) hold `vault_path` + `content_hash` only — pure index. Opening the vault in Obsidian MUST show everything; deleting SQLite MUST be recoverable by re-indexing.
 3. **Wiki compounds.** Every ingest MUST file at least one wiki page (source summary) and update relevant entity/topic pages. Drop-and-forget ingestion is a bug, not a feature.
 4. **Primary sources over commentary.** The curator MUST weight SEC filings, earnings transcripts, primary research, and official announcements above secondary commentary. Hype-tagged sources are tracked but never lead a brief.
@@ -205,7 +205,7 @@ Uebermensch is profile-parameterised. An ML researcher, policy wonk, or clinicia
 
 A single directory at `$UBER_VAULT_DIR` (default `~/uebermensch-vault`) holding:
 
-- **Authored tier** (git-tracked): `profile.md`, `topics.md`, `sources.md`, `theses/<slug>.md`, `prompts/*.md`, `.obsidian/` — edited by the user in Obsidian or any editor.
+- **Authored tier** (git-tracked): `profile.md`, `topics.md`, `sources.md`, `theses/<slug>.md`, `personas/<persona>.md` (per-persona prompt overrides), `prompts/<slug>.md` (free-form research queries), `.obsidian/` — edited by the user in Obsidian or any editor.
 - **Generated tier** (gitignored, R2-synced): `wiki/**` (`wiki/sources/<slug>.md`, `wiki/synthesis/<slug>.md`, entities, topics, questions) + `briefs/<YYYY-MM-DD>.md` — written by the kernel + Uebermensch services.
 
 Every file is CommonMark + YAML frontmatter. Wikilinks use plain `[[slug]]` — Obsidian and `gctrl-kb` share one resolver. A `VaultWatcher` fiber watches `fs.watch` events so user edits are reindexed without a restart. Full format in [specs/profile.md](specs/profile.md).

--- a/apps/uebermensch/ROADMAP.md
+++ b/apps/uebermensch/ROADMAP.md
@@ -8,7 +8,7 @@
 
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
-| Vault scaffolding | Template vault shape — `profile.md`, `topics.md`, `sources.md`, `theses/`, `prompts/`, `.obsidian/` defaults, `.gitignore` — emitted by `gctrl uber vault init` | P0 | — | TBD |
+| Vault scaffolding | Template vault shape — `profile.md`, `topics.md`, `sources.md`, `theses/`, `personas/`, `prompts/`, `.obsidian/` defaults, `.gitignore` — emitted by `gctrl uber vault init` | P0 | — | TBD |
 | Profile schema lock-in | Finalise profile+vault layout in `specs/profile.md`; commit sample vault | P0 | — | TBD |
 | Profile/Vault reader | Effect-TS `ProfileService` reading markdown + YAML frontmatter from `$UBER_VAULT_DIR` (authored tier) with schema validation; VaultWatcher fiber for `fs.watch` | P0 | Profile schema | TBD |
 | Kernel vault mount | Wire `gctrl-kb` with `context_root = $UBER_VAULT_DIR, wiki_subpath = "wiki"` so the kernel reads/writes wiki pages at the vault root. Retire the legacy `~/.local/share/gctrl/context/wiki` path for Uebermensch workspaces. | P0 | Profile/Vault reader | TBD |
@@ -104,7 +104,7 @@
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
 | `SinkInService` scaffold | Effect-TS service with gap-pass + answer-pass + file-pages stages; connected to `KbPort` + `LlmPort` | P0 | M1 | TBD |
-| `uber-sinkin` prompt templates | `prompts/sinkin-gap.md` + `prompts/sinkin-answer.md`; prompt-injection sentinels; gap cap enforcement | P0 | SinkInService scaffold | TBD |
+| `uber-sinkin` prompt templates | `personas/sinkin-gap.md` + `personas/sinkin-answer.md`; prompt-injection sentinels; gap cap enforcement | P0 | SinkInService scaffold | TBD |
 | `uber_sinkin_sessions` table | SQLite table tracking per-session cost, scope, gap/connection counts | P0 | M0 storage migration | TBD |
 | `gctrl uber sinkin` CLI | Run scheduled SinkIn; `--topic`, `--thesis`, `--dry-run` flags; session report to stdout | P0 | SinkInService | TBD |
 | `gctrl uber query` CLI | Answer a user question from the wiki; `--file` flag files as Question page | P0 | SinkInService | TBD |

--- a/apps/uebermensch/WORKFLOW.md
+++ b/apps/uebermensch/WORKFLOW.md
@@ -132,7 +132,7 @@ Uebermensch runs LLM work via kernel personas. Defaults configured in profile un
 | `uber-deepdive` | read, generation | Long-form thesis deep-dive synthesis |
 | `uber-evaluator` | read (briefs, sources), generation | LLM-as-judge eval over briefs |
 
-Each persona maps to a `prompt_versions` row templated under `apps/uebermensch/prompts/<persona>.md` with vault overrides from `$UBER_VAULT_DIR/prompts/<persona>.md` (authored tier) taking precedence.
+Each persona maps to a `prompt_versions` row templated under `apps/uebermensch/personas/<persona>.md` with vault overrides from `$UBER_VAULT_DIR/personas/<persona>.md` (authored tier) taking precedence. (Note: the vault's `prompts/` folder is reserved for user-authored research queries — see [profile.md § prompts/](specs/profile.md#promptsslugmd-optional).)
 
 ## Dispatch Flow (Agent Work on Uebermensch)
 
@@ -155,7 +155,7 @@ Local daemon + vault is always the source of truth during development. Cloud dep
 
 1. Install Obsidian (desktop / mobile).
 2. "Open folder as vault" → select `$UBER_VAULT_DIR`.
-3. First-run banner: "This vault is managed by Uebermensch. Authored files (`profile.md`, `theses/`, `prompts/`) are yours; generated files (`wiki/`, `briefs/`) are updated by the daemon — edit with care." — shipped via `README.md` at the vault root.
+3. First-run banner: "This vault is managed by Uebermensch. Authored files (`profile.md`, `theses/`, `personas/`, `prompts/`) are yours; generated files (`wiki/`, `briefs/`) are updated by the daemon — edit with care. Drop research questions into `prompts/` and run `gctrl uber query process`." — shipped via `README.md` at the vault root.
 4. Obsidian workspace state is per-machine (gitignored, not R2-synced) — each device has its own pinned notes and pane layout.
 
 ### Multi-device via R2
@@ -185,7 +185,7 @@ Profile references drivers by name; drivers read their own secrets from the kern
 | Effect-TS services | `apps/uebermensch/src/services/` (BriefingService, CuratorService, DelivererService, EvaluatorService) |
 | Effect-TS adapters | `apps/uebermensch/src/adapters/` (KernelClient, ProfileReader) |
 | Web UI | `apps/uebermensch/web/` (Vite SPA) |
-| Prompt templates | `apps/uebermensch/prompts/` (overridable by profile) |
+| Persona prompt templates | `apps/uebermensch/personas/` (overridable by profile) |
 | Rust storage (DuckDB / SQLite) | `kernel/crates/gctrl-storage/src/` (add `uber_*` tables to schema.rs) |
 | Rust HTTP routes (proxy to app) | `kernel/crates/gctrl-otel/src/receiver.rs` (if kernel surfaces routes) |
 | Rust driver-llm | `kernel/crates/gctrl-driver-llm/` |

--- a/apps/uebermensch/specs/architecture.md
+++ b/apps/uebermensch/specs/architecture.md
@@ -67,7 +67,7 @@ Dependencies MUST flow inward only (see [principles.md § Architectural Invarian
 
 | Concern | Layer | Component | Notes |
 |---------|-------|-----------|-------|
-| User topics, theses, delivery prefs (authored tier) | L0 filesystem | `$UBER_VAULT_DIR/{profile.md,topics.md,sources.md,theses/,prompts/}` | Git-versioned, Obsidian-mountable, portable — see [profile.md](profile.md) |
+| User topics, theses, delivery prefs (authored tier) | L0 filesystem | `$UBER_VAULT_DIR/{profile.md,topics.md,sources.md,theses/,personas/,prompts/}` | Git-versioned, Obsidian-mountable, portable — see [profile.md](profile.md). `personas/` holds per-persona prompt overrides; `prompts/` holds user-authored research queries processed by `gctrl uber prompts process`. |
 | Generated pages + briefs (generated tier) | L0 filesystem | `$UBER_VAULT_DIR/{wiki/,briefs/}` (`wiki/` contains `sources/`, `synthesis/`, `entities/`, `topics/`, `questions/`) | Gitignored, R2-synced, reproducible from sources |
 | Parse + validate profile | L4 | `ProfileService` | Effect-TS `Schema` over markdown/YAML |
 | Raw source capture | L2 extension | `gctrl-net`, `gctrl-context` | Reuses kernel primitives — no new storage |
@@ -194,7 +194,7 @@ apps/uebermensch/
       api/               # HTTP routes on app port
       cli/               # gctrl uber * command impls
   web/                   # Vite SPA
-  prompts/               # Shipped prompt templates (overridable by profile)
+  personas/              # Shipped persona prompt templates (overridable by profile)
   test/
     unit/                # Pure domain tests
     integration/         # Mock KernelClient layer

--- a/apps/uebermensch/specs/briefing-pipeline.md
+++ b/apps/uebermensch/specs/briefing-pipeline.md
@@ -78,7 +78,7 @@ Implementation: `CuratorService` (Effect-TS) → `LlmPort.generate`.
 
 ### Prompt Contracts
 
-Prompt templates under `apps/uebermensch/prompts/<persona>.md`, overridable by profile.
+Prompt templates under `apps/uebermensch/personas/<persona>.md`, overridable by profile (`$UBER_VAULT_DIR/personas/<persona>.md`).
 
 **Variables injected at render time** (required):
 

--- a/apps/uebermensch/specs/domain-model.md
+++ b/apps/uebermensch/specs/domain-model.md
@@ -172,7 +172,7 @@ export const Alert = Schema.Struct({
 
 ### 2.5 Profile (read-only projection)
 
-Defined fully in [profile.md](profile.md). A `Profile` Schema is the in-memory projection after parsing the authored tier of `$UBER_VAULT_DIR` (profile.md, topics.md, sources.md, theses/, prompts/).
+Defined fully in [profile.md](profile.md). A `Profile` Schema is the in-memory projection after parsing the authored tier of `$UBER_VAULT_DIR` (profile.md, topics.md, sources.md, theses/, personas/). User research queries under `prompts/` are loaded separately by `QueryService` (not part of `Profile`).
 
 ```ts
 export const Topic = Schema.Struct({

--- a/apps/uebermensch/specs/eval.md
+++ b/apps/uebermensch/specs/eval.md
@@ -279,7 +279,7 @@ Pipeline:
 4. Write scores with `target_type=prompt_version, target_id=<hash>, name=<dimension>`.
 5. Produce a comparison report (`wiki/synthesis/prompt-ab-<date>.md`) — stores the setup, scores, and winner.
 
-A winning prompt gets promoted via `gctrl uber prompt promote <hash>` → writes the prompt to `prompts/<persona>.md` in the profile. This is the one place prompts move from hashes to files automatically — and it's user-initiated.
+A winning prompt gets promoted via `gctrl uber prompt promote <hash>` → writes the prompt to `personas/<persona>.md` in the profile. This is the one place persona prompts move from hashes to files automatically — and it's user-initiated.
 
 ## Delivery Health
 

--- a/apps/uebermensch/specs/profile.md
+++ b/apps/uebermensch/specs/profile.md
@@ -1,12 +1,12 @@
 # Uebermensch — Profile & Vault
 
-> The profile directory is also the **Obsidian vault** — a single markdown-first root holding user-authored config (topics, theses, prompts) alongside LLM-generated content (wiki, briefs, synthesis). The user opens this directory in Obsidian; the app reads it; R2 syncs it.
+> The profile directory is also the **Obsidian vault** — a single markdown-first root holding user-authored config (topics, theses, prompts, persona overrides) alongside LLM-generated content (wiki, briefs, synthesis). The user opens this directory in Obsidian; the app reads it; R2 syncs it.
 
 ## Location & Identity
 
 - Default path: `~/uebermensch-vault` — overridable via `UBER_VAULT_DIR` (alias `UBER_PROFILE_DIR` retained for continuity).
 - The directory is a **git repository** the user owns *and* an **Obsidian vault** the user opens — one location, two hats.
-- `gctrl uber vault init` scaffolds an empty vault at `$UBER_VAULT_DIR` from the template (profile.md, topics.md, sources.md, theses/, prompts/, .gitignore).
+- `gctrl uber vault init` scaffolds an empty vault at `$UBER_VAULT_DIR` from the template (profile.md, topics.md, sources.md, theses/, prompts/, personas/, .gitignore).
 
 The identity (`identity.slug` × machine fingerprint) gates sync: each vault is keyed to one user identity; vault content MUST NOT leak between identities in shared storage. `identity.slug` is the canonical machine id — lowercase, `[a-z0-9-]+`, derived from `identity.name` at vault-init time (user may override). `identity.name` is the display name used in UI + generated markdown; it MAY contain spaces, mixed case, and non-ASCII.
 
@@ -14,7 +14,7 @@ The identity (`identity.slug` × machine fingerprint) gates sync: each vault is 
 
 | Tier | Path glob | Authored by | Git | R2 sync |
 |------|-----------|-------------|-----|---------|
-| **Authored** (source of truth = user) | `profile.md`, `topics.md`, `sources.md`, `theses/**`, `prompts/**`, `personas.md`, `avoid.md`, `ME.md`, `projects.md`, `README.md` | User | ✅ tracked | ✅ |
+| **Authored** (source of truth = user) | `profile.md`, `topics.md`, `sources.md`, `theses/**`, `prompts/**`, `personas.md`, `personas/**`, `avoid.md`, `ME.md`, `projects.md`, `README.md` | User | ✅ tracked | ✅ |
 | **Generated** (source of truth = LLM / app) | `wiki/**` (includes `wiki/synthesis/**`, `wiki/sources/**`), `briefs/**`, `.gctrl-uber/**`, `.obsidian/workspace*.json` | LLM personas (`uber-ingest`, `uber-curator`, `uber-deepdive`) + app | ❌ gitignored | ✅ |
 
 R2 syncs both tiers — git is for the authored tier only, so the user can `git diff` meaningful changes without generated noise.
@@ -44,11 +44,13 @@ $UBER_VAULT_DIR/
 ├── personas.md               # persona → model + prompt path map (optional; YAML frontmatter)
 ├── ME.md                     # free-form self-description; fed as system context
 ├── projects.md               # projects + commitments; fed as system context
-├── prompts/                  # per-persona prompt overrides (optional)
+├── personas/                 # per-persona prompt overrides (optional)
 │   ├── uber-curator.md
 │   ├── uber-ingest.md
 │   ├── uber-deepdive.md
 │   └── uber-evaluator.md
+├── prompts/                  # user-authored research queries (free-form notes — uebermensch researches & files results to wiki/research/)
+│   └── what-is-claudes-real-moat.md
 ├── theses/                   # one file per open thesis
 │   ├── llm-tooling-consolidation.md
 │   └── prediction-market-liquidity.md
@@ -227,7 +229,8 @@ After bootstrap, pulls are incremental and the daemon runs the push/pull protoco
 - `profile.md`, `topics.md`, `sources.md` — minimal viable config (data in YAML frontmatter)
 - `theses/` — empty
 - `ME.md`, `projects.md`, `avoid.md` — stubs
-- `prompts/` — shipped defaults
+- `personas/` — shipped persona-prompt defaults
+- `prompts/` — empty (user drops research queries here; processed by `gctrl uber prompts process`)
 - `.obsidian/` — default graph + appearance config
 - `.gitignore`
 - `README.md` — short onboarding note
@@ -277,8 +280,8 @@ delivery:
       target_ref: "dc:webhook:env:DISCORD_FEED_URL"
 
   personas:                    # persona → override prompt path (relative to $UBER_VAULT_DIR)
-    uber-curator: "prompts/uber-curator.md"
-    uber-deepdive: "prompts/uber-deepdive.md"
+    uber-curator: "personas/uber-curator.md"
+    uber-deepdive: "personas/uber-deepdive.md"
 
   retention:
     briefs_days: 180
@@ -412,25 +415,56 @@ Frontmatter:
 personas:
   uber-curator:
     model: "@cf/google/gemma-4-26b-a4b-it"  # routed via Cloudflare AI Gateway
-    prompt_path: "prompts/uber-curator.md"
+    prompt_path: "personas/uber-curator.md"
   uber-ingest:
     model: "claude-haiku-4-5"
-    prompt_path: "prompts/uber-ingest.md"
+    prompt_path: "personas/uber-ingest.md"
   uber-deepdive:
     model: "@cf/google/gemma-4-26b-a4b-it"  # routed via Cloudflare AI Gateway
-    prompt_path: "prompts/uber-deepdive.md"
+    prompt_path: "personas/uber-deepdive.md"
   uber-evaluator:
     model: "claude-haiku-4-5"
-    prompt_path: "prompts/uber-evaluator.md"
+    prompt_path: "personas/uber-evaluator.md"
 ```
 
-If omitted, the shipped defaults under `apps/uebermensch/prompts/` are used unchanged. Personas declare `model` at profile level so users can swap defaults without touching app code.
+If omitted, the shipped defaults under `apps/uebermensch/personas/` are used unchanged. Personas declare `model` at profile level so users can swap defaults without touching app code.
 
-### prompts/\<persona\>.md (optional)
+### personas/\<persona\>.md (optional)
 
 Prompt templates using `{{var}}` placeholders. See [briefing-pipeline.md § Prompt Contracts](briefing-pipeline.md#prompt-contracts) for the variables each persona receives.
 
 Overrides MUST keep the shipped template's required variables (parser rejects on missing) — but MAY add more. Missing required vars fail profile validation.
+
+### prompts/\<slug\>.md (optional)
+
+User-authored research queries. The user drops a free-form markdown note here; `gctrl uber query process` reads each pending file, runs an LLM research pass (with relevant wiki context), writes the consolidated answer to `wiki/research/<slug>.md`, and stamps the prompt's frontmatter with `status: processed`, `output`, `processed_at`, `content_hash`, `prompt_hash`, and `model`.
+
+Minimum frontmatter (everything optional except `slug`, which defaults to filename if omitted):
+
+```markdown
+---
+slug: what-is-claudes-real-moat
+title: "What is Claude's real moat?"
+topics: [ai-dev-workflows]   # optional — narrows wiki context
+status: pending              # pending | processed | failed | rerun
+---
+
+Question/notes go here in free-form markdown. Anything you'd jot in a notebook works —
+bullet points, half-formed ideas, links you saw. Uebermensch reads the whole file.
+```
+
+After processing:
+
+```yaml
+status: processed
+output: wiki/research/what-is-claudes-real-moat.md
+processed_at: 2026-04-25T08:14:11Z
+content_hash: sha256:…
+prompt_hash: sha256:…
+model: claude-opus-4-7
+```
+
+Set `status: rerun` (or delete the post-processing fields) to re-process. The query file itself is never overwritten by the LLM — only its frontmatter is updated; the body stays as the user wrote it.
 
 ### ME.md / projects.md
 
@@ -452,8 +486,9 @@ These two files anchor every prompt — they're the highest-leverage artifacts i
 3. `sources.md` frontmatter satisfies `Profile.sources`; every `topics: [...]` entry matches a topic slug.
 4. Every file under `theses/` has valid frontmatter and a non-empty body.
 5. Every thesis `topics: [...]` entry matches a topic slug.
-6. `personas.md` (if present) references files that exist under `prompts/`.
-7. `prompts/<persona>.md` (if present) declares all required template variables.
+6. `personas.md` (if present) references files that exist under `personas/`.
+7. `personas/<persona>.md` (if present) declares all required template variables.
+8. `prompts/<slug>.md` (if present) frontmatter parses; `slug` is unique within `prompts/` and matches `[a-z0-9-]+`.
 
 ### Semantic
 

--- a/apps/uebermensch/specs/sinkin.md
+++ b/apps/uebermensch/specs/sinkin.md
@@ -37,7 +37,7 @@ Scope flags (from CLI or profile):
 
 ### Stage 2 — Gap Pass (LLM)
 
-Persona: `uber-sinkin`, prompt template `prompts/sinkin-gap.md`.
+Persona: `uber-sinkin`, prompt template `personas/sinkin-gap.md`.
 
 Input: compact wiki survey, profile (topics, theses, identity), existing Question pages (so we don't re-ask answered questions).
 
@@ -178,7 +178,7 @@ Keyword + frontmatter search over the wiki for pages relevant to the question. A
 
 ### Answer
 
-Persona: `uber-sinkin`, prompt template `prompts/sinkin-answer.md`. Same wrapper as Gap Pass — all page content inside `<page>` sentinels.
+Persona: `uber-sinkin`, prompt template `personas/sinkin-answer.md`. Same wrapper as Gap Pass — all page content inside `<page>` sentinels.
 
 Output: markdown answer (1-5 paragraphs) with bare `[[slug]]` citations. Printed to stdout.
 
@@ -260,7 +260,7 @@ sinkin:
 
 ### `uber-sinkin` (Gap Pass + Answer Pass + Interactive Query)
 
-Lives at `prompts/sinkin-gap.md` and `prompts/sinkin-answer.md` (separate templates for gap and answer tasks; share the same persona name for cost attribution).
+Lives at `personas/sinkin-gap.md` and `personas/sinkin-answer.md` (separate templates for gap and answer tasks; share the same persona name for cost attribution).
 
 Default model: inherits `driver-llm` default (`@cf/google/gemma-4-26b-a4b-it` via Cloudflare AI Gateway). Can be overridden in `personas.md` under the vault's authored tier.
 

--- a/apps/uebermensch/src/adapters/FileSystemQuery.ts
+++ b/apps/uebermensch/src/adapters/FileSystemQuery.ts
@@ -1,0 +1,193 @@
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
+import { basename, extname, join, relative } from "node:path"
+import { Effect, Layer, Schema } from "effect"
+import matter from "gray-matter"
+import { VaultError } from "../errors.js"
+import { PromptFrontmatter } from "../schemas.js"
+import {
+  type Prompt,
+  type PromptStamp,
+  type PromptStatus,
+  QueryService,
+} from "../services/QueryService.js"
+
+const PROMPTS_DIR = "prompts"
+
+const slugify = (stem: string): string =>
+  stem
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+const titlize = (stem: string): string =>
+  stem
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^./, (c) => c.toUpperCase())
+
+type Loaded = {
+  readonly absPath: string
+  readonly relPath: string
+  readonly raw: string
+  readonly parsed: matter.GrayMatterFile<string>
+}
+
+const loadAll = (vaultDir: string): Effect.Effect<ReadonlyArray<Loaded>, VaultError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const root = join(vaultDir, PROMPTS_DIR)
+      let entries: Array<import("node:fs").Dirent>
+      try {
+        entries = await readdir(root, { recursive: true, withFileTypes: true })
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException
+        if (err.code === "ENOENT") return []
+        throw e
+      }
+      const out: Array<Loaded> = []
+      for (const e of entries) {
+        if (!e.isFile()) continue
+        if (extname(e.name).toLowerCase() !== ".md") continue
+        const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? root
+        const abs = join(parent, e.name)
+        const raw = await readFile(abs, "utf8")
+        out.push({ absPath: abs, relPath: relative(vaultDir, abs), raw, parsed: matter(raw) })
+      }
+      return out
+    },
+    catch: (e) =>
+      new VaultError({
+        message: `list prompts failed: ${String(e)}`,
+        path: vaultDir,
+        kind: "io_failure",
+      }),
+  })
+
+const decodePrompt = (l: Loaded): Effect.Effect<Prompt, VaultError> =>
+  Effect.gen(function* () {
+    const data = (l.parsed.data ?? {}) as Record<string, unknown>
+    const decoded = yield* Schema.decodeUnknown(PromptFrontmatter)(data).pipe(
+      Effect.mapError(
+        (e) =>
+          new VaultError({
+            message: `prompt ${l.relPath} invalid frontmatter: ${String(e)}`,
+            path: l.absPath,
+            kind: "parse_failure",
+          }),
+      ),
+    )
+    const stem = basename(l.absPath, ".md")
+    const slug = decoded.slug ?? slugify(stem)
+    if (slug.length === 0) {
+      return yield* Effect.fail(
+        new VaultError({
+          message: `prompt ${l.relPath} produced empty slug`,
+          path: l.absPath,
+          kind: "parse_failure",
+        }),
+      )
+    }
+    const status: PromptStatus = decoded.status ?? "pending"
+    return {
+      slug,
+      title: decoded.title ?? titlize(stem),
+      topics: decoded.topics ?? [],
+      status,
+      body: l.parsed.content,
+      relPath: l.relPath,
+      absPath: l.absPath,
+      output: decoded.output ?? null,
+      processedAt: decoded.processed_at ?? null,
+      contentHash: decoded.content_hash ?? null,
+      promptHash: decoded.prompt_hash ?? null,
+      model: decoded.model ?? null,
+    }
+  })
+
+const writeStamped = async (
+  l: Loaded,
+  stamp: PromptStamp,
+): Promise<void> => {
+  const data = (l.parsed.data ?? {}) as Record<string, unknown>
+  const next: Record<string, unknown> = {
+    ...data,
+    status: stamp.status,
+    processed_at: stamp.processedAt,
+  }
+  if (stamp.output !== undefined) next.output = stamp.output
+  if (stamp.contentHash !== undefined) next.content_hash = stamp.contentHash
+  if (stamp.promptHash !== undefined) next.prompt_hash = stamp.promptHash
+  if (stamp.model !== undefined) next.model = stamp.model
+  if (stamp.costUsd !== undefined) next.cost_usd = stamp.costUsd
+  if (stamp.failedReason !== undefined) next.failed_reason = stamp.failedReason
+  // Drop stale failure reason on success
+  if (stamp.status === "processed" && stamp.failedReason === undefined) {
+    delete next.failed_reason
+  }
+  const rebuilt = matter.stringify(l.parsed.content, next)
+  const tmpPath = `${l.absPath}.tmp-${process.pid}-${Date.now()}`
+  await mkdir(join(l.absPath, ".."), { recursive: true })
+  await writeFile(tmpPath, rebuilt, "utf8")
+  await rename(tmpPath, l.absPath)
+}
+
+export const FileSystemQueryLive = (vaultDir: string) =>
+  Layer.succeed(QueryService, {
+    list: () =>
+      Effect.gen(function* () {
+        const loaded = yield* loadAll(vaultDir)
+        const out: Array<Prompt> = []
+        for (const l of loaded) out.push(yield* decodePrompt(l))
+        return out
+      }),
+    get: (slug) =>
+      Effect.gen(function* () {
+        const loaded = yield* loadAll(vaultDir)
+        for (const l of loaded) {
+          const p = yield* decodePrompt(l)
+          if (p.slug === slug) return p
+        }
+        return yield* Effect.fail(
+          new VaultError({
+            message: `prompt not found: ${slug}`,
+            path: join(vaultDir, PROMPTS_DIR),
+            kind: "not_found",
+          }),
+        )
+      }),
+    stamp: (slug, stamp) =>
+      Effect.gen(function* () {
+        const loaded = yield* loadAll(vaultDir)
+        for (const l of loaded) {
+          const p = yield* decodePrompt(l)
+          if (p.slug !== slug) continue
+          // Re-stat to make sure the file wasn't replaced under us
+          yield* Effect.tryPromise({
+            try: () => stat(l.absPath),
+            catch: (e) =>
+              new VaultError({
+                message: `stat failed: ${String(e)}`,
+                path: l.absPath,
+                kind: "io_failure",
+              }),
+          })
+          return yield* Effect.tryPromise({
+            try: () => writeStamped(l, stamp),
+            catch: (e) =>
+              new VaultError({
+                message: `stamp prompt failed: ${String(e)}`,
+                path: l.absPath,
+                kind: "io_failure",
+              }),
+          })
+        }
+        return yield* Effect.fail(
+          new VaultError({
+            message: `prompt not found: ${slug}`,
+            path: join(vaultDir, PROMPTS_DIR),
+            kind: "not_found",
+          }),
+        )
+      }),
+  })

--- a/apps/uebermensch/src/adapters/FileSystemVault.ts
+++ b/apps/uebermensch/src/adapters/FileSystemVault.ts
@@ -171,6 +171,24 @@ export const FileSystemVaultLive = (vaultDir: string) =>
             kind: "io_failure",
           }),
       }),
+    writeResearch: (slug, content) =>
+      Effect.tryPromise({
+        try: async () => {
+          const relPath = `wiki/research/${slug}.md`
+          const absPath = join(vaultDir, relPath)
+          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
+          await mkdir(join(vaultDir, "wiki", "research"), { recursive: true })
+          await writeFile(tmpPath, content, "utf8")
+          await rename(tmpPath, absPath)
+          return { absPath, relPath, contentHash: hashContent(content) }
+        },
+        catch: (e) =>
+          new VaultError({
+            message: `write research failed: ${String(e)}`,
+            path: vaultDir,
+            kind: "io_failure",
+          }),
+      }),
     writeSource: (slug, content, options) =>
       Effect.gen(function* () {
         const relPath = `wiki/sources/${slug}.md`

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -6,6 +6,7 @@ import {
   type BriefRequest,
   type InterestReportRequest,
   LlmService,
+  type ResearchQueryRequest,
 } from "../services/LlmService.js";
 import type { CuratedItem } from "../services/RendererService.js";
 
@@ -381,6 +382,52 @@ const buildSummaryUserPrompt = (
   return lines.join("\n");
 };
 
+const RESEARCH_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst answering a single user-authored research question by consolidating across the user's existing wiki context.
+
+OUTPUT CONTRACT:
+- Output ONLY markdown — no preamble, no JSON, no fenced wrapper.
+- Begin with "## Question" on its own line followed by the question (one paragraph).
+- Then "## Answer" with 200–800 words of substantive consolidated analysis.
+- Then "## Key claims" with 3–7 concrete bullet claims, each ending with at least one bare \`[[stem]]\` citation when supported by a context page.
+- Then "## Open questions" with 1–4 bullets the wiki cannot yet answer.
+
+CITATION RULES (strict):
+- Every \`[[link]]\` MUST match a provided context page \`stem\` exactly.
+- Do NOT use typed-prefix links like \`[[source:x]]\`. Bare stems only.
+- If no context pages were provided, omit \`[[stem]]\` citations entirely and state "(no wiki context yet)" in the Answer's first sentence.
+
+STYLE:
+- Substantive insight only — no meta commentary about the wiki, no "the context covers X".
+- Concrete: name actors, numbers, dates, mechanisms.
+- The body of the user's prompt may include hints, half-formed ideas, or links — treat them as signal but never echo them back verbatim as the answer.`;
+
+const buildResearchQueryUserPrompt = (req: ResearchQueryRequest): string => {
+  const lines: Array<string> = [];
+  lines.push(`profile: ${req.profileName}`);
+  lines.push(`slug: ${req.slug}`);
+  lines.push(`title: ${req.title}`);
+  lines.push(`topics: [${req.topics.join(", ")}]`);
+  lines.push("");
+  lines.push("question: |");
+  for (const line of req.question.split("\n")) lines.push(`  ${line}`);
+  lines.push("");
+  lines.push("context_pages:");
+  if (req.contextPages.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const p of req.contextPages) {
+      lines.push(`- stem: ${p.stem}`);
+      lines.push(`  title: ${p.title}`);
+      lines.push(`  topics: [${p.topics.join(", ")}]`);
+      lines.push(`  excerpt: |`);
+      for (const line of p.excerpt.split("\n")) lines.push(`    ${line}`);
+    }
+  }
+  lines.push("");
+  lines.push("Return only the markdown body in the contract above.");
+  return lines.join("\n");
+};
+
 // Clip any preamble before the "## Key Insights" heading; trim trailing
 // whitespace. Models occasionally prefix with "Here are the key insights:" —
 // drop everything up to the first heading.
@@ -499,6 +546,32 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         model: res.model,
       };
     }),
+  researchQuery: (req) =>
+    Effect.gen(function* () {
+      const model = modelFor();
+      const userPrompt = buildResearchQueryUserPrompt(req);
+      const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const res = yield* postLlm(
+        model,
+        RESEARCH_SYSTEM_PROMPT,
+        userPrompt,
+        DEFAULT_MAX_TOKENS,
+        true,
+      );
+      const answerMd = res.text.trim();
+      if (answerMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "kernel researchQuery returned empty body"));
+      }
+      const costUsd = isWorkersAiModel(res.model)
+        ? 0
+        : tokensCost(
+            res.inputTokens,
+            res.outputTokens,
+            ANTHROPIC_INPUT_COST_PER_MTOK,
+            ANTHROPIC_OUTPUT_COST_PER_MTOK,
+          );
+      return { answerMd, promptHash, costUsd, model: res.model };
+    }),
   summarizeSource: (req) =>
     Effect.gen(function* () {
       const capped =
@@ -539,6 +612,7 @@ export const _internal = {
   buildUserPrompt,
   buildInterestReportUserPrompt,
   buildSummaryUserPrompt,
+  buildResearchQueryUserPrompt,
   extractJson,
   kernelBase,
   LlmOutputSchema,
@@ -547,6 +621,7 @@ export const _internal = {
   SYSTEM_PROMPT,
   REPORT_SYSTEM_PROMPT,
   SUMMARY_SYSTEM_PROMPT,
+  RESEARCH_SYSTEM_PROMPT,
   MODEL: DEFAULT_MODEL,
   DEFAULT_MODEL,
   SUMMARY_MODEL,

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -69,6 +69,32 @@ export const StubLlmLive = Layer.succeed(LlmService, {
       const promptHash = sha256(`stub-summarize\n${req.url}\n${req.text}`);
       return { insightsMd, promptHash, costUsd: 0, model: STUB_MODEL };
     }),
+  researchQuery: (req) =>
+    Effect.sync(() => {
+      const prompt = [
+        "persona: uber-researcher/stub",
+        `slug: ${req.slug}`,
+        `profile: ${req.profileName}`,
+        `topics: ${req.topics.join(",")}`,
+        `context: ${req.contextPages.map((p) => p.stem).join(",")}`,
+        `question: ${req.question}`,
+      ].join("\n");
+      const promptHash = sha256(prompt);
+      const cited =
+        req.contextPages.length > 0
+          ? req.contextPages.map((p) => `[[${p.stem}]]`).join(", ")
+          : "(no wiki context)";
+      const answerMd = [
+        `## Question`,
+        ``,
+        req.question.trim() || `(empty question for ${req.title})`,
+        ``,
+        `## Stub answer`,
+        ``,
+        `Stub research consolidation for "${req.title}" citing ${cited}.`,
+      ].join("\n");
+      return { answerMd, promptHash, costUsd: 0, model: STUB_MODEL };
+    }),
   generateInterestReport: (req) =>
     Effect.sync(() => {
       const it = req.interest;

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -4,13 +4,14 @@ import { Effect } from "effect"
 import { brief } from "../commands/brief.js"
 import { ingest } from "../commands/ingest.js"
 import { profile } from "../commands/profile-validate.js"
+import { prompts } from "../commands/prompts.js"
 import { report } from "../commands/report.js"
 import { send } from "../commands/send.js"
 import { sync } from "../commands/sync.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest, send, report, sync]),
+  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, sync]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/commands/prompts.ts
+++ b/apps/uebermensch/src/commands/prompts.ts
@@ -1,0 +1,283 @@
+import { createHash } from "node:crypto"
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Either, Option } from "effect"
+import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
+import { FileSystemQueryLive } from "../adapters/FileSystemQuery.js"
+import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
+import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { StubLlmLive } from "../adapters/StubLlm.js"
+import { resolveVaultDir } from "../lib/env.js"
+import {
+  LlmService,
+  type ResearchQueryContextPage,
+} from "../services/LlmService.js"
+import { ProfileService } from "../services/ProfileService.js"
+import {
+  type Prompt,
+  QueryService,
+} from "../services/QueryService.js"
+import { VaultService, type WikiPage } from "../services/VaultService.js"
+
+const MAX_CONTEXT_PAGES = 12
+const MAX_EXCERPT_CHARS = 1500
+
+const sha256 = (s: string): string =>
+  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
+
+const llmOpt = Options.choice("llm", ["kernel", "stub"]).pipe(
+  Options.withDescription(
+    "LLM backend: 'kernel' (real model via kernel /api/llm/messages) or 'stub'",
+  ),
+  Options.withDefault("kernel" as const),
+)
+
+const slugOpt = Options.text("slug").pipe(
+  Options.withDescription("Process a single prompt by slug (default: all pending)"),
+  Options.optional,
+)
+
+const forceOpt = Options.boolean("force").pipe(
+  Options.withDescription("Re-process prompts whose status is 'processed'"),
+  Options.withDefault(false),
+)
+
+const dryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Print the consolidated answer without writing to wiki/research/"),
+  Options.withDefault(false),
+)
+
+const titleOf = (p: WikiPage): string =>
+  (p.frontmatter.title as string | undefined) ?? p.stem
+
+const topicsOf = (p: WikiPage): ReadonlyArray<string> =>
+  (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+
+const excerptOf = (body: string, max: number): string => {
+  const trimmed = body.trim()
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max)}…`
+}
+
+const selectContext = (
+  pages: ReadonlyArray<WikiPage>,
+  prompt: Prompt,
+): ReadonlyArray<ResearchQueryContextPage> => {
+  if (pages.length === 0) return []
+  const promptTopics = new Set(prompt.topics)
+  const scored = pages
+    .map((p) => {
+      const pageTopics = topicsOf(p)
+      const overlap =
+        promptTopics.size === 0
+          ? 0
+          : pageTopics.reduce((n, t) => (promptTopics.has(t) ? n + 1 : n), 0)
+      const recencyBoost = (Date.now() - p.mtime.getTime()) / 86_400_000 // days
+      // higher overlap, then more recent
+      return { p, overlap, recencyBoost }
+    })
+    .filter((x) => promptTopics.size === 0 || x.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap || a.recencyBoost - b.recencyBoost)
+    .slice(0, MAX_CONTEXT_PAGES)
+  return scored.map(({ p }) => ({
+    stem: p.stem,
+    title: titleOf(p),
+    topics: topicsOf(p),
+    excerpt: excerptOf(p.body, MAX_EXCERPT_CHARS),
+  }))
+}
+
+const renderResearchPage = (args: {
+  prompt: Prompt
+  answerMd: string
+  promptHash: string
+  model: string
+  costUsd: number
+  generatedAt: string
+}): string => {
+  const fm = [
+    "---",
+    `page_type: research`,
+    `slug: ${args.prompt.slug}`,
+    `title: ${JSON.stringify(args.prompt.title)}`,
+    `source_prompt: prompts/${args.prompt.slug}.md`,
+    `topics: [${args.prompt.topics.join(", ")}]`,
+    `generated_at: ${args.generatedAt}`,
+    `model: ${args.model}`,
+    `prompt_hash: ${args.promptHash}`,
+    `cost_usd: ${args.costUsd.toFixed(6)}`,
+    "---",
+    "",
+  ].join("\n")
+  return `${fm}${args.answerMd.trimEnd()}\n`
+}
+
+const list = Command.make("list", {}, () =>
+  Effect.gen(function* () {
+    const vaultDir = yield* resolveVaultDir()
+    const program = Effect.gen(function* () {
+      const queries = yield* QueryService
+      const all = yield* queries.list()
+      if (all.length === 0) {
+        yield* Console.log(`(no prompts in ${vaultDir}/prompts/)`)
+        return
+      }
+      for (const p of all) {
+        const out = p.output ? ` → ${p.output}` : ""
+        const at = p.processedAt ? ` (${p.processedAt})` : ""
+        yield* Console.log(`${p.status.padEnd(9)} ${p.slug}${out}${at}`)
+      }
+    })
+    yield* program.pipe(Effect.provide(FileSystemQueryLive(vaultDir)))
+  }),
+).pipe(Command.withDescription("List prompts in the vault and their processing status"))
+
+const show = Command.make(
+  "show",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const queries = yield* QueryService
+        const p = yield* queries.get(slug)
+        yield* Console.log(`# ${p.title}`)
+        yield* Console.log(`slug: ${p.slug}  status: ${p.status}`)
+        if (p.output) yield* Console.log(`output: ${p.output}`)
+        if (p.processedAt) yield* Console.log(`processed_at: ${p.processedAt}`)
+        if (p.model) yield* Console.log(`model: ${p.model}`)
+        yield* Console.log("")
+        yield* Console.log("--- prompt body ---")
+        yield* Console.log(p.body.trim())
+      })
+      yield* program.pipe(Effect.provide(FileSystemQueryLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Show a prompt and its processing metadata"))
+
+const process_ = Command.make(
+  "process",
+  { slugOpt, llmOpt, forceOpt, dryRunOpt },
+  ({ slugOpt: slugOptVal, llmOpt: llmKind, forceOpt: force, dryRunOpt: dryRun }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      yield* Console.log(`processing prompts in ${vaultDir}/prompts/ (llm=${llmKind})`)
+
+      const program = Effect.gen(function* () {
+        const queries = yield* QueryService
+        const vault = yield* VaultService
+        const llm = yield* LlmService
+        const profileSvc = yield* ProfileService
+        const profile = yield* profileSvc.load()
+
+        const onlySlug = Option.getOrUndefined(slugOptVal)
+        const all = yield* queries.list()
+        const targets = all.filter((p) => {
+          if (onlySlug && p.slug !== onlySlug) return false
+          if (p.status === "rerun") return true
+          if (p.status === "processed" && !force) return false
+          return true
+        })
+
+        if (targets.length === 0) {
+          yield* Console.log(
+            onlySlug
+              ? `  no prompt matched slug=${onlySlug} (or already processed; --force to redo)`
+              : "  no pending prompts",
+          )
+          return
+        }
+
+        const wikiPages = yield* vault.listWikiPages()
+
+        for (const prompt of targets) {
+          const question = prompt.body.trim()
+          if (question.length === 0) {
+            yield* Console.log(`  ! ${prompt.slug}: empty body — skipping`)
+            continue
+          }
+          const contextPages = selectContext(wikiPages, prompt)
+          yield* Console.log(
+            `  → ${prompt.slug}: ${contextPages.length} context page(s); requesting research ...`,
+          )
+          const result = yield* llm
+            .researchQuery({
+              slug: prompt.slug,
+              title: prompt.title,
+              topics: prompt.topics,
+              question,
+              profileName: profile.profile.identity.name,
+              contextPages,
+            })
+            .pipe(
+              Effect.tapError((e) =>
+                Console.log(`  ✗ ${prompt.slug}: llm failed (${e.kind ?? "unknown"}): ${e.message}`),
+              ),
+              Effect.either,
+            )
+
+          const success = yield* Either.match(result, {
+            onLeft: (e) =>
+              queries
+                .stamp(prompt.slug, {
+                  status: "failed",
+                  processedAt: new Date().toISOString(),
+                  failedReason: `${e.kind ?? "unknown"}: ${e.message}`,
+                })
+                .pipe(Effect.as(null)),
+            onRight: (r) => Effect.succeed(r),
+          })
+          if (success === null) continue
+
+          const { answerMd, promptHash, costUsd, model } = success
+          const generatedAt = new Date().toISOString()
+          const markdown = renderResearchPage({
+            prompt,
+            answerMd,
+            promptHash,
+            model,
+            costUsd,
+            generatedAt,
+          })
+
+          if (dryRun) {
+            yield* Console.log(`  (dry-run) ${prompt.slug}`)
+            yield* Console.log("")
+            yield* Console.log(markdown)
+            continue
+          }
+
+          const written = yield* vault.writeResearch(prompt.slug, markdown)
+          yield* queries.stamp(prompt.slug, {
+            status: "processed",
+            output: written.relPath,
+            processedAt: generatedAt,
+            contentHash: written.contentHash,
+            promptHash,
+            model,
+            costUsd,
+          })
+          yield* Console.log(
+            `  ✓ ${prompt.slug} → ${written.relPath} (${written.contentHash})`,
+          )
+          yield* Console.log(`    cost: $${costUsd.toFixed(4)} model=${model}`)
+        }
+      })
+
+      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
+      yield* program.pipe(
+        Effect.provide(FileSystemQueryLive(vaultDir)),
+        Effect.provide(FileSystemVaultLive(vaultDir)),
+        Effect.provide(FileSystemProfileLive(vaultDir)),
+        Effect.provide(llmLayer),
+      )
+    }),
+).pipe(
+  Command.withDescription(
+    "Process pending prompts in $UBER_VAULT_DIR/prompts/ — research each via the LLM and write wiki/research/<slug>.md",
+  ),
+)
+
+export const _internal = { selectContext, renderResearchPage, sha256 }
+
+export const prompts = Command.make("prompts").pipe(
+  Command.withSubcommands([list, show, process_]),
+  Command.withDescription("Process user-authored research queries from $UBER_VAULT_DIR/prompts/"),
+)

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -89,3 +89,19 @@ export const ResearchInterestFrontmatter = Schema.Struct({
   horizon: Schema.optional(Schema.Literal("short", "long", "both")),
   weight: Schema.optional(Schema.Number),
 })
+
+export const PromptStatus = Schema.Literal("pending", "processed", "failed", "rerun")
+
+export const PromptFrontmatter = Schema.Struct({
+  slug: Schema.optional(Slug),
+  title: Schema.optional(Schema.String),
+  topics: Schema.optional(Schema.Array(Slug)),
+  status: Schema.optional(PromptStatus),
+  output: Schema.optional(Schema.String),
+  processed_at: Schema.optional(IsoLike),
+  content_hash: Schema.optional(Schema.String),
+  prompt_hash: Schema.optional(Schema.String),
+  model: Schema.optional(Schema.String),
+  cost_usd: Schema.optional(Schema.Number),
+  failed_reason: Schema.optional(Schema.String),
+})

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -64,6 +64,29 @@ export type SourceSummaryResponse = {
   readonly model: string;
 };
 
+export type ResearchQueryContextPage = {
+  readonly stem: string;
+  readonly title: string;
+  readonly topics: ReadonlyArray<string>;
+  readonly excerpt: string;
+};
+
+export type ResearchQueryRequest = {
+  readonly slug: string;
+  readonly title: string;
+  readonly topics: ReadonlyArray<string>;
+  readonly question: string;
+  readonly profileName: string;
+  readonly contextPages: ReadonlyArray<ResearchQueryContextPage>;
+};
+
+export type ResearchQueryResponse = {
+  readonly answerMd: string;
+  readonly promptHash: string;
+  readonly costUsd: number;
+  readonly model: string;
+};
+
 export interface LlmServiceShape {
   readonly name: () => string;
   readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>;
@@ -73,6 +96,9 @@ export interface LlmServiceShape {
   readonly summarizeSource: (
     req: SourceSummaryRequest,
   ) => Effect.Effect<SourceSummaryResponse, LlmError>;
+  readonly researchQuery: (
+    req: ResearchQueryRequest,
+  ) => Effect.Effect<ResearchQueryResponse, LlmError>;
 }
 
 export class LlmService extends Context.Tag("uebermensch/LlmService")<

--- a/apps/uebermensch/src/services/QueryService.ts
+++ b/apps/uebermensch/src/services/QueryService.ts
@@ -1,0 +1,41 @@
+import { Context, type Effect } from "effect"
+import type { VaultError } from "../errors.js"
+
+export type PromptStatus = "pending" | "processed" | "failed" | "rerun"
+
+export type Prompt = {
+  readonly slug: string
+  readonly title: string
+  readonly topics: ReadonlyArray<string>
+  readonly status: PromptStatus
+  readonly body: string
+  readonly relPath: string
+  readonly absPath: string
+  readonly output: string | null
+  readonly processedAt: string | null
+  readonly contentHash: string | null
+  readonly promptHash: string | null
+  readonly model: string | null
+}
+
+export type PromptStamp = {
+  readonly status: "processed" | "failed"
+  readonly output?: string
+  readonly processedAt: string
+  readonly contentHash?: string
+  readonly promptHash?: string
+  readonly model?: string
+  readonly costUsd?: number
+  readonly failedReason?: string
+}
+
+export interface QueryServiceShape {
+  readonly list: () => Effect.Effect<ReadonlyArray<Prompt>, VaultError>
+  readonly get: (slug: string) => Effect.Effect<Prompt, VaultError>
+  readonly stamp: (slug: string, stamp: PromptStamp) => Effect.Effect<void, VaultError>
+}
+
+export class QueryService extends Context.Tag("uebermensch/QueryService")<
+  QueryService,
+  QueryServiceShape
+>() {}

--- a/apps/uebermensch/src/services/VaultService.ts
+++ b/apps/uebermensch/src/services/VaultService.ts
@@ -28,6 +28,12 @@ export type WrittenReport = {
   readonly contentHash: string
 }
 
+export type WrittenResearch = {
+  readonly absPath: string
+  readonly relPath: string
+  readonly contentHash: string
+}
+
 export type ResearchInterest = {
   readonly slug: string
   readonly title: string
@@ -64,6 +70,10 @@ export interface VaultServiceShape {
     slug: string,
     content: string,
   ) => Effect.Effect<WrittenReport, VaultError>
+  readonly writeResearch: (
+    slug: string,
+    content: string,
+  ) => Effect.Effect<WrittenResearch, VaultError>
 }
 
 export class VaultService extends Context.Tag("uebermensch/VaultService")<

--- a/apps/uebermensch/tests/ingest.test.ts
+++ b/apps/uebermensch/tests/ingest.test.ts
@@ -249,6 +249,7 @@ describe("HttpIngest with summarization", () => {
       name: () => "fake-llm",
       generateBrief: () => Effect.die("not used"),
       generateInterestReport: () => Effect.die("not used"),
+      researchQuery: () => Effect.die("not used"),
       summarizeSource: () =>
         Effect.sync(() => {
           calls.count += 1
@@ -319,6 +320,7 @@ describe("HttpIngest with summarization", () => {
       name: () => "broken-llm",
       generateBrief: () => Effect.die("not used"),
       generateInterestReport: () => Effect.die("not used"),
+      researchQuery: () => Effect.die("not used"),
       summarizeSource: () =>
         Effect.fail(new LlmError({ message: "upstream 503", kind: "unavailable" })),
     })

--- a/apps/uebermensch/tests/query.test.ts
+++ b/apps/uebermensch/tests/query.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Layer } from "effect"
+import matter from "gray-matter"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileSystemQueryLive } from "../src/adapters/FileSystemQuery.js"
+import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import { StubLlmLive } from "../src/adapters/StubLlm.js"
+import { LlmService } from "../src/services/LlmService.js"
+import { QueryService } from "../src/services/QueryService.js"
+import { VaultService } from "../src/services/VaultService.js"
+
+const seedFile = async (root: string, rel: string, frontmatter: string, body: string) => {
+  const full = join(root, rel)
+  await mkdir(join(full, ".."), { recursive: true })
+  const fm = frontmatter.trim().length === 0 ? "" : `---\n${frontmatter}---\n\n`
+  await writeFile(full, `${fm}${body}\n`, "utf8")
+}
+
+const fileExists = async (p: string): Promise<boolean> => {
+  try {
+    await stat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe("prompts (user research queries)", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-vault-prompts-"))
+    await seedFile(
+      vaultDir,
+      "prompts/what-is-claudes-real-moat.md",
+      'slug: what-is-claudes-real-moat\ntitle: "What is Claude\'s real moat?"\ntopics: [ai-dev-workflows]\n',
+      "Some half-formed thoughts:\n\n- Tooling ergonomics?\n- Distribution via Claude Code?",
+    )
+    await seedFile(
+      vaultDir,
+      "prompts/no-frontmatter-question.md",
+      "",
+      "What does the wiki say about prediction markets?",
+    )
+    await seedFile(
+      vaultDir,
+      "wiki/sources/2026-04-22--anthropic-claude-code.md",
+      "page_type: source\nslug: 2026-04-22--anthropic-claude-code\ntitle: Anthropic Claude Code launch\ntopics: [ai-dev-workflows]\n",
+      "Anthropic launched Claude Code, a CLI agent.",
+    )
+    await seedFile(
+      vaultDir,
+      "wiki/sources/2026-04-20--kalshi-volume.md",
+      "page_type: source\nslug: 2026-04-20--kalshi-volume\ntitle: Kalshi weekly volume\ntopics: [prediction-market]\n",
+      "Kalshi reported $42M weekly volume.",
+    )
+  })
+
+  it("lists prompts including ones without frontmatter", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const q = yield* QueryService
+        return yield* q.list()
+      }).pipe(Effect.provide(FileSystemQueryLive(vaultDir))),
+    )
+    const slugs = result.map((p) => p.slug).sort()
+    expect(slugs).toEqual(["no-frontmatter-question", "what-is-claudes-real-moat"])
+    const claude = result.find((p) => p.slug === "what-is-claudes-real-moat")
+    expect(claude?.status).toBe("pending")
+    expect(claude?.topics).toEqual(["ai-dev-workflows"])
+    const noFm = result.find((p) => p.slug === "no-frontmatter-question")
+    expect(noFm?.status).toBe("pending")
+    expect(noFm?.topics).toEqual([])
+  })
+
+  it("processes a pending prompt: writes wiki/research/<slug>.md and stamps frontmatter", async () => {
+    const layer = Layer.mergeAll(
+      FileSystemQueryLive(vaultDir),
+      FileSystemVaultLive(vaultDir),
+      StubLlmLive,
+    )
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const q = yield* QueryService
+        const v = yield* VaultService
+        const llm = yield* LlmService
+        const prompt = yield* q.get("what-is-claudes-real-moat")
+        // Pull wiki context like the command does (topic match)
+        const pages = yield* v.listWikiPages()
+        const matched = pages.filter((p) => {
+          const topics = (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? []
+          return prompt.topics.some((t) => topics.includes(t))
+        })
+        expect(matched.map((p) => p.stem).sort()).toEqual([
+          "2026-04-22--anthropic-claude-code",
+        ])
+        const res = yield* llm.researchQuery({
+          slug: prompt.slug,
+          title: prompt.title,
+          topics: prompt.topics,
+          question: prompt.body,
+          profileName: "Test User",
+          contextPages: matched.map((p) => ({
+            stem: p.stem,
+            title: (p.frontmatter.title as string | undefined) ?? p.stem,
+            topics: (p.frontmatter.topics as ReadonlyArray<string> | undefined) ?? [],
+            excerpt: p.body,
+          })),
+        })
+        expect(res.answerMd).toContain("[[2026-04-22--anthropic-claude-code]]")
+        const written = yield* v.writeResearch(prompt.slug, res.answerMd)
+        expect(written.relPath).toBe("wiki/research/what-is-claudes-real-moat.md")
+        yield* q.stamp(prompt.slug, {
+          status: "processed",
+          output: written.relPath,
+          processedAt: "2026-04-25T08:14:11Z",
+          contentHash: written.contentHash,
+          promptHash: res.promptHash,
+          model: res.model,
+          costUsd: res.costUsd,
+        })
+      }).pipe(Effect.provide(layer)),
+    )
+
+    const writtenAbs = join(vaultDir, "wiki", "research", "what-is-claudes-real-moat.md")
+    expect(await fileExists(writtenAbs)).toBe(true)
+    const written = await readFile(writtenAbs, "utf8")
+    expect(written).toContain("Stub research consolidation")
+
+    const promptAbs = join(vaultDir, "prompts", "what-is-claudes-real-moat.md")
+    const updated = matter(await readFile(promptAbs, "utf8"))
+    expect(updated.data.status).toBe("processed")
+    expect(updated.data.output).toBe("wiki/research/what-is-claudes-real-moat.md")
+    expect(updated.data.processed_at).toBe("2026-04-25T08:14:11Z")
+    expect(updated.data.content_hash).toMatch(/^sha256:/)
+    expect(updated.data.prompt_hash).toMatch(/^sha256:/)
+    expect(updated.data.model).toBe("stub-llm@0.1")
+    expect(updated.data.title).toBe("What is Claude's real moat?")
+    // Body must be untouched
+    expect(updated.content.trim()).toContain("Tooling ergonomics?")
+  })
+
+  it("stamping a missing slug fails with not_found", async () => {
+    const program = Effect.gen(function* () {
+      const q = yield* QueryService
+      return yield* q.stamp("does-not-exist", {
+        status: "processed",
+        processedAt: new Date().toISOString(),
+      })
+    }).pipe(Effect.provide(FileSystemQueryLive(vaultDir)))
+    const result = await Effect.runPromise(Effect.either(program))
+    expect(result._tag).toBe("Left")
+  })
+
+  it("derives slug from filename when frontmatter has none", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const q = yield* QueryService
+        return yield* q.get("no-frontmatter-question")
+      }).pipe(Effect.provide(FileSystemQueryLive(vaultDir))),
+    )
+    expect(result.slug).toBe("no-frontmatter-question")
+    expect(result.title).toBe("No frontmatter question")
+    expect(result.body.trim()).toBe("What does the wiki say about prediction markets?")
+  })
+
+  it("returns empty list when prompts/ directory does not exist", async () => {
+    const empty = await mkdtemp(join(tmpdir(), "uber-vault-empty-"))
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const q = yield* QueryService
+        return yield* q.list()
+      }).pipe(Effect.provide(FileSystemQueryLive(empty))),
+    )
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Extends Uebermensch to process a `prompts/` folder in the vault. The user drops free-form markdown research questions into `$UBER_VAULT_DIR/prompts/<slug>.md`; `gctrl uber prompts process` researches each via the LLM (with topic-matched wiki context), writes the consolidated answer to `wiki/research/<slug>.md`, and stamps the prompt's frontmatter with `status`/`output`/`processed_at`/`content_hash`/`prompt_hash`/`model`/`cost_usd`. The prompt body is never overwritten — only metadata.

To free the `prompts/` folder for this user-facing role, persona prompt overrides are renamed to `personas/<persona>.md` across the specs. No persona-override code exists yet, so this is a docs-only rename for that surface.

## How it works

1. `QueryService` (port) + `FileSystemQuery` (adapter) — list/get/stamp on `$UBER_VAULT_DIR/prompts/*.md`. Slug and title fall back to filename when frontmatter is absent.
2. `LlmService.researchQuery` — new method on the existing port, with stub + kernel implementations. Kernel adapter ships a 4-section markdown contract (Question / Answer / Key claims / Open questions) and bare `[[stem]]` citation rules.
3. `VaultService.writeResearch` — atomic write to `wiki/research/<slug>.md` (tmp + rename + content hash, mirroring `writeBrief`/`writeReport`).
4. `gctrl uber prompts {list, show <slug>, process [--slug X] [--llm kernel|stub] [--force] [--dry-run]}` — selects up to 12 wiki context pages by topic overlap + recency, calls the LLM, writes the research page, stamps the prompt. On failure, stamps `status: failed` with `failed_reason`.

Lifecycle: `pending → processed | failed`. Set `status: rerun` (or `--force`) to re-process; the wiki output is overwritten and the prompt re-stamped.

## Spec changes

- `specs/profile.md` — new `prompts/<slug>.md` section; persona overrides moved to `personas/<persona>.md`; new validator rule for prompt files.
- `PRD.md`, `WORKFLOW.md`, `ROADMAP.md`, `specs/{architecture,briefing-pipeline,sinkin,eval,domain-model}.md` — updated to reference `personas/` instead of `prompts/` for persona prompt overrides; vault diagram and authored-tier glob now show both folders.

## Test plan

- [x] `pnpm vitest run` — 93 / 93 pass (88 prior + 5 new in `tests/query.test.ts`)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] New tests cover: list incl. file with no frontmatter, end-to-end process via stub LLM (writes `wiki/research/...md`, stamps frontmatter, body untouched), missing-slug `not_found`, slug-from-filename derivation, missing `prompts/` dir returns empty.
- [ ] Manual smoke against a real vault with `--llm kernel` (deferred to a follow-up — kernel adapter shape is symmetric with existing `generateBrief` / `generateInterestReport` paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
