### PR TITLE
feat(uebermensch): implement calendar M0 core (vault events + CLI)

### DIFF
--- a/apps/uebermensch/src/adapters/FileSystemCalendar.ts
+++ b/apps/uebermensch/src/adapters/FileSystemCalendar.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promi
 import { extname, join, relative } from "node:path"
 import { Effect, Layer, Schema } from "effect"
 import matter from "gray-matter"
-import { VaultError } from "../errors.js"
+import { VaultError, vaultIo } from "../errors.js"
 import { matchesFilter, sortByStart } from "../lib/calendar-filter.js"
 import { EventFrontmatter } from "../schemas.js"
 import {
@@ -29,7 +29,6 @@ const slugify = (s: string): string =>
     .slice(0, 60)
 
 const datePart = (startsAt: string): string => {
-  // Accept bare YYYY-MM-DD or full ISO 8601; emit YYYY-MM-DD.
   const bare = startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
   if (bare) return bare[1]
   const d = new Date(startsAt)
@@ -42,12 +41,16 @@ const datePart = (startsAt: string): string => {
   return `${y}-${m}-${day}`
 }
 
+const failVault = (
+  message: string,
+  path: string,
+  kind: "not_found" | "collision" | "io_failure" | "parse_failure",
+): Effect.Effect<never, VaultError> =>
+  Effect.fail(new VaultError({ message, path, kind }))
+
 type WalkEntry = { abs: string; rel: string }
 
-// Walk calendar/ recursively, skipping the recurring/ subdir for the first slice.
-const walkCalendar = async (
-  root: string,
-): Promise<ReadonlyArray<WalkEntry>> => {
+const walkCalendar = async (root: string): Promise<ReadonlyArray<WalkEntry>> => {
   const start = join(root, CALENDAR_DIR)
   const out: Array<WalkEntry> = []
   let entries: Array<import("node:fs").Dirent>
@@ -64,17 +67,15 @@ const walkCalendar = async (
     const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? start
     const abs = join(parent, e.name)
     const rel = relative(root, abs)
-    // Skip recurring/ files until RRULE expansion is implemented.
-    const insideRecurring = rel.split("/").includes(RECURRING_SUBDIR)
-    if (insideRecurring) continue
+    if (rel.split("/").includes(RECURRING_SUBDIR)) continue
     out.push({ abs, rel })
   }
   return out
 }
 
 // js-yaml auto-converts ISO 8601 strings to Date objects unless they're
-// quoted in the source. Normalise Date values back to ISO strings so the
-// schema (which expects strings) decodes hand-authored Obsidian files cleanly.
+// quoted in the source. Normalise back to ISO strings so the schema decodes
+// hand-authored Obsidian files cleanly.
 const normaliseDates = (v: unknown): unknown => {
   if (v instanceof Date) return v.toISOString()
   if (Array.isArray(v)) return v.map(normaliseDates)
@@ -88,26 +89,30 @@ const normaliseDates = (v: unknown): unknown => {
   return v
 }
 
+const decodeFrontmatter = (
+  data: unknown,
+  contextPath: string,
+  contextLabel: string,
+) =>
+  Schema.decodeUnknown(EventFrontmatter)(data).pipe(
+    Effect.mapError(
+      (e) =>
+        new VaultError({
+          message: `${contextLabel} invalid frontmatter: ${String(e)}`,
+          path: contextPath,
+          kind: "parse_failure",
+        }),
+    ),
+  )
+
 const decodeEvent = (
   entry: WalkEntry,
   raw: string,
 ): Effect.Effect<CalendarEvent, VaultError> =>
   Effect.gen(function* () {
     const parsed = matter(raw)
-    const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>) as Record<
-      string,
-      unknown
-    >
-    const decoded = yield* Schema.decodeUnknown(EventFrontmatter)(data).pipe(
-      Effect.mapError(
-        (e) =>
-          new VaultError({
-            message: `event ${entry.rel} invalid frontmatter: ${String(e)}`,
-            path: entry.abs,
-            kind: "parse_failure",
-          }),
-      ),
-    )
+    const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>)
+    const decoded = yield* decodeFrontmatter(data, entry.abs, `event ${entry.rel}`)
     return {
       slug: decoded.slug,
       title: decoded.title,
@@ -138,27 +143,19 @@ const decodeEvent = (
     }
   })
 
-const loadAll = (vaultDir: string): Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError> =>
+const loadAll = (
+  vaultDir: string,
+): Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError> =>
   Effect.gen(function* () {
-    const entries = yield* Effect.tryPromise({
-      try: () => walkCalendar(vaultDir),
-      catch: (e) =>
-        new VaultError({
-          message: `list calendar failed: ${String(e)}`,
-          path: vaultDir,
-          kind: "io_failure",
-        }),
+    const entries = yield* vaultIo(() => walkCalendar(vaultDir), {
+      message: "list calendar failed",
+      path: vaultDir,
     })
     const out: Array<CalendarEvent> = []
     for (const entry of entries) {
-      const raw = yield* Effect.tryPromise({
-        try: () => readFile(entry.abs, "utf8"),
-        catch: (e) =>
-          new VaultError({
-            message: `read event failed: ${String(e)}`,
-            path: entry.abs,
-            kind: "io_failure",
-          }),
+      const raw = yield* vaultIo(() => readFile(entry.abs, "utf8"), {
+        message: "read event failed",
+        path: entry.abs,
       })
       out.push(yield* decodeEvent(entry, raw))
     }
@@ -175,75 +172,73 @@ const atomicWrite = async (absPath: string, content: string): Promise<void> => {
 const renderFrontmatter = (data: Record<string, unknown>, body: string): string =>
   matter.stringify(body, data)
 
+// Drop empty arrays and nullish values so YAML stays clean.
+const omitEmpty = (rec: Record<string, unknown>): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(rec)) {
+    if (v === undefined || v === null) continue
+    if (Array.isArray(v) && v.length === 0) continue
+    out[k] = v
+  }
+  return out
+}
+
 export const FileSystemCalendarLive = (vaultDir: string) =>
   Layer.succeed(CalendarService, {
     list: (filter) =>
       Effect.gen(function* () {
         const all = yield* loadAll(vaultDir)
-        const matched = all.filter((e) => matchesFilter(e, filter))
-        return sortByStart(matched)
+        return sortByStart(all.filter((e) => matchesFilter(e, filter)))
       }),
 
     get: (slug) =>
       Effect.gen(function* () {
         const all = yield* loadAll(vaultDir)
-        for (const e of all) if (e.slug === slug) return e
-        return yield* Effect.fail(
-          new VaultError({
-            message: `event not found: ${slug}`,
-            path: join(vaultDir, CALENDAR_DIR),
-            kind: "not_found",
-          }),
+        const found = all.find((e) => e.slug === slug)
+        if (found) return found
+        return yield* failVault(
+          `event not found: ${slug}`,
+          join(vaultDir, CALENDAR_DIR),
+          "not_found",
         )
       }),
 
     add: (input: EventAddInput) =>
       Effect.gen(function* () {
         const all = yield* loadAll(vaultDir)
+        const calRoot = join(vaultDir, CALENDAR_DIR)
         const slug = input.slug ?? slugify(input.title)
         if (slug.length === 0) {
-          return yield* Effect.fail(
-            new VaultError({
-              message: `cannot derive slug from title: ${input.title}`,
-              path: join(vaultDir, CALENDAR_DIR),
-              kind: "parse_failure",
-            }),
+          return yield* failVault(
+            `cannot derive slug from title: ${input.title}`,
+            calRoot,
+            "parse_failure",
           )
         }
         if (all.some((e) => e.slug === slug)) {
-          return yield* Effect.fail(
-            new VaultError({
-              message: `event slug already exists: ${slug}`,
-              path: join(vaultDir, CALENDAR_DIR),
-              kind: "collision",
-            }),
+          return yield* failVault(
+            `event slug already exists: ${slug}`,
+            calRoot,
+            "collision",
           )
         }
 
-        const now = new Date().toISOString()
-        const datePrefix = (() => {
-          try {
-            return datePart(input.startsAt)
-          } catch {
-            return null
-          }
-        })()
-        if (!datePrefix) {
-          return yield* Effect.fail(
-            new VaultError({
-              message: `invalid starts_at: ${input.startsAt}`,
-              path: join(vaultDir, CALENDAR_DIR),
-              kind: "parse_failure",
-            }),
+        let datePrefix: string
+        try {
+          datePrefix = datePart(input.startsAt)
+        } catch {
+          return yield* failVault(
+            `invalid starts_at: ${input.startsAt}`,
+            calRoot,
+            "parse_failure",
           )
         }
-        const filename = `${datePrefix}--${slug}.md`
-        const relPath = `${CALENDAR_DIR}/${filename}`
+        const relPath = `${CALENDAR_DIR}/${datePrefix}--${slug}.md`
         const absPath = join(vaultDir, relPath)
-
         const body = (input.body ?? "").trimEnd()
-        // Build frontmatter object excluding undefined fields so YAML stays clean.
-        const fmInput: Record<string, unknown> = {
+        const now = new Date().toISOString()
+
+        const fmInput = omitEmpty({
           slug,
           title: input.title,
           kind: input.kind,
@@ -252,46 +247,29 @@ export const FileSystemCalendarLive = (vaultDir: string) =>
           tz: input.tz,
           status: input.status ?? "confirmed",
           all_day: input.allDay ?? false,
+          ends_at: input.endsAt,
+          location: input.location,
+          tickers: input.tickers,
+          topics: input.topics,
+          theses: input.theses,
+          tags: input.tags,
+          related_pages: input.relatedPages,
           created_at: now,
           updated_at: now,
           generator: GENERATOR,
-        }
-        if (input.endsAt) fmInput.ends_at = input.endsAt
-        if (input.location) fmInput.location = input.location
-        if (input.tickers && input.tickers.length > 0) fmInput.tickers = input.tickers
-        if (input.topics && input.topics.length > 0) fmInput.topics = input.topics
-        if (input.theses && input.theses.length > 0) fmInput.theses = input.theses
-        if (input.tags && input.tags.length > 0) fmInput.tags = input.tags
-        if (input.relatedPages && input.relatedPages.length > 0) {
-          fmInput.related_pages = input.relatedPages
-        }
+        })
 
-        // Validate the frontmatter we're about to write — fail fast on bad enum values.
-        yield* Schema.decodeUnknown(EventFrontmatter)(fmInput).pipe(
-          Effect.mapError(
-            (e) =>
-              new VaultError({
-                message: `event frontmatter invalid: ${String(e)}`,
-                path: absPath,
-                kind: "parse_failure",
-              }),
-          ),
-        )
+        // Validate before write — fail fast on bad enum values.
+        yield* decodeFrontmatter(fmInput, absPath, "event")
 
-        // Render once without content_hash, hash, then re-render with the hash embedded.
+        // Render once to compute the hash, then re-render with hash embedded.
         const draft = renderFrontmatter(fmInput, body)
         const contentHash = hashContent(draft)
-        const finalFm = { ...fmInput, content_hash: contentHash }
-        const final = renderFrontmatter(finalFm, body)
+        const final = renderFrontmatter({ ...fmInput, content_hash: contentHash }, body)
 
-        yield* Effect.tryPromise({
-          try: () => atomicWrite(absPath, final),
-          catch: (e) =>
-            new VaultError({
-              message: `write event failed: ${String(e)}`,
-              path: absPath,
-              kind: "io_failure",
-            }),
+        yield* vaultIo(() => atomicWrite(absPath, final), {
+          message: "write event failed",
+          path: absPath,
         })
 
         return { slug, absPath, relPath, contentHash }
@@ -302,22 +280,15 @@ export const FileSystemCalendarLive = (vaultDir: string) =>
         const all = yield* loadAll(vaultDir)
         const target = all.find((e) => e.slug === slug)
         if (!target) {
-          return yield* Effect.fail(
-            new VaultError({
-              message: `event not found: ${slug}`,
-              path: join(vaultDir, CALENDAR_DIR),
-              kind: "not_found",
-            }),
+          return yield* failVault(
+            `event not found: ${slug}`,
+            join(vaultDir, CALENDAR_DIR),
+            "not_found",
           )
         }
-        const raw = yield* Effect.tryPromise({
-          try: () => readFile(target.absPath, "utf8"),
-          catch: (e) =>
-            new VaultError({
-              message: `read event failed: ${String(e)}`,
-              path: target.absPath,
-              kind: "io_failure",
-            }),
+        const raw = yield* vaultIo(() => readFile(target.absPath, "utf8"), {
+          message: "read event failed",
+          path: target.absPath,
         })
         const parsed = matter(raw)
         const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
@@ -327,26 +298,15 @@ export const FileSystemCalendarLive = (vaultDir: string) =>
         data.updated_at = stamp.updatedAt ?? new Date().toISOString()
         const rebuilt = renderFrontmatter(data, parsed.content)
         // Re-stat to make sure the file wasn't replaced under us mid-stamp.
-        yield* Effect.tryPromise({
-          try: () => stat(target.absPath),
-          catch: (e) =>
-            new VaultError({
-              message: `stat failed: ${String(e)}`,
-              path: target.absPath,
-              kind: "io_failure",
-            }),
+        yield* vaultIo(() => stat(target.absPath), {
+          message: "stat failed",
+          path: target.absPath,
         })
-        yield* Effect.tryPromise({
-          try: () => atomicWrite(target.absPath, rebuilt),
-          catch: (e) =>
-            new VaultError({
-              message: `stamp event failed: ${String(e)}`,
-              path: target.absPath,
-              kind: "io_failure",
-            }),
+        yield* vaultIo(() => atomicWrite(target.absPath, rebuilt), {
+          message: "stamp event failed",
+          path: target.absPath,
         })
       }),
   })
 
-// Exported for tests.
 export const _internal = { slugify, datePart, hashContent }

--- a/apps/uebermensch/src/adapters/FileSystemCalendar.ts
+++ b/apps/uebermensch/src/adapters/FileSystemCalendar.ts
@@ -1,0 +1,352 @@
+import { createHash } from "node:crypto"
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
+import { extname, join, relative } from "node:path"
+import { Effect, Layer, Schema } from "effect"
+import matter from "gray-matter"
+import { VaultError } from "../errors.js"
+import { matchesFilter, sortByStart } from "../lib/calendar-filter.js"
+import { EventFrontmatter } from "../schemas.js"
+import {
+  CalendarService,
+  type CalendarEvent,
+  type EventAddInput,
+  type EventStamp,
+} from "../services/CalendarService.js"
+
+const CALENDAR_DIR = "calendar"
+const RECURRING_SUBDIR = "recurring" // deferred — see calendar.md open question #2
+const GENERATOR = "gctrl-uber-cli"
+
+const hashContent = (s: string): string =>
+  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
+
+const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+
+const datePart = (startsAt: string): string => {
+  // Accept bare YYYY-MM-DD or full ISO 8601; emit YYYY-MM-DD.
+  const bare = startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
+  if (bare) return bare[1]
+  const d = new Date(startsAt)
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`invalid starts_at: ${startsAt}`)
+  }
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(d.getUTCDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+type WalkEntry = { abs: string; rel: string }
+
+// Walk calendar/ recursively, skipping the recurring/ subdir for the first slice.
+const walkCalendar = async (
+  root: string,
+): Promise<ReadonlyArray<WalkEntry>> => {
+  const start = join(root, CALENDAR_DIR)
+  const out: Array<WalkEntry> = []
+  let entries: Array<import("node:fs").Dirent>
+  try {
+    entries = await readdir(start, { recursive: true, withFileTypes: true })
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException
+    if (err.code === "ENOENT") return []
+    throw e
+  }
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (extname(e.name).toLowerCase() !== ".md") continue
+    const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? start
+    const abs = join(parent, e.name)
+    const rel = relative(root, abs)
+    // Skip recurring/ files until RRULE expansion is implemented.
+    const insideRecurring = rel.split("/").includes(RECURRING_SUBDIR)
+    if (insideRecurring) continue
+    out.push({ abs, rel })
+  }
+  return out
+}
+
+// js-yaml auto-converts ISO 8601 strings to Date objects unless they're
+// quoted in the source. Normalise Date values back to ISO strings so the
+// schema (which expects strings) decodes hand-authored Obsidian files cleanly.
+const normaliseDates = (v: unknown): unknown => {
+  if (v instanceof Date) return v.toISOString()
+  if (Array.isArray(v)) return v.map(normaliseDates)
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      out[k] = normaliseDates(val)
+    }
+    return out
+  }
+  return v
+}
+
+const decodeEvent = (
+  entry: WalkEntry,
+  raw: string,
+): Effect.Effect<CalendarEvent, VaultError> =>
+  Effect.gen(function* () {
+    const parsed = matter(raw)
+    const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>) as Record<
+      string,
+      unknown
+    >
+    const decoded = yield* Schema.decodeUnknown(EventFrontmatter)(data).pipe(
+      Effect.mapError(
+        (e) =>
+          new VaultError({
+            message: `event ${entry.rel} invalid frontmatter: ${String(e)}`,
+            path: entry.abs,
+            kind: "parse_failure",
+          }),
+      ),
+    )
+    return {
+      slug: decoded.slug,
+      title: decoded.title,
+      kind: decoded.kind,
+      source: decoded.source,
+      startsAt: decoded.starts_at,
+      endsAt: decoded.ends_at ?? null,
+      allDay: decoded.all_day ?? false,
+      tz: decoded.tz,
+      status: decoded.status,
+      location: decoded.location ?? null,
+      tickers: decoded.tickers ?? [],
+      topics: decoded.topics ?? [],
+      theses: decoded.theses ?? [],
+      tags: decoded.tags ?? [],
+      links: (decoded.links ?? []).map((l) => ({ title: l.title, url: l.url })),
+      relatedPages: decoded.related_pages ?? [],
+      reminders: decoded.reminders ?? [],
+      externalId: decoded.external_id ?? null,
+      externalEtag: decoded.external_etag ?? null,
+      generator: decoded.generator ?? null,
+      contentHash: decoded.content_hash ?? null,
+      createdAt: decoded.created_at ?? null,
+      updatedAt: decoded.updated_at ?? null,
+      body: parsed.content,
+      relPath: entry.rel,
+      absPath: entry.abs,
+    }
+  })
+
+const loadAll = (vaultDir: string): Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError> =>
+  Effect.gen(function* () {
+    const entries = yield* Effect.tryPromise({
+      try: () => walkCalendar(vaultDir),
+      catch: (e) =>
+        new VaultError({
+          message: `list calendar failed: ${String(e)}`,
+          path: vaultDir,
+          kind: "io_failure",
+        }),
+    })
+    const out: Array<CalendarEvent> = []
+    for (const entry of entries) {
+      const raw = yield* Effect.tryPromise({
+        try: () => readFile(entry.abs, "utf8"),
+        catch: (e) =>
+          new VaultError({
+            message: `read event failed: ${String(e)}`,
+            path: entry.abs,
+            kind: "io_failure",
+          }),
+      })
+      out.push(yield* decodeEvent(entry, raw))
+    }
+    return out
+  })
+
+const atomicWrite = async (absPath: string, content: string): Promise<void> => {
+  const tmp = `${absPath}.tmp-${process.pid}-${Date.now()}`
+  await mkdir(join(absPath, ".."), { recursive: true })
+  await writeFile(tmp, content, "utf8")
+  await rename(tmp, absPath)
+}
+
+const renderFrontmatter = (data: Record<string, unknown>, body: string): string =>
+  matter.stringify(body, data)
+
+export const FileSystemCalendarLive = (vaultDir: string) =>
+  Layer.succeed(CalendarService, {
+    list: (filter) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const matched = all.filter((e) => matchesFilter(e, filter))
+        return sortByStart(matched)
+      }),
+
+    get: (slug) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        for (const e of all) if (e.slug === slug) return e
+        return yield* Effect.fail(
+          new VaultError({
+            message: `event not found: ${slug}`,
+            path: join(vaultDir, CALENDAR_DIR),
+            kind: "not_found",
+          }),
+        )
+      }),
+
+    add: (input: EventAddInput) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const slug = input.slug ?? slugify(input.title)
+        if (slug.length === 0) {
+          return yield* Effect.fail(
+            new VaultError({
+              message: `cannot derive slug from title: ${input.title}`,
+              path: join(vaultDir, CALENDAR_DIR),
+              kind: "parse_failure",
+            }),
+          )
+        }
+        if (all.some((e) => e.slug === slug)) {
+          return yield* Effect.fail(
+            new VaultError({
+              message: `event slug already exists: ${slug}`,
+              path: join(vaultDir, CALENDAR_DIR),
+              kind: "collision",
+            }),
+          )
+        }
+
+        const now = new Date().toISOString()
+        const datePrefix = (() => {
+          try {
+            return datePart(input.startsAt)
+          } catch {
+            return null
+          }
+        })()
+        if (!datePrefix) {
+          return yield* Effect.fail(
+            new VaultError({
+              message: `invalid starts_at: ${input.startsAt}`,
+              path: join(vaultDir, CALENDAR_DIR),
+              kind: "parse_failure",
+            }),
+          )
+        }
+        const filename = `${datePrefix}--${slug}.md`
+        const relPath = `${CALENDAR_DIR}/${filename}`
+        const absPath = join(vaultDir, relPath)
+
+        const body = (input.body ?? "").trimEnd()
+        // Build frontmatter object excluding undefined fields so YAML stays clean.
+        const fmInput: Record<string, unknown> = {
+          slug,
+          title: input.title,
+          kind: input.kind,
+          source: "user",
+          starts_at: input.startsAt,
+          tz: input.tz,
+          status: input.status ?? "confirmed",
+          all_day: input.allDay ?? false,
+          created_at: now,
+          updated_at: now,
+          generator: GENERATOR,
+        }
+        if (input.endsAt) fmInput.ends_at = input.endsAt
+        if (input.location) fmInput.location = input.location
+        if (input.tickers && input.tickers.length > 0) fmInput.tickers = input.tickers
+        if (input.topics && input.topics.length > 0) fmInput.topics = input.topics
+        if (input.theses && input.theses.length > 0) fmInput.theses = input.theses
+        if (input.tags && input.tags.length > 0) fmInput.tags = input.tags
+        if (input.relatedPages && input.relatedPages.length > 0) {
+          fmInput.related_pages = input.relatedPages
+        }
+
+        // Validate the frontmatter we're about to write — fail fast on bad enum values.
+        yield* Schema.decodeUnknown(EventFrontmatter)(fmInput).pipe(
+          Effect.mapError(
+            (e) =>
+              new VaultError({
+                message: `event frontmatter invalid: ${String(e)}`,
+                path: absPath,
+                kind: "parse_failure",
+              }),
+          ),
+        )
+
+        // Render once without content_hash, hash, then re-render with the hash embedded.
+        const draft = renderFrontmatter(fmInput, body)
+        const contentHash = hashContent(draft)
+        const finalFm = { ...fmInput, content_hash: contentHash }
+        const final = renderFrontmatter(finalFm, body)
+
+        yield* Effect.tryPromise({
+          try: () => atomicWrite(absPath, final),
+          catch: (e) =>
+            new VaultError({
+              message: `write event failed: ${String(e)}`,
+              path: absPath,
+              kind: "io_failure",
+            }),
+        })
+
+        return { slug, absPath, relPath, contentHash }
+      }),
+
+    stamp: (slug, stamp: EventStamp) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const target = all.find((e) => e.slug === slug)
+        if (!target) {
+          return yield* Effect.fail(
+            new VaultError({
+              message: `event not found: ${slug}`,
+              path: join(vaultDir, CALENDAR_DIR),
+              kind: "not_found",
+            }),
+          )
+        }
+        const raw = yield* Effect.tryPromise({
+          try: () => readFile(target.absPath, "utf8"),
+          catch: (e) =>
+            new VaultError({
+              message: `read event failed: ${String(e)}`,
+              path: target.absPath,
+              kind: "io_failure",
+            }),
+        })
+        const parsed = matter(raw)
+        const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
+        if (stamp.status !== undefined) data.status = stamp.status
+        if (stamp.externalEtag !== undefined) data.external_etag = stamp.externalEtag
+        if (stamp.contentHash !== undefined) data.content_hash = stamp.contentHash
+        data.updated_at = stamp.updatedAt ?? new Date().toISOString()
+        const rebuilt = renderFrontmatter(data, parsed.content)
+        // Re-stat to make sure the file wasn't replaced under us mid-stamp.
+        yield* Effect.tryPromise({
+          try: () => stat(target.absPath),
+          catch: (e) =>
+            new VaultError({
+              message: `stat failed: ${String(e)}`,
+              path: target.absPath,
+              kind: "io_failure",
+            }),
+        })
+        yield* Effect.tryPromise({
+          try: () => atomicWrite(target.absPath, rebuilt),
+          catch: (e) =>
+            new VaultError({
+              message: `stamp event failed: ${String(e)}`,
+              path: target.absPath,
+              kind: "io_failure",
+            }),
+        })
+      }),
+  })
+
+// Exported for tests.
+export const _internal = { slugify, datePart, hashContent }

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -2,6 +2,7 @@ import { Command } from "@effect/cli"
 import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 import { brief } from "../commands/brief.js"
+import { calendar } from "../commands/calendar.js"
 import { ingest } from "../commands/ingest.js"
 import { profile } from "../commands/profile-validate.js"
 import { prompts } from "../commands/prompts.js"
@@ -11,7 +12,7 @@ import { sync } from "../commands/sync.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, sync]),
+  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, calendar, sync]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/commands/calendar.ts
+++ b/apps/uebermensch/src/commands/calendar.ts
@@ -1,15 +1,18 @@
 import { Args, Command, Options } from "@effect/cli"
-import { Console, Effect, Option } from "effect"
+import { Console, Effect, Option, pipe } from "effect"
 import { FileSystemCalendarLive } from "../adapters/FileSystemCalendar.js"
 import { resolveVaultDir } from "../lib/env.js"
 import { parseDateShortcut } from "../lib/calendar-filter.js"
 import {
   CalendarService,
-  type EventFilter,
+  type CalendarEvent,
   type EventAddInput,
+  type EventFilter,
 } from "../services/CalendarService.js"
-import type { CalendarEvent } from "../services/CalendarService.js"
 import type { EventKind, EventSource, EventStatus } from "../schemas.js"
+
+// --- enum allowlists (mirror the Schema literals; kept here so option help text
+// can list them) ---
 
 const KINDS: ReadonlyArray<EventKind> = [
   "personal",
@@ -33,11 +36,15 @@ const SOURCES: ReadonlyArray<EventSource> = [
 ]
 const STATUSES: ReadonlyArray<EventStatus> = ["confirmed", "tentative", "cancelled"]
 
+// --- small helpers (Option / CSV / enum validation) ---
+
 const splitCsv = (s: string): ReadonlyArray<string> =>
-  s
-    .split(",")
-    .map((x) => x.trim())
-    .filter((x) => x.length > 0)
+  s.split(",").map((x) => x.trim()).filter((x) => x.length > 0)
+
+const csvOpt = (
+  opt: Option.Option<string>,
+): ReadonlyArray<string> | undefined =>
+  pipe(opt, Option.map(splitCsv), Option.getOrUndefined)
 
 const validateEnum = <T extends string>(
   values: ReadonlyArray<string>,
@@ -54,23 +61,14 @@ const validateEnum = <T extends string>(
     return values.filter((v): v is T => (allowed as ReadonlyArray<string>).includes(v))
   })
 
-// --- shared option helpers ---
+// --- shared option declarations (reused across list + add) ---
 
 const optList = (long: string, desc: string) =>
   Options.text(long).pipe(Options.withDescription(desc), Options.optional)
 
-const sourceOpt = optList(
-  "source",
-  "comma-separated origins (user,driver-markets,driver-sec,driver-gcal,import)",
-)
-const kindOpt = optList(
-  "kind",
-  "comma-separated event kinds (personal,earnings,macro,deadline,…)",
-)
-const fromOpt = optList(
-  "from",
-  "lower bound (today, tomorrow, +Nd, +Nw, eom, or YYYY-MM-DD)",
-)
+const sourceOpt = optList("source", `comma-separated origins (${SOURCES.join(",")})`)
+const kindOpt = optList("kind", "comma-separated event kinds (personal,earnings,macro,…)")
+const fromOpt = optList("from", "lower bound (today, tomorrow, +Nd, +Nw, eom, or YYYY-MM-DD)")
 const toOpt = optList("to", "upper bound (same shortcuts as --from)")
 const tickersOpt = optList("tickers", "comma-separated tickers (e.g. NVDA,AMZN)")
 const topicsOpt = optList("topics", "comma-separated topic slugs")
@@ -85,80 +83,72 @@ const qOpt = Options.text("q").pipe(
   Options.optional,
 )
 
-const buildFilter = (
-  source: Option.Option<string>,
-  kind: Option.Option<string>,
-  from: Option.Option<string>,
-  to: Option.Option<string>,
-  tickers: Option.Option<string>,
-  topics: Option.Option<string>,
-  theses: Option.Option<string>,
-  tag: Option.Option<string>,
-  status: Option.Option<string>,
-  q: Option.Option<string>,
-): Effect.Effect<EventFilter, never> =>
+// --- buildFilter: turns CLI-Option inputs into an EventFilter ---
+
+const resolveDate = (
+  opt: Option.Option<string>,
+  bound: "from" | "to",
+  now: Date,
+): Effect.Effect<string | undefined, never> =>
+  Effect.gen(function* () {
+    const raw = Option.getOrUndefined(opt)
+    if (!raw) return undefined
+    const d = parseDateShortcut(raw, now, bound)
+    if (!d) {
+      yield* Console.error(`  ! invalid --${bound}: ${raw}`)
+      return undefined
+    }
+    return d.toISOString()
+  })
+
+const buildFilter = (opts: {
+  sourceOpt: Option.Option<string>
+  kindOpt: Option.Option<string>
+  fromOpt: Option.Option<string>
+  toOpt: Option.Option<string>
+  tickersOpt: Option.Option<string>
+  topicsOpt: Option.Option<string>
+  thesesOpt: Option.Option<string>
+  tagOpt: Option.Option<string>
+  statusOpt: Option.Option<string>
+  qOpt: Option.Option<string>
+}): Effect.Effect<EventFilter, never> =>
   Effect.gen(function* () {
     const now = new Date()
-    const filter: {
-      source?: ReadonlyArray<EventSource>
-      kind?: ReadonlyArray<EventKind>
-      from?: string
-      to?: string
-      tickers?: ReadonlyArray<string>
-      topics?: ReadonlyArray<string>
-      theses?: ReadonlyArray<string>
-      tags?: ReadonlyArray<string>
-      status: ReadonlyArray<EventStatus>
-      q?: string
-    } = { status: ["confirmed"] }
-
-    const srcRaw = Option.getOrUndefined(source)
-    if (srcRaw) {
-      filter.source = yield* validateEnum<EventSource>(splitCsv(srcRaw), SOURCES, "source")
+    const sourceCsv = csvOpt(opts.sourceOpt)
+    const kindCsv = csvOpt(opts.kindOpt)
+    const statusCsv = csvOpt(opts.statusOpt)
+    const tickers = csvOpt(opts.tickersOpt)?.map((t) => t.toUpperCase())
+    return {
+      status: statusCsv
+        ? yield* validateEnum<EventStatus>(statusCsv, STATUSES, "status")
+        : ["confirmed"],
+      ...(sourceCsv && {
+        source: yield* validateEnum<EventSource>(sourceCsv, SOURCES, "source"),
+      }),
+      ...(kindCsv && {
+        kind: yield* validateEnum<EventKind>(kindCsv, KINDS, "kind"),
+      }),
+      ...(tickers && { tickers }),
+      ...partial("topics", csvOpt(opts.topicsOpt)),
+      ...partial("theses", csvOpt(opts.thesesOpt)),
+      ...partial("tags", csvOpt(opts.tagOpt)),
+      ...partial("from", yield* resolveDate(opts.fromOpt, "from", now)),
+      ...partial("to", yield* resolveDate(opts.toOpt, "to", now)),
+      ...partial("q", Option.getOrUndefined(opts.qOpt)),
     }
-    const kindRaw = Option.getOrUndefined(kind)
-    if (kindRaw) {
-      filter.kind = yield* validateEnum<EventKind>(splitCsv(kindRaw), KINDS, "kind")
-    }
-    const fromRaw = Option.getOrUndefined(from)
-    if (fromRaw) {
-      const d = parseDateShortcut(fromRaw, now, "from")
-      if (d) filter.from = d.toISOString()
-      else yield* Console.error(`  ! invalid --from: ${fromRaw}`)
-    }
-    const toRaw = Option.getOrUndefined(to)
-    if (toRaw) {
-      const d = parseDateShortcut(toRaw, now, "to")
-      if (d) filter.to = d.toISOString()
-      else yield* Console.error(`  ! invalid --to: ${toRaw}`)
-    }
-    const tickersRaw = Option.getOrUndefined(tickers)
-    if (tickersRaw) filter.tickers = splitCsv(tickersRaw).map((t) => t.toUpperCase())
-    const topicsRaw = Option.getOrUndefined(topics)
-    if (topicsRaw) filter.topics = splitCsv(topicsRaw)
-    const thesesRaw = Option.getOrUndefined(theses)
-    if (thesesRaw) filter.theses = splitCsv(thesesRaw)
-    const tagRaw = Option.getOrUndefined(tag)
-    if (tagRaw) filter.tags = splitCsv(tagRaw)
-    const statusRaw = Option.getOrUndefined(status)
-    if (statusRaw) {
-      filter.status = yield* validateEnum<EventStatus>(
-        splitCsv(statusRaw),
-        STATUSES,
-        "status",
-      )
-    }
-    const qRaw = Option.getOrUndefined(q)
-    if (qRaw) filter.q = qRaw
-
-    return filter
   })
+
+// {key: value} when value is defined, else {} — for clean object spreads.
+const partial = <K extends string, V>(
+  key: K,
+  value: V | undefined,
+): Partial<Record<K, V>> => (value === undefined ? {} : ({ [key]: value } as Record<K, V>))
 
 // --- output rendering ---
 
 const formatTime = (e: CalendarEvent): string => {
   if (e.allDay) return "all-day"
-  // Render in event's tz when supported by the host runtime; fall back to ISO time.
   const d = new Date(e.startsAt)
   if (Number.isNaN(d.getTime())) return e.startsAt
   try {
@@ -176,42 +166,19 @@ const formatTime = (e: CalendarEvent): string => {
 
 const formatLine = (e: CalendarEvent): string => {
   const date = e.startsAt.slice(0, 10)
-  const time = formatTime(e)
   const tickers = e.tickers.length > 0 ? ` [${e.tickers.join(",")}]` : ""
-  return `${e.status.padEnd(9)} ${date} ${time.padEnd(14)} ${e.kind.padEnd(17)} ${e.source.padEnd(15)} ${e.title}${tickers}  #${e.slug}`
+  return `${e.status.padEnd(9)} ${date} ${formatTime(e).padEnd(14)} ${e.kind.padEnd(17)} ${e.source.padEnd(15)} ${e.title}${tickers}  #${e.slug}`
 }
 
 // --- commands ---
 
 const list = Command.make(
   "list",
-  {
-    sourceOpt,
-    kindOpt,
-    fromOpt,
-    toOpt,
-    tickersOpt,
-    topicsOpt,
-    thesesOpt,
-    tagOpt,
-    statusOpt,
-    qOpt,
-  },
+  { sourceOpt, kindOpt, fromOpt, toOpt, tickersOpt, topicsOpt, thesesOpt, tagOpt, statusOpt, qOpt },
   (opts) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
-      const filter = yield* buildFilter(
-        opts.sourceOpt,
-        opts.kindOpt,
-        opts.fromOpt,
-        opts.toOpt,
-        opts.tickersOpt,
-        opts.topicsOpt,
-        opts.thesesOpt,
-        opts.tagOpt,
-        opts.statusOpt,
-        opts.qOpt,
-      )
+      const filter = yield* buildFilter(opts)
       const program = Effect.gen(function* () {
         const cal = yield* CalendarService
         const events = yield* cal.list(filter)
@@ -254,11 +221,9 @@ const show = Command.make(
     }),
 ).pipe(Command.withDescription("Show one event with frontmatter and body"))
 
-// --- add ---
+// --- add — required + optional fields ---
 
-const titleOpt = Options.text("title").pipe(
-  Options.withDescription("event title (required)"),
-)
+const titleOpt = Options.text("title").pipe(Options.withDescription("event title (required)"))
 const startOpt = Options.text("start").pipe(
   Options.withDescription("ISO 8601 start (e.g. 2026-05-08T14:00:00+08:00 or 2026-05-08 with --all-day)"),
 )
@@ -284,22 +249,6 @@ const locationOpt = Options.text("location").pipe(
   Options.withDescription("free-form location string"),
   Options.optional,
 )
-const addTickersOpt = Options.text("tickers").pipe(
-  Options.withDescription("comma-separated tickers"),
-  Options.optional,
-)
-const addTopicsOpt = Options.text("topics").pipe(
-  Options.withDescription("comma-separated topic slugs"),
-  Options.optional,
-)
-const addThesesOpt = Options.text("theses").pipe(
-  Options.withDescription("comma-separated thesis slugs"),
-  Options.optional,
-)
-const addTagsOpt = Options.text("tag").pipe(
-  Options.withDescription("comma-separated tags"),
-  Options.optional,
-)
 const bodyOpt = Options.text("body").pipe(
   Options.withDescription("free-form body markdown (notes, agenda)"),
   Options.optional,
@@ -316,20 +265,16 @@ const add = Command.make(
     allDayOpt,
     slugAddOpt,
     locationOpt,
-    addTickersOpt,
-    addTopicsOpt,
-    addThesesOpt,
-    addTagsOpt,
+    tickersOpt,
+    topicsOpt,
+    thesesOpt,
+    tagOpt,
     bodyOpt,
   },
   (opts) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
-      const tickers = Option.getOrUndefined(opts.addTickersOpt)
-      const topics = Option.getOrUndefined(opts.addTopicsOpt)
-      const theses = Option.getOrUndefined(opts.addThesesOpt)
-      const tags = Option.getOrUndefined(opts.addTagsOpt)
-
+      const tickers = csvOpt(opts.tickersOpt)?.map((t) => t.toUpperCase())
       const input: EventAddInput = {
         title: opts.titleOpt,
         startsAt: opts.startOpt,
@@ -340,12 +285,11 @@ const add = Command.make(
         location: Option.getOrUndefined(opts.locationOpt),
         slug: Option.getOrUndefined(opts.slugAddOpt),
         body: Option.getOrUndefined(opts.bodyOpt),
-        tickers: tickers ? splitCsv(tickers).map((t) => t.toUpperCase()) : undefined,
-        topics: topics ? splitCsv(topics) : undefined,
-        theses: theses ? splitCsv(theses) : undefined,
-        tags: tags ? splitCsv(tags) : undefined,
+        tickers,
+        topics: csvOpt(opts.topicsOpt),
+        theses: csvOpt(opts.thesesOpt),
+        tags: csvOpt(opts.tagOpt),
       }
-
       const program = Effect.gen(function* () {
         const cal = yield* CalendarService
         const w = yield* cal.add(input)

--- a/apps/uebermensch/src/commands/calendar.ts
+++ b/apps/uebermensch/src/commands/calendar.ts
@@ -1,0 +1,362 @@
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Option } from "effect"
+import { FileSystemCalendarLive } from "../adapters/FileSystemCalendar.js"
+import { resolveVaultDir } from "../lib/env.js"
+import { parseDateShortcut } from "../lib/calendar-filter.js"
+import {
+  CalendarService,
+  type EventFilter,
+  type EventAddInput,
+} from "../services/CalendarService.js"
+import type { CalendarEvent } from "../services/CalendarService.js"
+import type { EventKind, EventSource, EventStatus } from "../schemas.js"
+
+const KINDS: ReadonlyArray<EventKind> = [
+  "personal",
+  "deadline",
+  "travel",
+  "earnings",
+  "macro",
+  "regulatory",
+  "corporate-action",
+  "political",
+  "prediction-market",
+  "industry",
+  "other",
+]
+const SOURCES: ReadonlyArray<EventSource> = [
+  "user",
+  "driver-markets",
+  "driver-sec",
+  "driver-gcal",
+  "import",
+]
+const STATUSES: ReadonlyArray<EventStatus> = ["confirmed", "tentative", "cancelled"]
+
+const splitCsv = (s: string): ReadonlyArray<string> =>
+  s
+    .split(",")
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0)
+
+const validateEnum = <T extends string>(
+  values: ReadonlyArray<string>,
+  allowed: ReadonlyArray<T>,
+  field: string,
+): Effect.Effect<ReadonlyArray<T>, never> =>
+  Effect.gen(function* () {
+    const bad = values.filter((v) => !(allowed as ReadonlyArray<string>).includes(v))
+    if (bad.length > 0) {
+      yield* Console.error(
+        `  ! invalid ${field}: ${bad.join(", ")} (allowed: ${allowed.join(", ")})`,
+      )
+    }
+    return values.filter((v): v is T => (allowed as ReadonlyArray<string>).includes(v))
+  })
+
+// --- shared option helpers ---
+
+const optList = (long: string, desc: string) =>
+  Options.text(long).pipe(Options.withDescription(desc), Options.optional)
+
+const sourceOpt = optList(
+  "source",
+  "comma-separated origins (user,driver-markets,driver-sec,driver-gcal,import)",
+)
+const kindOpt = optList(
+  "kind",
+  "comma-separated event kinds (personal,earnings,macro,deadline,…)",
+)
+const fromOpt = optList(
+  "from",
+  "lower bound (today, tomorrow, +Nd, +Nw, eom, or YYYY-MM-DD)",
+)
+const toOpt = optList("to", "upper bound (same shortcuts as --from)")
+const tickersOpt = optList("tickers", "comma-separated tickers (e.g. NVDA,AMZN)")
+const topicsOpt = optList("topics", "comma-separated topic slugs")
+const thesesOpt = optList("theses", "comma-separated thesis slugs")
+const tagOpt = optList("tag", "comma-separated tags")
+const statusOpt = optList(
+  "status",
+  "comma-separated status (default: confirmed; pass tentative,confirmed to widen)",
+)
+const qOpt = Options.text("q").pipe(
+  Options.withDescription("case-insensitive substring on title or body"),
+  Options.optional,
+)
+
+const buildFilter = (
+  source: Option.Option<string>,
+  kind: Option.Option<string>,
+  from: Option.Option<string>,
+  to: Option.Option<string>,
+  tickers: Option.Option<string>,
+  topics: Option.Option<string>,
+  theses: Option.Option<string>,
+  tag: Option.Option<string>,
+  status: Option.Option<string>,
+  q: Option.Option<string>,
+): Effect.Effect<EventFilter, never> =>
+  Effect.gen(function* () {
+    const now = new Date()
+    const filter: {
+      source?: ReadonlyArray<EventSource>
+      kind?: ReadonlyArray<EventKind>
+      from?: string
+      to?: string
+      tickers?: ReadonlyArray<string>
+      topics?: ReadonlyArray<string>
+      theses?: ReadonlyArray<string>
+      tags?: ReadonlyArray<string>
+      status: ReadonlyArray<EventStatus>
+      q?: string
+    } = { status: ["confirmed"] }
+
+    const srcRaw = Option.getOrUndefined(source)
+    if (srcRaw) {
+      filter.source = yield* validateEnum<EventSource>(splitCsv(srcRaw), SOURCES, "source")
+    }
+    const kindRaw = Option.getOrUndefined(kind)
+    if (kindRaw) {
+      filter.kind = yield* validateEnum<EventKind>(splitCsv(kindRaw), KINDS, "kind")
+    }
+    const fromRaw = Option.getOrUndefined(from)
+    if (fromRaw) {
+      const d = parseDateShortcut(fromRaw, now, "from")
+      if (d) filter.from = d.toISOString()
+      else yield* Console.error(`  ! invalid --from: ${fromRaw}`)
+    }
+    const toRaw = Option.getOrUndefined(to)
+    if (toRaw) {
+      const d = parseDateShortcut(toRaw, now, "to")
+      if (d) filter.to = d.toISOString()
+      else yield* Console.error(`  ! invalid --to: ${toRaw}`)
+    }
+    const tickersRaw = Option.getOrUndefined(tickers)
+    if (tickersRaw) filter.tickers = splitCsv(tickersRaw).map((t) => t.toUpperCase())
+    const topicsRaw = Option.getOrUndefined(topics)
+    if (topicsRaw) filter.topics = splitCsv(topicsRaw)
+    const thesesRaw = Option.getOrUndefined(theses)
+    if (thesesRaw) filter.theses = splitCsv(thesesRaw)
+    const tagRaw = Option.getOrUndefined(tag)
+    if (tagRaw) filter.tags = splitCsv(tagRaw)
+    const statusRaw = Option.getOrUndefined(status)
+    if (statusRaw) {
+      filter.status = yield* validateEnum<EventStatus>(
+        splitCsv(statusRaw),
+        STATUSES,
+        "status",
+      )
+    }
+    const qRaw = Option.getOrUndefined(q)
+    if (qRaw) filter.q = qRaw
+
+    return filter
+  })
+
+// --- output rendering ---
+
+const formatTime = (e: CalendarEvent): string => {
+  if (e.allDay) return "all-day"
+  // Render in event's tz when supported by the host runtime; fall back to ISO time.
+  const d = new Date(e.startsAt)
+  if (Number.isNaN(d.getTime())) return e.startsAt
+  try {
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: e.tz,
+    })
+    return `${fmt.format(d)} ${e.tz}`
+  } catch {
+    return e.startsAt
+  }
+}
+
+const formatLine = (e: CalendarEvent): string => {
+  const date = e.startsAt.slice(0, 10)
+  const time = formatTime(e)
+  const tickers = e.tickers.length > 0 ? ` [${e.tickers.join(",")}]` : ""
+  return `${e.status.padEnd(9)} ${date} ${time.padEnd(14)} ${e.kind.padEnd(17)} ${e.source.padEnd(15)} ${e.title}${tickers}  #${e.slug}`
+}
+
+// --- commands ---
+
+const list = Command.make(
+  "list",
+  {
+    sourceOpt,
+    kindOpt,
+    fromOpt,
+    toOpt,
+    tickersOpt,
+    topicsOpt,
+    thesesOpt,
+    tagOpt,
+    statusOpt,
+    qOpt,
+  },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const filter = yield* buildFilter(
+        opts.sourceOpt,
+        opts.kindOpt,
+        opts.fromOpt,
+        opts.toOpt,
+        opts.tickersOpt,
+        opts.topicsOpt,
+        opts.thesesOpt,
+        opts.tagOpt,
+        opts.statusOpt,
+        opts.qOpt,
+      )
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const events = yield* cal.list(filter)
+        if (events.length === 0) {
+          yield* Console.log(`(no matching events in ${vaultDir}/calendar/)`)
+          return
+        }
+        for (const e of events) yield* Console.log(formatLine(e))
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("List calendar events with optional filters"))
+
+const show = Command.make(
+  "show",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const e = yield* cal.get(slug)
+        yield* Console.log(`# ${e.title}`)
+        yield* Console.log(
+          `slug: ${e.slug}  kind: ${e.kind}  source: ${e.source}  status: ${e.status}`,
+        )
+        yield* Console.log(
+          `starts_at: ${e.startsAt}${e.endsAt ? `  ends_at: ${e.endsAt}` : ""}  tz: ${e.tz}${e.allDay ? "  (all-day)" : ""}`,
+        )
+        if (e.location) yield* Console.log(`location: ${e.location}`)
+        if (e.tickers.length > 0) yield* Console.log(`tickers: ${e.tickers.join(", ")}`)
+        if (e.topics.length > 0) yield* Console.log(`topics: ${e.topics.join(", ")}`)
+        if (e.theses.length > 0) yield* Console.log(`theses: ${e.theses.join(", ")}`)
+        if (e.tags.length > 0) yield* Console.log(`tags: ${e.tags.join(", ")}`)
+        yield* Console.log("")
+        yield* Console.log("--- body ---")
+        yield* Console.log(e.body.trim().length > 0 ? e.body.trim() : "(empty)")
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Show one event with frontmatter and body"))
+
+// --- add ---
+
+const titleOpt = Options.text("title").pipe(
+  Options.withDescription("event title (required)"),
+)
+const startOpt = Options.text("start").pipe(
+  Options.withDescription("ISO 8601 start (e.g. 2026-05-08T14:00:00+08:00 or 2026-05-08 with --all-day)"),
+)
+const endOpt = Options.text("end").pipe(
+  Options.withDescription("ISO 8601 end (optional)"),
+  Options.optional,
+)
+const tzOpt = Options.text("tz").pipe(
+  Options.withDescription("IANA tz the event is anchored to (e.g. America/New_York)"),
+)
+const kindRequiredOpt = Options.choice("kind", [...KINDS]).pipe(
+  Options.withDescription("event kind"),
+)
+const allDayOpt = Options.boolean("all-day").pipe(
+  Options.withDescription("treat starts_at / ends_at as YYYY-MM-DD whole-day"),
+  Options.withDefault(false),
+)
+const slugAddOpt = Options.text("slug").pipe(
+  Options.withDescription("explicit slug (otherwise derived from title)"),
+  Options.optional,
+)
+const locationOpt = Options.text("location").pipe(
+  Options.withDescription("free-form location string"),
+  Options.optional,
+)
+const addTickersOpt = Options.text("tickers").pipe(
+  Options.withDescription("comma-separated tickers"),
+  Options.optional,
+)
+const addTopicsOpt = Options.text("topics").pipe(
+  Options.withDescription("comma-separated topic slugs"),
+  Options.optional,
+)
+const addThesesOpt = Options.text("theses").pipe(
+  Options.withDescription("comma-separated thesis slugs"),
+  Options.optional,
+)
+const addTagsOpt = Options.text("tag").pipe(
+  Options.withDescription("comma-separated tags"),
+  Options.optional,
+)
+const bodyOpt = Options.text("body").pipe(
+  Options.withDescription("free-form body markdown (notes, agenda)"),
+  Options.optional,
+)
+
+const add = Command.make(
+  "add",
+  {
+    titleOpt,
+    startOpt,
+    endOpt,
+    tzOpt,
+    kindRequiredOpt,
+    allDayOpt,
+    slugAddOpt,
+    locationOpt,
+    addTickersOpt,
+    addTopicsOpt,
+    addThesesOpt,
+    addTagsOpt,
+    bodyOpt,
+  },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const tickers = Option.getOrUndefined(opts.addTickersOpt)
+      const topics = Option.getOrUndefined(opts.addTopicsOpt)
+      const theses = Option.getOrUndefined(opts.addThesesOpt)
+      const tags = Option.getOrUndefined(opts.addTagsOpt)
+
+      const input: EventAddInput = {
+        title: opts.titleOpt,
+        startsAt: opts.startOpt,
+        tz: opts.tzOpt,
+        kind: opts.kindRequiredOpt,
+        allDay: opts.allDayOpt,
+        endsAt: Option.getOrUndefined(opts.endOpt),
+        location: Option.getOrUndefined(opts.locationOpt),
+        slug: Option.getOrUndefined(opts.slugAddOpt),
+        body: Option.getOrUndefined(opts.bodyOpt),
+        tickers: tickers ? splitCsv(tickers).map((t) => t.toUpperCase()) : undefined,
+        topics: topics ? splitCsv(topics) : undefined,
+        theses: theses ? splitCsv(theses) : undefined,
+        tags: tags ? splitCsv(tags) : undefined,
+      }
+
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const w = yield* cal.add(input)
+        yield* Console.log(`✓ ${w.relPath} (${w.contentHash})`)
+        yield* Console.log(`  slug: ${w.slug}`)
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Add a personal (source: user) calendar event"))
+
+export const calendar = Command.make("calendar").pipe(
+  Command.withSubcommands([list, show, add]),
+  Command.withDescription("Manage calendar events in $UBER_VAULT_DIR/calendar/"),
+)

--- a/apps/uebermensch/src/errors.ts
+++ b/apps/uebermensch/src/errors.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import { Effect, Schema } from "effect"
 
 export class VaultError extends Schema.TaggedError<VaultError>()("VaultError", {
   message: Schema.String,
@@ -7,6 +7,29 @@ export class VaultError extends Schema.TaggedError<VaultError>()("VaultError", {
     Schema.Literal("not_found", "collision", "io_failure", "parse_failure"),
   ),
 }) {}
+
+// Wrap a node:fs (or similar) Promise call as an Effect that fails with a
+// VaultError. Eliminates ~6 lines of catch-and-construct boilerplate per call site.
+export const vaultIo = <T>(
+  fn: () => Promise<T>,
+  opts: {
+    readonly message: string | ((e: unknown) => string)
+    readonly path?: string
+    readonly kind?: "not_found" | "collision" | "io_failure" | "parse_failure"
+  },
+): Effect.Effect<T, VaultError> =>
+  Effect.tryPromise({
+    try: fn,
+    catch: (e) =>
+      new VaultError({
+        message:
+          typeof opts.message === "function"
+            ? opts.message(e)
+            : `${opts.message}: ${String(e)}`,
+        path: opts.path,
+        kind: opts.kind ?? "io_failure",
+      }),
+  })
 
 export class ProfileError extends Schema.TaggedError<ProfileError>()("ProfileError", {
   message: Schema.String,

--- a/apps/uebermensch/src/lib/calendar-filter.ts
+++ b/apps/uebermensch/src/lib/calendar-filter.ts
@@ -1,0 +1,117 @@
+// Pure helpers for calendar filtering — no I/O.
+// Spec: apps/uebermensch/specs/calendar.md § Filter predicates.
+
+import type { CalendarEvent, EventFilter } from "../services/CalendarService.js"
+
+const DAY_MS = 86_400_000
+
+const startOfUtcDay = (d: Date): Date =>
+  new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+
+const endOfUtcDay = (d: Date): Date =>
+  new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 23, 59, 59, 999),
+  )
+
+const endOfUtcMonth = (d: Date): Date => {
+  // Day 0 of next month = last day of this month
+  const nextMonth = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0))
+  return endOfUtcDay(nextMonth)
+}
+
+// Spec § Filter predicates: today, tomorrow, +Nd, +Nw, eom, or YYYY-MM-DD passthrough.
+// `bound` distinguishes from-vs-to so plain YYYY-MM-DD shortcuts cover the whole day.
+export const parseDateShortcut = (
+  s: string,
+  now: Date,
+  bound: "from" | "to",
+): Date | null => {
+  const trimmed = s.trim().toLowerCase()
+  if (trimmed === "") return null
+
+  if (trimmed === "today") {
+    return bound === "from" ? startOfUtcDay(now) : endOfUtcDay(now)
+  }
+  if (trimmed === "tomorrow") {
+    const t = new Date(now.getTime() + DAY_MS)
+    return bound === "from" ? startOfUtcDay(t) : endOfUtcDay(t)
+  }
+  if (trimmed === "eom") {
+    // 'eom' as `from` means "from start of last day of month"; usually used as a `to`.
+    return bound === "from" ? startOfUtcDay(endOfUtcMonth(now)) : endOfUtcMonth(now)
+  }
+
+  // +Nd / +Nw (also accept -Nd / -Nw for symmetry, useful for "from -7d")
+  const rel = trimmed.match(/^([+-]?)(\d+)(d|w)$/)
+  if (rel) {
+    const sign = rel[1] === "-" ? -1 : 1
+    const n = Number.parseInt(rel[2], 10)
+    const days = rel[3] === "w" ? n * 7 : n
+    const t = new Date(now.getTime() + sign * days * DAY_MS)
+    return bound === "from" ? startOfUtcDay(t) : endOfUtcDay(t)
+  }
+
+  // Plain ISO date / datetime — passthrough; a bare YYYY-MM-DD covers the whole day.
+  const isoBare = trimmed.match(/^\d{4}-\d{2}-\d{2}$/)
+  if (isoBare) {
+    const d = new Date(`${trimmed}T00:00:00Z`)
+    if (Number.isNaN(d.getTime())) return null
+    return bound === "from" ? d : endOfUtcDay(d)
+  }
+  const full = new Date(s.trim())
+  if (Number.isNaN(full.getTime())) return null
+  return full
+}
+
+const intersects = (
+  a: ReadonlyArray<string> | undefined,
+  b: ReadonlyArray<string>,
+): boolean => {
+  if (!a || a.length === 0) return false
+  for (const x of a) if (b.includes(x)) return true
+  return false
+}
+
+const eventTime = (e: CalendarEvent): number => {
+  // For all-day or bare-date starts_at, parse as UTC start-of-day.
+  const s = e.startsAt
+  const isBare = /^\d{4}-\d{2}-\d{2}$/.test(s)
+  const ms = new Date(isBare ? `${s}T00:00:00Z` : s).getTime()
+  return Number.isFinite(ms) ? ms : 0
+}
+
+export const matchesFilter = (e: CalendarEvent, f: EventFilter | undefined): boolean => {
+  if (!f) return true
+  if (f.source && f.source.length > 0 && !f.source.includes(e.source)) return false
+  if (f.kind && f.kind.length > 0 && !f.kind.includes(e.kind)) return false
+  if (f.status && f.status.length > 0 && !f.status.includes(e.status)) return false
+
+  if (f.from || f.to) {
+    const t = eventTime(e)
+    if (f.from) {
+      const fromMs = new Date(f.from).getTime()
+      if (Number.isFinite(fromMs) && t < fromMs) return false
+    }
+    if (f.to) {
+      const toMs = new Date(f.to).getTime()
+      if (Number.isFinite(toMs) && t > toMs) return false
+    }
+  }
+
+  if (f.tickers && f.tickers.length > 0 && !intersects(e.tickers, f.tickers)) return false
+  if (f.topics && f.topics.length > 0 && !intersects(e.topics, f.topics)) return false
+  if (f.theses && f.theses.length > 0 && !intersects(e.theses, f.theses)) return false
+  if (f.tags && f.tags.length > 0 && !intersects(e.tags, f.tags)) return false
+
+  if (f.q && f.q.length > 0) {
+    const needle = f.q.toLowerCase()
+    const hay = `${e.title}\n${e.body}`.toLowerCase()
+    if (!hay.includes(needle)) return false
+  }
+
+  return true
+}
+
+// Stable display order: by event start time ascending.
+export const sortByStart = (events: ReadonlyArray<CalendarEvent>): ReadonlyArray<CalendarEvent> =>
+  [...events].sort((a, b) => eventTime(a) - eventTime(b))

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -105,3 +105,80 @@ export const PromptFrontmatter = Schema.Struct({
   cost_usd: Schema.optional(Schema.Number),
   failed_reason: Schema.optional(Schema.String),
 })
+
+// --- Calendar (specs/calendar.md) ---
+
+export const EventKind = Schema.Literal(
+  "personal",
+  "deadline",
+  "travel",
+  "earnings",
+  "macro",
+  "regulatory",
+  "corporate-action",
+  "political",
+  "prediction-market",
+  "industry",
+  "other",
+)
+export type EventKind = typeof EventKind.Type
+
+export const EventSource = Schema.Literal(
+  "user",
+  "driver-markets",
+  "driver-sec",
+  "driver-gcal",
+  "import",
+)
+export type EventSource = typeof EventSource.Type
+
+export const EventStatus = Schema.Literal("confirmed", "tentative", "cancelled")
+export type EventStatus = typeof EventStatus.Type
+
+// Uppercase ticker per spec § Validation Rules #5
+export const Ticker = Schema.String.pipe(Schema.pattern(/^[A-Z][A-Z0-9.\-]{0,9}$/))
+
+// ISO 8601 duration with leading sign (per spec § Validation Rules #9 — "-P1D", "-PT2H", "-PT15M")
+export const ReminderOffset = Schema.String.pipe(
+  Schema.pattern(/^-?P(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$/),
+)
+
+export const ReminderEntry = Schema.Struct({
+  offset: ReminderOffset,
+  channel: Schema.String,
+})
+export type ReminderEntry = typeof ReminderEntry.Type
+
+export const EventLink = Schema.Struct({
+  title: Schema.String,
+  url: Schema.String,
+})
+
+// Spec § Event Frontmatter — required: slug, title, kind, source, starts_at, tz, status.
+// Everything else optional. Unknown fields are tolerated by the loader (forward-compat).
+export const EventFrontmatter = Schema.Struct({
+  slug: Slug,
+  title: Schema.String,
+  kind: EventKind,
+  source: EventSource,
+  starts_at: IsoLike,
+  ends_at: Schema.optional(IsoLike),
+  all_day: Schema.optional(Schema.Boolean),
+  tz: Schema.String,
+  location: Schema.optional(Schema.String),
+  tickers: Schema.optional(Schema.Array(Ticker)),
+  topics: Schema.optional(Schema.Array(Slug)),
+  theses: Schema.optional(Schema.Array(Slug)),
+  tags: Schema.optional(Schema.Array(Schema.String)),
+  links: Schema.optional(Schema.Array(EventLink)),
+  related_pages: Schema.optional(Schema.Array(Slug)),
+  reminders: Schema.optional(Schema.Array(ReminderEntry)),
+  external_id: Schema.optional(Schema.String),
+  external_etag: Schema.optional(Schema.String),
+  status: EventStatus,
+  created_at: Schema.optional(IsoLike),
+  updated_at: Schema.optional(IsoLike),
+  generator: Schema.optional(Schema.String),
+  content_hash: Schema.optional(Schema.String),
+})
+export type EventFrontmatter = typeof EventFrontmatter.Type

--- a/apps/uebermensch/src/services/CalendarService.ts
+++ b/apps/uebermensch/src/services/CalendarService.ts
@@ -1,0 +1,103 @@
+import { Context, type Effect } from "effect"
+import type { VaultError } from "../errors.js"
+import type {
+  EventKind,
+  EventSource,
+  EventStatus,
+  ReminderEntry,
+} from "../schemas.js"
+
+export type EventLink = { readonly title: string; readonly url: string }
+
+export type CalendarEvent = {
+  readonly slug: string
+  readonly title: string
+  readonly kind: EventKind
+  readonly source: EventSource
+  readonly startsAt: string
+  readonly endsAt: string | null
+  readonly allDay: boolean
+  readonly tz: string
+  readonly status: EventStatus
+  readonly location: string | null
+  readonly tickers: ReadonlyArray<string>
+  readonly topics: ReadonlyArray<string>
+  readonly theses: ReadonlyArray<string>
+  readonly tags: ReadonlyArray<string>
+  readonly links: ReadonlyArray<EventLink>
+  readonly relatedPages: ReadonlyArray<string>
+  readonly reminders: ReadonlyArray<ReminderEntry>
+  readonly externalId: string | null
+  readonly externalEtag: string | null
+  readonly generator: string | null
+  readonly contentHash: string | null
+  readonly createdAt: string | null
+  readonly updatedAt: string | null
+  readonly body: string
+  readonly relPath: string
+  readonly absPath: string
+}
+
+// Filter predicates from spec § Filtering & Views.
+// Within a field, multi-value lists OR. Across fields, predicates AND.
+// `from`/`to` are pre-resolved absolute ISO strings (caller resolves shortcuts via lib/calendar-filter).
+export type EventFilter = {
+  readonly source?: ReadonlyArray<EventSource>
+  readonly kind?: ReadonlyArray<EventKind>
+  readonly from?: string
+  readonly to?: string
+  readonly tickers?: ReadonlyArray<string>
+  readonly topics?: ReadonlyArray<string>
+  readonly theses?: ReadonlyArray<string>
+  readonly tags?: ReadonlyArray<string>
+  readonly status?: ReadonlyArray<EventStatus>
+  readonly q?: string
+}
+
+// Inputs to add() — only what the user supplies; the adapter fills the rest
+// (slug, source=user, status=confirmed, generator, hashes, timestamps).
+export type EventAddInput = {
+  readonly title: string
+  readonly kind: EventKind
+  readonly startsAt: string
+  readonly endsAt?: string
+  readonly allDay?: boolean
+  readonly tz: string
+  readonly status?: EventStatus
+  readonly location?: string
+  readonly tickers?: ReadonlyArray<string>
+  readonly topics?: ReadonlyArray<string>
+  readonly theses?: ReadonlyArray<string>
+  readonly tags?: ReadonlyArray<string>
+  readonly relatedPages?: ReadonlyArray<string>
+  readonly body?: string
+  // Caller may force a slug; otherwise derived from title + starts_at date.
+  readonly slug?: string
+}
+
+export type WrittenEvent = {
+  readonly slug: string
+  readonly absPath: string
+  readonly relPath: string
+  readonly contentHash: string
+}
+
+// Partial frontmatter overlay, used by future driver upserts. Body is preserved.
+export type EventStamp = {
+  readonly status?: EventStatus
+  readonly externalEtag?: string
+  readonly updatedAt?: string
+  readonly contentHash?: string
+}
+
+export interface CalendarServiceShape {
+  readonly list: (filter?: EventFilter) => Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError>
+  readonly get: (slug: string) => Effect.Effect<CalendarEvent, VaultError>
+  readonly add: (input: EventAddInput) => Effect.Effect<WrittenEvent, VaultError>
+  readonly stamp: (slug: string, stamp: EventStamp) => Effect.Effect<void, VaultError>
+}
+
+export class CalendarService extends Context.Tag("uebermensch/CalendarService")<
+  CalendarService,
+  CalendarServiceShape
+>() {}

--- a/apps/uebermensch/tests/calendar.test.ts
+++ b/apps/uebermensch/tests/calendar.test.ts
@@ -1,0 +1,419 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect } from "effect"
+import matter from "gray-matter"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileSystemCalendarLive } from "../src/adapters/FileSystemCalendar.js"
+import {
+  matchesFilter,
+  parseDateShortcut,
+  sortByStart,
+} from "../src/lib/calendar-filter.js"
+import {
+  CalendarService,
+  type CalendarEvent,
+} from "../src/services/CalendarService.js"
+
+const seedFile = async (root: string, rel: string, frontmatter: string, body = "") => {
+  const full = join(root, rel)
+  await mkdir(join(full, ".."), { recursive: true })
+  const fm = frontmatter.trim().length === 0 ? "" : `---\n${frontmatter}---\n\n`
+  await writeFile(full, `${fm}${body}\n`, "utf8")
+}
+
+const baseFrontmatter = (overrides: Record<string, string>) => {
+  const fields: Record<string, string> = {
+    title: '"sample"',
+    kind: "personal",
+    source: "user",
+    starts_at: "2026-05-01T09:00:00Z",
+    tz: "UTC",
+    status: "confirmed",
+    ...overrides,
+  }
+  return `${Object.entries(fields)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n")}\n`
+}
+
+describe("calendar — pure helpers (parseDateShortcut, matchesFilter, sortByStart)", () => {
+  const now = new Date("2026-04-25T12:00:00Z")
+
+  describe("parseDateShortcut", () => {
+    it("today resolves to start/end of UTC day", () => {
+      expect(parseDateShortcut("today", now, "from")?.toISOString()).toBe(
+        "2026-04-25T00:00:00.000Z",
+      )
+      expect(parseDateShortcut("today", now, "to")?.toISOString()).toBe(
+        "2026-04-25T23:59:59.999Z",
+      )
+    })
+    it("tomorrow advances by one UTC day", () => {
+      expect(parseDateShortcut("tomorrow", now, "from")?.toISOString()).toBe(
+        "2026-04-26T00:00:00.000Z",
+      )
+    })
+    it("+7d advances by seven days", () => {
+      expect(parseDateShortcut("+7d", now, "to")?.toISOString()).toBe(
+        "2026-05-02T23:59:59.999Z",
+      )
+    })
+    it("+2w advances by two weeks", () => {
+      expect(parseDateShortcut("+2w", now, "to")?.toISOString()).toBe(
+        "2026-05-09T23:59:59.999Z",
+      )
+    })
+    it("eom resolves to end of current UTC month", () => {
+      expect(parseDateShortcut("eom", now, "to")?.toISOString()).toBe(
+        "2026-04-30T23:59:59.999Z",
+      )
+    })
+    it("plain YYYY-MM-DD covers the whole day", () => {
+      expect(parseDateShortcut("2026-06-15", now, "from")?.toISOString()).toBe(
+        "2026-06-15T00:00:00.000Z",
+      )
+      expect(parseDateShortcut("2026-06-15", now, "to")?.toISOString()).toBe(
+        "2026-06-15T23:59:59.999Z",
+      )
+    })
+    it("returns null on garbage", () => {
+      expect(parseDateShortcut("not-a-date", now, "from")).toBeNull()
+    })
+  })
+
+  describe("matchesFilter", () => {
+    const e: CalendarEvent = {
+      slug: "x",
+      title: "NVDA earnings",
+      kind: "earnings",
+      source: "driver-markets",
+      startsAt: "2026-05-21T20:00:00-04:00",
+      endsAt: null,
+      allDay: false,
+      tz: "America/New_York",
+      status: "confirmed",
+      location: null,
+      tickers: ["NVDA"],
+      topics: ["ai-infra-capex"],
+      theses: ["ai-infra-capex"],
+      tags: ["q1-2026"],
+      links: [],
+      relatedPages: ["nvidia"],
+      reminders: [],
+      externalId: null,
+      externalEtag: null,
+      generator: null,
+      contentHash: null,
+      createdAt: null,
+      updatedAt: null,
+      body: "Quarterly call",
+      relPath: "calendar/2026-05-21--nvda.md",
+      absPath: "/x",
+    }
+
+    it("returns true with no filter", () => {
+      expect(matchesFilter(e, undefined)).toBe(true)
+      expect(matchesFilter(e, {})).toBe(true)
+    })
+    it("filters by kind", () => {
+      expect(matchesFilter(e, { kind: ["earnings"] })).toBe(true)
+      expect(matchesFilter(e, { kind: ["personal"] })).toBe(false)
+      expect(matchesFilter(e, { kind: ["earnings", "personal"] })).toBe(true)
+    })
+    it("filters by source", () => {
+      expect(matchesFilter(e, { source: ["driver-markets"] })).toBe(true)
+      expect(matchesFilter(e, { source: ["user"] })).toBe(false)
+    })
+    it("filters by tickers (intersection)", () => {
+      expect(matchesFilter(e, { tickers: ["NVDA", "AMZN"] })).toBe(true)
+      expect(matchesFilter(e, { tickers: ["AMZN"] })).toBe(false)
+    })
+    it("filters by topics / theses / tags", () => {
+      expect(matchesFilter(e, { topics: ["ai-infra-capex"] })).toBe(true)
+      expect(matchesFilter(e, { topics: ["other"] })).toBe(false)
+      expect(matchesFilter(e, { theses: ["ai-infra-capex"] })).toBe(true)
+      expect(matchesFilter(e, { tags: ["q1-2026"] })).toBe(true)
+      expect(matchesFilter(e, { tags: ["q4-2025"] })).toBe(false)
+    })
+    it("filters by from/to time window", () => {
+      // Event is 2026-05-21T20:00 ET → 2026-05-22T00:00 UTC
+      expect(matchesFilter(e, { from: "2026-05-21T00:00:00Z" })).toBe(true)
+      expect(matchesFilter(e, { from: "2026-05-22T00:00:01Z" })).toBe(false)
+      expect(matchesFilter(e, { to: "2026-05-22T23:59:59Z" })).toBe(true)
+      expect(matchesFilter(e, { to: "2026-05-21T00:00:00Z" })).toBe(false)
+    })
+    it("q matches title or body, case-insensitive", () => {
+      expect(matchesFilter(e, { q: "NVDA" })).toBe(true)
+      expect(matchesFilter(e, { q: "quarterly" })).toBe(true)
+      expect(matchesFilter(e, { q: "fomc" })).toBe(false)
+    })
+    it("predicates AND together", () => {
+      expect(matchesFilter(e, { kind: ["earnings"], tickers: ["NVDA"] })).toBe(true)
+      expect(matchesFilter(e, { kind: ["earnings"], tickers: ["AMZN"] })).toBe(false)
+    })
+  })
+
+  describe("sortByStart", () => {
+    it("sorts events ascending by startsAt", () => {
+      const mk = (slug: string, startsAt: string): CalendarEvent => ({
+        ...({} as CalendarEvent),
+        slug,
+        title: slug,
+        kind: "personal",
+        source: "user",
+        startsAt,
+        endsAt: null,
+        allDay: false,
+        tz: "UTC",
+        status: "confirmed",
+        location: null,
+        tickers: [],
+        topics: [],
+        theses: [],
+        tags: [],
+        links: [],
+        relatedPages: [],
+        reminders: [],
+        externalId: null,
+        externalEtag: null,
+        generator: null,
+        contentHash: null,
+        createdAt: null,
+        updatedAt: null,
+        body: "",
+        relPath: `calendar/${slug}.md`,
+        absPath: `/${slug}`,
+      })
+      const a = mk("c", "2026-05-03T00:00:00Z")
+      const b = mk("a", "2026-05-01T00:00:00Z")
+      const c = mk("b", "2026-05-02T00:00:00Z")
+      expect(sortByStart([a, b, c]).map((x) => x.slug)).toEqual(["a", "b", "c"])
+    })
+  })
+})
+
+describe("calendar — FileSystemCalendar adapter", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-vault-cal-"))
+    await seedFile(
+      vaultDir,
+      "calendar/2026-05-08--board-meeting.md",
+      baseFrontmatter({
+        slug: "board-meeting",
+        title: '"Board meeting"',
+        kind: "personal",
+        starts_at: "2026-05-08T14:00:00+08:00",
+        tz: "Asia/Hong_Kong",
+      }),
+      "Quarterly board review with [[projects/quarterly-review]].",
+    )
+    await seedFile(
+      vaultDir,
+      "calendar/generated/2026-05-21--nvda-q1-2026-earnings.md",
+      baseFrontmatter({
+        slug: "nvda-q1-2026-earnings",
+        title: '"NVDA Q1 2026 earnings call"',
+        kind: "earnings",
+        source: "driver-markets",
+        starts_at: "2026-05-21T20:00:00-04:00",
+        tz: "America/New_York",
+        tickers: "[NVDA]",
+        topics: "[ai-infra-capex]",
+        theses: "[ai-infra-capex]",
+        tags: "[earnings, q1-2026]",
+      }),
+    )
+    await seedFile(
+      vaultDir,
+      "calendar/generated/2026-05-15--us-cpi.md",
+      baseFrontmatter({
+        slug: "us-cpi-2026-04",
+        title: '"US CPI release (Apr 2026)"',
+        kind: "macro",
+        source: "driver-markets",
+        starts_at: "2026-05-15T08:30:00-04:00",
+        tz: "America/New_York",
+        tags: "[macro, cpi]",
+      }),
+    )
+    // Recurring file — must be skipped by the loader for this slice.
+    await seedFile(
+      vaultDir,
+      "calendar/recurring/weekly-team-standup.md",
+      baseFrontmatter({
+        slug: "weekly-team-standup",
+        title: '"Weekly team standup"',
+        kind: "personal",
+        starts_at: "2026-04-27T10:00:00Z",
+      }),
+    )
+  })
+
+  it("lists all events excluding recurring/", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.list({ status: ["confirmed", "tentative", "cancelled"] })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(events.map((e) => e.slug).sort()).toEqual([
+      "board-meeting",
+      "nvda-q1-2026-earnings",
+      "us-cpi-2026-04",
+    ])
+  })
+
+  it("filters by source (only personal user events)", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.list({ source: ["user"] })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(events.map((e) => e.slug)).toEqual(["board-meeting"])
+  })
+
+  it("filters by kind + tickers (earnings on NVDA)", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.list({ kind: ["earnings"], tickers: ["NVDA"] })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(events.map((e) => e.slug)).toEqual(["nvda-q1-2026-earnings"])
+  })
+
+  it("filters by date window via from/to", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.list({
+          from: "2026-05-14T00:00:00Z",
+          to: "2026-05-16T23:59:59Z",
+        })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(events.map((e) => e.slug)).toEqual(["us-cpi-2026-04"])
+  })
+
+  it("get returns one event by slug", async () => {
+    const event = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.get("board-meeting")
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(event.title).toBe("Board meeting")
+    expect(event.tz).toBe("Asia/Hong_Kong")
+    expect(event.body.trim()).toContain("Quarterly board review")
+  })
+
+  it("get fails not_found for missing slug", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const cal = yield* CalendarService
+          return yield* cal.get("does-not-exist")
+        }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+      ),
+    )
+    expect(result._tag).toBe("Left")
+  })
+
+  it("add writes a personal event with derived slug + content_hash", async () => {
+    const written = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.add({
+          title: "Family dinner",
+          kind: "personal",
+          startsAt: "2026-05-30T19:30:00+08:00",
+          tz: "Asia/Hong_Kong",
+        })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(written.slug).toBe("family-dinner")
+    expect(written.relPath).toBe("calendar/2026-05-30--family-dinner.md")
+    expect(written.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    const onDisk = matter(await readFile(written.absPath, "utf8"))
+    expect(onDisk.data.source).toBe("user")
+    expect(onDisk.data.status).toBe("confirmed")
+    expect(onDisk.data.generator).toBe("gctrl-uber-cli")
+    expect(onDisk.data.content_hash).toBe(written.contentHash)
+    expect(onDisk.data.created_at).toBeTypeOf("string")
+  })
+
+  it("add rejects invalid kind via schema", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const cal = yield* CalendarService
+          return yield* cal.add({
+            title: "Bad event",
+            // biome-ignore lint/suspicious/noExplicitAny: testing invalid value
+            kind: "not-a-kind" as any,
+            startsAt: "2026-06-01T09:00:00Z",
+            tz: "UTC",
+          })
+        }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+      ),
+    )
+    expect(result._tag).toBe("Left")
+  })
+
+  it("add rejects duplicate slug", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const cal = yield* CalendarService
+          return yield* cal.add({
+            title: "Board meeting again",
+            slug: "board-meeting",
+            kind: "personal",
+            startsAt: "2026-06-01T09:00:00Z",
+            tz: "UTC",
+          })
+        }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+      ),
+    )
+    expect(result._tag).toBe("Left")
+  })
+
+  it("stamp updates frontmatter without touching the body", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        yield* cal.stamp("nvda-q1-2026-earnings", {
+          status: "tentative",
+          externalEtag: 'W/"new-etag"',
+          updatedAt: "2026-04-26T08:00:00Z",
+        })
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    const onDisk = matter(
+      await readFile(
+        join(vaultDir, "calendar/generated/2026-05-21--nvda-q1-2026-earnings.md"),
+        "utf8",
+      ),
+    )
+    expect(onDisk.data.status).toBe("tentative")
+    expect(onDisk.data.external_etag).toBe('W/"new-etag"')
+    expect(onDisk.data.updated_at).toBe("2026-04-26T08:00:00Z")
+    // Body untouched (the seeded body is empty, but the title etc. remain)
+    expect(onDisk.data.title).toBe("NVDA Q1 2026 earnings call")
+  })
+
+  it("returns empty list when calendar/ does not exist", async () => {
+    const empty = await mkdtemp(join(tmpdir(), "uber-vault-cal-empty-"))
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.list()
+      }).pipe(Effect.provide(FileSystemCalendarLive(empty))),
+    )
+    expect(events).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

First implementation slice of the calendar spec ([apps/uebermensch/specs/calendar.md](https://github.com/OpenHackersClub/gctrl/blob/main/apps/uebermensch/specs/calendar.md), shipped in #61). Calendar events live as markdown under `$UBER_VAULT_DIR/calendar/` with a unified `EventFrontmatter` shape, and a CLI lets you list/show/add events with the spec's full filter predicate set.

- **Schema** (`schemas.ts`) — `EventFrontmatter` with required `slug/title/kind/source/starts_at/tz/status` and 17 optional fields (incl. `ends_at`, `all_day`, `tickers`, `topics`, `theses`, `tags`, `links`, `related_pages`, `reminders`, `external_id`/`etag`, timestamps, `generator`, `content_hash`). Enums: `EventKind` (11 values), `EventSource` (5), `EventStatus` (3). Branded `Ticker` (uppercase regex per spec § Validation #5) and `ReminderOffset` (ISO 8601 duration regex per spec § Validation #9).
- **Service port** (`services/CalendarService.ts`) — `list(filter)`, `get(slug)`, `add(input)`, `stamp(slug, partial)`. Filter type matches spec § Filter predicates 1:1.
- **Filesystem adapter** (`adapters/FileSystemCalendar.ts`) — walks `calendar/**/*.md`, **skips `calendar/recurring/`** (RRULE expansion deferred per open question #2). Atomic write for `add` (tmp+rename, computes `content_hash`, fills `source: user`, `status: confirmed`, `created_at/updated_at/generator`). Atomic frontmatter-only update for `stamp` (body untouched). Normalises `Date` values back to ISO strings so hand-authored Obsidian files (where js-yaml auto-Date-parses ISO 8601) decode cleanly.
- **Predicate engine** (`lib/calendar-filter.ts`) — pure `matchesFilter` (AND across fields, OR within), `parseDateShortcut` covering `today`/`tomorrow`/`+Nd`/`+Nw`/`eom`/plain `YYYY-MM-DD`, `sortByStart`. Reusable by future HTTP API.
- **CLI** (`commands/calendar.ts`) — `gctrl uber calendar {list, show, add}`:
  - `list` flags: `--source --kind --from --to --tickers --topics --theses --tag --status --q` (comma-separated lists). Default status filter is `confirmed` per spec.
  - `add` flags: `--title --start --end --tz --kind --all-day --slug --location --tickers --topics --theses --tag --body`.
- **`vaultIo` helper** in `errors.ts` — wraps `Effect.tryPromise` with automatic `VaultError` construction. Used throughout the calendar adapter; reusable by `FileSystemQuery` / `FileSystemVault` in a future cleanup.

## Commits

1. `ae7bb2a` — initial calendar M0 core (schema, service, adapter, filter engine, CLI, 27 tests)
2. `585b540` — refactor: DRY adapter + CLI (vaultIo helper, dedup'd list/add options, `partial`+`csvOpt` spreads in `buildFilter`). Net calendar code −96 LOC; behaviour and tests unchanged.

## What's deferred (follow-up PRs)

To keep this slice the size of the prompts/research feature:
- `edit` / `remove` / `pull` / `push` / `reindex` CLI commands
- Recurring events (RRULE expansion) — spec open question #2
- Reminder fan-out via Scheduler + `uber_calendar_reminders`
- `.ics` feed at `/api/uber/calendar/feed.ics`
- SQLite `uber_calendar` index migration (kernel-side Rust work)
- Briefing-pipeline integration ("On the calendar today" section)
- Drivers (`driver-markets` earnings/macro, `driver-sec`, `driver-gcal`)
- Web UI calendar view
- Saved views from `profile.md` (CLI flags only for now)

## Test plan

- [x] `pnpm --filter uebermensch test` — 120 / 120 pass (93 prior + 27 new in `tests/calendar.test.ts`); same suite passes after the refactor commit
- [x] `pnpm exec tsc --noEmit -p apps/uebermensch` — clean
- [x] `pnpm --filter uebermensch build` — clean ESM output
- [x] Smoke-tested end-to-end via the built CLI: add → list (with and without `--tickers` / `--from` / `--to`) → show

🤖 Generated with [Claude Code](https://claude.com/claude-code)
