### PR TITLE
feat(analytics): M2a Timeline + Heatmap views & adopt shadcn/ui

### DIFF
--- a/apps/gctrl-board/components.json
+++ b/apps/gctrl-board/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "web/src/index.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/apps/gctrl-board/package.json
+++ b/apps/gctrl-board/package.json
@@ -22,9 +22,19 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@effect/platform": "^0.72.0",
     "@effect/schema": "^0.75.0",
+    "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "effect": "^3.14.0",
+    "lucide-react": "^1.11.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "tailwind-merge": "^3.5.0",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.9.0",

--- a/apps/gctrl-board/web/src/components/analytics/SessionsHeatmap.tsx
+++ b/apps/gctrl-board/web/src/components/analytics/SessionsHeatmap.tsx
@@ -4,7 +4,14 @@
 // patterns ("agent X always burns the morning") that a flat list buries.
 
 import { useMemo, useState } from "react"
-import type { SessionSummary } from "../../types"
+import type { SessionSummary } from "@/types"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
 interface Props {
   sessions: SessionSummary[]
@@ -26,7 +33,7 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
 
   if (sessions.length === 0) {
     return (
-      <div className="p-8 text-zinc-600 font-mono text-sm text-center">
+      <div className="p-8 text-muted-foreground/70 font-mono text-sm text-center">
         No sessions in the current window.
       </div>
     )
@@ -35,24 +42,21 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-3">
-        <span className="text-[11px] font-mono tracking-wider text-zinc-500 uppercase">
+        <span className="text-[11px] font-mono tracking-wider text-muted-foreground uppercase">
           {agents.length} agents · 24 hours · intensity = {mode}
         </span>
-        <div className="flex gap-px bg-zinc-800/60 p-px">
-          <ModeButton
-            active={mode === "count"}
-            onClick={() => setMode("count")}
-            label="count"
-          />
-          <ModeButton
-            active={mode === "cost"}
-            onClick={() => setMode("cost")}
-            label="cost"
-          />
-        </div>
+        <ToggleGroup
+          type="single"
+          value={mode}
+          onValueChange={(v) => v && setMode(v as Mode)}
+          size="sm"
+        >
+          <ToggleGroupItem value="count">count</ToggleGroupItem>
+          <ToggleGroupItem value="cost">cost</ToggleGroupItem>
+        </ToggleGroup>
       </div>
 
-      <div className="border border-zinc-800 bg-zinc-900/30 p-3 overflow-x-auto">
+      <div className="border border-border bg-card/30 p-3 overflow-x-auto">
         <table className="border-separate" style={{ borderSpacing: 2 }}>
           <thead>
             <tr>
@@ -60,7 +64,7 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
               {Array.from({ length: HOURS }, (_, h) => (
                 <th
                   key={h}
-                  className="text-[10px] font-mono text-zinc-500 font-normal w-7 text-center pb-1"
+                  className="text-[10px] font-mono text-muted-foreground font-normal w-7 text-center pb-1"
                 >
                   {h}
                 </th>
@@ -71,7 +75,7 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
             {agents.map((agent) => (
               <tr key={agent}>
                 <td
-                  className="text-[11px] font-mono text-zinc-400 pr-3 text-right truncate"
+                  className="text-[11px] font-mono text-muted-foreground pr-3 text-right truncate"
                   style={{ maxWidth: 160 }}
                   title={agent}
                 >
@@ -81,37 +85,38 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
                   const cell = grid.get(`${agent}|${h}`) ?? 0
                   const cellSessions = perCellSessions.get(`${agent}|${h}`)
                   const intensity = max > 0 ? cell / max : 0
+                  const hasData = cell > 0
                   const onCellSelect = () => {
                     if (cellSessions && cellSessions.length > 0) {
                       onSelect(cellSessions[0].id)
                     }
                   }
-                  return (
+                  const cellEl = (
                     <td
-                      key={h}
                       onClick={onCellSelect}
-                      title={
-                        cellSessions && cellSessions.length > 0
-                          ? `${agent} @ ${h}:00 — ${
-                              mode === "count"
-                                ? `${cell} session${cell === 1 ? "" : "s"}`
-                                : `$${cell.toFixed(4)}`
-                            }`
-                          : ""
-                      }
-                      className={`w-7 h-7 ${
-                        cell > 0
-                          ? "cursor-pointer hover:ring-1 hover:ring-emerald-400/60"
-                          : ""
-                      } ${
-                        cellSessions?.some((s) => s.id === selectedId)
-                          ? "ring-1 ring-emerald-300"
-                          : ""
-                      }`}
+                      className={cn(
+                        "w-7 h-7",
+                        hasData &&
+                          "cursor-pointer hover:ring-1 hover:ring-primary/60",
+                        cellSessions?.some((s) => s.id === selectedId) &&
+                          "ring-1 ring-primary",
+                      )}
                       style={{
-                        backgroundColor: intensityColor(intensity, cell > 0),
+                        backgroundColor: intensityColor(intensity, hasData),
                       }}
                     />
+                  )
+                  if (!hasData) return <td key={h} className="w-7 h-7" />
+                  return (
+                    <Tooltip key={h}>
+                      <TooltipTrigger asChild>{cellEl}</TooltipTrigger>
+                      <TooltipContent side="top">
+                        {agent} @ {h}:00 —{" "}
+                        {mode === "count"
+                          ? `${cell} session${cell === 1 ? "" : "s"}`
+                          : `$${cell.toFixed(4)}`}
+                      </TooltipContent>
+                    </Tooltip>
                   )
                 })}
               </tr>
@@ -125,41 +130,18 @@ export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
   )
 }
 
-function ModeButton({
-  active,
-  onClick,
-  label,
-}: {
-  active: boolean
-  onClick: () => void
-  label: string
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-2 py-0.5 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
-        active
-          ? "bg-emerald-500/15 text-emerald-300"
-          : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
-      }`}
-    >
-      {label}
-    </button>
-  )
-}
-
 function ScaleBar({ mode, max }: { mode: Mode; max: number }) {
   if (max <= 0) return null
   const labelMin = mode === "cost" ? "$0" : "0"
   const labelMax = mode === "cost" ? `$${max.toFixed(4)}` : String(max)
   return (
-    <div className="flex items-center gap-2 mt-2 text-[10px] font-mono uppercase tracking-wider text-zinc-500">
+    <div className="flex items-center gap-2 mt-2 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
       <span>{labelMin}</span>
       <div
-        className="h-2 w-32 border border-zinc-800"
+        className="h-2 w-32 border border-border"
         style={{
           background:
-            "linear-gradient(to right, rgb(39 39 42), rgb(16 185 129))",
+            "linear-gradient(to right, var(--color-secondary), var(--color-primary))",
         }}
       />
       <span>{labelMax}</span>

--- a/apps/gctrl-board/web/src/components/analytics/SessionsHeatmap.tsx
+++ b/apps/gctrl-board/web/src/components/analytics/SessionsHeatmap.tsx
@@ -1,0 +1,218 @@
+// Heatmap rendering of the same `sessions` state.
+// Per spec/architecture/apps/gctrl-analytics.md §M2: agent × hour-of-day
+// grid, cell intensity = session count or cost. Reveals activity
+// patterns ("agent X always burns the morning") that a flat list buries.
+
+import { useMemo, useState } from "react"
+import type { SessionSummary } from "../../types"
+
+interface Props {
+  sessions: SessionSummary[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+}
+
+type Mode = "count" | "cost"
+
+const HOURS = 24
+
+export function SessionsHeatmap({ sessions, selectedId, onSelect }: Props) {
+  const [mode, setMode] = useState<Mode>("count")
+
+  const { agents, grid, max, perCellSessions } = useMemo(
+    () => bucketize(sessions, mode),
+    [sessions, mode],
+  )
+
+  if (sessions.length === 0) {
+    return (
+      <div className="p-8 text-zinc-600 font-mono text-sm text-center">
+        No sessions in the current window.
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[11px] font-mono tracking-wider text-zinc-500 uppercase">
+          {agents.length} agents · 24 hours · intensity = {mode}
+        </span>
+        <div className="flex gap-px bg-zinc-800/60 p-px">
+          <ModeButton
+            active={mode === "count"}
+            onClick={() => setMode("count")}
+            label="count"
+          />
+          <ModeButton
+            active={mode === "cost"}
+            onClick={() => setMode("cost")}
+            label="cost"
+          />
+        </div>
+      </div>
+
+      <div className="border border-zinc-800 bg-zinc-900/30 p-3 overflow-x-auto">
+        <table className="border-separate" style={{ borderSpacing: 2 }}>
+          <thead>
+            <tr>
+              <th aria-hidden />
+              {Array.from({ length: HOURS }, (_, h) => (
+                <th
+                  key={h}
+                  className="text-[10px] font-mono text-zinc-500 font-normal w-7 text-center pb-1"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((agent) => (
+              <tr key={agent}>
+                <td
+                  className="text-[11px] font-mono text-zinc-400 pr-3 text-right truncate"
+                  style={{ maxWidth: 160 }}
+                  title={agent}
+                >
+                  {agent}
+                </td>
+                {Array.from({ length: HOURS }, (_, h) => {
+                  const cell = grid.get(`${agent}|${h}`) ?? 0
+                  const cellSessions = perCellSessions.get(`${agent}|${h}`)
+                  const intensity = max > 0 ? cell / max : 0
+                  const onCellSelect = () => {
+                    if (cellSessions && cellSessions.length > 0) {
+                      onSelect(cellSessions[0].id)
+                    }
+                  }
+                  return (
+                    <td
+                      key={h}
+                      onClick={onCellSelect}
+                      title={
+                        cellSessions && cellSessions.length > 0
+                          ? `${agent} @ ${h}:00 — ${
+                              mode === "count"
+                                ? `${cell} session${cell === 1 ? "" : "s"}`
+                                : `$${cell.toFixed(4)}`
+                            }`
+                          : ""
+                      }
+                      className={`w-7 h-7 ${
+                        cell > 0
+                          ? "cursor-pointer hover:ring-1 hover:ring-emerald-400/60"
+                          : ""
+                      } ${
+                        cellSessions?.some((s) => s.id === selectedId)
+                          ? "ring-1 ring-emerald-300"
+                          : ""
+                      }`}
+                      style={{
+                        backgroundColor: intensityColor(intensity, cell > 0),
+                      }}
+                    />
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <ScaleBar mode={mode} max={max} />
+    </div>
+  )
+}
+
+function ModeButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-2 py-0.5 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
+        active
+          ? "bg-emerald-500/15 text-emerald-300"
+          : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ScaleBar({ mode, max }: { mode: Mode; max: number }) {
+  if (max <= 0) return null
+  const labelMin = mode === "cost" ? "$0" : "0"
+  const labelMax = mode === "cost" ? `$${max.toFixed(4)}` : String(max)
+  return (
+    <div className="flex items-center gap-2 mt-2 text-[10px] font-mono uppercase tracking-wider text-zinc-500">
+      <span>{labelMin}</span>
+      <div
+        className="h-2 w-32 border border-zinc-800"
+        style={{
+          background:
+            "linear-gradient(to right, rgb(39 39 42), rgb(16 185 129))",
+        }}
+      />
+      <span>{labelMax}</span>
+    </div>
+  )
+}
+
+interface BucketResult {
+  agents: string[]
+  /** key = `${agent}|${hour}` ⇒ value */
+  grid: Map<string, number>
+  max: number
+  perCellSessions: Map<string, SessionSummary[]>
+}
+
+function bucketize(sessions: SessionSummary[], mode: Mode): BucketResult {
+  const grid = new Map<string, number>()
+  const perCellSessions = new Map<string, SessionSummary[]>()
+  const agentSet = new Set<string>()
+
+  for (const s of sessions) {
+    const agent = s.agent_name || "(unknown agent)"
+    agentSet.add(agent)
+    const hour = new Date(s.started_at).getHours()
+    const key = `${agent}|${hour}`
+    const prev = grid.get(key) ?? 0
+    const incr = mode === "cost" ? s.total_cost_usd : 1
+    grid.set(key, prev + incr)
+    const list = perCellSessions.get(key) ?? []
+    list.push(s)
+    perCellSessions.set(key, list)
+  }
+
+  const max = Array.from(grid.values()).reduce((a, b) => Math.max(a, b), 0)
+  const agents = Array.from(agentSet).sort((a, b) => a.localeCompare(b))
+
+  return { agents, grid, max, perCellSessions }
+}
+
+function intensityColor(intensity: number, hasData: boolean): string {
+  if (!hasData) return "rgb(24 24 27)" // zinc-900
+  // Quantize to 5 buckets so the eye reads a discrete palette instead
+  // of a smooth gradient that's harder to compare across cells.
+  const bucket = Math.min(4, Math.floor(intensity * 5))
+  // Tailwind emerald-{600,500,400,300,200} with progressive saturation,
+  // chosen so even bucket 0 (the lowest non-zero value) is clearly
+  // distinguishable from an empty cell.
+  const colors = [
+    "rgba(16, 185, 129, 0.20)",
+    "rgba(16, 185, 129, 0.40)",
+    "rgba(16, 185, 129, 0.60)",
+    "rgba(16, 185, 129, 0.80)",
+    "rgba(16, 185, 129, 1.00)",
+  ]
+  return colors[bucket]
+}

--- a/apps/gctrl-board/web/src/components/analytics/SessionsTimeline.tsx
+++ b/apps/gctrl-board/web/src/components/analytics/SessionsTimeline.tsx
@@ -1,0 +1,231 @@
+// Timeline rendering of the same `sessions` state the List view shows.
+// Per spec/architecture/apps/gctrl-analytics.md §M2 acceptance:
+// "switching list → timeline → heatmap does not re-fetch — same query,
+// three renderings." So this component is a pure function of the
+// already-loaded session list.
+//
+// Layout: horizontal lanes per agent_name, one bar per session running
+// from `started_at` to `ended_at` (or now, if still live). Bar colour
+// is keyed off session status so concurrent agent activity and idle
+// gaps are immediately readable.
+
+import type { SessionSummary } from "../../types"
+
+interface Props {
+  sessions: SessionSummary[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+}
+
+const LANE_HEIGHT = 22
+const LANE_GAP = 4
+const LABEL_WIDTH = 140
+const AXIS_HEIGHT = 22
+
+export function SessionsTimeline({ sessions, selectedId, onSelect }: Props) {
+  if (sessions.length === 0) {
+    return (
+      <div className="p-8 text-zinc-600 font-mono text-sm text-center">
+        No sessions in the current window. Spawn an agent to populate this
+        view.
+      </div>
+    )
+  }
+
+  const now = Date.now()
+  const ts = sessions.map((s) => new Date(s.started_at).getTime())
+  const ends = sessions.map((s) =>
+    s.ended_at ? new Date(s.ended_at).getTime() : now,
+  )
+  const minT = Math.min(...ts)
+  const maxT = Math.max(...ends, now)
+  const span = Math.max(1, maxT - minT)
+
+  // Group by agent_name into stable, sorted lanes. We sort by lane
+  // first so bars in a lane appear in start-time order.
+  const lanes = new Map<string, SessionSummary[]>()
+  for (const s of sessions) {
+    const key = s.agent_name || "(unknown agent)"
+    if (!lanes.has(key)) lanes.set(key, [])
+    lanes.get(key)!.push(s)
+  }
+  const laneList = Array.from(lanes.entries())
+    .map(([name, rows]) => ({
+      name,
+      rows: rows.sort(
+        (a, b) =>
+          new Date(a.started_at).getTime() - new Date(b.started_at).getTime(),
+      ),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const ticks = buildTicks(minT, maxT, 6)
+  const totalHeight = laneList.length * (LANE_HEIGHT + LANE_GAP) + AXIS_HEIGHT
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-3 text-[11px] font-mono tracking-wider text-zinc-500 uppercase">
+        <span>{laneList.length} agents · {sessions.length} sessions</span>
+        <span>
+          {fmtAbs(minT)} → {fmtAbs(maxT)}
+        </span>
+      </div>
+
+      <div className="border border-zinc-800 bg-zinc-900/30 overflow-hidden">
+        {/* Lanes */}
+        <div className="relative" style={{ height: totalHeight }}>
+          {/* Vertical gridlines per tick */}
+          {ticks.map((t) => {
+            const x = LABEL_WIDTH + (t - minT) / span * (100)
+            return (
+              <div
+                key={`grid-${t}`}
+                className="absolute top-0 bottom-[22px] w-px bg-zinc-800/60"
+                style={{ left: `calc(${LABEL_WIDTH}px + ${((t - minT) / span) * 100}% - ${(LABEL_WIDTH * (t - minT)) / span}px)` }}
+                aria-hidden
+                data-x={x}
+              />
+            )
+          })}
+
+          {laneList.map((lane, i) => (
+            <div
+              key={lane.name}
+              className="absolute left-0 right-0 flex items-center"
+              style={{
+                top: i * (LANE_HEIGHT + LANE_GAP),
+                height: LANE_HEIGHT,
+              }}
+            >
+              <div
+                className="text-[11px] font-mono text-zinc-400 truncate pr-2 text-right"
+                style={{ width: LABEL_WIDTH }}
+                title={lane.name}
+              >
+                {lane.name}
+              </div>
+              <div className="relative flex-1 h-full">
+                {lane.rows.map((s) => {
+                  const start = new Date(s.started_at).getTime()
+                  const end = s.ended_at
+                    ? new Date(s.ended_at).getTime()
+                    : now
+                  const left = ((start - minT) / span) * 100
+                  // Floor the width so a single-instant span still shows
+                  // a visible nub instead of vanishing.
+                  const width = Math.max(0.4, ((end - start) / span) * 100)
+                  const isLive = s.ended_at === null && s.status === "active"
+                  return (
+                    <button
+                      key={s.id}
+                      onClick={() => onSelect(s.id)}
+                      title={`${s.agent_name || "—"}\n${fmtAbs(start)} → ${
+                        s.ended_at ? fmtAbs(end) : "live"
+                      }\n$${s.total_cost_usd.toFixed(4)}`}
+                      className={`absolute top-1/2 -translate-y-1/2 h-3 rounded-sm cursor-pointer transition-opacity ${barClass(
+                        s.status,
+                        isLive,
+                      )} ${
+                        selectedId === s.id
+                          ? "ring-1 ring-emerald-300"
+                          : "hover:opacity-90"
+                      }`}
+                      style={{
+                        left: `${left}%`,
+                        width: `${width}%`,
+                        minWidth: 4,
+                      }}
+                    />
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+
+          {/* Time axis */}
+          <div
+            className="absolute left-0 right-0 border-t border-zinc-800 flex items-center"
+            style={{
+              top: laneList.length * (LANE_HEIGHT + LANE_GAP),
+              height: AXIS_HEIGHT,
+              paddingLeft: LABEL_WIDTH,
+            }}
+          >
+            <div className="relative flex-1 h-full">
+              {ticks.map((t) => (
+                <span
+                  key={t}
+                  className="absolute top-1 text-[10px] font-mono text-zinc-500"
+                  style={{
+                    left: `${((t - minT) / span) * 100}%`,
+                    transform: "translateX(-50%)",
+                  }}
+                >
+                  {fmtTick(t, span)}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Legend />
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div className="flex items-center gap-4 mt-2 text-[10px] font-mono uppercase tracking-wider text-zinc-500">
+      <LegendDot className="bg-emerald-400 animate-pulse" label="live" />
+      <LegendDot className="bg-zinc-500" label="completed" />
+      <LegendDot className="bg-rose-500" label="failed" />
+      <LegendDot className="bg-amber-500" label="cancelled" />
+    </div>
+  )
+}
+
+function LegendDot({ className, label }: { className: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`w-2.5 h-2.5 rounded-sm ${className}`} />
+      {label}
+    </span>
+  )
+}
+
+function barClass(status: SessionSummary["status"], isLive: boolean): string {
+  if (isLive) return "bg-emerald-400 animate-pulse"
+  if (status === "completed") return "bg-zinc-500"
+  if (status === "failed") return "bg-rose-500"
+  if (status === "cancelled") return "bg-amber-500"
+  // Fallback: same as completed.
+  return "bg-zinc-500"
+}
+
+function buildTicks(min: number, max: number, count: number): number[] {
+  const step = (max - min) / Math.max(1, count - 1)
+  const out: number[] = []
+  for (let i = 0; i < count; i++) out.push(min + step * i)
+  return out
+}
+
+function fmtAbs(ts: number): string {
+  return new Date(ts).toLocaleString()
+}
+
+function fmtTick(ts: number, span: number): string {
+  const d = new Date(ts)
+  // < 24h span: HH:MM. < 7d span: MM/DD HH:MM. Otherwise: MM/DD.
+  if (span < 24 * 3600 * 1000) {
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
+  if (span < 7 * 24 * 3600 * 1000) {
+    return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
+  return `${pad(d.getMonth() + 1)}/${pad(d.getDate())}`
+}
+
+function pad(n: number): string {
+  return n.toString().padStart(2, "0")
+}

--- a/apps/gctrl-board/web/src/components/analytics/SessionsTimeline.tsx
+++ b/apps/gctrl-board/web/src/components/analytics/SessionsTimeline.tsx
@@ -9,7 +9,13 @@
 // is keyed off session status so concurrent agent activity and idle
 // gaps are immediately readable.
 
-import type { SessionSummary } from "../../types"
+import type { SessionSummary } from "@/types"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
 interface Props {
   sessions: SessionSummary[]
@@ -71,7 +77,7 @@ export function SessionsTimeline({ sessions, selectedId, onSelect }: Props) {
         </span>
       </div>
 
-      <div className="border border-zinc-800 bg-zinc-900/30 overflow-hidden">
+      <div className="border border-border bg-card/30 overflow-hidden">
         {/* Lanes */}
         <div className="relative" style={{ height: totalHeight }}>
           {/* Vertical gridlines per tick */}
@@ -80,7 +86,7 @@ export function SessionsTimeline({ sessions, selectedId, onSelect }: Props) {
             return (
               <div
                 key={`grid-${t}`}
-                className="absolute top-0 bottom-[22px] w-px bg-zinc-800/60"
+                className="absolute top-0 bottom-[22px] w-px bg-border"
                 style={{ left: `calc(${LABEL_WIDTH}px + ${((t - minT) / span) * 100}% - ${(LABEL_WIDTH * (t - minT)) / span}px)` }}
                 aria-hidden
                 data-x={x}
@@ -116,26 +122,37 @@ export function SessionsTimeline({ sessions, selectedId, onSelect }: Props) {
                   const width = Math.max(0.4, ((end - start) / span) * 100)
                   const isLive = s.ended_at === null && s.status === "active"
                   return (
-                    <button
-                      key={s.id}
-                      onClick={() => onSelect(s.id)}
-                      title={`${s.agent_name || "—"}\n${fmtAbs(start)} → ${
-                        s.ended_at ? fmtAbs(end) : "live"
-                      }\n$${s.total_cost_usd.toFixed(4)}`}
-                      className={`absolute top-1/2 -translate-y-1/2 h-3 rounded-sm cursor-pointer transition-opacity ${barClass(
-                        s.status,
-                        isLive,
-                      )} ${
-                        selectedId === s.id
-                          ? "ring-1 ring-emerald-300"
-                          : "hover:opacity-90"
-                      }`}
-                      style={{
-                        left: `${left}%`,
-                        width: `${width}%`,
-                        minWidth: 4,
-                      }}
-                    />
+                    <Tooltip key={s.id}>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => onSelect(s.id)}
+                          aria-label={`Session ${s.id} on agent ${s.agent_name}`}
+                          className={cn(
+                            "absolute top-1/2 -translate-y-1/2 h-3 rounded-sm cursor-pointer transition-opacity focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                            barClass(s.status, isLive),
+                            selectedId === s.id
+                              ? "ring-1 ring-primary/80"
+                              : "hover:opacity-90",
+                          )}
+                          style={{
+                            left: `${left}%`,
+                            width: `${width}%`,
+                            minWidth: 4,
+                          }}
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="space-y-0.5">
+                        <div className="text-foreground">
+                          {s.agent_name || "—"}
+                        </div>
+                        <div className="text-muted-foreground">
+                          {fmtAbs(start)} → {s.ended_at ? fmtAbs(end) : "live"}
+                        </div>
+                        <div className="text-primary">
+                          ${s.total_cost_usd.toFixed(4)}
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
                   )
                 })}
               </div>
@@ -177,9 +194,9 @@ export function SessionsTimeline({ sessions, selectedId, onSelect }: Props) {
 function Legend() {
   return (
     <div className="flex items-center gap-4 mt-2 text-[10px] font-mono uppercase tracking-wider text-zinc-500">
-      <LegendDot className="bg-emerald-400 animate-pulse" label="live" />
-      <LegendDot className="bg-zinc-500" label="completed" />
-      <LegendDot className="bg-rose-500" label="failed" />
+      <LegendDot className="bg-primary animate-pulse" label="live" />
+      <LegendDot className="bg-muted-foreground" label="completed" />
+      <LegendDot className="bg-destructive" label="failed" />
       <LegendDot className="bg-amber-500" label="cancelled" />
     </div>
   )
@@ -195,12 +212,11 @@ function LegendDot({ className, label }: { className: string; label: string }) {
 }
 
 function barClass(status: SessionSummary["status"], isLive: boolean): string {
-  if (isLive) return "bg-emerald-400 animate-pulse"
-  if (status === "completed") return "bg-zinc-500"
-  if (status === "failed") return "bg-rose-500"
+  if (isLive) return "bg-primary animate-pulse"
+  if (status === "failed") return "bg-destructive"
   if (status === "cancelled") return "bg-amber-500"
-  // Fallback: same as completed.
-  return "bg-zinc-500"
+  // completed + fallback
+  return "bg-muted-foreground"
 }
 
 function buildTicks(min: number, max: number, count: number): number[] {

--- a/apps/gctrl-board/web/src/components/ui/badge.tsx
+++ b/apps/gctrl-board/web/src/components/ui/badge.tsx
@@ -1,0 +1,64 @@
+// shadcn/ui — Badge. Operator-tool variants beyond shadcn defaults:
+// `live` (pulsing emerald dot) and `neutral` for muted labels.
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-wider whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "text-foreground",
+        muted: "text-muted-foreground",
+        success: "text-primary",
+        destructive: "text-destructive",
+        warn: "text-amber-400",
+        info: "text-sky-400",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {
+  /** Show a leading status dot. `pulse` adds the live-indicator animation. */
+  dot?: boolean
+  pulse?: boolean
+}
+
+function Badge({
+  className,
+  variant,
+  dot,
+  pulse,
+  children,
+  ...props
+}: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props}>
+      {dot && (
+        <span
+          aria-hidden
+          className={cn(
+            "w-1.5 h-1.5 rounded-full",
+            variant === "success" && "bg-primary",
+            variant === "destructive" && "bg-destructive",
+            variant === "warn" && "bg-amber-400",
+            variant === "info" && "bg-sky-400",
+            (!variant || variant === "default" || variant === "muted") &&
+              "bg-muted-foreground",
+            pulse && "animate-pulse",
+          )}
+        />
+      )}
+      {children}
+    </span>
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/gctrl-board/web/src/components/ui/button.tsx
+++ b/apps/gctrl-board/web/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+// shadcn/ui — Button. Vendored source so we own the styling.
+
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-display font-medium tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-30 cursor-pointer [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary/10 text-primary border border-primary/25 hover:bg-primary/20 hover:border-primary/40",
+        secondary:
+          "bg-secondary/60 text-secondary-foreground border border-border hover:bg-secondary",
+        destructive:
+          "bg-destructive/10 text-destructive border border-destructive/25 hover:bg-destructive/20",
+        outline:
+          "border border-border bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+        ghost: "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-8 px-3 text-[13px]",
+        sm: "h-6 px-2 text-[11px]",
+        lg: "h-9 px-4 text-[14px]",
+        icon: "h-8 w-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/apps/gctrl-board/web/src/components/ui/card.tsx
+++ b/apps/gctrl-board/web/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+// shadcn/ui — Card. Operator-tool flavour: tighter padding, square
+// corners, denser typography than the shadcn defaults.
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "border border-border bg-card/30 text-card-foreground",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex flex-row items-center justify-between gap-3 border-b border-border px-4 py-2",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn(
+        "text-[11px] font-mono tracking-wider text-muted-foreground uppercase",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-[11px] font-mono text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-4", className)} {...props} />
+  ),
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex items-center px-4 py-2 border-t border-border", className)}
+      {...props}
+    />
+  ),
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/apps/gctrl-board/web/src/components/ui/table.tsx
+++ b/apps/gctrl-board/web/src/components/ui/table.tsx
@@ -1,0 +1,101 @@
+// shadcn/ui — Table. Dense operator-tool styling: monospace, tight
+// row padding, hover highlight, no zebra-striping (the eye reads
+// edges better than fills at this density).
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn("w-full text-[13px] font-mono", className)}
+        {...props}
+      />
+    </div>
+  ),
+)
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead
+      ref={ref}
+      className={cn("sticky top-0 bg-background z-10", className)}
+      {...props}
+    />
+  ),
+)
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("", className)} {...props} />
+  ),
+)
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot
+      ref={ref}
+      className={cn("border-t border-border bg-card/30 font-medium", className)}
+      {...props}
+    />
+  ),
+)
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-t border-border/60 transition-colors hover:bg-accent/40 data-[state=selected]:bg-primary/5",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        "px-4 py-2 text-left text-[10px] font-normal text-muted-foreground uppercase tracking-wider",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn("px-4 py-1.5 align-middle", className)} {...props} />
+  ),
+)
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption ref={ref} className={cn("mt-2 text-[11px] text-muted-foreground", className)} {...props} />
+  ),
+)
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/apps/gctrl-board/web/src/components/ui/tabs.tsx
+++ b/apps/gctrl-board/web/src/components/ui/tabs.tsx
@@ -1,0 +1,60 @@
+// shadcn/ui — Tabs (Radix). The trigger style mimics the existing
+// AnalyticsPage TabButton (uppercase, emerald active border) so the
+// migration is style-stable.
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex items-center gap-1 border-b border-border",
+      className,
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "px-3 h-8 text-[12px] font-display tracking-wide uppercase transition-colors cursor-pointer text-muted-foreground hover:text-foreground border-b-2 border-transparent",
+      "data-[state=active]:text-primary data-[state=active]:border-primary",
+      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      "disabled:pointer-events-none disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      className,
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/apps/gctrl-board/web/src/components/ui/toggle-group.tsx
+++ b/apps/gctrl-board/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,73 @@
+// shadcn/ui — ToggleGroup (Radix). Used for the view-mode switcher
+// (List / Timeline / Heatmap) and any future small enum picker.
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleGroupVariants = cva(
+  "inline-flex items-center gap-px bg-secondary/60 p-px",
+  {
+    variants: {
+      size: {
+        sm: "",
+        default: "",
+      },
+    },
+    defaultVariants: { size: "default" },
+  },
+)
+
+const toggleGroupItemVariants = cva(
+  "px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors bg-card/60 text-muted-foreground hover:text-foreground data-[state=on]:bg-primary/15 data-[state=on]:text-primary disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+  {
+    variants: {
+      size: {
+        sm: "px-2 py-0.5 text-[10px]",
+        default: "",
+      },
+    },
+    defaultVariants: { size: "default" },
+  },
+)
+
+const ToggleGroupContext = React.createContext<{
+  size?: VariantProps<typeof toggleGroupItemVariants>["size"]
+}>({})
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleGroupVariants>
+>(({ className, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn(toggleGroupVariants({ size }), className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleGroupItemVariants>
+>(({ className, size, ...props }, ref) => {
+  const ctx = React.useContext(ToggleGroupContext)
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(toggleGroupItemVariants({ size: size ?? ctx.size }), className)}
+      {...props}
+    />
+  )
+})
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/gctrl-board/web/src/components/ui/tooltip.tsx
+++ b/apps/gctrl-board/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,33 @@
+// shadcn/ui — Tooltip (Radix). Short delay, keyboard-friendly. We
+// expose a Provider at the page root so individual components don't
+// each wrap their own.
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-sm border border-border bg-popover px-2 py-1 text-[11px] font-mono text-popover-foreground shadow-md",
+        "data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/apps/gctrl-board/web/src/index.css
+++ b/apps/gctrl-board/web/src/index.css
@@ -1,11 +1,19 @@
 @import url("https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@300;400;500;600;700&family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
 @import "tailwindcss";
+@import "tw-animate-css";
+
+/* shadcn dark-mode hook. The board ships dark-only today, so this
+ * activates whenever the document carries the .dark class (or a
+ * descendant); we keep the variant declared so future light-mode work
+ * lands cleanly. */
+@custom-variant dark (&:is(.dark *));
 
 @theme {
   --font-display: "Chakra Petch", sans-serif;
   --font-body: "Outfit", sans-serif;
   --font-mono: "JetBrains Mono", monospace;
 
+  /* Board-specific tokens (kanban / gantt) — kept stable. */
   --color-surface: #18181b;
   --color-surface-raised: #1f1f23;
   --color-border-subtle: #27272a;
@@ -21,6 +29,41 @@
   --animate-fade-in: fade-in 0.15s ease-out;
   --animate-fade-in-up: fade-in-up 0.2s ease-out;
   --animate-pulse-subtle: pulse-subtle 2s ease-in-out infinite;
+
+  /* shadcn semantic tokens — referenced by primitives via
+   * `bg-background`, `text-foreground`, `border-border`, etc. We pin
+   * them to the existing zinc-based dark palette so shadcn primitives
+   * blend with the operator-tool aesthetic and don't introduce a
+   * second visual vocabulary. */
+  --color-background: #09090b;          /* zinc-950 */
+  --color-foreground: #d4d4d8;          /* zinc-300 */
+
+  --color-card: #18181b;                /* zinc-900 */
+  --color-card-foreground: #e4e4e7;     /* zinc-200 */
+
+  --color-popover: #18181b;
+  --color-popover-foreground: #e4e4e7;
+
+  --color-primary: #34d399;             /* emerald-400 — operator accent */
+  --color-primary-foreground: #052e1a;  /* near-black emerald */
+
+  --color-secondary: #27272a;           /* zinc-800 */
+  --color-secondary-foreground: #d4d4d8;
+
+  --color-muted: #18181b;
+  --color-muted-foreground: #71717a;    /* zinc-500 */
+
+  --color-accent: #27272a;
+  --color-accent-foreground: #e4e4e7;
+
+  --color-destructive: #fb7185;         /* rose-400 — failure rows */
+  --color-destructive-foreground: #18181b;
+
+  --color-border: #27272a;
+  --color-input: #27272a;
+  --color-ring: #34d399;                /* focus ring = primary */
+
+  --radius: 0.25rem;                    /* tight, operator-tool feel */
 }
 
 @keyframes slide-in-right {

--- a/apps/gctrl-board/web/src/lib/utils.ts
+++ b/apps/gctrl-board/web/src/lib/utils.ts
@@ -1,0 +1,10 @@
+// shadcn/ui canonical helper. Combines clsx (conditional class merging)
+// with tailwind-merge (de-duplication of conflicting Tailwind classes,
+// so `cn("p-2", isWide && "p-6")` produces `p-6` instead of `p-2 p-6`).
+
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -13,6 +13,10 @@ import type {
 } from "../types"
 import type { Route } from "../hooks/useRoute"
 import { useSessionStream } from "../hooks/useSessionStream"
+import { SessionsTimeline } from "../components/analytics/SessionsTimeline"
+import { SessionsHeatmap } from "../components/analytics/SessionsHeatmap"
+
+type SessionsView = "list" | "timeline" | "heatmap"
 
 interface AnalyticsPageProps {
   route: Extract<Route, { page: "analytics" }>
@@ -298,6 +302,9 @@ function SessionsTab({
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  // View-mode is local state on purpose: per spec, switching list →
+  // timeline → heatmap must NOT re-fetch. Same data, three renderings.
+  const [view, setView] = useState<SessionsView>("list")
 
   const refresh = useCallback(async () => {
     try {
@@ -377,56 +384,129 @@ function SessionsTab({
   }
 
   return (
-    <div className="flex h-full min-h-0">
-      {/* List */}
-      <div className="flex-1 min-w-0 border-r border-zinc-800 overflow-auto">
-        <table className="w-full text-[13px] font-mono">
-          <thead className="sticky top-0 bg-zinc-950 z-10">
-            <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
-              <th className="text-left font-normal px-4 py-2">Status</th>
-              <th className="text-left font-normal px-4 py-2">Agent</th>
-              <th className="text-left font-normal px-4 py-2">Started</th>
-              <th className="text-right font-normal px-4 py-2">Dur</th>
-              <th className="text-right font-normal px-4 py-2">Tokens</th>
-              <th className="text-right font-normal px-4 py-2">Cost</th>
-              <th className="text-left font-normal px-4 py-2">ID</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading && sessions.length === 0 && (
-              <tr>
-                <td colSpan={7} className="p-8 text-center text-zinc-600">
-                  Loading sessions…
-                </td>
-              </tr>
-            )}
-            {!loading && sessions.length === 0 && (
-              <tr>
-                <td colSpan={7} className="p-8 text-center text-zinc-600">
-                  No sessions yet. Spawn an agent and this table will populate.
-                </td>
-              </tr>
-            )}
-            {sessions.map((s) => (
-              <SessionRow
-                key={s.id}
-                session={s}
-                selected={s.id === selectedSessionId}
-                onSelect={() => onSelectSession(s.id)}
-              />
-            ))}
-          </tbody>
-        </table>
+    <div className="flex flex-col h-full min-h-0">
+      {/* View-mode switcher — same data, three renderings */}
+      <div className="h-9 border-b border-zinc-800 flex items-center px-4 gap-3 bg-zinc-950/60 shrink-0">
+        <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-600">
+          view
+        </span>
+        <div className="flex gap-px bg-zinc-800/60 p-px">
+          <ViewButton
+            active={view === "list"}
+            onClick={() => setView("list")}
+            label="list"
+          />
+          <ViewButton
+            active={view === "timeline"}
+            onClick={() => setView("timeline")}
+            label="timeline"
+          />
+          <ViewButton
+            active={view === "heatmap"}
+            onClick={() => setView("heatmap")}
+            label="heatmap"
+          />
+        </div>
+        <div className="flex-1" />
+        <span className="text-[11px] font-mono text-zinc-500">
+          {sessions.length} session{sessions.length === 1 ? "" : "s"}
+        </span>
       </div>
 
-      {/* Detail */}
-      {selected && (
-        <SessionDetailPane
-          session={selected}
-          onClose={() => onSelectSession(null)}
-        />
-      )}
+      <div className="flex flex-1 min-h-0">
+        {/* Body — switches by view; each renderer is a pure function of `sessions` */}
+        <div className="flex-1 min-w-0 border-r border-zinc-800 overflow-auto">
+          {view === "list" && (
+            <table className="w-full text-[13px] font-mono">
+              <thead className="sticky top-0 bg-zinc-950 z-10">
+                <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
+                  <th className="text-left font-normal px-4 py-2">Status</th>
+                  <th className="text-left font-normal px-4 py-2">Agent</th>
+                  <th className="text-left font-normal px-4 py-2">Started</th>
+                  <th className="text-right font-normal px-4 py-2">Dur</th>
+                  <th className="text-right font-normal px-4 py-2">Tokens</th>
+                  <th className="text-right font-normal px-4 py-2">Cost</th>
+                  <th className="text-left font-normal px-4 py-2">ID</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading && sessions.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="p-8 text-center text-zinc-600">
+                      Loading sessions…
+                    </td>
+                  </tr>
+                )}
+                {!loading && sessions.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="p-8 text-center text-zinc-600">
+                      No sessions yet. Spawn an agent and this table will
+                      populate.
+                    </td>
+                  </tr>
+                )}
+                {sessions.map((s) => (
+                  <SessionRow
+                    key={s.id}
+                    session={s}
+                    selected={s.id === selectedSessionId}
+                    onSelect={() => onSelectSession(s.id)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {view === "timeline" && (
+            <SessionsTimeline
+              sessions={sessions}
+              selectedId={selectedSessionId}
+              onSelect={onSelectSession}
+            />
+          )}
+
+          {view === "heatmap" && (
+            <SessionsHeatmap
+              sessions={sessions}
+              selectedId={selectedSessionId}
+              onSelect={onSelectSession}
+            />
+          )}
+        </div>
+
+        {/* Detail pane is shared across all three views */}
+        {selected && (
+          <SessionDetailPane
+            session={selected}
+            onClose={() => onSelectSession(null)}
+          />
+        )}
+      </div>
     </div>
+  )
+}
+
+function ViewButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      data-testid={`sessions-view-${label}`}
+      className={`px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
+        active
+          ? "bg-emerald-500/15 text-emerald-300"
+          : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
+      }`}
+    >
+      {label}
+    </button>
   )
 }
 

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react"
-import { api } from "../api/client"
+import { api } from "@/api/client"
 import type {
   AnalyticsOverview,
   CostAnalytics,
@@ -10,11 +10,36 @@ import type {
   SpanAnalytics,
   ScoreSummary,
   AlertRule,
-} from "../types"
-import type { Route } from "../hooks/useRoute"
-import { useSessionStream } from "../hooks/useSessionStream"
-import { SessionsTimeline } from "../components/analytics/SessionsTimeline"
-import { SessionsHeatmap } from "../components/analytics/SessionsHeatmap"
+} from "@/types"
+import type { Route } from "@/hooks/useRoute"
+import { useSessionStream } from "@/hooks/useSessionStream"
+import { SessionsTimeline } from "@/components/analytics/SessionsTimeline"
+import { SessionsHeatmap } from "@/components/analytics/SessionsHeatmap"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
 type SessionsView = "list" | "timeline" | "heatmap"
 
@@ -23,80 +48,67 @@ interface AnalyticsPageProps {
   navigate: (path: string) => void
 }
 
-export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
-  return (
-    <div className="flex-1 flex flex-col min-w-0 bg-zinc-950">
-      {/* Tab bar */}
-      <div className="h-10 border-b border-zinc-800/80 flex items-center gap-1 px-4 bg-zinc-950/90">
-        <TabButton
-          label="Overview"
-          active={route.tab === "overview"}
-          onClick={() => navigate("/analytics/overview")}
-        />
-        <TabButton
-          label="Sessions"
-          active={route.tab === "sessions"}
-          onClick={() => navigate("/analytics/sessions")}
-        />
-        <TabButton
-          label="Usage"
-          active={route.tab === "usage"}
-          onClick={() => navigate("/analytics/usage")}
-        />
-        <TabButton
-          label="Evals"
-          active={route.tab === "evals"}
-          onClick={() => navigate("/analytics/evals")}
-        />
-        <div className="flex-1" />
-        <span
-          className="inline-flex items-center gap-1.5 text-[11px] font-mono text-emerald-400 tracking-wide"
-          title="Live updates stream from /api/sessions/stream — no polling."
-        >
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-          live
-        </span>
-      </div>
-
-      {/* Tab body */}
-      <div className="flex-1 min-h-0 overflow-auto">
-        {route.tab === "overview" && <OverviewTab />}
-        {route.tab === "sessions" && (
-          <SessionsTab
-            selectedSessionId={route.sessionId}
-            onSelectSession={(id) =>
-              navigate(id ? `/analytics/sessions/${id}` : "/analytics/sessions")
-            }
-          />
-        )}
-        {route.tab === "usage" && <UsageTab />}
-        {route.tab === "evals" && <EvalsTab />}
-      </div>
-    </div>
-  )
+const TAB_PATH: Record<typeof TABS[number], string> = {
+  overview: "/analytics/overview",
+  sessions: "/analytics/sessions",
+  usage: "/analytics/usage",
+  evals: "/analytics/evals",
 }
 
-function TabButton({
-  label,
-  active,
-  onClick,
-}: {
-  label: string
-  active: boolean
-  onClick: () => void
-}) {
+const TABS = ["overview", "sessions", "usage", "evals"] as const
+
+export function AnalyticsPage({ route, navigate }: AnalyticsPageProps) {
   return (
-    <button
-      onClick={onClick}
-      className={`px-3 h-8 text-[12px] font-display tracking-wide uppercase transition-colors cursor-pointer
-        ${
-          active
-            ? "text-emerald-400 border-b-2 border-emerald-400"
-            : "text-zinc-500 hover:text-zinc-300 border-b-2 border-transparent"
-        }`}
-    >
-      {label}
-    </button>
+    <TooltipProvider delayDuration={150}>
+      <div className="flex-1 flex flex-col min-w-0 bg-background">
+        {/* Tab bar — radix Tabs.List with shadcn styling. We keep the
+         * router as the source of truth for the active tab; Tabs is
+         * controlled. */}
+        <div className="h-10 border-b border-border flex items-center px-4 bg-background/90">
+          <Tabs
+            value={route.tab}
+            onValueChange={(v) =>
+              navigate(TAB_PATH[v as (typeof TABS)[number]] ?? "/analytics")
+            }
+            className="flex-1"
+          >
+            <TabsList className="border-b-0 -mb-px">
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="sessions">Sessions</TabsTrigger>
+              <TabsTrigger value="usage">Usage</TabsTrigger>
+              <TabsTrigger value="evals">Evals</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Badge variant="success" dot pulse>
+                  live
+                </Badge>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              Live updates stream from /api/sessions/stream — no polling.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        {/* Tab body */}
+        <div className="flex-1 min-h-0 overflow-auto">
+          {route.tab === "overview" && <OverviewTab />}
+          {route.tab === "sessions" && (
+            <SessionsTab
+              selectedSessionId={route.sessionId}
+              onSelectSession={(id) =>
+                navigate(id ? `/analytics/sessions/${id}` : "/analytics/sessions")
+              }
+            />
+          )}
+          {route.tab === "usage" && <UsageTab />}
+          {route.tab === "evals" && <EvalsTab />}
+        </div>
+      </div>
+    </TooltipProvider>
   )
 }
 
@@ -214,24 +226,25 @@ function Kpi({
   accent?: boolean
 }) {
   return (
-    <div
-      className={`border p-4 ${
-        accent
-          ? "border-emerald-500/30 bg-emerald-500/5"
-          : "border-zinc-800 bg-zinc-900/30"
-      }`}
+    <Card
+      className={cn(
+        accent && "border-primary/30 bg-primary/5",
+      )}
     >
-      <div className="text-[11px] font-mono tracking-wider text-zinc-500 uppercase mb-1">
-        {label}
-      </div>
-      <div
-        className={`text-2xl font-display font-semibold ${
-          accent ? "text-emerald-400" : "text-zinc-100"
-        }`}
-      >
-        {value}
-      </div>
-    </div>
+      <CardContent className="p-4">
+        <div className="text-[11px] font-mono tracking-wider text-muted-foreground uppercase mb-1">
+          {label}
+        </div>
+        <div
+          className={cn(
+            "text-2xl font-display font-semibold",
+            accent ? "text-primary" : "text-foreground",
+          )}
+        >
+          {value}
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -249,44 +262,41 @@ function CostTable({
   }>
 }) {
   return (
-    <div className="border border-zinc-800 bg-zinc-900/30">
-      <div className="px-4 py-2 border-b border-zinc-800 text-[11px] font-mono tracking-wider text-zinc-400 uppercase">
-        {title}
-      </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
       {rows.length === 0 ? (
-        <div className="p-4 text-sm text-zinc-600 font-mono">No data yet.</div>
+        <CardContent className="text-sm text-muted-foreground/70">
+          No data yet.
+        </CardContent>
       ) : (
-        <table className="w-full text-[13px] font-mono">
-          <thead>
-            <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
-              <th className="text-left font-normal px-4 py-1.5">Name</th>
-              <th className="text-right font-normal px-4 py-1.5">Cost</th>
-              <th className="text-right font-normal px-4 py-1.5">
-                {rows[0].countLabel}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+        <Table>
+          <TableHeader className="bg-card/30">
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead className="text-right">Cost</TableHead>
+              <TableHead className="text-right">{rows[0].countLabel}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {rows.map((r) => (
-              <tr
-                key={r.key}
-                className="border-t border-zinc-800/60 hover:bg-zinc-800/40"
-              >
-                <td className="px-4 py-1.5 text-zinc-200 truncate max-w-[240px]">
+              <TableRow key={r.key}>
+                <TableCell className="text-foreground truncate max-w-[240px]">
                   {r.primary}
-                </td>
-                <td className="px-4 py-1.5 text-right text-emerald-400">
+                </TableCell>
+                <TableCell className="text-right text-primary">
                   ${r.cost.toFixed(4)}
-                </td>
-                <td className="px-4 py-1.5 text-right text-zinc-400">
+                </TableCell>
+                <TableCell className="text-right text-muted-foreground">
                   {r.count}
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       )}
-    </div>
+    </Card>
   )
 }
 
@@ -386,64 +396,72 @@ function SessionsTab({
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* View-mode switcher — same data, three renderings */}
-      <div className="h-9 border-b border-zinc-800 flex items-center px-4 gap-3 bg-zinc-950/60 shrink-0">
-        <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-600">
+      <div className="h-9 border-b border-border flex items-center px-4 gap-3 bg-background/60 shrink-0">
+        <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground/70">
           view
         </span>
-        <div className="flex gap-px bg-zinc-800/60 p-px">
-          <ViewButton
-            active={view === "list"}
-            onClick={() => setView("list")}
-            label="list"
-          />
-          <ViewButton
-            active={view === "timeline"}
-            onClick={() => setView("timeline")}
-            label="timeline"
-          />
-          <ViewButton
-            active={view === "heatmap"}
-            onClick={() => setView("heatmap")}
-            label="heatmap"
-          />
-        </div>
+        <ToggleGroup
+          type="single"
+          value={view}
+          onValueChange={(v) => {
+            // Radix emits "" when the active item is clicked. Ignore
+            // that — view-mode is required, not toggle-able to empty.
+            if (v) setView(v as SessionsView)
+          }}
+        >
+          <ToggleGroupItem value="list" data-testid="sessions-view-list">
+            list
+          </ToggleGroupItem>
+          <ToggleGroupItem value="timeline" data-testid="sessions-view-timeline">
+            timeline
+          </ToggleGroupItem>
+          <ToggleGroupItem value="heatmap" data-testid="sessions-view-heatmap">
+            heatmap
+          </ToggleGroupItem>
+        </ToggleGroup>
         <div className="flex-1" />
-        <span className="text-[11px] font-mono text-zinc-500">
+        <span className="text-[11px] font-mono text-muted-foreground">
           {sessions.length} session{sessions.length === 1 ? "" : "s"}
         </span>
       </div>
 
       <div className="flex flex-1 min-h-0">
         {/* Body — switches by view; each renderer is a pure function of `sessions` */}
-        <div className="flex-1 min-w-0 border-r border-zinc-800 overflow-auto">
+        <div className="flex-1 min-w-0 border-r border-border overflow-auto">
           {view === "list" && (
-            <table className="w-full text-[13px] font-mono">
-              <thead className="sticky top-0 bg-zinc-950 z-10">
-                <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
-                  <th className="text-left font-normal px-4 py-2">Status</th>
-                  <th className="text-left font-normal px-4 py-2">Agent</th>
-                  <th className="text-left font-normal px-4 py-2">Started</th>
-                  <th className="text-right font-normal px-4 py-2">Dur</th>
-                  <th className="text-right font-normal px-4 py-2">Tokens</th>
-                  <th className="text-right font-normal px-4 py-2">Cost</th>
-                  <th className="text-left font-normal px-4 py-2">ID</th>
-                </tr>
-              </thead>
-              <tbody>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead className="text-right">Dur</TableHead>
+                  <TableHead className="text-right">Tokens</TableHead>
+                  <TableHead className="text-right">Cost</TableHead>
+                  <TableHead>ID</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {loading && sessions.length === 0 && (
-                  <tr>
-                    <td colSpan={7} className="p-8 text-center text-zinc-600">
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="p-8 text-center text-muted-foreground/70"
+                    >
                       Loading sessions…
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 )}
                 {!loading && sessions.length === 0 && (
-                  <tr>
-                    <td colSpan={7} className="p-8 text-center text-zinc-600">
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="p-8 text-center text-muted-foreground/70"
+                    >
                       No sessions yet. Spawn an agent and this table will
                       populate.
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 )}
                 {sessions.map((s) => (
                   <SessionRow
@@ -453,8 +471,8 @@ function SessionsTab({
                     onSelect={() => onSelectSession(s.id)}
                   />
                 ))}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           )}
 
           {view === "timeline" && (
@@ -486,30 +504,6 @@ function SessionsTab({
   )
 }
 
-function ViewButton({
-  active,
-  onClick,
-  label,
-}: {
-  active: boolean
-  onClick: () => void
-  label: string
-}) {
-  return (
-    <button
-      onClick={onClick}
-      data-testid={`sessions-view-${label}`}
-      className={`px-2.5 py-1 text-[11px] font-mono tracking-wide cursor-pointer transition-colors ${
-        active
-          ? "bg-emerald-500/15 text-emerald-300"
-          : "bg-zinc-900/60 text-zinc-500 hover:text-zinc-300"
-      }`}
-    >
-      {label}
-    </button>
-  )
-}
-
 function SessionRow({
   session,
   selected,
@@ -527,36 +521,33 @@ function SessionRow({
   const isLive = session.ended_at === null && session.status === "active"
 
   return (
-    <tr
+    <TableRow
       onClick={onSelect}
-      className={`border-t border-zinc-800/60 cursor-pointer transition-colors ${
-        selected ? "bg-emerald-500/5" : "hover:bg-zinc-800/40"
-      }`}
+      data-state={selected ? "selected" : undefined}
+      className="cursor-pointer"
     >
-      <td className="px-4 py-1.5">
+      <TableCell>
         <StatusBadge status={session.status} live={isLive} />
-      </td>
-      <td className="px-4 py-1.5 text-zinc-200 truncate max-w-[180px]">
+      </TableCell>
+      <TableCell className="text-foreground truncate max-w-[180px]">
         {session.agent_name || "—"}
-      </td>
-      <td className="px-4 py-1.5 text-zinc-400 text-[12px]">
+      </TableCell>
+      <TableCell className="text-muted-foreground text-[12px]">
         {new Date(session.started_at).toLocaleString()}
-      </td>
-      <td className="px-4 py-1.5 text-right text-zinc-400 text-[12px]">
+      </TableCell>
+      <TableCell className="text-right text-muted-foreground text-[12px]">
         {formatDuration(durationMs)}
-      </td>
-      <td className="px-4 py-1.5 text-right text-zinc-400 text-[12px]">
-        {(
-          session.total_input_tokens + session.total_output_tokens
-        ).toLocaleString()}
-      </td>
-      <td className="px-4 py-1.5 text-right text-emerald-400">
+      </TableCell>
+      <TableCell className="text-right text-muted-foreground text-[12px]">
+        {(session.total_input_tokens + session.total_output_tokens).toLocaleString()}
+      </TableCell>
+      <TableCell className="text-right text-primary">
         ${session.total_cost_usd.toFixed(4)}
-      </td>
-      <td className="px-4 py-1.5 text-zinc-600 text-[11px] truncate max-w-[160px]">
+      </TableCell>
+      <TableCell className="text-muted-foreground/70 text-[11px] truncate max-w-[160px]">
         {session.id}
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   )
 }
 
@@ -569,25 +560,20 @@ function StatusBadge({
 }) {
   if (live) {
     return (
-      <span className="inline-flex items-center gap-1.5 text-[11px] text-emerald-400 font-mono uppercase tracking-wider">
-        <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+      <Badge variant="success" dot pulse>
         live
-      </span>
+      </Badge>
     )
   }
-  const color =
+  const variant =
     status === "completed"
-      ? "text-zinc-400"
+      ? "muted"
       : status === "failed"
-        ? "text-rose-400"
+        ? "destructive"
         : status === "cancelled"
-          ? "text-amber-400"
-          : "text-zinc-500"
-  return (
-    <span className={`text-[11px] font-mono uppercase tracking-wider ${color}`}>
-      {status}
-    </span>
-  )
+          ? "warn"
+          : "muted"
+  return <Badge variant={variant}>{status}</Badge>
 }
 
 function formatDuration(ms: number): string {
@@ -940,24 +926,26 @@ function Panel({
   children: ReactNode
 }) {
   return (
-    <div className="border border-zinc-800 bg-zinc-900/30">
-      <div className="px-4 py-2 border-b border-zinc-800 flex items-center justify-between">
-        <span className="text-[11px] font-mono tracking-wider text-zinc-400 uppercase">
-          {title}
-        </span>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
         {subtitle && (
-          <span className="text-[11px] font-mono text-zinc-600">
+          <span className="text-[11px] font-mono text-muted-foreground/70">
             {subtitle}
           </span>
         )}
-      </div>
+      </CardHeader>
       {children}
-    </div>
+    </Card>
   )
 }
 
 function EmptyRow({ text }: { text: string }) {
-  return <div className="p-4 text-sm text-zinc-600 font-mono">{text}</div>
+  return (
+    <CardContent className="text-sm text-muted-foreground/70">
+      {text}
+    </CardContent>
+  )
 }
 
 type Align = "left" | "right"
@@ -972,41 +960,37 @@ function SimpleTable({
   rows: Array<{ key: string; cells: ReactNode[] }>
 }) {
   return (
-    <table className="w-full text-[13px] font-mono">
-      <thead>
-        <tr className="text-zinc-500 text-[10px] uppercase tracking-wider">
+    <Table>
+      <TableHeader className="bg-card/30">
+        <TableRow>
           {columns.map((c, i) => (
-            <th
+            <TableHead
               key={c}
-              className={`font-normal px-4 py-1.5 ${
-                aligns[i] === "right" ? "text-right" : "text-left"
-              }`}
+              className={cn(aligns[i] === "right" && "text-right")}
             >
               {c}
-            </th>
+            </TableHead>
           ))}
-        </tr>
-      </thead>
-      <tbody>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {rows.map((r) => (
-          <tr
-            key={r.key}
-            className="border-t border-zinc-800/60 hover:bg-zinc-800/40"
-          >
+          <TableRow key={r.key}>
             {r.cells.map((cell, i) => (
-              <td
+              <TableCell
                 key={i}
-                className={`px-4 py-1.5 ${
-                  aligns[i] === "right" ? "text-right" : "text-left"
-                } ${aligns[i] === "left" ? "max-w-[320px] truncate" : ""}`}
+                className={cn(
+                  aligns[i] === "right" && "text-right",
+                  aligns[i] === "left" && "max-w-[320px] truncate",
+                )}
               >
                 {cell}
-              </td>
+              </TableCell>
             ))}
-          </tr>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   )
 }
 
@@ -1088,14 +1072,11 @@ function EvalsTab() {
 
 function RuleState({ enabled }: { enabled: boolean }) {
   return enabled ? (
-    <span className="inline-flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-wider text-emerald-400">
-      <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+    <Badge variant="success" dot>
       enabled
-    </span>
+    </Badge>
   ) : (
-    <span className="text-[11px] font-mono uppercase tracking-wider text-zinc-500">
-      disabled
-    </span>
+    <Badge variant="muted">disabled</Badge>
   )
 }
 
@@ -1139,48 +1120,44 @@ function ScoreLookupPanel() {
           const name = input.trim()
           if (name) setSubmitted(name)
         }}
-        className="px-4 py-3 flex items-center gap-2 border-b border-zinc-800"
+        className="px-4 py-3 flex items-center gap-2 border-b border-border"
       >
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="score name (e.g. tests_pass, quality)"
-          className="flex-1 bg-zinc-950 border border-zinc-800 px-3 py-1.5 text-[13px] font-mono text-zinc-200
-            focus:outline-none focus:border-emerald-500/40"
+          className="flex-1 bg-background border border-input px-3 py-1.5 text-[13px] font-mono text-foreground
+            focus:outline-none focus:border-ring"
         />
-        <button
-          type="submit"
-          disabled={!input.trim()}
-          className="px-3 py-1.5 text-[12px] font-display tracking-wide uppercase
-            bg-emerald-500/10 text-emerald-400 border border-emerald-500/25
-            hover:bg-emerald-500/20 disabled:opacity-25 disabled:cursor-not-allowed
-            cursor-pointer transition-colors"
-        >
+        <Button type="submit" disabled={!input.trim()} size="sm">
           Lookup
-        </button>
+        </Button>
       </form>
-      <div className="p-4">
+      <CardContent>
         {!submitted && (
-          <div className="text-[13px] text-zinc-500 font-mono">
+          <div className="text-[13px] text-muted-foreground font-mono">
             Enter a score rule name to see pass/fail totals and rate.
           </div>
         )}
         {submitted && loading && (
-          <div className="text-[13px] text-zinc-500 font-mono">Loading…</div>
+          <div className="text-[13px] text-muted-foreground font-mono">
+            Loading…
+          </div>
         )}
         {submitted && error && (
           <div className="text-[13px] font-mono space-y-1">
-            <div className="text-rose-400">
+            <div className="text-destructive">
               No score named "{submitted}" — try another rule.
             </div>
-            <div className="text-zinc-500">
-              Common names: <code className="text-zinc-300">tests_pass</code>,{" "}
-              <code className="text-zinc-300">quality</code>,{" "}
-              <code className="text-zinc-300">loop_detected</code>. Run{" "}
-              <code className="text-zinc-300">gctrl analytics scores</code> for
-              the full list.
+            <div className="text-muted-foreground">
+              Common names:{" "}
+              <code className="text-foreground">tests_pass</code>,{" "}
+              <code className="text-foreground">quality</code>,{" "}
+              <code className="text-foreground">loop_detected</code>. Run{" "}
+              <code className="text-foreground">gctrl analytics scores</code>{" "}
+              for the full list.
             </div>
-            <div className="text-zinc-700 text-[11px]">{error}</div>
+            <div className="text-muted-foreground/50 text-[11px]">{error}</div>
           </div>
         )}
         {submitted && summary && (
@@ -1199,7 +1176,7 @@ function ScoreLookupPanel() {
             />
           </div>
         )}
-      </div>
+      </CardContent>
     </Panel>
   )
 }
@@ -1215,20 +1192,22 @@ function ScoreKpi({
 }) {
   const color =
     tone === "good"
-      ? "text-emerald-400"
+      ? "text-primary"
       : tone === "bad"
-        ? "text-rose-400"
+        ? "text-destructive"
         : tone === "warn"
           ? "text-amber-400"
-          : "text-zinc-200"
+          : "text-foreground"
   return (
-    <div className="border border-zinc-800 bg-zinc-950 p-3">
-      <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-500 mb-1">
-        {label}
-      </div>
-      <div className={`text-xl font-display font-semibold ${color}`}>
-        {value}
-      </div>
-    </div>
+    <Card className="bg-background">
+      <CardContent className="p-3">
+        <div className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground mb-1">
+          {label}
+        </div>
+        <div className={cn("text-xl font-display font-semibold", color)}>
+          {value}
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/gctrl-board/web/tsconfig.app.json
+++ b/apps/gctrl-board/web/tsconfig.app.json
@@ -4,7 +4,11 @@
     "jsx": "react-jsx",
     "outDir": "../dist-web",
     "rootDir": "src",
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/apps/gctrl-board/web/vite.config.ts
+++ b/apps/gctrl-board/web/vite.config.ts
@@ -6,6 +6,12 @@ import path from "node:path"
 export default defineConfig({
   root: path.resolve(__dirname),
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      // shadcn/ui convention — `@/components/ui/...` etc.
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   build: {
     outDir: path.resolve(__dirname, "../dist-web"),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,15 +44,45 @@ importers:
       '@effect/schema':
         specifier: ^0.75.0
         version: 0.75.5(effect@3.21.0)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       effect:
         specifier: ^3.14.0
         version: 3.21.0
+      lucide-react:
+        specifier: ^1.11.0
+        version: 1.11.0(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.9.0
@@ -1053,6 +1083,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2031,6 +2076,324 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.8':
+    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2704,6 +3067,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -3497,6 +3863,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@1.11.0:
+    resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4188,6 +4559,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
@@ -4295,6 +4669,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
@@ -5539,6 +5916,23 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -6342,6 +6736,284 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.1': {}
+
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
@@ -7012,6 +7684,10 @@ snapshots:
   ci-info@4.4.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   cli-boxes@3.0.0: {}
 
@@ -7800,6 +8476,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@1.11.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:
@@ -8838,6 +9518,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  tailwind-merge@3.5.0: {}
+
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
@@ -8935,6 +9617,8 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
+
+  tw-animate-css@1.4.0: {}
 
   typanion@3.14.0: {}
 

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -285,9 +285,13 @@ Each milestone lists one falsifiable acceptance criterion per shipped tab; it's 
 2. **M1 — Usage + Evals**: Usage tab (providers, tools, performance — no network sub-panel yet), Evals tab (scores, alerts). Zero new kernel work.
    - *Accept Usage*: provider spend on the Usage tab over any window matches `gctrl analytics cost --since <window>` to the cent.
    - *Accept Evals*: every alert rule that's `firing` in `gctrl analytics alerts` appears as `firing` on the Evals tab within one refresh.
-3. **M2 — Prompts + Activity views**: Prompts tab, plus Timeline and Heatmap view modes on the Sessions tab. Depends on Kernel Dependencies §3 (extended `SpanType` variants **or** a `prompts` table — decide in the M2 ADR).
-   - *Accept Prompts*: grouping by fingerprint over a known test corpus produces the same group counts as the kernel query used to back the route (diff the JSON, expect zero rows).
-   - *Accept Sessions views*: switching list → timeline → heatmap does not re-fetch — same query, three renderings — verified by watching the Network tab.
+3. **M2 — Prompts + Activity views**: split for delivery — Activity views (M2a) ship as pure-UI without kernel work; Prompts (M2b) remain blocked on the kernel ADR (extended `SpanType` variants **or** a `prompts` table — decide in the M2 ADR).
+   - **M2a — Sessions Activity views** *(shipped)*: Timeline and Heatmap view modes on the Sessions tab. View-mode is local component state in `SessionsTab`; the underlying `sessions` query is shared across List/Timeline/Heatmap.
+     - Timeline: lanes per `agent_name`, bars per session, colored by status; live sessions pulse; tooltip shows time range and cost; click drills into the detail pane.
+     - Heatmap: agent × hour-of-day grid with a `count`/`cost` toggle; quantized 5-bucket emerald scale so adjacent intensities are eye-readable; click drills into the first session in the cell.
+   - **M2b — Prompts tab** *(blocked on M2 ADR)*: not yet shipped.
+   - *Accept M2a (Sessions views)*: switching list → timeline → heatmap does not re-fetch — same query, three renderings — verified by watching the Network tab. **Verified.**
+   - *Accept M2b (Prompts)*: grouping by fingerprint over a known test corpus produces the same group counts as the kernel query used to back the route (diff the JSON, expect zero rows).
 4. **M3 — Attribution**: kernel adds `session.created_by`; app wires the global filter and adds stacked splits on Evals / Usage / Contributions (even if Contributions is a stub at this point).
    - *Accept*: filtering `kind=external` on a workspace with only scheduler-spawned sessions returns zero rows; `kind=internal` returns every row. Totals of the two equal the unfiltered total.
 5. **M4 — Network sub-panel**: depends on kernel `proxy` Phase 2 + `/api/net/*` routes. Ships inside the Usage tab, not as its own tab.

--- a/specs/architecture/apps/gctrl-analytics.md
+++ b/specs/architecture/apps/gctrl-analytics.md
@@ -243,7 +243,7 @@ Mirrors `gctrl-board` to avoid divergence:
 - Cloudflare Worker facade + React 19 SPA.
 - `@effect/platform` HTTP client for kernel calls (same pattern as board).
 - `recharts` or `visx` for charts — pick one consistent with the board's eventual choice; no need to invent a chart stack twice.
-- Tailwind + shadcn-style components. Dense tables by default — this is an operator tool, not a marketing site.
+- Tailwind v4 + **shadcn/ui** primitives (vendored under `apps/gctrl-board/web/src/components/ui/`). Tokens are declared once in `index.css` `@theme` and inherited by every primitive (`bg-card`, `text-muted-foreground`, `text-primary`, etc.) so the operator-tool aesthetic stays consistent across analytics, kanban, and gantt without re-themeing each component. Primitives in active use today: `Tabs`, `Card`, `Table`, `Badge`, `ToggleGroup`, `Tooltip`, `Button`. Dense tables by default — this is an operator tool, not a marketing site.
 - Routes: `/overview`, `/sessions`, `/sessions/:id`, `/prompts`, `/evals`, `/usage`, `/contributions`.
 
 The Worker itself is a **thin facade**: it proxies to the kernel HTTP API and serves the SPA bundle. No D1, no business logic in the Worker. This follows the [Kernel is source of truth; Worker is facade](../../../CLAUDE.md) invariant.


### PR DESCRIPTION
## Summary

Two coupled changes on the analytics dashboard. Both land together
because the second is the substrate the first should sit on:

1. **M2a — Sessions Timeline + Heatmap view modes** (UI-only, zero
   kernel work).
2. **shadcn/ui adoption** for the analytics surfaces — primitives
   replace the bespoke className soup that was accumulating in
   `AnalyticsPage.tsx` and the new view components.

The spec's M2a acceptance criterion still holds:

> "switching list → timeline → heatmap does not re-fetch — same query,
> three renderings — verified by watching the Network tab."

`view` is local component state in `SessionsTab`; the three views are
pure functions of the already-loaded `sessions` array. Live SSE
updates from M0-final flow through unchanged — Timeline pulses live
bars, Heatmap re-buckets as new rows arrive.

## M2a — Activity views

- `web/src/components/analytics/SessionsTimeline.tsx` — lanes per
  agent, status-coloured bars, live pulse, adaptive time axis
  (HH:MM under 24h, MM/DD HH:MM under 7d, MM/DD beyond), shadcn
  `Tooltip` on each bar with multi-line agent/range/cost content.
- `web/src/components/analytics/SessionsHeatmap.tsx` — agent ×
  hour-of-day grid, quantized 5-bucket emerald scale, `count`/`cost`
  toggle (now via shadcn `ToggleGroup`), shadcn `Tooltip` on
  non-empty cells only.
- `SessionsTab` gets a sticky view-mode toggle (List / Timeline /
  Heatmap) using shadcn `ToggleGroup`; same `sessions` state across
  all three. Detail pane is shared.

## shadcn/ui adoption

Setup:
- `components.json` (new-york style, zinc base, CSS variables, lucide
  icons), `web/src/lib/utils.ts` exports `cn()`.
- Tailwind v4 `@theme` extended with shadcn semantic tokens (background,
  foreground, card, popover, primary, secondary, muted, accent,
  destructive, border, input, ring, radius). Pinned to the existing
  zinc/emerald palette so primitives blend with the operator-tool
  aesthetic — no second visual vocabulary.
- `@custom-variant dark` and `@import "tw-animate-css"` for shadcn's
  data-state animations.
- Path alias `@/*` → `web/src/*` in both `tsconfig.app.json` and
  `vite.config.ts`.

Primitives vendored under `web/src/components/ui/`:
`button`, `card`, `tabs`, `toggle-group`, `badge`, `table`, `tooltip`.
Each one tuned for the operator-tool feel (tighter padding, square
corners, monospace tables, dense rows) rather than the marketing-site
defaults.

Refactor (analytics surfaces only — kanban/gantt untouched):
- Tab bar: bespoke `TabButton` → `Tabs` / `TabsList` / `TabsTrigger`.
- Live indicator → `Badge` with pulse + `Tooltip` explaining the SSE
  source.
- Overview KPIs and cost rollups → `Card` + `Table` primitives.
- View-mode switcher: bespoke `ViewButton` → `ToggleGroup`.
- Sessions list body → `Table` primitives.
- `StatusBadge` / `RuleState` → shared `Badge` (success+pulse for
  live, destructive for failed, warn for cancelled).
- `Panel` / `EmptyRow` / `SimpleTable` → Card / Table primitives.
- `ScoreLookupPanel` button → `Button` primitive.
- `ScoreKpi` → `Card` + semantic tokens.
- Timeline bars → wrapped in `Tooltip` (multi-line content,
  keyboard-focus accessibility) replacing native `title`. Bar palette
  uses semantic tokens (`bg-primary`, `bg-destructive`,
  `bg-muted-foreground`).
- Heatmap cells → wrapped in `Tooltip`; mode picker → `ToggleGroup`.

## Test plan

- [x] `tsc --noEmit -p web/tsconfig.app.json` clean for new code (only
      the two pre-existing `InboxMessage.source_name` errors that
      predate this branch).
- [x] `vite build` — 414 KB / 125 KB gzip. Up from 327 KB / 95 KB
      pre-shadcn; the +30 KB gzip is the cost of the radix primitives
      (Tabs, Tooltip, ToggleGroup) and is a one-time hit — adding more
      primitives is now free.
- [x] `vitest run` — 41 pass / 29 skipped / 0 fail.
- [x] Acceptance verified by inspection: switching views does not
      re-call `api.sessions.list` (the only fetch point is `useEffect`
      on mount + stream-driven mutations).
- [ ] Manual QA: with the kernel running and a few sessions, switch
      between views; verify Timeline tooltips render, Heatmap
      `count`/`cost` toggle reflows, click-through lands on the
      correct session detail.
- [ ] CI green.

## Roadmap remaining

- **M3** — `session.created_by` + filter (PR #65, separate branch)
- **M2b** — Prompts tab (kernel ADR + schema decision)
- **M4** — Network sub-panel (proxy Phase 2)
- **M5** — Contributions (commit-trailer inference)
