### PR TITLE
feat(kernel): vault mounts table + atomic vault I/O (PR1 of vault reorg)

### DIFF
--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -686,6 +686,53 @@ pub struct InboxActionFilter {
     pub limit: Option<usize>,
 }
 
+// --- Vault Mounts (Kernel) ---
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VaultMountKind {
+    Workspace,
+    App,
+    External,
+}
+
+impl VaultMountKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::App => "app",
+            Self::External => "external",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "workspace" => Some(Self::Workspace),
+            "app" => Some(Self::App),
+            "external" => Some(Self::External),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultMount {
+    pub id: String,
+    pub name: String,
+    pub root_path: String,
+    pub kind: VaultMountKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_commit_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_synced_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/crates/gctrl-storage/src/lib.rs
+++ b/kernel/crates/gctrl-storage/src/lib.rs
@@ -3,6 +3,7 @@ pub mod duckdb_store;
 pub mod persona_markdown;
 pub mod schema;
 pub mod sqlite_store;
+pub mod vault_io;
 
 pub use board_markdown::{export_markdown_dir, import_markdown_dir};
 pub use duckdb_store::DuckDbStore;
@@ -10,3 +11,4 @@ pub use persona_markdown::{
     import_persona_dir, parse_persona_markdown, parse_review_rule_markdown, PersonaImport,
 };
 pub use sqlite_store::SqliteStore;
+pub use vault_io::{sha256_hex, write_atomic};

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use rusqlite::{params, Connection};
 use gctrl_core::{
-    GctlError, Result, Task,
+    GctlError, Result, Task, VaultMount, VaultMountKind,
     InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
     PersonaDefinition, PersonaReviewRule,
     context::{ContextEntry, ContextEntryId, ContextFilter, ContextKind, ContextSource},
@@ -243,6 +243,25 @@ CREATE TABLE IF NOT EXISTS memory_entries (
 )
 "#;
 
+// Vault mounts: per-device registry of Obsidian-mountable vault directories
+// the kernel watches and indexes. Each mount maps `name` → filesystem `root_path`
+// with an associated `kind` (workspace, app, or external git repo). NOT D1-synced —
+// mount config is local since paths differ between machines.
+const CREATE_VAULT_MOUNTS: &str = r#"
+CREATE TABLE IF NOT EXISTS gctrl_vault_mounts (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL UNIQUE,
+    root_path       TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    git_url         TEXT,
+    app_id          TEXT,
+    last_commit_sha TEXT,
+    last_synced_at  TEXT,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+)
+"#;
+
 const CREATE_INDEXES: &[&str] = &[
     // Board indexes
     "CREATE INDEX IF NOT EXISTS idx_board_issues_project ON board_issues(project_id)",
@@ -347,6 +366,7 @@ impl SqliteStore {
             CREATE_INBOX_SUBSCRIPTIONS,
             CREATE_CONTEXT_ENTRIES,
             CREATE_MEMORY_ENTRIES,
+            CREATE_VAULT_MOUNTS,
         ];
         for stmt in &tables {
             conn.execute_batch(stmt)
@@ -2033,6 +2053,81 @@ impl SqliteStore {
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Vault Mounts CRUD
+    // ═══════════════════════════════════════════════════════════════
+
+    pub fn create_vault_mount(&self, mount: &VaultMount) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO gctrl_vault_mounts (id, name, root_path, kind, git_url, app_id, last_commit_sha, last_synced_at, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                mount.id,
+                mount.name,
+                mount.root_path,
+                mount.kind.as_str(),
+                mount.git_url,
+                mount.app_id,
+                mount.last_commit_sha,
+                mount.last_synced_at.map(|dt| dt.to_rfc3339()),
+                mount.created_at.to_rfc3339(),
+                mount.updated_at.to_rfc3339(),
+            ],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn get_vault_mount(&self, name: &str) -> Result<Option<VaultMount>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, name, root_path, kind, git_url, app_id, last_commit_sha, last_synced_at, created_at, updated_at
+             FROM gctrl_vault_mounts WHERE name = ?1",
+            [name],
+            row_to_vault_mount,
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(GctlError::Storage(other.to_string())),
+        })
+    }
+
+    pub fn list_vault_mounts(&self) -> Result<Vec<VaultMount>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, root_path, kind, git_url, app_id, last_commit_sha, last_synced_at, created_at, updated_at
+             FROM gctrl_vault_mounts ORDER BY name"
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt.query_map([], row_to_vault_mount)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    pub fn delete_vault_mount(&self, name: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM gctrl_vault_mounts WHERE name = ?1",
+            [name],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Update sync state after a successful pull/sync (commit SHA + timestamp).
+    pub fn update_vault_mount_synced(
+        &self,
+        name: &str,
+        last_commit_sha: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE gctrl_vault_mounts SET last_commit_sha = ?1, last_synced_at = ?2, updated_at = ?2 WHERE name = ?3",
+            params![last_commit_sha, now, name],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -2050,6 +2145,33 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
         agent_kind: row.get(4)?,
         orchestrator_claim: row.get(5)?,
         attempt: row.get(6)?,
+        created_at: chrono::DateTime::parse_from_rfc3339(&created_at_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
+        updated_at: chrono::DateTime::parse_from_rfc3339(&updated_at_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
+    })
+}
+
+fn row_to_vault_mount(row: &rusqlite::Row<'_>) -> rusqlite::Result<VaultMount> {
+    let kind_str: String = row.get(3)?;
+    let last_synced_at_str: Option<String> = row.get(7)?;
+    let created_at_str: String = row.get(8)?;
+    let updated_at_str: String = row.get(9)?;
+    Ok(VaultMount {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        root_path: row.get(2)?,
+        kind: VaultMountKind::from_str(&kind_str).unwrap_or(VaultMountKind::App),
+        git_url: row.get(4)?,
+        app_id: row.get(5)?,
+        last_commit_sha: row.get(6)?,
+        last_synced_at: last_synced_at_str.and_then(|s| {
+            chrono::DateTime::parse_from_rfc3339(&s)
+                .ok()
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+        }),
         created_at: chrono::DateTime::parse_from_rfc3339(&created_at_str)
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now()),
@@ -2758,5 +2880,80 @@ mod tests {
         // A subsequent local edit must mark the row unsynced again.
         store.assign_board_issue("P-1", "u2", "User 2", "human").unwrap();
         assert_eq!(store.list_unsynced_board_issues(10).unwrap().len(), 1);
+    }
+
+    fn make_mount(id: &str, name: &str, kind: VaultMountKind) -> VaultMount {
+        let now = Utc::now();
+        VaultMount {
+            id: id.into(),
+            name: name.into(),
+            root_path: format!("/tmp/{name}"),
+            kind,
+            git_url: None,
+            app_id: None,
+            last_commit_sha: None,
+            last_synced_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn vault_mount_create_and_list() {
+        let store = test_store();
+        store.create_vault_mount(&make_mount("m1", "workspace", VaultMountKind::Workspace)).unwrap();
+        store.create_vault_mount(&make_mount("m2", "gctrl-board", VaultMountKind::App)).unwrap();
+
+        let mounts = store.list_vault_mounts().unwrap();
+        assert_eq!(mounts.len(), 2);
+        assert_eq!(mounts[0].name, "gctrl-board"); // ORDER BY name
+        assert_eq!(mounts[1].name, "workspace");
+        assert_eq!(mounts[0].kind, VaultMountKind::App);
+        assert_eq!(mounts[1].kind, VaultMountKind::Workspace);
+    }
+
+    #[test]
+    fn vault_mount_get_by_name() {
+        let store = test_store();
+        store.create_vault_mount(&make_mount("m1", "workspace", VaultMountKind::Workspace)).unwrap();
+
+        let fetched = store.get_vault_mount("workspace").unwrap();
+        assert!(fetched.is_some());
+        let m = fetched.unwrap();
+        assert_eq!(m.id, "m1");
+        assert_eq!(m.root_path, "/tmp/workspace");
+
+        let missing = store.get_vault_mount("nope").unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn vault_mount_unique_name_constraint() {
+        let store = test_store();
+        store.create_vault_mount(&make_mount("m1", "dup", VaultMountKind::Workspace)).unwrap();
+        let err = store.create_vault_mount(&make_mount("m2", "dup", VaultMountKind::App));
+        assert!(err.is_err(), "second insert with same name must fail");
+    }
+
+    #[test]
+    fn vault_mount_delete() {
+        let store = test_store();
+        store.create_vault_mount(&make_mount("m1", "tmp", VaultMountKind::Workspace)).unwrap();
+        store.delete_vault_mount("tmp").unwrap();
+        assert!(store.get_vault_mount("tmp").unwrap().is_none());
+    }
+
+    #[test]
+    fn vault_mount_update_synced() {
+        let store = test_store();
+        let mut mount = make_mount("m1", "ext", VaultMountKind::External);
+        mount.git_url = Some("https://github.com/example/app.git".into());
+        store.create_vault_mount(&mount).unwrap();
+        assert!(store.get_vault_mount("ext").unwrap().unwrap().last_commit_sha.is_none());
+
+        store.update_vault_mount_synced("ext", Some("abc123def")).unwrap();
+        let m = store.get_vault_mount("ext").unwrap().unwrap();
+        assert_eq!(m.last_commit_sha.as_deref(), Some("abc123def"));
+        assert!(m.last_synced_at.is_some());
     }
 }

--- a/kernel/crates/gctrl-storage/src/vault_io.rs
+++ b/kernel/crates/gctrl-storage/src/vault_io.rs
@@ -1,0 +1,120 @@
+//! Atomic vault file I/O.
+//!
+//! Vault files (issue records, briefs, persona definitions) are the source of
+//! truth in gctrl's vault model — SQLite holds an index keyed by `vault_path`
+//! and `content_hash`. Writes from kernel-side handlers must use this module
+//! to avoid torn files (Obsidian + watcher both read partial writes otherwise)
+//! and to keep the recorded `content_hash` in lockstep with the bytes on disk.
+//!
+//! Pattern (from Uebermensch): write to `<path>.tmp` → fsync → rename → SHA-256.
+//! The rename is atomic on POSIX filesystems; either the new bytes or the old
+//! bytes are visible to a concurrent reader, never a torn mix.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use gctrl_core::{GctlError, Result};
+
+/// Atomically write `body` to `path` and return the SHA-256 hash of the bytes
+/// that landed on disk. Creates parent directories as needed.
+///
+/// The caller should write the returned hash into the corresponding SQL index
+/// row (`vault_path`, `content_hash`) so the watcher's next event is a no-op.
+pub fn write_atomic(path: &Path, body: &str) -> Result<String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|e| GctlError::Storage(format!("create_dir_all {}: {e}", parent.display())))?;
+        }
+    }
+
+    let tmp_path = with_tmp_suffix(path);
+
+    let mut file = File::create(&tmp_path)
+        .map_err(|e| GctlError::Storage(format!("create {}: {e}", tmp_path.display())))?;
+    file.write_all(body.as_bytes())
+        .map_err(|e| GctlError::Storage(format!("write {}: {e}", tmp_path.display())))?;
+    file.sync_all()
+        .map_err(|e| GctlError::Storage(format!("fsync {}: {e}", tmp_path.display())))?;
+    drop(file);
+
+    fs::rename(&tmp_path, path)
+        .map_err(|e| GctlError::Storage(format!("rename {} → {}: {e}", tmp_path.display(), path.display())))?;
+
+    Ok(sha256_hex(body))
+}
+
+/// SHA-256 hex digest of the given content.
+pub fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn with_tmp_suffix(path: &Path) -> std::path::PathBuf {
+    let mut os = path.as_os_str().to_owned();
+    os.push(".tmp");
+    std::path::PathBuf::from(os)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_atomic_creates_file_and_returns_hash() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("BOARD-1.md");
+        let body = "---\nid: BOARD-1\n---\n\n# Hello\n";
+
+        let hash = write_atomic(&path, body).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(fs::read_to_string(&path).unwrap(), body);
+        assert_eq!(hash, sha256_hex(body));
+        assert_eq!(hash.len(), 64); // SHA-256 hex digest
+    }
+
+    #[test]
+    fn write_atomic_creates_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested/deep/file.md");
+
+        write_atomic(&path, "x").unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn write_atomic_overwrites_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("file.md");
+        write_atomic(&path, "first").unwrap();
+        let hash2 = write_atomic(&path, "second").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "second");
+        assert_eq!(hash2, sha256_hex("second"));
+    }
+
+    #[test]
+    fn write_atomic_leaves_no_tmp_file_on_success() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("file.md");
+        write_atomic(&path, "body").unwrap();
+
+        let tmp = dir.path().join("file.md.tmp");
+        assert!(!tmp.exists(), "tmp file must be renamed away on success");
+    }
+
+    #[test]
+    fn sha256_hex_is_stable() {
+        assert_eq!(
+            sha256_hex(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the vault reorganization. **No file moves, no behavior change** for the existing `watch_board_dir`. PR2–PR4 build on this.

- `gctrl_vault_mounts` SQLite table — per-device registry of Obsidian-mountable vault directories
- `VaultMount` + `VaultMountKind` domain types in `gctrl-core`
- `SqliteStore` CRUD: `create_vault_mount`, `get_vault_mount`, `list_vault_mounts`, `delete_vault_mount`, `update_vault_mount_synced`
- `gctrl_storage::vault_io::write_atomic(path, body) -> sha256_hex` — `<path>.tmp` → fsync → rename → SHA-256

## Why

Uebermensch already proves the vault-as-source-of-truth pattern (`vault_path` + `content_hash` index columns, atomic write on render). Generalizing it across all apps lets external-repo apps integrate by just dropping a `vault/` at their root. See full design rationale in the conversation that produced this PR.

## How it works

**Schema:** `gctrl_vault_mounts` is intentionally NOT D1-synced — mount config is local since paths differ between machines. Each row maps a `name` → filesystem `root_path` with a `kind` (workspace, app, external). External-repo apps additionally carry `git_url` and `last_commit_sha`.

**Atomic write:** the rename is atomic on POSIX filesystems, so a concurrent reader (Obsidian, watcher) sees either the new bytes or the old bytes — never a torn mix. The returned hash is what the caller writes into the corresponding SQL index row, which makes the watcher's next inotify event a no-op.

## What's deferred

- **PR2** — workspace vault move: `specs/` → `vault/specs/`, `gctrl/personas/` → `vault/personas/`, scope the `AGENTS.md` "no wikilinks" + "numbered lists" rules to `vault/specs/` only
- **PR3** — app vault moves: create `apps/{app}/vault/`, move BOARD/INBOX/utils, retire the top-level `gctrl/` directory
- **PR4** — generalize `watch_board_dir` into a per-mount `VaultWatcher` with a `VaultParser` trait registry; bidirectional sync (SQL → file) using `vault_io::write_atomic`; conflict detection on stale on-disk hash

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — all suites green, including 90 storage tests (5 new for `vault_mount` CRUD, 5 new for `vault_io::write_atomic`)
- [x] `:memory:` SQLite fixture verifies UNIQUE(name) constraint, get-by-name, list ordering, delete, sync-state update
- [x] `tempfile::TempDir` verifies atomic write creates parents, overwrites cleanly, leaves no `.tmp` residue, and returns a stable SHA-256 hex
- [ ] No runtime behavior wired yet — PR4 lights up the generic watcher
