### PR TITLE
docs(board): recommend agent handoff via issue comments

### DIFF
--- a/apps/gctrl-board/WORKFLOW.md
+++ b/apps/gctrl-board/WORKFLOW.md
@@ -33,6 +33,7 @@ Transitions are validated at the Rust storage layer. Invalid transitions return 
 | PR opened referencing issue key | Move to `in_review` |
 | PR merged | Move to `done` |
 | All blockers resolved | Move blocked issue to `todo` |
+| Agent hands off work (review / pause / completion) | Post `## Agent: <name>` comment on the Issue — see [pr-review.md § Agent Handoff via Issue Comments](specs/workflows/pr-review.md#agent-handoff-via-issue-comments) |
 
 ## Agent Dispatch Flow
 

--- a/apps/gctrl-board/specs/workflows/issue-lifecycle.md
+++ b/apps/gctrl-board/specs/workflows/issue-lifecycle.md
@@ -26,6 +26,7 @@ These are enforced by the Tracker at the application API boundary, not in the st
 3. An Issue SHOULD auto-transition to `in_review` when a PR referencing it is opened.
 4. An Issue SHOULD auto-transition to `done` when the linked PR is merged.
 5. Moving to `cancelled` MUST include a note explaining why.
+6. Agents handing off work to another agent or human SHOULD post a comment on the Issue describing what's done and what the next picker-up should do — see [pr-review.md § Agent Handoff via Issue Comments](pr-review.md#agent-handoff-via-issue-comments). The Issue (not the PR thread) is the durable handoff surface so the convention works across PR-less work, multi-PR Issues, and cross-agent reviews (e.g. `opencode` reviewing a `claude-code` WIP PR).
 
 ## Issue Requirements
 

--- a/apps/gctrl-board/specs/workflows/pr-review.md
+++ b/apps/gctrl-board/specs/workflows/pr-review.md
@@ -46,6 +46,56 @@ PRs authored by agents SHOULD:
 1. Be smaller and more focused than human PRs — one Issue per PR.
 2. Include a note if the agent encountered difficulties (error loops, retries).
 
+## Agent Handoff via Issue Comments
+
+Agents hand off work to other agents (or humans) by **commenting on the linked Issue**, not by DM-ing, not by editing the PR description, not by posting to the PR thread alone.
+
+The Issue is the durable artifact — PRs come and go, but the Issue persists across PRs, branches, and agent identities. Posting handoff context to the Issue means the next picker-up — whether that's a different agent (e.g. `opencode` running `gemma-3-26b` reviewing a `claude-code` WIP PR), the same agent on a fresh session, or a human — has a single chronological place to read what's been done and what's expected next.
+
+### When to post a handoff comment
+
+Post a comment on the linked Issue when:
+
+1. **Opening a PR** — summarize what's implemented, what's deferred, and what the next agent should verify or extend.
+2. **Requesting review from another agent** — name the agent, the model, and the specific question (e.g. "spec correctness", "perf regression risk", "API surface review"). The reviewing agent reads its assignment from the Issue.
+3. **Returning a review** — the reviewing agent posts findings as a comment on the Issue. Inline PR comments are fine *in addition* but are not a substitute — they're not visible from the board.
+4. **Pausing or yielding** — when an agent stops mid-Issue (cost cap, ambiguity, blocker), it MUST leave a comment describing state and what unblocks the next attempt.
+5. **Completing an acceptance criterion partially** — note which criteria are satisfied so the next agent doesn't redo the work.
+
+### Comment shape
+
+Handoff comments SHOULD use a `## Agent: <name>` header so the orchestrator and board UI can group them. Body conventions:
+
+```markdown
+## Agent: opencode (gemma-3-26b)
+
+**Role:** Review WIP PR #123 against acceptance criteria.
+
+**Findings:**
+- Criterion 1 (rate limiting) — implemented, tests cover happy path only
+- Criterion 2 (audit log) — not yet implemented
+
+**Handing off to:** claude-code — please add error-path tests for criterion 1 and implement criterion 2.
+```
+
+### What does NOT belong in a handoff comment
+
+- Long diffs or full file dumps — link to the PR or commit instead.
+- Internal agent reasoning traces — keep those in session telemetry.
+- Status changes — those go through `gctrl board move`, which emits its own event.
+
+### Why issue, not PR
+
+| Concern | Issue comment | PR comment |
+|---------|--------------|------------|
+| Survives PR close / re-open | ✅ | ❌ |
+| One thread across multiple PRs for the same Issue | ✅ | ❌ |
+| Visible in board UI alongside session/cost data | ✅ | ❌ |
+| Picked up by orchestrator dispatch | ✅ | ❌ |
+| Useful for inline code-line discussion | ❌ | ✅ |
+
+Inline code-level discussion still belongs on the PR. Handoff and review *summary* belong on the Issue.
+
 ## Merge Strategy
 
 1. Default merge strategy MUST be **squash merge** for feature branches.


### PR DESCRIPTION
## Summary

Codifies the convention that agents hand off work — to another agent or to a human — by commenting on the **linked Issue**, not on the PR thread alone. The Issue is the durable artifact across PRs, branches, and agent identities, so the convention works for cross-agent reviews (e.g. `opencode` running `gemma-3-26b` reviewing a `claude-code` WIP PR) and for multi-PR / PR-less Issues.

## What lands

- **`apps/gctrl-board/specs/workflows/pr-review.md`** — new "Agent Handoff via Issue Comments" section: when to post, `## Agent: <name>` comment shape, what NOT to put in handoff comments, and an issue-vs-PR comparison table (inline code discussion still belongs on the PR; handoff/review summary belongs on the Issue).
- **`apps/gctrl-board/specs/workflows/issue-lifecycle.md`** — handoff comment listed as transition side-effect #6.
- **`apps/gctrl-board/WORKFLOW.md`** — handoff added as a row in the auto-transition triggers table.

## Why Issue, not PR

| Concern | Issue comment | PR comment |
|---|---|---|
| Survives PR close / re-open | ✅ | ❌ |
| One thread across multiple PRs for the same Issue | ✅ | ❌ |
| Visible in board UI alongside session/cost data | ✅ | ❌ |
| Picked up by orchestrator dispatch | ✅ | ❌ |
| Useful for inline code-line discussion | ❌ | ✅ |

## Test plan

- [x] Docs-only — no code changes
- [x] Cross-references between the three files render correctly
- [x] Convention aligns with existing `DispatchDialog` behavior (`## Agent: {name}` comments on Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
