### PR TITLE
test(board): poll API in comment-race acceptance test

### DIFF
--- a/apps/gctrl-board/tests/acceptance/issue-lifecycle.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/issue-lifecycle.spec.ts
@@ -161,13 +161,19 @@ test.describe("Issue Lifecycle", () => {
       panel.getByText("Playwright acceptance test comment")
     ).toBeVisible()
 
-    // Verify via kernel
-    const comments = await kernel.getComments(issue.id)
-    expect(
-      comments.some(
-        (c) => c.body === "Playwright acceptance test comment"
+    // Verify via kernel — poll because the optimistic UI render can
+    // race the Worker → D1 commit on remote (CDP) runs.
+    await expect
+      .poll(
+        async () => {
+          const comments = await kernel.getComments(issue.id)
+          return comments.some(
+            (c) => c.body === "Playwright acceptance test comment"
+          )
+        },
+        { timeout: 5_000, intervals: [100, 250, 500] }
       )
-    ).toBe(true)
+      .toBe(true)
   })
 
   test("full forward transition: backlog → todo → in_progress → in_review → done", async ({


### PR DESCRIPTION
## Summary

The Playwright acceptance test "adds comment via detail panel"
(`apps/gctrl-board/tests/acceptance/issue-lifecycle.spec.ts:136`) is
flaky on the Cloudflare Browser Rendering (`cloudflare-cdp`) target.
The UI renders the new comment optimistically before the Worker → D1
commit returns, so the immediate `kernel.getComments()` API check
could race the persistence path and miss the row.

- Wrap the kernel-side verification in `expect.poll()` (5s budget,
  intervals [100, 250, 500]ms) so the assertion tolerates the
  Worker → D1 propagation lag instead of racing the optimistic UI
  render.
- No change to the test's intent — still verifies the comment is
  actually persisted via the API, not just rendered locally.
- No change to `playwright.config.ts` retry settings; they are
  intentionally tuned for CDP rate-limit pressure (comment in the
  file explains).

## Out of scope

The same Deploy Board run also surfaced
`issue-detail-panel.spec.ts:128` failing with `browserContext.newPage:
Target page, context or browser has been closed`. That is a pure
Cloudflare Browser Rendering websocket disconnect at session startup
(see `<ws connect error>` line in the failure log) and is not a
test-code defect — handling it requires infrastructure-side work
(retry policy under CDP rate limits) outside this small fix.

## Test plan

- [x] tsc skipped — deps not installed in fresh worktree, would exceed
      small-fix budget
- [ ] CI Deploy Board acceptance suite passes against the PR preview
- [ ] No regression in the local Chromium acceptance run
