### PR TITLE
feat(kernel): gctrl-scheduler crate (PR1 of 3 for periodic ingestion)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +919,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +988,24 @@ checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "derive_arbitrary"
@@ -1324,8 +1363,10 @@ dependencies = [
  "gctrl-orch",
  "gctrl-otel",
  "gctrl-query",
+ "gctrl-scheduler",
  "gctrl-storage",
  "notify",
+ "reqwest 0.12.28",
  "serde_json",
  "tokio",
  "tracing",
@@ -1430,6 +1471,7 @@ dependencies = [
  "gctrl-context",
  "gctrl-core",
  "gctrl-net",
+ "gctrl-scheduler",
  "gctrl-storage",
  "gctrl-sync",
  "http 1.4.0",
@@ -1468,6 +1510,29 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "gctrl-scheduler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "chrono",
+ "cron",
+ "gctrl-core",
+ "gctrl-storage",
+ "http 1.4.0",
+ "http-body-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1675,6 +1740,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "htmd"
@@ -2579,6 +2650,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4074,7 +4155,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4083,7 +4164,7 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4805,6 +4886,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
@@ -4820,6 +4910,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "kernel/crates/gctrl-sync",
     "kernel/crates/gctrl-context",
     "kernel/crates/gctrl-orch",
+    "kernel/crates/gctrl-scheduler",
 ]
 
 [workspace.package]

--- a/kernel/crates/gctrl-cli/Cargo.toml
+++ b/kernel/crates/gctrl-cli/Cargo.toml
@@ -16,6 +16,8 @@ gctrl-query = { path = "../gctrl-query" }
 gctrl-net = { path = "../gctrl-net" }
 gctrl-context = { path = "../gctrl-context" }
 gctrl-orch = { path = "../gctrl-orch" }
+gctrl-scheduler = { path = "../gctrl-scheduler" }
+reqwest = { workspace = true }
 
 clap = { workspace = true }
 tokio = { workspace = true }

--- a/kernel/crates/gctrl-cli/src/commands/mod.rs
+++ b/kernel/crates/gctrl-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod check;
 pub mod net;
 pub mod orch;
 pub mod personas;
+pub mod scheduler;
 pub mod prompt;
 pub mod query;
 pub mod score;

--- a/kernel/crates/gctrl-cli/src/commands/scheduler.rs
+++ b/kernel/crates/gctrl-cli/src/commands/scheduler.rs
@@ -1,0 +1,180 @@
+//! `gctrld scheduler ...` — admin/debug commands against the schedules table.
+//!
+//! These open the SQLite store directly (same pattern as `board`, `personas`,
+//! `prompt`). The runner fiber lives in the long-running `gctrld serve` process;
+//! these commands manipulate rows that the runner picks up on its next tick.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use gctrl_core::{Schedule, ScheduleFilter};
+use gctrl_scheduler::cron::next_after;
+use gctrl_storage::SqliteStore;
+
+fn open_store(db_path: &str) -> Result<Arc<SqliteStore>> {
+    let sqlite_path = if db_path == ":memory:" {
+        ":memory:".to_string()
+    } else {
+        db_path.replace(".duckdb", ".sqlite")
+    };
+    Ok(Arc::new(SqliteStore::open(&sqlite_path)?))
+}
+
+pub fn list(db_path: &str, enabled_only: bool, format: &str) -> Result<()> {
+    let store = open_store(db_path)?;
+    let filter = ScheduleFilter {
+        enabled: if enabled_only { Some(true) } else { None },
+        ..Default::default()
+    };
+    let rows = store.list_schedules(&filter)?;
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(&rows)?),
+        _ => print_table(&rows),
+    }
+    Ok(())
+}
+
+pub fn show(db_path: &str, id_or_name: &str) -> Result<()> {
+    let store = open_store(db_path)?;
+    match store.get_schedule(id_or_name)? {
+        Some(s) => println!("{}", serde_json::to_string_pretty(&s)?),
+        None => return Err(anyhow!("no schedule named or with id '{id_or_name}'")),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn add(
+    db_path: &str,
+    name: &str,
+    cron: &str,
+    target_url: &str,
+    method: &str,
+    body: Option<&str>,
+    timeout_secs: i64,
+) -> Result<()> {
+    let store = open_store(db_path)?;
+    // Validate cron up-front. A bad expression here means the schedule would
+    // never compute next_run_at; better to fail loudly at create time.
+    let next = next_after(cron, Utc::now())
+        .map_err(|e| anyhow!("invalid cron '{cron}': {e}"))?
+        .map(|dt| dt.to_rfc3339());
+
+    let body_json = body
+        .map(|b| serde_json::from_str::<serde_json::Value>(b))
+        .transpose()
+        .map_err(|e| anyhow!("--body must be valid JSON: {e}"))?;
+
+    let now = Utc::now().to_rfc3339();
+    let sched = Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        cron: cron.to_string(),
+        target_url: target_url.to_string(),
+        target_method: method.to_uppercase(),
+        body_json,
+        headers_json: None,
+        timeout_secs,
+        enabled: true,
+        next_run_at: next,
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    store.create_schedule(&sched)?;
+    println!("created schedule '{}' (id={})", sched.name, sched.id);
+    if let Some(n) = sched.next_run_at {
+        println!("  next_run_at: {n}");
+    }
+    Ok(())
+}
+
+pub fn rm(db_path: &str, id_or_name: &str) -> Result<()> {
+    let store = open_store(db_path)?;
+    if store.delete_schedule(id_or_name)? {
+        println!("deleted schedule '{id_or_name}'");
+        Ok(())
+    } else {
+        Err(anyhow!("no schedule named or with id '{id_or_name}'"))
+    }
+}
+
+pub fn enable(db_path: &str, id_or_name: &str, enabled: bool) -> Result<()> {
+    let store = open_store(db_path)?;
+    if !store.set_schedule_enabled(id_or_name, enabled)? {
+        return Err(anyhow!("no schedule named or with id '{id_or_name}'"));
+    }
+    if enabled {
+        if let Some(s) = store.get_schedule(id_or_name)? {
+            let next = next_after(&s.cron, Utc::now())
+                .ok()
+                .flatten()
+                .map(|dt| dt.to_rfc3339());
+            store.set_schedule_next_run(&s.id, next.as_deref())?;
+        }
+    }
+    println!(
+        "{} schedule '{id_or_name}'",
+        if enabled { "enabled" } else { "disabled" }
+    );
+    Ok(())
+}
+
+/// Fire a schedule immediately via the daemon's HTTP API. Requires the daemon
+/// to be running — we don't replicate the dispatch logic here because that
+/// would split ownership of run_count / last_status across two code paths.
+pub async fn run_now(db_path: &str, id_or_name: &str, daemon_url: &str) -> Result<()> {
+    let store = open_store(db_path)?;
+    let sched = store
+        .get_schedule(id_or_name)?
+        .ok_or_else(|| anyhow!("no schedule named or with id '{id_or_name}'"))?;
+    let url = format!("{}/api/schedules/{}/run", daemon_url.trim_end_matches('/'), sched.id);
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .send()
+        .await
+        .map_err(|e| anyhow!("contacting daemon at {daemon_url}: {e}"))?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(anyhow!("daemon returned {status}: {body}"));
+    }
+    println!("{body}");
+    Ok(())
+}
+
+fn print_table(rows: &[Schedule]) {
+    if rows.is_empty() {
+        println!("(no schedules)");
+        return;
+    }
+    println!(
+        "{:<24} {:<20} {:<8} {:<26} {}",
+        "name", "cron", "enabled", "next_run_at", "target_url"
+    );
+    println!("{}", "─".repeat(120));
+    for s in rows {
+        println!(
+            "{:<24} {:<20} {:<8} {:<26} {}",
+            truncate_col(&s.name, 24),
+            truncate_col(&s.cron, 20),
+            s.enabled,
+            s.next_run_at.as_deref().unwrap_or("-"),
+            s.target_url
+        );
+    }
+}
+
+fn truncate_col(s: &str, w: usize) -> String {
+    if s.len() <= w {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..w.saturating_sub(1)])
+    }
+}

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
-use gctrl_core::{NetConfig, SyncConfig};
+use gctrl_core::{NetConfig, SchedulerConfig, SyncConfig};
+use gctrl_scheduler::ScheduleRunner;
 use gctrl_storage::{DuckDbStore, SqliteStore};
 
 use super::watch;
@@ -41,6 +42,19 @@ pub async fn run(host: String, port: u16, db_path: &str, board_dir: Option<PathB
     }
     if net_config.cf_browser_enabled() {
         tracing::info!("Cloudflare Browser Rendering enabled");
+    }
+
+    // Spawn the scheduler runner. Uses defaults from `SchedulerConfig::default()`
+    // (30s poll, 16 jobs/tick, 60s timeout) — operators can override later via
+    // config file once we wire `~/.config/gctrl/config.toml` parsing.
+    let scheduler_config = SchedulerConfig::default();
+    if scheduler_config.enabled {
+        let runner_store = Arc::clone(&sqlite);
+        let runner_cfg = scheduler_config.clone();
+        tokio::spawn(async move {
+            ScheduleRunner::new(runner_store, runner_cfg).run_forever().await;
+        });
+        tracing::info!("scheduler runner spawned (poll={}s)", scheduler_config.poll_interval_secs);
     }
 
     let router = gctrl_otel::create_router_full(

--- a/kernel/crates/gctrl-cli/src/main.rs
+++ b/kernel/crates/gctrl-cli/src/main.rs
@@ -139,6 +139,71 @@ enum Commands {
     /// Orchestrator — spawn agents for dispatch-eligible tasks
     #[command(subcommand)]
     Orch(OrchCmd),
+    /// Periodic HTTP-callback scheduler (cron-driven jobs)
+    #[command(subcommand)]
+    Scheduler(SchedulerCmd),
+}
+
+#[derive(Subcommand)]
+enum SchedulerCmd {
+    /// List schedules
+    List {
+        /// Only show enabled schedules
+        #[arg(long)]
+        enabled: bool,
+        /// Output format: table, json
+        #[arg(short, long, default_value = "table")]
+        format: String,
+    },
+    /// Show a single schedule (by id or name) as JSON
+    Show {
+        /// Schedule id or name
+        id: String,
+    },
+    /// Create a new schedule
+    Add {
+        /// Unique schedule name
+        #[arg(long)]
+        name: String,
+        /// Cron expression (5/6/7 fields, e.g. "0 */2 * * *" for every 2 hours)
+        #[arg(long)]
+        cron: String,
+        /// HTTP target URL the runner POSTs to when due
+        #[arg(long = "target-url")]
+        target_url: String,
+        /// HTTP method (GET, POST, PUT, DELETE, PATCH)
+        #[arg(long, default_value = "POST")]
+        method: String,
+        /// Request body as JSON string
+        #[arg(long)]
+        body: Option<String>,
+        /// Per-request timeout in seconds
+        #[arg(long, default_value = "60")]
+        timeout: i64,
+    },
+    /// Delete a schedule by id or name
+    Rm {
+        /// Schedule id or name
+        id: String,
+    },
+    /// Enable a schedule
+    Enable {
+        /// Schedule id or name
+        id: String,
+    },
+    /// Disable a schedule
+    Disable {
+        /// Schedule id or name
+        id: String,
+    },
+    /// Manually fire a schedule via the running daemon's HTTP API
+    Run {
+        /// Schedule id or name
+        id: String,
+        /// Daemon base URL
+        #[arg(long, default_value = "http://127.0.0.1:4318")]
+        daemon: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -577,6 +642,21 @@ async fn main() -> Result<()> {
                 commands::net::compact(&domain, &format, output.as_deref())
             }
             NetCmd::Stats { domain } => commands::net::stats(&domain),
+        },
+        Commands::Scheduler(cmd) => match cmd {
+            SchedulerCmd::List { enabled, format } => {
+                commands::scheduler::list(&db_path, enabled, &format)
+            }
+            SchedulerCmd::Show { id } => commands::scheduler::show(&db_path, &id),
+            SchedulerCmd::Add { name, cron, target_url, method, body, timeout } => {
+                commands::scheduler::add(&db_path, &name, &cron, &target_url, &method, body.as_deref(), timeout)
+            }
+            SchedulerCmd::Rm { id } => commands::scheduler::rm(&db_path, &id),
+            SchedulerCmd::Enable { id } => commands::scheduler::enable(&db_path, &id, true),
+            SchedulerCmd::Disable { id } => commands::scheduler::enable(&db_path, &id, false),
+            SchedulerCmd::Run { id, daemon } => {
+                commands::scheduler::run_now(&db_path, &id, &daemon).await
+            }
         },
     }
 }

--- a/kernel/crates/gctrl-core/src/config.rs
+++ b/kernel/crates/gctrl-core/src/config.rs
@@ -15,6 +15,8 @@ pub struct GctlConfig {
     pub guardrails: GuardrailsConfig,
     #[serde(default)]
     pub net: NetConfig,
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
 }
 
 impl Default for GctlConfig {
@@ -26,6 +28,7 @@ impl Default for GctlConfig {
             sync: SyncConfig::default(),
             guardrails: GuardrailsConfig::default(),
             net: NetConfig::default(),
+            scheduler: SchedulerConfig::default(),
         }
     }
 }
@@ -206,6 +209,35 @@ impl Default for GuardrailsConfig {
     }
 }
 
+/// Configuration for the kernel scheduler (gctrl-scheduler crate).
+///
+/// Defaults are tuned for "dozens of jobs firing on the order of minutes-hours,"
+/// not "thousands of jobs firing per second." If you need finer-grained polling,
+/// drop `poll_interval_secs` — at 5s you'll still wake the runner only ~17k
+/// times/day on an idle box.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchedulerConfig {
+    pub enabled: bool,
+    pub poll_interval_secs: u64,
+    /// Cap on schedules dispatched per tick. Prevents a backlog of overdue
+    /// jobs from monopolising the runner.
+    pub max_per_tick: usize,
+    /// Default per-job HTTP timeout in seconds. Individual schedules may
+    /// override via `Schedule::timeout_secs`.
+    pub default_timeout_secs: u64,
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            poll_interval_secs: 30,
+            max_per_tick: 16,
+            default_timeout_secs: 60,
+        }
+    }
+}
+
 fn dirs_default_data() -> PathBuf {
     if let Some(home) = std::env::var_os("HOME") {
         PathBuf::from(home).join(".local/share")
@@ -252,5 +284,14 @@ mod tests {
         let cfg = SyncConfig::default();
         assert!(!cfg.enabled);
         assert!(cfg.r2_bucket.is_empty());
+    }
+
+    #[test]
+    fn scheduler_defaults_enabled_30s() {
+        let cfg = SchedulerConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.poll_interval_secs, 30);
+        assert_eq!(cfg.max_per_tick, 16);
+        assert_eq!(cfg.default_timeout_secs, 60);
     }
 }

--- a/kernel/crates/gctrl-core/src/lib.rs
+++ b/kernel/crates/gctrl-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod context;
 pub mod error;
 pub mod memory;
+pub mod schedule;
 pub mod types;
 
 pub use acceptance::*;
@@ -10,4 +11,5 @@ pub use config::*;
 pub use context::*;
 pub use error::*;
 pub use memory::*;
+pub use schedule::*;
 pub use types::*;

--- a/kernel/crates/gctrl-core/src/schedule.rs
+++ b/kernel/crates/gctrl-core/src/schedule.rs
@@ -1,0 +1,57 @@
+//! Schedule types for the kernel scheduler — periodic HTTP-callback jobs.
+//!
+//! A `Schedule` is a cron-driven row in the `schedules` table that fires an
+//! HTTP request to a target URL on its cron expression. The scheduler
+//! daemon owns liveness; this module only defines the row shape and the
+//! filter used by the list endpoint.
+
+use serde::{Deserialize, Serialize};
+
+/// HTTP method for the callback. Stored as VARCHAR; only POST/GET/PUT/DELETE
+/// are accepted. Defaults to POST since most schedule callbacks mutate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Schedule {
+    pub id: String,
+    /// Unique human-readable name (e.g. `uber.ingest.tick`).
+    pub name: String,
+    /// Standard 5- or 6-field cron expression evaluated in UTC.
+    pub cron: String,
+    pub target_url: String,
+    pub target_method: String,
+    /// Optional JSON body sent with the request. Stored as serialized JSON.
+    pub body_json: Option<serde_json::Value>,
+    /// Optional headers (object → key/value). Stored as serialized JSON.
+    pub headers_json: Option<serde_json::Value>,
+    pub timeout_secs: i64,
+    pub enabled: bool,
+    /// RFC3339 UTC timestamps. `None` means never run / never computed.
+    pub next_run_at: Option<String>,
+    pub last_run_at: Option<String>,
+    pub last_status: Option<i64>,
+    pub last_response: Option<String>,
+    pub last_error: Option<String>,
+    pub run_count: i64,
+    pub failure_count: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Optional filter for `list_schedules`. None fields = no filter applied.
+#[derive(Debug, Default, Clone)]
+pub struct ScheduleFilter {
+    pub enabled: Option<bool>,
+    pub name_prefix: Option<String>,
+}
+
+/// Update payload written after a runner attempt fires. Captures both the
+/// outcome of *this* run and the precomputed next firing time so the runner
+/// stays stateless.
+#[derive(Debug, Clone)]
+pub struct ScheduleRunUpdate {
+    pub last_run_at: String,
+    pub next_run_at: Option<String>,
+    pub last_status: Option<i64>,
+    pub last_response: Option<String>,
+    pub last_error: Option<String>,
+    pub success: bool,
+}

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -9,6 +9,7 @@ gctrl-storage = { path = "../gctrl-storage" }
 gctrl-context = { path = "../gctrl-context" }
 gctrl-sync = { path = "../gctrl-sync" }
 gctrl-net = { path = "../gctrl-net" }
+gctrl-scheduler = { path = "../gctrl-scheduler" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -75,6 +75,11 @@ pub fn create_router_dual_with_sync(
 }
 
 /// Create router with dual stores, D1 sync, and external network drivers (Brave, CF Browser).
+///
+/// Mounts the scheduler routes (`/api/schedules*`) alongside the main router
+/// using a separate state — the scheduler is self-contained and only needs
+/// the SQLite store, so it owns its own `with_state` rather than fattening
+/// `AppState`.
 pub fn create_router_full(
     store: Arc<DuckDbStore>,
     sqlite: Arc<SqliteStore>,
@@ -83,7 +88,7 @@ pub fn create_router_full(
 ) -> Router {
     let state = Arc::new(AppState {
         store,
-        sqlite,
+        sqlite: Arc::clone(&sqlite),
         context: None,
         started_at: std::time::Instant::now(),
         sync_config,
@@ -91,7 +96,7 @@ pub fn create_router_full(
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
     });
-    build_router(state)
+    build_router(state).merge(gctrl_scheduler::http::router(sqlite))
 }
 
 pub fn create_router_with_context(store: DuckDbStore, context: Option<ContextManager>) -> Router {

--- a/kernel/crates/gctrl-scheduler/Cargo.toml
+++ b/kernel/crates/gctrl-scheduler/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "gctrl-scheduler"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+gctrl-core = { path = "../gctrl-core" }
+gctrl-storage = { path = "../gctrl-storage" }
+tokio = { workspace = true }
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+reqwest = { workspace = true }
+cron = "0.15"
+
+[dev-dependencies]
+tower = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+wiremock = "0.6"

--- a/kernel/crates/gctrl-scheduler/src/cron.rs
+++ b/kernel/crates/gctrl-scheduler/src/cron.rs
@@ -1,0 +1,76 @@
+//! Cron expression parsing + next-fire computation.
+//!
+//! The upstream `cron` crate uses 6- or 7-field expressions (with leading
+//! seconds and optional trailing year). Standard Unix cron is 5 fields. We
+//! accept either and normalise to 6 by prepending `0` for the seconds field
+//! when needed, so users can write `0 */2 * * *` and get the obvious
+//! "every 2 hours on the hour" behaviour.
+
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use cron::Schedule as CronExpr;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CronError {
+    #[error("cron expression must have 5, 6 or 7 fields, got {0}")]
+    BadFieldCount(usize),
+    #[error("invalid cron expression: {0}")]
+    Parse(String),
+}
+
+/// Parse a 5/6/7-field cron expression into the upstream type. 5-field input
+/// is normalised by prepending a `0` seconds field.
+pub fn parse(input: &str) -> Result<CronExpr, CronError> {
+    let trimmed = input.trim();
+    let n = trimmed.split_whitespace().count();
+    let normalised = match n {
+        5 => format!("0 {}", trimmed),
+        6 | 7 => trimmed.to_string(),
+        other => return Err(CronError::BadFieldCount(other)),
+    };
+    CronExpr::from_str(&normalised).map_err(|e| CronError::Parse(e.to_string()))
+}
+
+/// Compute the next fire time strictly after `after`. Returns `None` if the
+/// cron has no future occurrences in the supported range (cron crate caps at
+/// year 2100).
+pub fn next_after(input: &str, after: DateTime<Utc>) -> Result<Option<DateTime<Utc>>, CronError> {
+    let expr = parse(input)?;
+    Ok(expr.after(&after).next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Timelike};
+
+    #[test]
+    fn five_field_every_two_hours() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 1, 30, 0).unwrap();
+        let next = next_after("0 */2 * * *", now).unwrap().unwrap();
+        // Next *:00 hour that is even after 01:30 is 02:00.
+        assert_eq!(next.hour(), 2);
+        assert_eq!(next.minute(), 0);
+    }
+
+    #[test]
+    fn six_field_passes_through() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap();
+        // every minute on second :00
+        let next = next_after("0 * * * * *", now).unwrap().unwrap();
+        assert!(next > now);
+        assert_eq!(next.second(), 0);
+    }
+
+    #[test]
+    fn rejects_bad_field_count() {
+        assert!(matches!(parse("* * *"), Err(CronError::BadFieldCount(3))));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(matches!(parse("not a cron"), Err(CronError::BadFieldCount(_))));
+        assert!(matches!(parse("xyz abc def ghi jkl"), Err(CronError::Parse(_))));
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/http.rs
+++ b/kernel/crates/gctrl-scheduler/src/http.rs
@@ -18,6 +18,7 @@ use gctrl_storage::SqliteStore;
 use serde::{Deserialize, Serialize};
 
 use crate::cron::next_after;
+use crate::runner::read_capped_body;
 
 pub fn router(sqlite: Arc<SqliteStore>) -> Router {
     Router::new()
@@ -178,9 +179,9 @@ async fn run_now(
     }
 
     let (success, status, response, error) = match req.send().await {
-        Ok(r) => {
+        Ok(mut r) => {
             let st = r.status().as_u16() as i64;
-            let body = r.text().await.unwrap_or_default();
+            let body = read_capped_body(&mut r).await;
             ((200..400).contains(&st), Some(st), Some(body), None)
         }
         Err(e) => (false, None, None, Some(e.to_string())),

--- a/kernel/crates/gctrl-scheduler/src/http.rs
+++ b/kernel/crates/gctrl-scheduler/src/http.rs
@@ -1,0 +1,256 @@
+//! Axum router for `/api/schedules` — CRUD + manual run-now endpoint.
+//!
+//! Mounted into the main kernel router via `.merge(http::router(sqlite))`.
+//! State is just `Arc<SqliteStore>`; the runner fiber owns its own state.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::Utc;
+use gctrl_core::{Schedule, ScheduleFilter, ScheduleRunUpdate};
+use gctrl_storage::SqliteStore;
+use serde::{Deserialize, Serialize};
+
+use crate::cron::next_after;
+
+pub fn router(sqlite: Arc<SqliteStore>) -> Router {
+    Router::new()
+        .route("/api/schedules", get(list).post(create))
+        .route("/api/schedules/{id}", get(get_one).delete(delete_one))
+        .route("/api/schedules/{id}/run", post(run_now))
+        .route("/api/schedules/{id}/enable", post(enable))
+        .route("/api/schedules/{id}/disable", post(disable))
+        .with_state(sqlite)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub enabled: Option<bool>,
+    pub name_prefix: Option<String>,
+}
+
+async fn list(
+    State(store): State<Arc<SqliteStore>>,
+    Query(q): Query<ListQuery>,
+) -> impl IntoResponse {
+    let filter = ScheduleFilter {
+        enabled: q.enabled,
+        name_prefix: q.name_prefix,
+    };
+    match store.list_schedules(&filter) {
+        Ok(rows) => Json(serde_json::json!({ "schedules": rows })).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateBody {
+    pub name: String,
+    pub cron: String,
+    pub target_url: String,
+    #[serde(default = "default_method")]
+    pub target_method: String,
+    pub body_json: Option<serde_json::Value>,
+    pub headers_json: Option<serde_json::Value>,
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: i64,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_method() -> String {
+    "POST".into()
+}
+fn default_timeout() -> i64 {
+    60
+}
+fn default_enabled() -> bool {
+    true
+}
+
+async fn create(
+    State(store): State<Arc<SqliteStore>>,
+    Json(body): Json<CreateBody>,
+) -> impl IntoResponse {
+    // Validate cron up-front; reject 400 rather than persist a row that will
+    // never fire and confuse the operator.
+    let next = match next_after(&body.cron, Utc::now()) {
+        Ok(opt) => opt.map(|dt| dt.to_rfc3339()),
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("invalid cron: {e}") })),
+            )
+                .into_response();
+        }
+    };
+    let now = Utc::now().to_rfc3339();
+    let sched = Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: body.name,
+        cron: body.cron,
+        target_url: body.target_url,
+        target_method: body.target_method,
+        body_json: body.body_json,
+        headers_json: body.headers_json,
+        timeout_secs: body.timeout_secs,
+        enabled: body.enabled,
+        next_run_at: if body.enabled { next } else { None },
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    match store.create_schedule(&sched) {
+        Ok(()) => (StatusCode::CREATED, Json(sched)).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+async fn get_one(
+    State(store): State<Arc<SqliteStore>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match store.get_schedule(&id) {
+        Ok(Some(s)) => Json(s).into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+async fn delete_one(
+    State(store): State<Arc<SqliteStore>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match store.delete_schedule(&id) {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RunResult {
+    id: String,
+    name: String,
+    fired: bool,
+    status: Option<i64>,
+    error: Option<String>,
+}
+
+/// Manual fire — bypasses cron, updates last_* fields, recomputes next_run_at.
+/// Useful for ops ("did this thing actually work?") and as the primary tool
+/// while iterating on a new schedule.
+async fn run_now(
+    State(store): State<Arc<SqliteStore>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let sched = match store.get_schedule(&id) {
+        Ok(Some(s)) => s,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return err500(e),
+    };
+    let client = reqwest::Client::new();
+    let method = match sched.target_method.to_uppercase().as_str() {
+        "GET" => reqwest::Method::GET,
+        "PUT" => reqwest::Method::PUT,
+        "DELETE" => reqwest::Method::DELETE,
+        "PATCH" => reqwest::Method::PATCH,
+        _ => reqwest::Method::POST,
+    };
+    let mut req = client
+        .request(method, &sched.target_url)
+        .timeout(std::time::Duration::from_secs(
+            sched.timeout_secs.max(1) as u64,
+        ));
+    if let Some(b) = &sched.body_json {
+        req = req.json(b);
+    }
+
+    let (success, status, response, error) = match req.send().await {
+        Ok(r) => {
+            let st = r.status().as_u16() as i64;
+            let body = r.text().await.unwrap_or_default();
+            ((200..400).contains(&st), Some(st), Some(body), None)
+        }
+        Err(e) => (false, None, None, Some(e.to_string())),
+    };
+
+    let now = Utc::now();
+    let next = next_after(&sched.cron, now)
+        .ok()
+        .flatten()
+        .map(|dt| dt.to_rfc3339());
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: next,
+        last_status: status,
+        last_response: response.clone(),
+        last_error: error.clone(),
+        success,
+    };
+    if let Err(e) = store.record_schedule_run(&sched.id, &update) {
+        return err500(e);
+    }
+
+    Json(RunResult {
+        id: sched.id,
+        name: sched.name,
+        fired: success,
+        status,
+        error,
+    })
+    .into_response()
+}
+
+async fn enable(
+    State(store): State<Arc<SqliteStore>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    set_enabled(&store, &id, true).await
+}
+
+async fn disable(
+    State(store): State<Arc<SqliteStore>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    set_enabled(&store, &id, false).await
+}
+
+async fn set_enabled(store: &SqliteStore, id: &str, enabled: bool) -> axum::response::Response {
+    match store.set_schedule_enabled(id, enabled) {
+        Ok(true) => {}
+        Ok(false) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return err500(e),
+    }
+    if enabled {
+        // Recompute next_run_at on enable so a previously-disabled job fires
+        // at its next cron boundary, not whatever stale value sat in the row.
+        if let Ok(Some(s)) = store.get_schedule(id) {
+            let next = next_after(&s.cron, Utc::now())
+                .ok()
+                .flatten()
+                .map(|dt| dt.to_rfc3339());
+            let _ = store.set_schedule_next_run(&s.id, next.as_deref());
+        }
+    }
+    StatusCode::NO_CONTENT.into_response()
+}
+
+fn err500<E: std::fmt::Display>(e: E) -> axum::response::Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": e.to_string() })),
+    )
+        .into_response()
+}

--- a/kernel/crates/gctrl-scheduler/src/lib.rs
+++ b/kernel/crates/gctrl-scheduler/src/lib.rs
@@ -1,0 +1,22 @@
+//! gctrl-scheduler — periodic HTTP-callback scheduler for the kernel.
+//!
+//! A `Schedule` (in `gctrl-core`) is a row in the `schedules` SQLite table that
+//! fires an HTTP request to `target_url` whenever its cron expression is due.
+//! The runner ([`runner::ScheduleRunner`]) is a tokio fiber spawned by the
+//! kernel daemon; the HTTP surface ([`http::router`]) is mounted into the main
+//! kernel `Router` so users can list/create/delete/run schedules over the
+//! existing `:4318` API.
+//!
+//! # Why not reuse `gctrl-orch`?
+//!
+//! `gctrl-orch` is the *agent task dispatcher* — it claims board tasks, runs
+//! Claude agents against them, and posts results back. The scheduler is the
+//! generic "fire HTTP at this URL on this cron" primitive. They share the
+//! polling-loop shape but nothing else; conflating them would tangle agent
+//! orchestration with periodic ingest/cleanup/health jobs.
+
+pub mod cron;
+pub mod http;
+pub mod runner;
+
+pub use runner::ScheduleRunner;

--- a/kernel/crates/gctrl-scheduler/src/runner.rs
+++ b/kernel/crates/gctrl-scheduler/src/runner.rs
@@ -1,0 +1,252 @@
+//! Scheduler runner — the tokio fiber that polls the `schedules` table and
+//! fires HTTP callbacks for due rows.
+//!
+//! The fiber is intentionally simple:
+//!   1. Sleep `poll_interval`.
+//!   2. Query rows where `enabled=1 AND next_run_at <= now`.
+//!   3. For each due row, fire its HTTP request, capture status + body, and
+//!      record the result + recompute `next_run_at` from the cron expression.
+//!
+//! It does *not* try to make up missed fires (no catch-up): if the daemon was
+//! down for an hour and a "every 5min" job missed 12 fires, the next tick
+//! fires it once and resumes. This matches user intuition (cron itself does
+//! the same on most systems) and avoids a thundering-herd backlog after a
+//! restart.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use gctrl_core::{ScheduleRunUpdate, SchedulerConfig};
+use gctrl_storage::SqliteStore;
+use tracing::{debug, error, info, warn};
+
+use crate::cron::next_after;
+
+const RESPONSE_PREVIEW_BYTES: usize = 4_096;
+
+pub struct ScheduleRunner {
+    store: Arc<SqliteStore>,
+    config: SchedulerConfig,
+    http: reqwest::Client,
+}
+
+impl ScheduleRunner {
+    pub fn new(store: Arc<SqliteStore>, config: SchedulerConfig) -> Self {
+        Self {
+            store,
+            config,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Run forever. Cancellation is via dropping the parent runtime — same
+    /// pattern as `gctrl-orch::Worker::run_forever`.
+    pub async fn run_forever(self) {
+        if !self.config.enabled {
+            info!("scheduler: disabled by config; runner not started");
+            return;
+        }
+        info!(
+            poll_interval_secs = self.config.poll_interval_secs,
+            "scheduler: runner started"
+        );
+        // Backfill `next_run_at` for any schedule that has none (e.g. created
+        // while the daemon was down). One pass on startup; the runner loop
+        // recomputes on every fire after that.
+        self.backfill_next_run().await;
+
+        loop {
+            if let Err(e) = self.tick().await {
+                error!("scheduler: tick failed: {e:#}");
+            }
+            tokio::time::sleep(Duration::from_secs(self.config.poll_interval_secs)).await;
+        }
+    }
+
+    /// One pass over due schedules. Public for tests.
+    pub async fn tick(&self) -> anyhow::Result<usize> {
+        let now = Utc::now();
+        let due = self
+            .store
+            .list_due_schedules(&now.to_rfc3339(), self.config.max_per_tick)
+            .map_err(|e| anyhow::anyhow!("list_due_schedules: {e}"))?;
+        if due.is_empty() {
+            debug!("scheduler: no due schedules");
+            return Ok(0);
+        }
+        let n = due.len();
+        for sched in due {
+            self.fire_one(sched).await;
+        }
+        Ok(n)
+    }
+
+    async fn fire_one(&self, sched: gctrl_core::Schedule) {
+        let started = std::time::Instant::now();
+        let timeout_secs = if sched.timeout_secs > 0 {
+            sched.timeout_secs as u64
+        } else {
+            self.config.default_timeout_secs
+        };
+        let method = match sched.target_method.to_uppercase().as_str() {
+            "GET" => reqwest::Method::GET,
+            "PUT" => reqwest::Method::PUT,
+            "DELETE" => reqwest::Method::DELETE,
+            "PATCH" => reqwest::Method::PATCH,
+            _ => reqwest::Method::POST,
+        };
+        let mut req = self
+            .http
+            .request(method, &sched.target_url)
+            .timeout(Duration::from_secs(timeout_secs));
+        if let Some(body) = &sched.body_json {
+            req = req.json(body);
+        }
+        if let Some(headers) = sched.headers_json.as_ref().and_then(|v| v.as_object()) {
+            for (k, v) in headers {
+                if let Some(s) = v.as_str() {
+                    req = req.header(k, s);
+                }
+            }
+        }
+
+        let outcome = match req.send().await {
+            Ok(resp) => {
+                let status = resp.status().as_u16() as i64;
+                let body = resp.text().await.unwrap_or_default();
+                let preview = truncate(&body, RESPONSE_PREVIEW_BYTES);
+                let success = (200..400).contains(&status);
+                if success {
+                    info!(
+                        schedule = %sched.name,
+                        status = status,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "scheduler: fire ok"
+                    );
+                } else {
+                    warn!(
+                        schedule = %sched.name,
+                        status = status,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "scheduler: fire returned non-2xx"
+                    );
+                }
+                FireOutcome {
+                    success,
+                    status: Some(status),
+                    response: Some(preview),
+                    error: None,
+                }
+            }
+            Err(e) => {
+                warn!(
+                    schedule = %sched.name,
+                    error = %e,
+                    "scheduler: fire failed"
+                );
+                FireOutcome {
+                    success: false,
+                    status: None,
+                    response: None,
+                    error: Some(e.to_string()),
+                }
+            }
+        };
+
+        // Recompute next fire from "now" (not from previous next_run_at) so a
+        // slow tick doesn't compound drift across firings.
+        let now = Utc::now();
+        let next = match next_after(&sched.cron, now) {
+            Ok(Some(dt)) => Some(dt.to_rfc3339()),
+            Ok(None) => None,
+            Err(e) => {
+                error!(
+                    schedule = %sched.name,
+                    cron = %sched.cron,
+                    "scheduler: cron parse failed at next_after; disabling next_run_at: {e}"
+                );
+                None
+            }
+        };
+
+        let update = ScheduleRunUpdate {
+            last_run_at: now.to_rfc3339(),
+            next_run_at: next,
+            last_status: outcome.status,
+            last_response: outcome.response,
+            last_error: outcome.error,
+            success: outcome.success,
+        };
+        if let Err(e) = self.store.record_schedule_run(&sched.id, &update) {
+            error!(schedule = %sched.name, "scheduler: record_schedule_run failed: {e}");
+        }
+    }
+
+    async fn backfill_next_run(&self) {
+        let all = match self
+            .store
+            .list_schedules(&gctrl_core::ScheduleFilter {
+                enabled: Some(true),
+                ..Default::default()
+            }) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("scheduler: backfill list failed: {e}");
+                return;
+            }
+        };
+        let now = Utc::now();
+        for s in all {
+            if s.next_run_at.is_some() {
+                continue;
+            }
+            match next_after(&s.cron, now) {
+                Ok(Some(dt)) => {
+                    if let Err(e) = self.store.set_schedule_next_run(&s.id, Some(&dt.to_rfc3339()))
+                    {
+                        error!(schedule = %s.name, "scheduler: backfill set_next_run failed: {e}");
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => warn!(schedule = %s.name, cron = %s.cron, "scheduler: backfill cron error: {e}"),
+            }
+        }
+    }
+}
+
+struct FireOutcome {
+    success: bool,
+    status: Option<i64>,
+    response: Option<String>,
+    error: Option<String>,
+}
+
+fn truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_passthrough() {
+        assert_eq!(truncate("abc", 100), "abc");
+    }
+
+    #[test]
+    fn truncate_long_appends_marker() {
+        let s = "x".repeat(50);
+        let t = truncate(&s, 10);
+        assert!(t.starts_with("xxxxxxxxxx"));
+        assert!(t.contains("truncated"));
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/runner.rs
+++ b/kernel/crates/gctrl-scheduler/src/runner.rs
@@ -23,6 +23,11 @@ use tracing::{debug, error, info, warn};
 
 use crate::cron::next_after;
 
+/// Hard cap on bytes read from a callback response. A misconfigured or
+/// malicious target could otherwise stream gigabytes into memory before we
+/// truncate. We chunk-read up to this and bail; the preview field then
+/// further trims to `RESPONSE_PREVIEW_BYTES` for storage.
+const RESPONSE_BODY_CAP_BYTES: usize = 64 * 1024;
 const RESPONSE_PREVIEW_BYTES: usize = 4_096;
 
 pub struct ScheduleRunner {
@@ -112,9 +117,9 @@ impl ScheduleRunner {
         }
 
         let outcome = match req.send().await {
-            Ok(resp) => {
+            Ok(mut resp) => {
                 let status = resp.status().as_u16() as i64;
-                let body = resp.text().await.unwrap_or_default();
+                let body = read_capped_body(&mut resp).await;
                 let preview = truncate(&body, RESPONSE_PREVIEW_BYTES);
                 let success = (200..400).contains(&status);
                 if success {
@@ -220,6 +225,33 @@ struct FireOutcome {
     status: Option<i64>,
     response: Option<String>,
     error: Option<String>,
+}
+
+/// Read at most `RESPONSE_BODY_CAP_BYTES` from `resp` using chunked reads.
+/// Stops streaming the moment the cap is reached, so a 1 GB response body
+/// only ever costs us 64 KB of buffer + whatever single chunk reqwest hands
+/// us next. Made `pub(crate)` so the `run_now` HTTP handler can reuse it.
+pub(crate) async fn read_capped_body(resp: &mut reqwest::Response) -> String {
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    let mut overflow = false;
+    while let Ok(Some(chunk)) = resp.chunk().await {
+        if buf.len() + chunk.len() > RESPONSE_BODY_CAP_BYTES {
+            let take = RESPONSE_BODY_CAP_BYTES.saturating_sub(buf.len());
+            buf.extend_from_slice(&chunk[..take]);
+            overflow = true;
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8_lossy(&buf).into_owned();
+    if overflow {
+        format!(
+            "{body}…[truncated at {}-byte response cap]",
+            RESPONSE_BODY_CAP_BYTES
+        )
+    } else {
+        body
+    }
 }
 
 fn truncate(s: &str, max_bytes: usize) -> String {

--- a/kernel/crates/gctrl-scheduler/tests/http_routes.rs
+++ b/kernel/crates/gctrl-scheduler/tests/http_routes.rs
@@ -1,0 +1,212 @@
+//! Integration tests for the scheduler HTTP routes — exercises the full
+//! axum Router with an in-memory SqliteStore.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use gctrl_scheduler::http;
+use gctrl_storage::SqliteStore;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+fn router() -> axum::Router {
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    http::router(store)
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+}
+
+#[tokio::test]
+async fn list_starts_empty() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["schedules"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn create_then_list_and_get() {
+    let app = router();
+
+    let create_body = serde_json::json!({
+        "name": "test.every-2h",
+        "cron": "0 */2 * * *",
+        "target_url": "http://127.0.0.1:9999/noop",
+        "target_method": "POST"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(create_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let created = body_json(resp).await;
+    let id = created["id"].as_str().unwrap().to_string();
+    assert_eq!(created["name"], "test.every-2h");
+    assert!(created["next_run_at"].is_string(), "next_run_at must be precomputed");
+
+    // List shows the row.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    assert_eq!(json["schedules"].as_array().unwrap().len(), 1);
+
+    // GET by id round-trips.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/schedules/{}", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["name"], "test.every-2h");
+}
+
+#[tokio::test]
+async fn create_rejects_bad_cron() {
+    let app = router();
+    let body = serde_json::json!({
+        "name": "broken",
+        "cron": "not-a-cron",
+        "target_url": "http://x"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_returns_no_content_then_404() {
+    let app = router();
+    let body = serde_json::json!({
+        "name": "to-delete",
+        "cron": "0 */2 * * *",
+        "target_url": "http://x"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&format!("/api/schedules/{}", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/schedules/{}", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn disable_clears_due_status() {
+    let app = router();
+    let body = serde_json::json!({
+        "name": "togglable",
+        "cron": "0 */2 * * *",
+        "target_url": "http://x"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/api/schedules/{}/disable", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/schedules/{}", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    assert_eq!(json["enabled"], false);
+}

--- a/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
+++ b/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
@@ -94,6 +94,33 @@ async fn runner_records_failure_on_5xx() {
 }
 
 #[tokio::test]
+async fn runner_caps_huge_response_body() {
+    // Target returns 256 KB; runner cap is 64 KB. Stored response must be
+    // bounded — otherwise a misbehaving target could OOM the daemon.
+    let big_body: String = "x".repeat(256 * 1024);
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/big"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(big_body))
+        .mount(&mock)
+        .await;
+
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let sched = make_due_schedule(&format!("{}/big", mock.uri()));
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    runner.tick().await.unwrap();
+
+    let after = store.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.last_status, Some(200));
+    let stored = after.last_response.expect("response stored");
+    // Preview cap (4 KB) is what actually lands in storage; the body cap
+    // (64 KB) is what's read off the wire. The preview is well below either.
+    assert!(stored.len() <= 8 * 1024, "stored len {}", stored.len());
+}
+
+#[tokio::test]
 async fn runner_skips_non_due_schedules() {
     let store = Arc::new(SqliteStore::open(":memory:").unwrap());
     // Schedule whose next_run is far in the future.

--- a/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
+++ b/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
@@ -1,0 +1,113 @@
+//! End-to-end test of the runner: insert a due schedule pointing at a
+//! `wiremock` stub, run one tick, assert the stub was hit and the row was
+//! updated with status + recomputed `next_run_at`.
+
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+use gctrl_core::{Schedule, SchedulerConfig};
+use gctrl_scheduler::ScheduleRunner;
+use gctrl_storage::SqliteStore;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_due_schedule(target_url: &str) -> Schedule {
+    let now = Utc::now();
+    // next_run_at in the past → guaranteed due on next tick.
+    let past = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: "test.due".into(),
+        cron: "0 */2 * * *".into(),
+        target_url: target_url.into(),
+        target_method: "POST".into(),
+        body_json: Some(serde_json::json!({ "hello": "world" })),
+        headers_json: None,
+        timeout_secs: 5,
+        enabled: true,
+        next_run_at: Some(past.to_rfc3339()),
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.to_rfc3339(),
+        updated_at: now.to_rfc3339(),
+    }
+}
+
+#[tokio::test]
+async fn runner_fires_due_schedule_and_records_outcome() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/hook"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let sched = make_due_schedule(&format!("{}/hook", mock.uri()));
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    let n = runner.tick().await.unwrap();
+    assert_eq!(n, 1, "exactly one schedule should fire");
+
+    let after = store.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.last_status, Some(200));
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 0);
+    assert!(after.last_run_at.is_some());
+    // Recomputed next_run_at must be in the future, not the historical past
+    // value we seeded with.
+    let next = after.next_run_at.expect("next_run_at recomputed");
+    let next_dt: chrono::DateTime<Utc> = chrono::DateTime::parse_from_rfc3339(&next)
+        .unwrap()
+        .with_timezone(&Utc);
+    assert!(next_dt > Utc::now());
+
+    drop(mock); // verifies `expect(1)`.
+}
+
+#[tokio::test]
+async fn runner_records_failure_on_5xx() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/boom"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("nope"))
+        .mount(&mock)
+        .await;
+
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let sched = make_due_schedule(&format!("{}/boom", mock.uri()));
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    runner.tick().await.unwrap();
+
+    let after = store.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.last_status, Some(503));
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 1, "5xx must increment failure_count");
+}
+
+#[tokio::test]
+async fn runner_skips_non_due_schedules() {
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    // Schedule whose next_run is far in the future.
+    let mut sched = make_due_schedule("http://127.0.0.1:1");
+    sched.next_run_at = Some(
+        Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0)
+            .unwrap()
+            .to_rfc3339(),
+    );
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    let n = runner.tick().await.unwrap();
+    assert_eq!(n, 0);
+    let after = store.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 0);
+}

--- a/kernel/crates/gctrl-storage/src/schema.rs
+++ b/kernel/crates/gctrl-storage/src/schema.rs
@@ -335,6 +335,29 @@ CREATE TABLE IF NOT EXISTS inbox_subscriptions (
 )
 "#;
 
+pub const CREATE_SCHEDULES_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS schedules (
+    id              VARCHAR PRIMARY KEY,
+    name            VARCHAR NOT NULL UNIQUE,
+    cron            VARCHAR NOT NULL,
+    target_url      VARCHAR NOT NULL,
+    target_method   VARCHAR NOT NULL DEFAULT 'POST',
+    body_json       JSON,
+    headers_json    JSON,
+    timeout_secs    INTEGER NOT NULL DEFAULT 60,
+    enabled         BOOLEAN NOT NULL DEFAULT true,
+    next_run_at     VARCHAR,
+    last_run_at     VARCHAR,
+    last_status     INTEGER,
+    last_response   VARCHAR,
+    last_error      VARCHAR,
+    run_count       INTEGER NOT NULL DEFAULT 0,
+    failure_count   INTEGER NOT NULL DEFAULT 0,
+    created_at      VARCHAR NOT NULL,
+    updated_at      VARCHAR NOT NULL
+)
+"#;
+
 pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_spans_session ON spans(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_spans_trace ON spans(trace_id)",
@@ -372,6 +395,8 @@ pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_inbox_actions_message ON inbox_actions(message_id)",
     "CREATE INDEX IF NOT EXISTS idx_inbox_actions_actor ON inbox_actions(actor_id)",
     "CREATE INDEX IF NOT EXISTS idx_inbox_subscriptions_user ON inbox_subscriptions(user_id)",
+    "CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(enabled, next_run_at)",
+    "CREATE INDEX IF NOT EXISTS idx_schedules_name ON schedules(name)",
 ];
 
 pub fn all_migrations() -> Vec<&'static str> {
@@ -399,6 +424,7 @@ pub fn all_migrations() -> Vec<&'static str> {
         CREATE_INBOX_THREADS_TABLE,
         CREATE_INBOX_ACTIONS_TABLE,
         CREATE_INBOX_SUBSCRIPTIONS_TABLE,
+        CREATE_SCHEDULES_TABLE,
     ];
     stmts.extend(CREATE_INDEXES.iter());
     stmts

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -13,7 +13,8 @@ use gctrl_core::{
     memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
-    PersonaDefinition, PersonaReviewRule, Result, Task, VaultMount, VaultMountKind,
+    PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRunUpdate,
+    Task, VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 
@@ -284,6 +285,29 @@ CREATE TABLE IF NOT EXISTS gctrl_vault_mounts (
 )
 "#;
 
+const CREATE_SCHEDULES: &str = r#"
+CREATE TABLE IF NOT EXISTS schedules (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL UNIQUE,
+    cron            TEXT NOT NULL,
+    target_url      TEXT NOT NULL,
+    target_method   TEXT NOT NULL DEFAULT 'POST',
+    body_json       TEXT,
+    headers_json    TEXT,
+    timeout_secs    INTEGER NOT NULL DEFAULT 60,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    next_run_at     TEXT,
+    last_run_at     TEXT,
+    last_status     INTEGER,
+    last_response   TEXT,
+    last_error      TEXT,
+    run_count       INTEGER NOT NULL DEFAULT 0,
+    failure_count   INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+)
+"#;
+
 const CREATE_INDEXES: &[&str] = &[
     // Board indexes
     "CREATE INDEX IF NOT EXISTS idx_board_issues_project ON board_issues(project_id)",
@@ -331,6 +355,9 @@ const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_memory_synced ON memory_entries(synced)",
     "CREATE INDEX IF NOT EXISTS idx_memory_device ON memory_entries(device_id)",
     "CREATE INDEX IF NOT EXISTS idx_memory_updated ON memory_entries(updated_at)",
+    // Schedule indexes — `due` is the hot path for the runner poll loop
+    "CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(enabled, next_run_at)",
+    "CREATE INDEX IF NOT EXISTS idx_schedules_name ON schedules(name)",
 ];
 
 // ═══════════════════════════════════════════════════════════════
@@ -392,6 +419,7 @@ impl SqliteStore {
             CREATE_CONTEXT_ENTRIES,
             CREATE_MEMORY_ENTRIES,
             CREATE_VAULT_MOUNTS,
+            CREATE_SCHEDULES,
         ];
         for stmt in &tables {
             conn.execute_batch(stmt)
@@ -2408,6 +2436,153 @@ impl SqliteStore {
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
     }
+
+    // ───────────────────────── Schedules ─────────────────────────
+
+    pub fn create_schedule(&self, sched: &Schedule) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO schedules (id, name, cron, target_url, target_method, body_json, headers_json, timeout_secs, enabled, next_run_at, last_run_at, last_status, last_response, last_error, run_count, failure_count, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+            params![
+                sched.id,
+                sched.name,
+                sched.cron,
+                sched.target_url,
+                sched.target_method,
+                sched.body_json.as_ref().map(|v| v.to_string()),
+                sched.headers_json.as_ref().map(|v| v.to_string()),
+                sched.timeout_secs,
+                sched.enabled,
+                sched.next_run_at,
+                sched.last_run_at,
+                sched.last_status,
+                sched.last_response,
+                sched.last_error,
+                sched.run_count,
+                sched.failure_count,
+                sched.created_at,
+                sched.updated_at,
+            ],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn get_schedule(&self, id_or_name: &str) -> Result<Option<Schedule>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, name, cron, target_url, target_method, body_json, headers_json, timeout_secs, enabled, next_run_at, last_run_at, last_status, last_response, last_error, run_count, failure_count, created_at, updated_at
+             FROM schedules WHERE id = ?1 OR name = ?1",
+            [id_or_name],
+            row_to_schedule,
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(GctlError::Storage(other.to_string())),
+        })
+    }
+
+    pub fn list_schedules(&self, filter: &ScheduleFilter) -> Result<Vec<Schedule>> {
+        let conn = self.conn.lock().unwrap();
+        let mut sql = "SELECT id, name, cron, target_url, target_method, body_json, headers_json, timeout_secs, enabled, next_run_at, last_run_at, last_status, last_response, last_error, run_count, failure_count, created_at, updated_at FROM schedules WHERE 1=1".to_string();
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut idx = 1;
+        if let Some(en) = filter.enabled {
+            sql.push_str(&format!(" AND enabled = ?{}", idx));
+            params_vec.push(Box::new(en));
+            idx += 1;
+        }
+        if let Some(ref pre) = filter.name_prefix {
+            sql.push_str(&format!(" AND name LIKE ?{}", idx));
+            params_vec.push(Box::new(format!("{}%", pre)));
+        }
+        sql.push_str(" ORDER BY name");
+        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let p: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt.query_map(rusqlite::params_from_iter(p), row_to_schedule)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Schedules whose `next_run_at` is `<= now` AND `enabled = 1`. The hot path
+    /// for the runner — caller polls this on every tick.
+    pub fn list_due_schedules(&self, now_rfc3339: &str, limit: usize) -> Result<Vec<Schedule>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, cron, target_url, target_method, body_json, headers_json, timeout_secs, enabled, next_run_at, last_run_at, last_status, last_response, last_error, run_count, failure_count, created_at, updated_at
+             FROM schedules
+             WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?1
+             ORDER BY next_run_at LIMIT ?2"
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let rows = stmt.query_map(params![now_rfc3339, limit as i64], row_to_schedule)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    pub fn delete_schedule(&self, id_or_name: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn.execute(
+            "DELETE FROM schedules WHERE id = ?1 OR name = ?1",
+            [id_or_name],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n > 0)
+    }
+
+    pub fn set_schedule_enabled(&self, id_or_name: &str, enabled: bool) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let n = conn.execute(
+            "UPDATE schedules SET enabled = ?1, updated_at = ?2 WHERE id = ?3 OR name = ?3",
+            params![enabled, now, id_or_name],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n > 0)
+    }
+
+    /// Persist outcome of a runner attempt + the precomputed next firing time.
+    /// `failure_count` increments on `update.success == false`; `run_count`
+    /// increments unconditionally so the user can tell "fired but failed" from
+    /// "never fired."
+    pub fn record_schedule_run(&self, id: &str, update: &ScheduleRunUpdate) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let failure_inc: i64 = if update.success { 0 } else { 1 };
+        conn.execute(
+            "UPDATE schedules
+             SET last_run_at = ?1,
+                 next_run_at = ?2,
+                 last_status = ?3,
+                 last_response = ?4,
+                 last_error = ?5,
+                 run_count = run_count + 1,
+                 failure_count = failure_count + ?6,
+                 updated_at = ?7
+             WHERE id = ?8",
+            params![
+                update.last_run_at,
+                update.next_run_at,
+                update.last_status,
+                update.last_response,
+                update.last_error,
+                failure_inc,
+                now,
+                id,
+            ],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Set `next_run_at` without touching run history — used after creating a
+    /// schedule or when re-enabling one whose stored `next_run_at` is stale.
+    pub fn set_schedule_next_run(&self, id: &str, next_run_at: Option<&str>) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE schedules SET next_run_at = ?1, updated_at = ?2 WHERE id = ?3",
+            params![next_run_at, now, id],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -2431,6 +2606,31 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
         updated_at: chrono::DateTime::parse_from_rfc3339(&updated_at_str)
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now()),
+    })
+}
+
+fn row_to_schedule(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedule> {
+    let body_json_str: Option<String> = row.get(5)?;
+    let headers_json_str: Option<String> = row.get(6)?;
+    Ok(Schedule {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        cron: row.get(2)?,
+        target_url: row.get(3)?,
+        target_method: row.get(4)?,
+        body_json: body_json_str.and_then(|s| serde_json::from_str(&s).ok()),
+        headers_json: headers_json_str.and_then(|s| serde_json::from_str(&s).ok()),
+        timeout_secs: row.get(7)?,
+        enabled: row.get(8)?,
+        next_run_at: row.get(9)?,
+        last_run_at: row.get(10)?,
+        last_status: row.get(11)?,
+        last_response: row.get(12)?,
+        last_error: row.get(13)?,
+        run_count: row.get(14)?,
+        failure_count: row.get(15)?,
+        created_at: row.get(16)?,
+        updated_at: row.get(17)?,
     })
 }
 

--- a/vault/specs/architecture/kernel/scheduler.md
+++ b/vault/specs/architecture/kernel/scheduler.md
@@ -9,6 +9,19 @@ Defined as a **kernel interface trait** with **platform-specific implementations
 
 > **Terminology note:** "Adapter" here refers to internal kernel implementations (tokio timers, launchd, DO Alarms), not external app drivers. See [os.md § 5](../os.md) for the driver/adapter distinction.
 
+## Implementation status (April 2026)
+
+The unified `SchedulerPort` described below is the **target shape**. The current code splits these responsibilities across two crates:
+
+| Responsibility | Crate | Storage |
+|---|---|---|
+| Task tracking (#1) — claim, dispatch, complete agent work | `gctrl-orch` | `tasks` table |
+| Deferred & recurring execution (#2) — cron-driven HTTP callbacks | `gctrl-scheduler` | `schedules` table |
+
+`gctrl-scheduler` today is a generic "fire HTTP at a URL on a cron" runner. It does NOT yet read from or write to the `tasks` table, and it does NOT normalize agent-system metadata. The `Schedule` row in storage is a callback definition (cron + target URL + body), not a `Task`.
+
+Unifying the two behind a single `SchedulerPort` is **deferred** — the contracts and lifecycles are different enough (long-lived agent claims with retries vs. short HTTP callbacks with idempotent re-fires) that conflating them prematurely would tangle agent orchestration with periodic ingest. When unification ships, `schedule_recurring(cron)` will produce `Task` rows that the orch dispatcher claims; until then, recurring HTTP callbacks live in their own table and the two crates communicate over the kernel HTTP API.
+
 ---
 
 ## Tasks


### PR DESCRIPTION
## Summary

PR1 of 3 toward "kernel auto-runs ingest every 2h and analyses with a local LMStudio model." This is the foundational piece — a periodic HTTP-callback scheduler in the kernel.

- New `gctrl-scheduler` crate: cron parser (5/6/7-field, 5 normalised by prepending `0` for seconds), tokio runner fiber, axum routes
- `schedules` SQLite table with the standard kernel shape (id, name, cron, target_url, body_json, enabled, next_run_at, last_status, run_count, …)
- `SchedulerConfig` on `GctlConfig` (defaults: enabled, 30s poll, 16 jobs/tick, 60s per-job timeout)
- HTTP routes mounted via `.merge()` into the main `:4318` router:
  - `GET/POST /api/schedules`
  - `GET/DELETE /api/schedules/{id}`
  - `POST /api/schedules/{id}/run` (manual fire — bypasses cron)
  - `POST /api/schedules/{id}/{enable,disable}`
- `gctrld scheduler {list,show,add,rm,enable,disable,run}` CLI
- Runner spawned by `gctrld serve` (skipped when disabled in config)

PR2 (`gctrl-driver-llm`, OpenAI-compatible adapter for LMStudio + Cloudflare Gateway) and PR3 (`uber.ingest.tick` job that uses both) ride on top of this.

## Design notes

- **Separate crate from `gctrl-orch`.** Orch dispatches Claude agents to claimed board tasks; the scheduler fires HTTP at arbitrary URLs on cron. Only the polling-loop *shape* is shared. Fusing them would tangle agent orchestration with periodic ingest/cleanup/health jobs.
- **No catch-up after restart.** A missed window fires *once* on the next due tick, not N times. Matches Unix cron, avoids thundering-herd backlog after a daemon restart.
- **Routes own their own state.** `Arc<SqliteStore>` is the only thing the scheduler routes need, so they get their own `.with_state()` and `.merge()` rather than fattening `AppState`.
- **Scheduler CLI talks SQLite directly** for read/write (matches `board`, `prompt`, `personas` pattern). `scheduler run` is the one exception — it POSTs to the running daemon's `/api/schedules/{id}/run` so dispatch logic isn't duplicated.

## Sample API usage

```sh
# Register an "every 2 hours" callback
curl -X POST http://127.0.0.1:4318/api/schedules \
  -H 'content-type: application/json' \
  -d '{"name":"uber.ingest.tick","cron":"0 */2 * * *","target_url":"http://127.0.0.1:4318/api/uber/ingest/run"}'

# Or via the CLI
gctrld scheduler add \
  --name uber.ingest.tick \
  --cron '0 */2 * * *' \
  --target-url http://127.0.0.1:4318/api/uber/ingest/run

gctrld scheduler list
gctrld scheduler run uber.ingest.tick   # manual fire via daemon
```

## Test plan

- [x] `cargo test -p gctrl-scheduler` — 14 tests pass
  - 6 unit (cron parsing for 5/6 fields, edge cases, response truncation)
  - 5 HTTP integration (`tower::ServiceExt::oneshot` against in-memory SqliteStore)
  - 3 runner integration (fires due schedule against `wiremock` server, records 5xx as failure, skips non-due rows)
- [x] `cargo test --workspace` — all green, no regressions in other crates
- [x] `cargo build` — clean
- [ ] Manual: start `gctrld serve`, register a schedule pointing at `httpbin.org/post` with `* * * * *` cron, observe periodic fire in logs and `last_status` rolling forward in SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
