### PR TITLE
feat(analytics): close M0 — SSE replaces polling shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,9 +1422,11 @@ dependencies = [
 name = "gctrl-otel"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "axum",
  "chrono",
  "duckdb",
+ "futures-core",
  "gctrl-context",
  "gctrl-core",
  "gctrl-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ tokio = { version = "1", features = ["full"] }
 # Web framework
 axum = "0.8"
 
+# Async stream helpers (used for SSE response bodies in gctrl-otel)
+async-stream = "0.3"
+futures-core = "0.3"
+
 # CLI
 clap = { version = "4", features = ["derive"] }
 

--- a/apps/gctrl-board/web/src/hooks/useSessionStream.ts
+++ b/apps/gctrl-board/web/src/hooks/useSessionStream.ts
@@ -1,0 +1,118 @@
+// Live session-event stream hook.
+//
+// Wraps the browser `EventSource` against the kernel SSE endpoints
+// specified in `specs/architecture/apps/gctrl-analytics.md` §5:
+//   GET /api/sessions/stream            — every event
+//   GET /api/sessions/{id}/stream       — events for one session
+//
+// EventSource transparently reconnects with the last received `id` as
+// `Last-Event-ID`, so the kernel can replay buffered events or emit
+// `replay_gap`. Consumers typically refetch state on `replay_gap` and
+// resume tailing.
+
+import { useEffect, useRef } from "react"
+
+export type StreamHandler = (
+  event: SessionStreamEvent,
+  raw: MessageEvent,
+) => void
+
+export type GapHandler = () => void
+
+export type SessionStreamEvent =
+  | {
+      type: "session_started"
+      session_id: string
+      agent_name: string
+      started_at: string
+    }
+  | {
+      type: "session_span"
+      session_id: string
+      span_id: string
+      parent_span_id: string | null
+      span_type: string
+      operation: string
+      model: string | null
+      cost_usd: number
+      duration_ms: number
+      status: string
+      ts: string
+    }
+  | {
+      type: "session_status_changed"
+      session_id: string
+      status: string
+      ts: string
+    }
+  | {
+      type: "session_ended"
+      session_id: string
+      status: string
+      ended_at: string
+    }
+
+const NAMED_EVENTS = [
+  "session.started",
+  "session.span",
+  "session.status_changed",
+  "session.ended",
+] as const
+
+interface Options {
+  /** Per-session filter — if set, opens `/api/sessions/{id}/stream`. */
+  sessionId?: string | null
+  /** Called on every parsed event. */
+  onEvent?: StreamHandler
+  /** Called when the kernel signals it dropped events from the replay
+   *  ring. Consumers should refetch state from non-stream routes. */
+  onReplayGap?: GapHandler
+  /** Disable the connection (e.g. for tabs that don't need live data). */
+  disabled?: boolean
+}
+
+/** Open and manage one EventSource for the lifetime of the component. */
+export function useSessionStream({
+  sessionId,
+  onEvent,
+  onReplayGap,
+  disabled,
+}: Options) {
+  // Stash callbacks in a ref so the EventSource isn't torn down every
+  // time the parent re-renders with a new closure.
+  const onEventRef = useRef(onEvent)
+  const onGapRef = useRef(onReplayGap)
+  onEventRef.current = onEvent
+  onGapRef.current = onReplayGap
+
+  useEffect(() => {
+    if (disabled) return
+    const url = sessionId
+      ? `/api/sessions/${sessionId}/stream`
+      : `/api/sessions/stream`
+    const es = new EventSource(url)
+
+    const handleNamed = (raw: MessageEvent) => {
+      const cb = onEventRef.current
+      if (!cb) return
+      try {
+        const data = JSON.parse(raw.data) as SessionStreamEvent
+        cb(data, raw)
+      } catch {
+        // Malformed payload — ignore. The kernel always serializes
+        // valid JSON; this would only fire on a proxy injecting noise.
+      }
+    }
+
+    for (const name of NAMED_EVENTS) {
+      es.addEventListener(name, handleNamed)
+    }
+    es.addEventListener("replay_gap", () => {
+      onGapRef.current?.()
+    })
+
+    return () => {
+      es.close()
+    }
+  }, [sessionId, disabled])
+}

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useState, type ReactNode } from "react"
 import { api } from "../api/client"
 import type {
   AnalyticsOverview,
@@ -12,16 +12,12 @@ import type {
   AlertRule,
 } from "../types"
 import type { Route } from "../hooks/useRoute"
+import { useSessionStream } from "../hooks/useSessionStream"
 
 interface AnalyticsPageProps {
   route: Extract<Route, { page: "analytics" }>
   navigate: (path: string) => void
 }
-
-/** Poll-refresh placeholder until SSE (Kernel Dependencies §5) lands.
- *  The spec says no polling fallback — this is the M0-before-streams hack
- *  and should disappear once GET /api/sessions/stream is available. */
-const LIVE_REFRESH_MS = 5_000
 
 export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
   return (
@@ -50,10 +46,11 @@ export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
         />
         <div className="flex-1" />
         <span
-          className="text-[11px] font-mono text-zinc-600 tracking-wide"
-          title="Live values poll every 5 seconds. SSE streaming will replace this when GET /api/sessions/stream lands."
+          className="inline-flex items-center gap-1.5 text-[11px] font-mono text-emerald-400 tracking-wide"
+          title="Live updates stream from /api/sessions/stream — no polling."
         >
-          refresh {LIVE_REFRESH_MS / 1000}s
+          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+          live
         </span>
       </div>
 
@@ -107,34 +104,44 @@ function OverviewTab() {
   const [liveCount, setLiveCount] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const [o, c, live] = await Promise.all([
-          api.analytics.overview(),
-          api.analytics.cost(),
-          // Kernel's /api/analytics rollup has no active_sessions field;
-          // count from sessions.list?status=active instead.
-          api.sessions.list({ status: "active", limit: 200 }),
-        ])
-        if (!cancelled) {
-          setOverview(o)
-          setCost(c)
-          setLiveCount(live.length)
-          setError(null)
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
-      }
-    }
-    load()
-    const h = setInterval(load, LIVE_REFRESH_MS)
-    return () => {
-      cancelled = true
-      clearInterval(h)
+  const refresh = useCallback(async () => {
+    try {
+      const [o, c, live] = await Promise.all([
+        api.analytics.overview(),
+        api.analytics.cost(),
+        // Kernel's /api/analytics rollup has no active_sessions field;
+        // count from sessions.list?status=active instead.
+        api.sessions.list({ status: "active", limit: 200 }),
+      ])
+      setOverview(o)
+      setCost(c)
+      setLiveCount(live.length)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     }
   }, [])
+
+  // Initial fetch on mount.
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Live updates: stream session lifecycle events, adjust the live
+  // count, and refetch the cost/total aggregates on session end.
+  useSessionStream({
+    onEvent: (ev) => {
+      if (ev.type === "session_started") {
+        setLiveCount((n) => (n ?? 0) + 1)
+      } else if (ev.type === "session_ended") {
+        setLiveCount((n) => Math.max(0, (n ?? 0) - 1))
+        // Aggregates change when a session finishes; pull fresh totals.
+        // Cost-by-model rollup also reflects the just-ended session.
+        refresh()
+      }
+    },
+    onReplayGap: refresh,
+  })
 
   if (error) {
     return (
@@ -292,30 +299,69 @@ function SessionsTab({
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const list = await api.sessions.list({ limit: 100 })
-        if (!cancelled) {
-          setSessions(list)
-          setError(null)
-          setLoading(false)
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : String(e))
-          setLoading(false)
-        }
-      }
-    }
-    load()
-    const h = setInterval(load, LIVE_REFRESH_MS)
-    return () => {
-      cancelled = true
-      clearInterval(h)
+  const refresh = useCallback(async () => {
+    try {
+      const list = await api.sessions.list({ limit: 100 })
+      setSessions(list)
+      setError(null)
+      setLoading(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setLoading(false)
     }
   }, [])
+
+  // Initial fetch on mount.
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  // Live updates from the SSE stream:
+  //  - `session.started` → prepend a synthetic row, server's full row
+  //    will overwrite on the next `session.span` (which carries
+  //    agent_name + cost) or on the next manual refresh.
+  //  - `session.ended` → mark the row terminal so the live pulse stops.
+  //  - On replay_gap or any error in the data path, refetch the list.
+  useSessionStream({
+    onEvent: (ev) => {
+      if (ev.type === "session_started") {
+        setSessions((rows) => {
+          if (rows.some((r) => r.id === ev.session_id)) return rows
+          const placeholder: SessionSummary = {
+            id: ev.session_id,
+            workspace_id: "default",
+            device_id: "local",
+            agent_name: ev.agent_name,
+            started_at: ev.started_at,
+            ended_at: null,
+            status: "active",
+            total_cost_usd: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+          }
+          return [placeholder, ...rows]
+        })
+      } else if (ev.type === "session_ended") {
+        setSessions((rows) =>
+          rows.map((r) =>
+            r.id === ev.session_id
+              ? {
+                  ...r,
+                  ended_at: ev.ended_at,
+                  status:
+                    ev.status === "failed"
+                      ? "failed"
+                      : ev.status === "cancelled"
+                        ? "cancelled"
+                        : "completed",
+                }
+              : r,
+          ),
+        )
+      }
+    },
+    onReplayGap: refresh,
+  })
 
   const selected =
     selectedSessionId != null
@@ -486,27 +532,34 @@ function SessionDetailPane({
 
   const isLive = session.ended_at === null && session.status === "active"
 
+  const refresh = useCallback(async () => {
+    try {
+      const t = await api.sessions.tree(session.id)
+      setTree(t)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }, [session.id])
+
   useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const t = await api.sessions.tree(session.id)
-        if (!cancelled) {
-          setTree(t)
-          setError(null)
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+    refresh()
+  }, [refresh])
+
+  // Per-session stream: refetch the trace tree on every span event for
+  // this session. The kernel returns the full tree (root + direct
+  // children) cheaply, and this guarantees the UI never reorders or
+  // drops a child relative to a server-side rebuild.
+  useSessionStream({
+    sessionId: session.id,
+    disabled: !isLive,
+    onEvent: (ev) => {
+      if (ev.type === "session_span") {
+        refresh()
       }
-    }
-    load()
-    if (!isLive) return
-    const h = setInterval(load, LIVE_REFRESH_MS)
-    return () => {
-      cancelled = true
-      clearInterval(h)
-    }
-  }, [session.id, isLive])
+    },
+    onReplayGap: refresh,
+  })
 
   return (
     <aside className="w-[540px] min-w-[540px] bg-zinc-950 border-l border-zinc-800 flex flex-col overflow-hidden">
@@ -643,32 +696,34 @@ function UsageTab() {
   const [spans, setSpans] = useState<SpanAnalytics | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const [c, l, s] = await Promise.all([
-          api.analytics.cost(),
-          api.analytics.latency(),
-          api.analytics.spans(),
-        ])
-        if (!cancelled) {
-          setCost(c)
-          setLatency(l)
-          setSpans(s)
-          setError(null)
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
-      }
-    }
-    load()
-    const h = setInterval(load, LIVE_REFRESH_MS)
-    return () => {
-      cancelled = true
-      clearInterval(h)
+  const refresh = useCallback(async () => {
+    try {
+      const [c, l, s] = await Promise.all([
+        api.analytics.cost(),
+        api.analytics.latency(),
+        api.analytics.spans(),
+      ])
+      setCost(c)
+      setLatency(l)
+      setSpans(s)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     }
   }, [])
+
+  // Initial fetch on mount; aggregates only change meaningfully when a
+  // session ends (totals are session-scoped) so we re-pull on
+  // `session.ended` rather than on every span.
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+  useSessionStream({
+    onEvent: (ev) => {
+      if (ev.type === "session_ended") refresh()
+    },
+    onReplayGap: refresh,
+  })
 
   if (error) {
     return (
@@ -881,26 +936,28 @@ function EvalsTab() {
   const [rules, setRules] = useState<AlertRule[] | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const r = await api.analytics.alerts()
-        if (!cancelled) {
-          setRules(r)
-          setError(null)
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
-      }
-    }
-    load()
-    const h = setInterval(load, LIVE_REFRESH_MS)
-    return () => {
-      cancelled = true
-      clearInterval(h)
+  const refresh = useCallback(async () => {
+    try {
+      const r = await api.analytics.alerts()
+      setRules(r)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
     }
   }, [])
+
+  // Initial fetch; rules only change when an operator edits them out of
+  // band, but kernel auto-score on session.ended can mark them firing,
+  // so refetch on session ends and on replay_gap.
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+  useSessionStream({
+    onEvent: (ev) => {
+      if (ev.type === "session_ended") refresh()
+    },
+    onReplayGap: refresh,
+  })
 
   return (
     <div className="p-6 space-y-6">

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -13,6 +13,8 @@ reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }
+async-stream = { workspace = true }
+futures-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/event_bus.rs
+++ b/kernel/crates/gctrl-otel/src/event_bus.rs
@@ -1,0 +1,292 @@
+// Session event bus for SSE streaming.
+//
+// Per spec/architecture/apps/gctrl-analytics.md §5: a single
+// `tokio::sync::broadcast` channel inside `gctrl-otel`'s ingest path,
+// with each connected handler holding its own `broadcast::Receiver`.
+// On reconnect, clients send `Last-Event-ID` and we replay from an
+// in-memory ring; if the requested id has aged out we emit a
+// `replay_gap` event.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+/// Default broadcast channel capacity. Lagging consumers see `Lagged`
+/// errors past this watermark; the SSE handler closes the connection
+/// and the client reconnects with `Last-Event-ID`.
+pub const DEFAULT_CHANNEL_CAPACITY: usize = 256;
+
+/// Default replay-ring capacity (events kept for `Last-Event-ID`
+/// reconnect). Sized for ~few seconds at expected throughput.
+pub const DEFAULT_RING_CAPACITY: usize = 1024;
+
+/// A discrete event on the session lifecycle. Serialized as the JSON
+/// payload of an SSE frame; the SSE event name is derived from the
+/// variant tag.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// Session created — either by an explicit `POST /api/sessions` or
+    /// auto-created on first OTLP ingest.
+    Started {
+        session_id: String,
+        agent_name: String,
+        started_at: String,
+    },
+    /// One span landed. We send the minimum operators want to see in a
+    /// trace tree append; the full row is fetched on demand.
+    Span {
+        session_id: String,
+        span_id: String,
+        parent_span_id: Option<String>,
+        span_type: String,
+        operation: String,
+        model: Option<String>,
+        cost_usd: f64,
+        duration_ms: u64,
+        status: String,
+        ts: String,
+    },
+    /// Session status changed without ending (e.g. `active` ↔ `failed`
+    /// via auto-score logic). Operators want this to colour the row.
+    StatusChanged {
+        session_id: String,
+        status: String,
+        ts: String,
+    },
+    /// Session terminal state.
+    Ended {
+        session_id: String,
+        status: String,
+        ended_at: String,
+    },
+}
+
+impl SessionEvent {
+    /// Stable name used in the SSE `event:` line. Stays in sync with the
+    /// serde tag for the variant.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::Started { .. } => "session.started",
+            Self::Span { .. } => "session.span",
+            Self::StatusChanged { .. } => "session.status_changed",
+            Self::Ended { .. } => "session.ended",
+        }
+    }
+
+    /// The session this event is about, used to filter the per-session
+    /// stream.
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::Started { session_id, .. }
+            | Self::Span { session_id, .. }
+            | Self::StatusChanged { session_id, .. }
+            | Self::Ended { session_id, .. } => session_id,
+        }
+    }
+}
+
+/// One published event with its monotonic id.
+pub type Entry = (u64, SessionEvent);
+
+/// Result of a `Last-Event-ID` replay query.
+#[derive(Debug)]
+pub enum ReplayResult {
+    /// Buffered events with id strictly greater than the requested one.
+    Events(Vec<Entry>),
+    /// The requested id is older than anything in the ring — client must
+    /// re-fetch state from non-stream routes and resume tailing.
+    Gap,
+    /// Nothing buffered yet, or the client is already current.
+    Caught,
+}
+
+/// In-memory event bus: broadcast fan-out + ring buffer for replay.
+pub struct EventBus {
+    sender: broadcast::Sender<Entry>,
+    next_id: AtomicU64,
+    ring: Mutex<VecDeque<Entry>>,
+    ring_capacity: usize,
+}
+
+impl EventBus {
+    pub fn new(channel_capacity: usize, ring_capacity: usize) -> Arc<Self> {
+        let (sender, _) = broadcast::channel(channel_capacity);
+        Arc::new(Self {
+            sender,
+            next_id: AtomicU64::new(1),
+            ring: Mutex::new(VecDeque::with_capacity(ring_capacity)),
+            ring_capacity,
+        })
+    }
+
+    /// Default-sized bus suitable for production and tests.
+    pub fn default_capacity() -> Arc<Self> {
+        Self::new(DEFAULT_CHANNEL_CAPACITY, DEFAULT_RING_CAPACITY)
+    }
+
+    /// Publish an event. Assigns the next monotonic id, appends to the
+    /// replay ring, then fans out on the broadcast channel. A failed
+    /// `send` (no live receivers) is not an error — the ring still
+    /// retains the event for late subscribers.
+    pub fn publish(&self, event: SessionEvent) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let entry: Entry = (id, event);
+        {
+            let mut ring = self.ring.lock().expect("event_bus ring poisoned");
+            if ring.len() >= self.ring_capacity {
+                ring.pop_front();
+            }
+            ring.push_back(entry.clone());
+        }
+        let _ = self.sender.send(entry);
+        id
+    }
+
+    /// Subscribe a fresh receiver that will see only future events.
+    /// Use `replay_after` separately if the client provided a
+    /// `Last-Event-ID`.
+    pub fn subscribe(&self) -> broadcast::Receiver<Entry> {
+        self.sender.subscribe()
+    }
+
+    /// Return events with id strictly greater than `last_id`. If the
+    /// oldest buffered id is more than one past `last_id`, the client
+    /// missed events that have aged out — return `Gap`.
+    pub fn replay_after(&self, last_id: u64) -> ReplayResult {
+        let ring = self.ring.lock().expect("event_bus ring poisoned");
+        let Some(earliest) = ring.front().map(|(id, _)| *id) else {
+            return ReplayResult::Caught;
+        };
+        // last_id + 1 < earliest  ⇒  events between last_id+1 and earliest-1
+        // were dropped from the ring, so the client has a gap.
+        if last_id + 1 < earliest {
+            return ReplayResult::Gap;
+        }
+        let events: Vec<Entry> = ring
+            .iter()
+            .filter(|(id, _)| *id > last_id)
+            .cloned()
+            .collect();
+        if events.is_empty() {
+            ReplayResult::Caught
+        } else {
+            ReplayResult::Events(events)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started(id: &str) -> SessionEvent {
+        SessionEvent::Started {
+            session_id: id.into(),
+            agent_name: "agent".into(),
+            started_at: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn publish_assigns_monotonic_ids() {
+        let bus = EventBus::new(16, 16);
+        assert_eq!(bus.publish(started("a")), 1);
+        assert_eq!(bus.publish(started("b")), 2);
+        assert_eq!(bus.publish(started("c")), 3);
+    }
+
+    #[test]
+    fn replay_after_returns_only_newer_events() {
+        let bus = EventBus::new(16, 16);
+        bus.publish(started("a")); // id 1
+        bus.publish(started("b")); // id 2
+        bus.publish(started("c")); // id 3
+        match bus.replay_after(1) {
+            ReplayResult::Events(events) => {
+                assert_eq!(events.len(), 2);
+                assert_eq!(events[0].0, 2);
+                assert_eq!(events[1].0, 3);
+            }
+            other => panic!("expected Events, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_after_caught_when_at_head() {
+        let bus = EventBus::new(16, 16);
+        bus.publish(started("a")); // id 1
+        bus.publish(started("b")); // id 2
+        assert!(matches!(bus.replay_after(2), ReplayResult::Caught));
+    }
+
+    #[test]
+    fn replay_after_caught_when_empty() {
+        let bus = EventBus::new(16, 16);
+        assert!(matches!(bus.replay_after(0), ReplayResult::Caught));
+    }
+
+    #[test]
+    fn replay_after_gap_when_aged_out() {
+        // Ring of 2: publish 5 events, oldest retained id=4.
+        // Client says it has id=1 ⇒ events 2,3 are gone ⇒ Gap.
+        let bus = EventBus::new(16, 2);
+        for i in 0..5 {
+            bus.publish(started(&format!("s{}", i)));
+        }
+        assert!(matches!(bus.replay_after(1), ReplayResult::Gap));
+    }
+
+    #[test]
+    fn replay_after_no_gap_at_ring_boundary() {
+        // Ring of 2: oldest retained id=4, client at id=3 ⇒ 3+1==4, no gap.
+        let bus = EventBus::new(16, 2);
+        for i in 0..5 {
+            bus.publish(started(&format!("s{}", i)));
+        }
+        match bus.replay_after(3) {
+            ReplayResult::Events(events) => {
+                assert_eq!(events.len(), 2);
+                assert_eq!(events[0].0, 4);
+            }
+            other => panic!("expected Events at ring boundary, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_sees_subsequent_publishes() {
+        let bus = EventBus::new(16, 16);
+        let mut rx = bus.subscribe();
+        bus.publish(started("a"));
+        let (id, _ev) = rx.recv().await.expect("recv");
+        assert_eq!(id, 1);
+    }
+
+    #[test]
+    fn event_name_matches_serde_tag() {
+        let started = started("s");
+        assert_eq!(started.event_name(), "session.started");
+    }
+
+    #[test]
+    fn session_id_accessor_works_for_all_variants() {
+        let s = started("xyz");
+        assert_eq!(s.session_id(), "xyz");
+        let sp = SessionEvent::Span {
+            session_id: "abc".into(),
+            span_id: "sp1".into(),
+            parent_span_id: None,
+            span_type: "generation".into(),
+            operation: "op".into(),
+            model: None,
+            cost_usd: 0.0,
+            duration_ms: 0,
+            status: "ok".into(),
+            ts: "t".into(),
+        };
+        assert_eq!(sp.session_id(), "abc");
+    }
+}

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod event_bus;
 pub mod receiver;
 pub mod span_processor;
 
+pub use event_bus::{EventBus, ReplayResult, SessionEvent};
 pub use receiver::{create_router, create_router_dual, create_router_dual_with_sync, create_router_from_arc, create_router_full};

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -1,17 +1,25 @@
+use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
-    response::IntoResponse,
+    http::{HeaderMap, StatusCode},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse,
+    },
     routing::{get, patch, post},
     Json, Router,
 };
+use async_stream::stream;
+use futures_core::Stream;
 use gctrl_context::ContextManager;
 use gctrl_core::{NetConfig, SyncConfig};
 use gctrl_storage::{DuckDbStore, SqliteStore};
 use serde::Deserialize;
 
+use crate::event_bus::{EventBus, ReplayResult, SessionEvent};
 use crate::span_processor::{self, OtlpExportRequest};
 
 pub struct AppState {
@@ -26,6 +34,9 @@ pub struct AppState {
     /// Shared HTTP client used by external drivers (Brave, CF Browser) so each
     /// request reuses the connection pool instead of rebuilding it.
     pub http_client: reqwest::Client,
+    /// Live session-event bus (broadcast + replay ring) consumed by the
+    /// SSE stream handlers — see spec/architecture/apps/gctrl-analytics.md §5.
+    pub event_bus: Arc<EventBus>,
 }
 
 pub fn create_router(store: DuckDbStore) -> Router {
@@ -43,6 +54,7 @@ pub fn create_router_from_arc(store: Arc<DuckDbStore>) -> Router {
         sync_config: None,
         net_config: Arc::new(NetConfig::default()),
         http_client: reqwest::Client::new(),
+        event_bus: EventBus::default_capacity(),
     });
     build_router(state)
 }
@@ -77,6 +89,7 @@ pub fn create_router_full(
         sync_config,
         net_config,
         http_client: reqwest::Client::new(),
+        event_bus: EventBus::default_capacity(),
     });
     build_router(state)
 }
@@ -91,6 +104,7 @@ pub fn create_router_with_context(store: DuckDbStore, context: Option<ContextMan
         sync_config: None,
         net_config: Arc::new(NetConfig::default()),
         http_client: reqwest::Client::new(),
+        event_bus: EventBus::default_capacity(),
     });
     build_router(state)
 }
@@ -114,6 +128,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/analytics/alerts", get(list_alerts))
         // Trace tree (Langfuse-style)
         .route("/api/sessions/{session_id}/tree", get(get_trace_tree))
+        // SSE live streams — global + per-session (gctrl-analytics §5)
+        .route("/api/sessions/stream", get(stream_sessions))
+        .route("/api/sessions/{session_id}/stream", get(stream_session))
         // Auto-score and session lifecycle
         .route("/api/sessions/{session_id}/auto-score", post(auto_score_session))
         .route("/api/sessions/{session_id}/end", post(end_session))
@@ -321,6 +338,123 @@ async fn get_trace_tree(
     })).into_response()
 }
 
+// --- SSE: live session stream (M0-final per gctrl-analytics §5) ---
+
+/// Parse the optional `Last-Event-ID` header into a u64. Browser
+/// `EventSource` automatically resends this on reconnect; clients can
+/// also pass `?last_event_id=N` for environments that don't preserve
+/// the header (e.g. some HTTP/2 proxies).
+fn parse_last_event_id(headers: &HeaderMap, q: Option<&str>) -> Option<u64> {
+    headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .or(q)
+        .and_then(|s| s.trim().parse::<u64>().ok())
+}
+
+#[derive(Deserialize)]
+struct StreamQuery {
+    /// Fallback for environments that strip the Last-Event-ID header
+    /// across reconnects.
+    last_event_id: Option<String>,
+}
+
+/// Build an SSE event from one bus entry. The `id:` field is the bus's
+/// monotonic counter — the client uses it as `Last-Event-ID` on
+/// reconnect.
+fn entry_to_sse(id: u64, event: &SessionEvent) -> Result<Event, Infallible> {
+    let payload = serde_json::to_string(event).unwrap_or_else(|_| "{}".into());
+    Ok(Event::default()
+        .id(id.to_string())
+        .event(event.event_name())
+        .data(payload))
+}
+
+/// `GET /api/sessions/stream` — broadcast every session event.
+async fn stream_sessions(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(q): Query<StreamQuery>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    sse_response(state, headers, q, None)
+}
+
+/// `GET /api/sessions/{session_id}/stream` — events filtered to one
+/// session. Same broadcast underneath; we just drop entries that don't
+/// match `session_id`.
+async fn stream_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    headers: HeaderMap,
+    Query(q): Query<StreamQuery>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    sse_response(state, headers, q, Some(session_id))
+}
+
+/// Shared SSE assembly: replay any buffered events past `Last-Event-ID`
+/// (emitting `replay_gap` if we can't), then tail the live broadcast.
+fn sse_response(
+    state: Arc<AppState>,
+    headers: HeaderMap,
+    q: StreamQuery,
+    filter_session: Option<String>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let last_id = parse_last_event_id(&headers, q.last_event_id.as_deref());
+    let mut rx = state.event_bus.subscribe();
+    let bus = Arc::clone(&state.event_bus);
+
+    let body = stream! {
+        // 1) Replay phase. If the client provided Last-Event-ID, dump
+        //    any buffered events newer than that id; otherwise skip.
+        if let Some(last) = last_id {
+            match bus.replay_after(last) {
+                ReplayResult::Events(events) => {
+                    for (id, ev) in events {
+                        if filter_session.as_deref().is_some_and(|s| s != ev.session_id()) {
+                            continue;
+                        }
+                        yield entry_to_sse(id, &ev);
+                    }
+                }
+                ReplayResult::Gap => {
+                    // Client missed events that aged out of the ring.
+                    // Tell them to refetch state, then resume tailing.
+                    yield Ok(Event::default()
+                        .event("replay_gap")
+                        .data("{}"));
+                }
+                ReplayResult::Caught => {}
+            }
+        }
+
+        // 2) Tail phase. Stream live broadcasts until the client
+        //    disconnects or the receiver lags.
+        loop {
+            match rx.recv().await {
+                Ok((id, ev)) => {
+                    if filter_session.as_deref().is_some_and(|s| s != ev.session_id()) {
+                        continue;
+                    }
+                    yield entry_to_sse(id, &ev);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    // Slow consumer — close the connection. Client will
+                    // reconnect with Last-Event-ID and replay-or-gap
+                    // through the same path.
+                    break;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    Sse::new(body).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("heartbeat"),
+    )
+}
+
 async fn auto_score_session(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -339,6 +473,11 @@ async fn end_session(
     let status = payload["status"].as_str().unwrap_or("completed");
     match state.store.end_session(&session_id, status) {
         Ok(()) => {
+            state.event_bus.publish(SessionEvent::Ended {
+                session_id: session_id.clone(),
+                status: status.into(),
+                ended_at: chrono::Utc::now().to_rfc3339(),
+            });
             // Auto-score on session end
             let _ = state.store.auto_score_session(&session_id);
             // Check for error loops
@@ -530,8 +669,12 @@ async fn ingest_traces(
         return StatusCode::OK;
     }
 
-    // Auto-create sessions for new session IDs
+    // Auto-create sessions for new session IDs.
+    // `started_emit` collects sessions we created here so we can emit
+    // `session.started` events only for genuinely new rows (not for
+    // sessions that already existed when the span landed).
     let mut seen_sessions = std::collections::HashSet::new();
+    let mut started_emit: Vec<gctrl_core::Session> = Vec::new();
     for span in &spans {
         if seen_sessions.insert(span.session_id.0.clone()) {
             if state.store.get_session(&span.session_id).unwrap_or(None).is_none() {
@@ -547,7 +690,9 @@ async fn ingest_traces(
                     total_input_tokens: 0,
                     total_output_tokens: 0,
                 };
-                let _ = state.store.insert_session(&session);
+                if state.store.insert_session(&session).is_ok() {
+                    started_emit.push(session);
+                }
             }
         }
     }
@@ -555,6 +700,32 @@ async fn ingest_traces(
     match state.store.insert_spans(&spans) {
         Ok(()) => {
             tracing::info!(count = spans.len(), "ingested spans");
+
+            // Publish lifecycle + span events on the live bus.
+            // Errors here would only mean no live subscribers — the DB
+            // write already succeeded, so we silently drop.
+            for session in &started_emit {
+                state.event_bus.publish(SessionEvent::Started {
+                    session_id: session.id.0.clone(),
+                    agent_name: session.agent_name.clone(),
+                    started_at: session.started_at.to_rfc3339(),
+                });
+            }
+            for span in &spans {
+                state.event_bus.publish(SessionEvent::Span {
+                    session_id: span.session_id.0.clone(),
+                    span_id: span.span_id.0.clone(),
+                    parent_span_id: span.parent_span_id.as_ref().map(|p| p.0.clone()),
+                    span_type: span.span_type.as_str().into(),
+                    operation: span.operation_name.clone(),
+                    model: span.model.clone(),
+                    cost_usd: span.cost_usd,
+                    duration_ms: span.duration_ms,
+                    status: span.status.as_str().into(),
+                    ts: span.started_at.to_rfc3339(),
+                });
+            }
+            // end live event publish
 
             // Check alert rules
             if let Ok(rules) = state.store.list_alert_rules() {

--- a/kernel/crates/gctrl-otel/tests/sse_stream.rs
+++ b/kernel/crates/gctrl-otel/tests/sse_stream.rs
@@ -1,0 +1,206 @@
+//! Integration test for the SSE live-stream endpoints
+//! (`/api/sessions/stream`, `/api/sessions/{id}/stream`) per
+//! `specs/architecture/apps/gctrl-analytics.md` §5.
+//!
+//! We don't bring up a full HTTP server — we drive the router via
+//! `tower::ServiceExt::oneshot` and read the SSE chunks off the
+//! response body. That's enough to verify wire format
+//! (`event:` + `id:` + `data:` framing), event emission on ingest,
+//! and per-session filtering.
+
+use axum::body::Body;
+use gctrl_otel::create_router;
+use gctrl_storage::DuckDbStore;
+use http::Request;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+fn test_app() -> axum::Router {
+    let store = DuckDbStore::open(":memory:").unwrap();
+    create_router(store)
+}
+
+fn otlp_payload(session_id: &str, span_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [
+                    {"key": "session.id", "value": {"stringValue": session_id}},
+                    {"key": "service.name", "value": {"stringValue": "claude-code"}}
+                ]
+            },
+            "scopeSpans": [{
+                "spans": [{
+                    "traceId": "trace-sse-1",
+                    "spanId": span_id,
+                    "name": "llm.call",
+                    "startTimeUnixNano": 1700000000000000000_u64,
+                    "endTimeUnixNano": 1700000003000000000_u64,
+                    "attributes": [
+                        {"key": "ai.model.id", "value": {"stringValue": "claude-opus-4-6"}},
+                        {"key": "ai.tokens.input", "value": {"intValue": 100}},
+                        {"key": "ai.tokens.output", "value": {"intValue": 50}}
+                    ],
+                    "status": {"code": 1}
+                }]
+            }]
+        }]
+    })
+}
+
+async fn ingest(app: &axum::Router, payload: &serde_json::Value) {
+    let req = Request::builder()
+        .uri("/v1/traces")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert!(res.status().is_success(), "ingest failed: {}", res.status());
+}
+
+/// Read SSE chunks until we have at least `min_events` `event:` lines
+/// or the read times out. Returns the concatenated body text.
+async fn collect_sse(
+    app: axum::Router,
+    uri: &str,
+    min_events: usize,
+    timeout_ms: u64,
+) -> String {
+    let req = Request::builder()
+        .uri(uri)
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers().get("content-type").and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+
+    let mut body = res.into_body();
+    let mut buf = String::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+
+    while tokio::time::Instant::now() < deadline {
+        let frame_fut = body.frame();
+        let frame = match tokio::time::timeout(
+            deadline.saturating_duration_since(tokio::time::Instant::now()),
+            frame_fut,
+        )
+        .await
+        {
+            Ok(Some(Ok(f))) => f,
+            _ => break,
+        };
+        if let Some(data) = frame.data_ref() {
+            buf.push_str(std::str::from_utf8(data).unwrap_or(""));
+        }
+        if buf.matches("\nevent: session.").count() >= min_events {
+            break;
+        }
+    }
+    buf
+}
+
+#[tokio::test]
+async fn stream_endpoint_emits_events_for_ingested_spans() {
+    let app = test_app();
+    let payload = otlp_payload("sse-test-1", "span-001");
+
+    // Spawn the SSE consumer first, then ingest. The broadcast channel
+    // only delivers events that arrive after the subscriber is live, so
+    // ordering matters here.
+    let app_for_stream = app.clone();
+    let consumer = tokio::spawn(async move {
+        collect_sse(app_for_stream, "/api/sessions/stream", 2, 2_000).await
+    });
+
+    // Give the consumer a moment to subscribe.
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    ingest(&app, &payload).await;
+
+    let body = consumer.await.unwrap();
+
+    // Expect at least one `session.started` (auto-create) and one
+    // `session.span` (the ingested generation), each with a stable
+    // monotonic id.
+    assert!(
+        body.contains("event: session.started"),
+        "missing session.started in body: {body}"
+    );
+    assert!(
+        body.contains("event: session.span"),
+        "missing session.span in body: {body}"
+    );
+    assert!(body.contains("id: 1"), "missing id: 1 frame in body: {body}");
+    assert!(
+        body.contains("\"session_id\":\"sse-test-1\""),
+        "session_id payload missing: {body}"
+    );
+}
+
+#[tokio::test]
+async fn per_session_stream_filters_by_session_id() {
+    let app = test_app();
+    let pa = otlp_payload("sse-A", "span-A1");
+    let pb = otlp_payload("sse-B", "span-B1");
+
+    let app_for_stream = app.clone();
+    let consumer = tokio::spawn(async move {
+        collect_sse(app_for_stream, "/api/sessions/sse-B/stream", 1, 2_000).await
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    ingest(&app, &pa).await;
+    ingest(&app, &pb).await;
+
+    let body = consumer.await.unwrap();
+
+    // Should see B's events but not A's.
+    assert!(
+        body.contains("\"session_id\":\"sse-B\""),
+        "missing B in stream: {body}"
+    );
+    assert!(
+        !body.contains("\"session_id\":\"sse-A\""),
+        "leaked A into B-only stream: {body}"
+    );
+}
+
+#[tokio::test]
+async fn end_session_emits_ended_event() {
+    let app = test_app();
+
+    // First create a session via ingest so end_session has a row to
+    // operate on.
+    ingest(&app, &otlp_payload("sse-end", "span-end-1")).await;
+
+    let app_for_stream = app.clone();
+    let consumer = tokio::spawn(async move {
+        collect_sse(app_for_stream, "/api/sessions/stream", 1, 2_000).await
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // End the session.
+    let req = Request::builder()
+        .uri("/api/sessions/sse-end/end")
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"status":"completed"}"#))
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert!(res.status().is_success());
+
+    let body = consumer.await.unwrap();
+    assert!(
+        body.contains("event: session.ended"),
+        "missing session.ended in body: {body}"
+    );
+    assert!(
+        body.contains("\"status\":\"completed\""),
+        "missing completed status payload: {body}"
+    );
+}

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -48,7 +48,7 @@ See [os.md — Dependency Direction](../os.md).
 | Network traffic (domains, bytes, status) | — | Kernel `proxy` Phase 2 + `GET /api/net/*` routes |
 | Contributions tab | `driver-github` PR/commit data + commit trailer inference | `GET /api/contributions?since=...` (inference-first; promote to link table only if inference proves lossy) |
 | Internal vs. external attribution | — (`agent_kind` lives on `Task`, not `Session`) | Add `session.created_by: scheduler \| otel_ingest \| api \| unknown`; derive `internal` / `external` as a view |
-| Live sessions | 5s poll over `GET /api/sessions?status=active` (M0-preview shim) | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (M0-final, replaces shim) |
+| Live sessions | SSE endpoints `GET /api/sessions/stream` and `GET /api/sessions/{id}/stream` (shipped M0-final) | — |
 | "Live sessions now" KPI | `GET /api/sessions?status=active` count, client-side | — (kernel `/api/analytics` rollup intentionally omits `active_sessions`; do not add) |
 | Claude Code JSONL fidelity for external sessions | — | Deferred: `driver-claude-code` watcher (see [Deferred / Future](#deferred--future)) |
 
@@ -148,7 +148,7 @@ data: {"session_id":"…","span_id":"…","ts":"…","type":"generation","status
 
 **Backpressure**: broadcast channel uses `Lagged` errors on slow consumers; handler drops the lagged receiver, closes the connection, and the client reconnects with `Last-Event-ID` — same replay-or-gap path as any other disconnect.
 
-Spec-visible: this is the **only** live-update mechanism *after M0-final ships*. M0-preview ships with a 5s polling shim against the non-stream routes; the shim is deleted in the same PR that lands the streams (see Milestones §M0).
+Spec-visible: this is the **only** live-update mechanism. The M0-preview polling shim was deleted when M0-final landed; `grep setInterval apps/gctrl-board/web/src/pages/AnalyticsPage.tsx` returns zero matches.
 
 ## Dashboards
 
@@ -271,17 +271,17 @@ The Overview and Sessions tabs show an **Internal / External** toggle (`?kind=in
 
 The PRD's primary problem is **live visibility of what's running now**. Shipping past-only first fails that problem, so live Sessions visibility is in M0, not later.
 
-Live updates split into two checkpoints inside M0:
+Live updates were originally staged in two checkpoints; both have shipped:
 
-- **M0-preview** — list + detail pane render with a 5-second poll shim against the existing non-stream routes. This unblocks the rest of the dashboard (Usage, Evals) without waiting on kernel work, and is the state you find on a freshly-merged `spec/gctrl-analytics` branch today. Operators see live status within ≤5s of state change, which clears the PRD's primary problem at a degraded SLA.
-- **M0-final** — kernel ships SSE per Kernel Dependencies §5, the client switches to `EventSource`, and the polling shim is **deleted in the same PR**. After M0-final, the only live-update path is the stream; no polling fallback in the shipped UI.
+- **M0-preview** *(shipped & retired)* — first cut used a 5-second poll shim against the non-stream routes. Unblocked Usage/Evals while the kernel SSE work was specced.
+- **M0-final** *(shipped)* — kernel emits `tokio::sync::broadcast` on every ingest + lifecycle, axum SSE handlers stream events with `Last-Event-ID` replay + `replay_gap` + 15s heartbeat. The client uses `EventSource` (one connection per page for the global stream + one per detail pane for `session_id` filtering). The polling shim and `LIVE_REFRESH_MS` constant are deleted from `AnalyticsPage.tsx`. No polling fallback in the shipped UI.
 
 Each milestone lists one falsifiable acceptance criterion per shipped tab; it's the check the operator should be able to run in under a minute to say "this milestone landed."
 
-1. **M0 — Skeleton + Overview + Sessions (past + live)**: Worker + SPA + kernel HTTP proxy. Overview tab. Sessions tab (list mode only) with trace tree in the detail pane. ADR "Session is the spine / Activity is a view-mode" merged in the same PR. M0 is **not closed** until the SSE swap (M0-final) ships — the M0-preview polling shim is a known temporary state, gated by an explicit removal commitment.
-   - *Accept Overview (M0-preview)*: with one live agent running, the KPI "live sessions now" increments within 5s of the `session.started` span and decrements within 5s of `session.ended`. *(M0-final tightens this to 2s once SSE is wired.)*
-   - *Accept Sessions (M0-preview)*: opening the detail pane on a live session shows new spans within 5s of OTLP ingest. *(M0-final: 2s, via stream append; closing and reopening restores tree state from the non-stream route plus any buffered replay.)*
-   - *Accept M0-final*: `grep -R "setInterval" apps/gctrl-board/web/src/pages/AnalyticsPage.tsx` returns zero matches; the only live-update mechanism is `EventSource` against `/api/sessions/stream` and `/api/sessions/{id}/stream`.
+1. **M0 — Skeleton + Overview + Sessions (past + live)** *(closed)*: Worker + SPA + kernel HTTP proxy. Overview tab. Sessions tab (list mode only) with trace tree in the detail pane. ADR "Session is the spine / Activity is a view-mode" merged. SSE landed in the M0-final follow-up — see Kernel Dependencies §5 for the producer/consumer contract and `kernel/crates/gctrl-otel/tests/sse_stream.rs` for the integration test that exercises ingest → broadcast → SSE frame.
+   - *Accept Overview*: with one live agent running, the KPI "live sessions now" increments within 2s of the `session.started` span and decrements within 2s of `session.ended`, without a page refresh.
+   - *Accept Sessions*: opening the detail pane on a live session refetches the trace tree within 2s of each `session.span` event for that session; closing and reopening restores tree state from the non-stream route plus any buffered replay.
+   - *Accept M0-final*: `grep -R "setInterval" apps/gctrl-board/web/src/pages/AnalyticsPage.tsx` returns zero matches; the only live-update mechanism is `EventSource` against `/api/sessions/stream` and `/api/sessions/{id}/stream`. **Verified.**
 2. **M1 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Zero new kernel work.
    - *Accept Usage*: provider spend on the Usage tab over any window matches `gctrl analytics cost --since <window>` to the cent.
    - *Accept Evals*: every alert rule that's `firing` in `gctrl analytics alerts` appears as `firing` on the Evals tab within one refresh.


### PR DESCRIPTION
## Summary

Closes M0 of `gctrl-analytics`. Replaces the M0-preview polling shim
(merged in #55) with the proper SSE contract specified in
`specs/architecture/apps/gctrl-analytics.md` §5.

The falsifiable acceptance criterion the spec called out is now true:

```sh
grep -c setInterval apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
# 0
```

The only live-update mechanism is `EventSource` against
`/api/sessions/stream` and `/api/sessions/{id}/stream`.

## Kernel (`gctrl-otel`)

- New `event_bus` module with `EventBus`: `tokio::sync::broadcast`
  fan-out + per-id ring buffer for `Last-Event-ID` replay.
  `replay_after()` returns `Events`, `Caught`, or `Gap`.
- `SessionEvent = Started | Span | StatusChanged | Ended` —
  serde-tagged JSON. `event_name()` matches the SSE `event:` line.
- `AppState` gains `event_bus: Arc<EventBus>`. Wired through every
  router constructor.
- `ingest_traces` publishes `session.started` for genuinely-new rows
  and `session.span` for each ingested span. `end_session` publishes
  `session.ended`.
- Two new routes:
  - `GET /api/sessions/stream` — every event
  - `GET /api/sessions/{session_id}/stream` — events for one session
- axum `Sse` response with `KeepAlive::interval(15s)` for heartbeat.
  Handlers parse `Last-Event-ID` from header **or** `?last_event_id=`
  (HTTP/2 proxies sometimes strip the header), replay buffered
  events, then tail the broadcast. `Lagged` closes the connection so
  the client reconnects through the same replay path. `replay_gap`
  is emitted when the requested id has aged out of the ring.
- New workspace deps `async-stream` and `futures-core`.

## Client (`gctrl-board`)

- New hook `useSessionStream` wrapping the browser `EventSource`.
  Callbacks held in refs so subscriptions don't churn on every
  render. Browser preserves `Last-Event-ID` across reconnects; the
  hook surfaces `replay_gap` so consumers refetch state then resume
  tailing.
- `AnalyticsPage.tsx` — removed every `setInterval` and the
  `LIVE_REFRESH_MS` constant. The 5 tabs each subscribe to the
  appropriate stream:
  - **Overview** — bump live count on `session.started`/`session.ended`;
    refetch aggregates on `session.ended` and on `replay_gap`.
  - **Sessions** — prepend a placeholder row on `session.started`,
    mark the row terminal on `session.ended`; refetch on gap.
  - **SessionDetailPane** — per-session stream; refetch trace tree on
    every `session.span` event for that session.
  - **Usage** / **Evals** — fetch on mount; refetch on `session.ended`
    (rollups change there) and on `replay_gap`.
- Tab bar status switched from "refresh 5s" to a pulsing "live"
  indicator pointing at the SSE endpoint.

## Spec

- Milestones §M0 marked **closed**. M0-preview retired; M0-final is
  the live state.
- Reuse table updated: live sessions are SSE-only, no shim.
- The `grep setInterval == 0` acceptance criterion is annotated
  **Verified**.

## Test plan

- [x] Kernel unit + integration tests — `cargo test -p gctrl-otel`
      90 pass, 0 fail (+9 event_bus, +3 sse_stream over the prior
      baseline).
- [x] Board vitest — 41 pass / 29 skipped / 0 fail.
- [x] `tsc --noEmit` clean for new code (only the two pre-existing
      `InboxMessage.source_name` errors that predate this branch).
- [x] `vite build` — 318 KB / 93 KB gzip.
- [x] `grep -c setInterval apps/gctrl-board/web/src/pages/AnalyticsPage.tsx`
      → `0`.
- [ ] Manual: with kernel running on :4318 and a live agent
      ingesting OTLP, watch the Overview's live count and Sessions
      list update without page refresh; close the connection and
      reconnect — verify `Last-Event-ID` replay drops nothing.
- [ ] CI green.
