### PR TITLE
specs(observe-eval): position evals as harness + substrate across lifecycle

### DIFF
--- a/vault/specs/architecture/apps/observe-eval.md
+++ b/vault/specs/architecture/apps/observe-eval.md
@@ -1,0 +1,150 @@
+# Application: Observe & Eval
+
+Observe & Eval is the gctrl native application for **lifecycle evaluation of agent-built and agent-using products**. It owns both the **substrate** (metric registry, prompt registry, judges, score store, trends) and the **harness** (runner, suites, regression gates) over a single set of primitives.
+
+A metric named `faithfulness` defined once in Observe & Eval is the same metric whether it runs in local development, in CI, in staging, or against live production sessions. That continuity — one metric name, one chart, one query, dev → prod — is the differentiator. It is not a pytest plugin and not a single-phase test framework.
+
+## Architectural Position
+
+Observe & Eval is a **native application** in the Unix layer model. Like `gctrl-board`, it depends on the shell and kernel; nothing in the kernel depends on it.
+
+```
+App (Observe & Eval) → Shell (HTTP API :4318) → Kernel (Storage, Telemetry, Model Router)
+```
+
+- **Depends on the shell** — reads/writes via the kernel HTTP API and CLI. MUST NOT import kernel crates from app code (Rust app components compiled into the binary may, per OS § 3).
+- **Never depended on by the shell or kernel** — the kernel knows nothing about metrics, judges, datasets, or runs. Removing the app breaks nothing below it.
+- **Reuses the kernel's `scores` table** — per [domain-model § 5.3](../domain-model.md#53-eval-application-tables), scores are kernel-owned and shared. Observe & Eval adds its own namespaced tables (`eval_*`) for the primitives the kernel does not own.
+
+See [os.md — Dependency Direction](../os.md) for the full invariant.
+
+## Why Both Harness and Substrate
+
+A pure substrate (metrics + score store, no runner) forces every consuming app to write its own loop. A pure harness (a runner, no shared store) forces every consuming app to adopt the runner's opinions and gives up dev→prod continuity. gctrl owns both because the same primitives — metrics, prompts, judges, scores — must be reachable from either entry point and produce identical results.
+
+| Mode | Loop owner | Entry point | Use cases |
+|---|---|---|---|
+| **Harness** | Observe & Eval | `gctrl eval run <suite>` | CI gates, "just run my evals" path, baseline comparisons |
+| **Substrate** | Application | `POST /api/eval/score` and SDK | Embedded eval (dev test loop, prod sampler), custom flows, apps with their own runner |
+
+Both modes hit the same internals: metric registry → judge prompt → model router → `Score` row. The harness is a built-in client of the substrate API. There is no private path the runner can take that an application cannot.
+
+## Lifecycle Coverage
+
+Observe & Eval is scoped to the full product-development lifecycle. Each phase uses the same metrics and judges with phase-specific framing:
+
+| Phase | How Observe & Eval is used | What gets stored |
+|---|---|---|
+| **Spec/design** | Author judges and acceptance criteria as named metrics | `eval_metrics`, `eval_prompts` |
+| **Local dev** | App calls substrate API while iterating; or `gctrl eval run --watch` | `eval_runs`, `scores` |
+| **Pre-merge CI** | Harness mode: `gctrl eval run <suite> --baseline <run-id>`, exits non-zero on regression | `eval_runs`, `scores` |
+| **Pre-deploy / staging** | A/B prompts and models against the same suite | `eval_runs`, `scores` (with prompt/model tags) |
+| **Post-deploy** | App samples live sessions via substrate API; auto-scoring runs on session end | `scores` (with `target_type='session'`) |
+
+A query like `SELECT date_trunc('day', created_at), avg(value) FROM scores WHERE name='faithfulness'` answers "Faithfulness over time" across every phase in one chart.
+
+## Primitives
+
+### Metric
+A named scoring function. Resolves to either an in-process evaluator (deterministic check, statistical metric) or a judge prompt (LLM-as-judge) referenced by `prompt_id`. Has a threshold for pass/fail when used as a gate. Examples: `faithfulness`, `tool_correctness`, `json_correctness`, `cost_per_generation`. Custom metrics are first-class — apps register them via the API.
+
+### Prompt (Judge Prompt)
+A versioned text artifact stored in the kernel's existing `prompt_versions` table (content-addressed by hash). Reused for both agent prompts and judge prompts; the difference is purpose, not storage. A judge prompt is referenced by metric definitions.
+
+### Dataset / Case
+A dataset is a named collection of cases. A case is `{ input, expected?, context? }` — schema is intentionally permissive. Datasets are not required for substrate-mode evals; apps may pass cases inline. They become important in harness mode and for replayable baselines.
+
+### Eval Run
+A grouping row that ties a batch of `Score`s together — one row per `gctrl eval run` invocation, or per app-initiated batch. Carries metadata (suite name, model, prompt version, baseline run-id, git sha, environment). Enables baseline diffs and "show me runs of suite X over the last 30 days."
+
+### Score
+The kernel-owned `scores` table (see [domain-model § 5.3](../domain-model.md#53-eval-application-tables)) carries every score from every mode. `target_type` extends to include `eval_case` and `eval_run` alongside the existing `session`, `span`, `task`. The metric continuity property depends on this table being the single sink.
+
+## Tables
+
+Per the namespacing invariant, Observe & Eval owns the `eval_*` prefix. The kernel-owned `scores` table is shared.
+
+| Table | Owner | Purpose |
+|---|---|---|
+| `scores` | Kernel | Every score from every mode (substrate + harness, dev + prod). Existing. |
+| `eval_metrics` | Observe & Eval | Metric definitions: name, kind (deterministic / judge), prompt_id, threshold, schema |
+| `eval_datasets` | Observe & Eval | Named dataset metadata |
+| `eval_cases` | Observe & Eval | Cases belonging to datasets — `input`, `expected`, `context`, all JSON-typed |
+| `eval_runs` | Observe & Eval | Run-level metadata that groups scores: suite name, baseline_run_id, git_sha, env, model |
+
+`prompt_versions` (kernel) is reused for judge prompts; no new table is needed for them.
+
+## API Surface
+
+The substrate API is the load-bearing surface. The harness CLI is a thin client of it.
+
+### Substrate (HTTP + SDK)
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/eval/score` | Score one output against a named metric. Body: `{ metric, input, output, context?, target_type?, target_id?, run_id? }`. Returns `{ score, pass, judge_trace_id }` and persists a `scores` row. |
+| `POST /api/eval/metrics` | Register or update a metric definition. |
+| `GET /api/eval/metrics` | List metric definitions. |
+| `POST /api/eval/datasets` / `POST /api/eval/cases` | Manage datasets and cases. |
+| `POST /api/eval/runs` | Open a new run; returns `run_id` for grouping subsequent scores. |
+| `GET /api/eval/runs/{id}` | Run summary: pass/fail counts, score distributions, baseline diff. |
+| `GET /api/analytics/scores?name=...` | Existing endpoint, unchanged. The substrate writes here. |
+
+The SDK is a thin language-specific wrapper (TypeScript first, matching `gctrl-board`) around these endpoints.
+
+### Harness (CLI)
+
+| Command | Purpose |
+|---|---|
+| `gctrl eval run <suite>` | Load suite (dataset + metrics), iterate cases, score each, persist a run, print summary. |
+| `gctrl eval run <suite> --baseline <run-id>` | Compare against a prior run; exit non-zero on regression. |
+| `gctrl eval run <suite> --watch` | Re-run on file change for local dev. |
+| `gctrl eval metrics list/show <name>` | Inspect the registry. |
+| `gctrl eval runs list` | Browse historical runs. |
+
+The runner calls the substrate `POST /api/eval/score` for every case. There is no internal shortcut.
+
+## Integration with the Kernel
+
+| Kernel piece | Role for Observe & Eval |
+|---|---|
+| **Telemetry** | Every eval run is itself a Session. Judge LLM calls become Spans like any other generation. Cost and latency of evals are first-class. |
+| **Storage** | DuckDB `scores` is shared; `eval_*` tables are app-namespaced. Indexes follow [domain-model § 5.4](../domain-model.md#54-indexes). |
+| **Model Router** | Judges call the same model router as agents. The recent Workers AI / AI Gateway routing for `@cf/*` (commit `63c50fc`) applies to judge calls without modification. |
+| **Sync** | `eval_*` tables are exported via the same Parquet/R2 pipeline as kernel telemetry. No special sync path. |
+| **Event Bus** | `SessionEnded` continues to trigger the existing `auto_score_session` post-hoc metrics. New event `EvalRunCompleted` lets the board surface regressions. |
+| **Guardrails** | Cost budgets and loop detection apply to eval runs without change. Judges are LLM calls; they are governed. |
+
+## Integration with Other Applications
+
+- **gctrl-board** — Surfaces eval run summaries on Issue cards (e.g., "this branch's run #422 regressed `faithfulness` 0.78 → 0.61"). Subscribes to `EvalRunCompleted`.
+- **gctl-inbox** — `eval_request` items (already defined in [gctl-inbox.md](gctl-inbox.md)) trigger harness runs.
+- **Observability drivers** — `ObservabilityExportPort` exports `scores` and `eval_runs` to Phoenix / Langfuse / SigNoz for teams that want them mirrored.
+
+## Status
+
+| Capability | Status |
+|---|---|
+| `scores` table, manual scoring API, daily aggregates | Implemented (kernel) |
+| `auto_score_session` (span_count, error_count, generation_count, cost_per_generation, error_loops) | Implemented (kernel) |
+| `eval_metrics` / `eval_datasets` / `eval_cases` / `eval_runs` tables | **Planned (M4)** |
+| Substrate API (`POST /api/eval/*`) | **Planned (M4)** |
+| Harness CLI (`gctrl eval run`) | **Planned (M4)** |
+| Built-in judge metrics (faithfulness, tool_correctness, json_correctness, hallucination, etc.) | **Planned (M4)** |
+| Baseline diff and CI gating | **Planned (M4)** |
+| `EvalRunCompleted` event and gctrl-board surface | **Planned (M4)** |
+
+## Non-goals
+
+- **Not a pytest plugin.** Observe & Eval has no pytest collector, no fixture, no `assert_test`. Apps that already use pytest call the substrate API from inside their tests.
+- **Not an exhaustive metric catalog.** The built-in metric set is curated for product-dev needs; specialised families (RAG composites, multimodal, MCP) are not core deliverables. Apps register the metrics they need.
+- **No mandatory test-case schema.** The substrate accepts whatever shape the app has. `LLMTestCase`-style rigidity is rejected.
+- **Not a separate process.** Observe & Eval ships as Rust app components compiled into the gctrl binary (per [os.md § 3](../os.md), Status row), not a sidecar. The boundary is logical, not OS-level.
+
+## References
+
+- [PRD § Native Applications](../../gctrl/PRD.md) — product positioning
+- [ROADMAP § M4](../../gctrl/ROADMAP.md) — delivery milestones
+- [domain-model § 5.3](../domain-model.md#53-eval-application-tables) — table DDL and ownership
+- [os.md § 3](../os.md) — application invariants
+- [glossary](../../glossary.md) — Metric, Judge, Eval Run, Eval Score

--- a/vault/specs/architecture/domain-model.md
+++ b/vault/specs/architecture/domain-model.md
@@ -363,7 +363,25 @@ Per Invariant #3, application tables carry the `board_` namespace prefix.
 
 ### 5.3 Eval application tables
 
-From `schema.rs`: `scores` (kernel-owned, general target_type/target_id). The `eval_scores` prefix in earlier spec revisions was folded into the kernel-owned `scores` table; eval uses it with `target_type IN ('session', 'span', 'task')`.
+The Observe & Eval application owns evaluation primitives across the full product-dev lifecycle (dev → CI → staging → prod). It uses both kernel-owned and app-namespaced tables. See [Observe & Eval architecture](apps/observe-eval.md) for design rationale.
+
+**Kernel-owned (shared sink):**
+
+- `scores` — every score from every mode (substrate API + harness runner, dev runs + live sessions). `target_type` extends to `eval_case` and `eval_run` alongside the existing `session`, `span`, `task`. The metric-continuity property (one metric name spanning the lifecycle) depends on this table being the single sink.
+- `prompt_versions` — reused for judge prompts (content-addressed by hash, same as agent prompts).
+
+**App-namespaced (`eval_*` per Invariant #3):**
+
+| Table | Purpose |
+|---|---|
+| `eval_metrics` | Metric definitions: `name`, `kind` (`deterministic` \| `judge` \| `composite`), `prompt_id` (for judges), `threshold`, `schema` |
+| `eval_datasets` | Named dataset metadata |
+| `eval_cases` | Cases belonging to datasets — `input`, `expected`, `context` (JSON-typed; permissive schema) |
+| `eval_runs` | Run-level metadata grouping a batch of `Score`s: suite name, `baseline_run_id`, `git_sha`, env, model, prompt version |
+
+DDL lands in `kernel/crates/gctrl-storage/src/schema.rs` under `CREATE_EVAL_*_TABLE` constants when M4 implementation begins.
+
+The earlier `eval_scores` prefix was folded into the kernel-owned `scores` table for the continuity reasons above; the `eval_*` namespace is reserved for app-owned tables that the kernel does not need to know about.
 
 ### 5.4 Indexes
 

--- a/vault/specs/architecture/os.md
+++ b/vault/specs/architecture/os.md
@@ -259,7 +259,7 @@ Applications are larger, stateful programs that orchestrate kernel primitives th
 | Application | Tables Owned | Kernel Primitives Used | Runtime | Status |
 |-------------|-------------|----------------------|---------|--------|
 | **gctrl-board** | `board_projects`, `board_issues`, `board_events`, `board_comments` | Storage, Telemetry (session-issue linking) | Effect-TS | Implemented |
-| **Observe & Eval** | `scores` | Telemetry, Storage, Query Engine | Rust (compiled into binary) | Partial (auto-scoring implemented, no separate app boundary) |
+| **Observe & Eval** | `scores` (kernel-shared), `eval_metrics`, `eval_datasets`, `eval_cases`, `eval_runs` | Telemetry, Storage, Model Router, Query Engine | Rust (compiled into binary) | Partial (auto-scoring + score store implemented; metric/prompt/dataset/run primitives, substrate API, and harness runner planned for M4 — see [apps/observe-eval.md](apps/observe-eval.md)) |
 | **Capacity Engine** | `capacity_*` | Storage, Telemetry, Query Engine | Rust (compiled into binary) | **Planned** |
 
 > **Note:** `tasks`, `prompt_versions`, `tags`, `daily_aggregates`, `alert_rules`, `alert_events` are **kernel-owned** tables — they support kernel primitives (Scheduler, Telemetry, Guardrails) and do NOT carry application namespace prefixes. See [domain-model.md](domain-model.md) § 5.1 and § 5.3 for DDL.

--- a/vault/specs/gctrl/PRD.md
+++ b/vault/specs/gctrl/PRD.md
@@ -124,7 +124,7 @@ Four core primitives that every agent team needs:
 
 **gctrl-board** — Lightweight project management and kanban. Issues with status lifecycle, dependency graph, agent assignment, auto-transitions from kernel events. The first application built on gctrl.
 
-**Observe & Eval** — Langfuse-grade analytics, local-first. Cost/token analytics, latency percentiles, trace exploration, scoring (human + auto + model), prompt version management. Everything Langfuse shows in its dashboard, gctrl can produce from local DuckDB.
+**Observe & Eval** — Lifecycle eval substrate and harness, local-first. Owns metrics, judge prompts, datasets, eval runs, and the score store across dev → CI → staging → prod. Both an embeddable API/SDK applications call from their own loops (substrate) and a `gctrl eval run` runner that owns the loop end-to-end (harness) — same primitives, same metric names, same store. Plus Langfuse-grade observability: cost/token analytics, latency percentiles, trace exploration, prompt version management. Not a pytest plugin; not a single-phase test framework. See [Observe & Eval architecture](../architecture/apps/observe-eval.md).
 
 **Capacity Engine** — Throughput measurement and delivery forecasting. Answers "how many issues can our agents close per week?" and "are we on track for this milestone?" by correlating telemetry with project data.
 

--- a/vault/specs/gctrl/ROADMAP.md
+++ b/vault/specs/gctrl/ROADMAP.md
@@ -73,18 +73,26 @@
 
 ## M4: Eval, Capacity & Intelligence — Planned
 
-**Goal:** Agents understand their own performance; teams can forecast delivery.
+**Goal:** Apps can author and run evals across the full product-dev lifecycle (dev → CI → staging → prod) on a single set of primitives. Agents understand their own performance; teams can forecast delivery.
+
+Observe & Eval owns both the **substrate** (metrics, prompts, judges, datasets, runs, score store) and the **harness** (`gctrl eval run`). See [Observe & Eval architecture](../architecture/apps/observe-eval.md) for the full design.
 
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
-| Eval scoring pipeline | Configurable auto-scoring rules beyond `auto-score` (custom evaluators) | P1 | M1 Scoring | TBD |
-| Prompt A/B comparison | Compare prompt versions by score distributions | P2 | Eval scoring, M1 Prompt versions | TBD |
+| Eval primitives schema | `eval_metrics`, `eval_datasets`, `eval_cases`, `eval_runs` tables; extend `scores.target_type` for `eval_case`/`eval_run` | P1 | M1 Storage | TBD |
+| Substrate API | `POST /api/eval/score`, `/metrics`, `/datasets`, `/cases`, `/runs` — applications call directly from their own loops | P1 | Eval primitives schema | TBD |
+| Built-in judge metrics | Curated set: `faithfulness`, `tool_correctness`, `json_correctness`, `hallucination`, generic `g_eval` | P1 | Substrate API, M1 Model router | TBD |
+| Harness runner | `gctrl eval run <suite>` end-to-end runner; thin client of the substrate API | P1 | Substrate API | TBD |
+| Baseline & CI gating | `--baseline <run-id>` regression diff, non-zero exit on threshold breach | P1 | Harness runner | TBD |
+| Prompt A/B comparison | Compare prompt versions / models against the same suite by score distributions | P2 | Harness runner, M1 Prompt versions | TBD |
+| `EvalRunCompleted` event + board surface | Surface regressions on Issue cards in gctrl-board | P2 | Harness runner | TBD |
+| TypeScript SDK | Thin wrapper over substrate API for embedded eval in TS apps | P2 | Substrate API | TBD |
 | Throughput metrics | Issues closed/week, avg cost/issue, avg duration/issue by agent | P1 | M2c Cost accumulation | TBD |
 | Delivery forecast | Given open issues + throughput, estimate completion date | P2 | Throughput metrics | TBD |
 | NL→SQL query interface | Natural language → guardrailed SQL for agent self-inspection | P2 | M1 Query engine | TBD |
 | Board snapshots | `gctrl board snapshot` → markdown context entry for agent consumption | P1 | M2a Board, M1 Context Manager | TBD |
 
-**Done when:** An agent can run `gctrl query "my cost this session"` and get an answer. A team lead can run `gctrl capacity forecast --milestone v2` and get a date estimate.
+**Done when:** An app can call `POST /api/eval/score` with `{ metric: "faithfulness", input, output }` from its own dev loop, *and* `gctrl eval run <suite> --baseline <run-id>` exits non-zero on regression in CI — both writing to the same `scores` table queryable as one trend. An agent can run `gctrl query "my cost this session"` and get an answer. A team lead can run `gctrl capacity forecast --milestone v2` and get a date estimate.
 
 ## Backlog (unprioritized)
 

--- a/vault/specs/glossary.md
+++ b/vault/specs/glossary.md
@@ -32,7 +32,14 @@ Canonical definitions for gctrl domain terms. When terms are used in specs, they
 | **Issue Key** | A formatted identifier like `BACK-42` — composed of `{PROJECT_KEY}-{COUNTER}`. Project key is from `board_projects.key`; counter auto-increments per project. | Application | gctrl-board |
 | **Tracker** | An application component of gctrl-board that manages Issue lifecycle, dependency DAG, and auto-transitions. Subscribes to kernel IPC events. NOT a kernel primitive. | Application | gctrl-board |
 | **Board** | A kanban view of Issues (human-managed) and Tasks (agent-managed, read-only). Configured per-project with columns and WIP limits. | Application | gctrl-board |
-| **Eval Score** | A quality rating attached to a Session, Span, or Task — human-annotated or auto-computed. Stored in `eval_scores` (Observe & Eval application). | Application | Observe & Eval |
+| **Eval Score** | A quality rating attached to a Session, Span, Task, Eval Case, or Eval Run — human-annotated, auto-computed, or judge-produced. Stored in the kernel-owned `scores` table; the same row carries scores from every lifecycle phase (dev, CI, staging, prod). | Application | Observe & Eval |
+| **Metric** | A named scoring function registered in `eval_metrics`. Resolves to either an in-process evaluator (deterministic check) or a judge prompt (LLM-as-judge). The unit of metric-name continuity from dev → prod. | Application | Observe & Eval |
+| **Judge** | An LLM-as-judge invocation produced by a metric of `kind='judge'`. Calls the kernel Model Router; the call itself is captured as Spans like any other generation. | Application | Observe & Eval |
+| **Eval Run** | A grouping row in `eval_runs` that ties a batch of `Score`s together (one per `gctrl eval run` invocation or app-initiated batch). Carries suite name, baseline ref, git sha, env, model. | Application | Observe & Eval |
+| **Eval Case** | A single `{ input, expected?, context? }` item belonging to a Dataset. Schema is intentionally permissive — apps may also pass cases inline without registering them. | Application | Observe & Eval |
+| **Eval Dataset** | A named collection of Eval Cases. Required for harness mode and replayable baselines; not required for substrate-mode calls. | Application | Observe & Eval |
+| **Eval Substrate** | The metrics, prompts, judges, and score store reachable via `POST /api/eval/*`. Applications drive their own loops and call into it. | Application | Observe & Eval |
+| **Eval Harness** | The `gctrl eval run` runner that loads a suite, iterates cases, calls the substrate per case, and gates pass/fail. A built-in client of the substrate — no private path. | Application | Observe & Eval |
 
 ## Shell Concepts
 


### PR DESCRIPTION
## Summary

- Reframes Observe & Eval from Langfuse-style post-hoc analytics only to a full product-development lifecycle eval system (dev → CI → staging → prod), owning **both** the **substrate** (metrics, prompts, judges, datasets, runs, score store reachable via API/SDK) and the **harness** (`gctrl eval run` runner) over a single set of primitives.
- New canonical spec at `vault/specs/architecture/apps/observe-eval.md`; PRD, ROADMAP M4, domain-model § 5.3, os.md § 3, and glossary aligned.
- Explicit non-goals: not a pytest plugin, no mandatory `LLMTestCase`-style schema.

## What changed

- **New** `vault/specs/architecture/apps/observe-eval.md` — architectural position, harness/substrate rationale, lifecycle table, primitives (Metric, Judge Prompt, Dataset/Case, Eval Run, Score), tables (`scores` kernel-shared + `eval_metrics`/`eval_datasets`/`eval_cases`/`eval_runs` app-namespaced), API surface, kernel integration, status, non-goals.
- **PRD** — Observe & Eval description rewritten to cover lifecycle + substrate + harness.
- **ROADMAP M4** — replaced two vague rows with seven concrete deliverables (eval primitives schema, substrate API, built-in judge metrics, harness runner, baseline & CI gating, prompt A/B, board surface, TS SDK). Updated "Done when" to require both substrate and harness writing the same `scores` table.
- **domain-model § 5.3** — enumerated `eval_metrics` / `eval_datasets` / `eval_cases` / `eval_runs`; noted `scores.target_type` extends to `eval_case` / `eval_run` so dev runs and live sessions share one sink.
- **os.md § 3** — Observe & Eval row updated with all owned tables and Model Router as a used primitive; links to new spec.
- **glossary** — added Metric, Judge, Eval Run, Eval Case, Eval Dataset, Eval Substrate, Eval Harness; updated Eval Score for new target types.

## Key design points the spec commits to

1. Substrate is the load-bearing surface; harness is a built-in client of it (no private runner path).
2. One `scores` table is the single sink across substrate + harness, dev + prod.
3. Permissive case schema — apps may pass cases inline without registering datasets.
4. Judges reuse `prompt_versions` (content-hashed, same as agent prompts).
5. Observe & Eval ships as Rust app components compiled into the gctrl binary, not a sidecar.

## Test plan

- [ ] Spec-only PR — no code, no tests. Reviewers verify framing matches product intent.
- [ ] Cross-references resolve (PRD → observe-eval.md, ROADMAP → observe-eval.md, os.md row → observe-eval.md, domain-model § 5.3 → observe-eval.md).
- [ ] M4 deliverables read as concrete enough to scope into issues.
- [ ] Glossary terms are consistent with their use in observe-eval.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
