### PR TITLE
chore(dev): add dev.sh launcher for kernel + gctrl-board

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Start kernel daemon (gctrld serve on :4318) and gctrl-board dev server together.
+# Ctrl-C stops both.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+pids=()
+cleanup() {
+  trap - INT TERM EXIT
+  for pid in "${pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "[dev] starting kernel on :4318..."
+( cargo run -p gctrl-cli -- serve ) &
+pids+=($!)
+
+echo "[dev] waiting for kernel health on :4318..."
+for i in {1..120}; do
+  if curl -sf http://127.0.0.1:4318/health >/dev/null 2>&1; then
+    echo "[dev] kernel ready"
+    break
+  fi
+  if ! kill -0 "${pids[0]}" 2>/dev/null; then
+    echo "[dev] kernel exited before becoming healthy" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "[dev] starting gctrl-board dev server..."
+( pnpm --filter gctrl-board dev ) &
+pids+=($!)
+
+while true; do
+  for pid in "${pids[@]}"; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid"
+      exit $?
+    fi
+  done
+  sleep 1
+done


### PR DESCRIPTION
## Summary

- Adds `dev.sh` at the repo root — convenience launcher that starts the kernel daemon (`gctrld serve` on `:4318`), waits for `/health`, then runs the `gctrl-board` dev server. Ctrl-C cleans up both children via a single TERM trap.
- Replaces the two-terminal dance (`cargo run -p gctrl-cli -- serve` + `pnpm --filter gctrl-board dev`) with a single command for everyday work.
- Single new file, executable bit set (`100755`).

## Test plan

- [x] `bash -n dev.sh` parses cleanly
- [x] `shellcheck dev.sh` — only SC2034 on the polling counter `i` (intentional, can be silenced later as `for _ in ...` if desired)
- [ ] Manual: `./dev.sh` starts kernel + board, both reachable, Ctrl-C terminates both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
