### PR TITLE
feat(board): make Worker a kernel facade with D1-mirrored analytics

### DIFF
--- a/apps/gctrl-board/migrations/0004_analytics.sql
+++ b/apps/gctrl-board/migrations/0004_analytics.sql
@@ -1,0 +1,91 @@
+-- Analytics mirror tables.
+-- Kernel DuckDB is source of truth; the Worker's scheduled handler pulls from
+-- KERNEL_URL/api/analytics/* and /api/sessions periodically and upserts here.
+-- Read endpoints (/api/analytics, /api/analytics/cost, etc.) serve from these
+-- tables, so analytics works even when the kernel is offline.
+
+-- Sessions mirror — full row mirror for list + detail reads.
+CREATE TABLE IF NOT EXISTS analytics_sessions (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  agent_name TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  total_cost_usd REAL NOT NULL DEFAULT 0,
+  total_input_tokens INTEGER NOT NULL DEFAULT 0,
+  total_output_tokens INTEGER NOT NULL DEFAULT 0,
+  created_by TEXT NOT NULL DEFAULT 'unknown',
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_sessions_started ON analytics_sessions(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_sessions_agent   ON analytics_sessions(agent_name);
+CREATE INDEX IF NOT EXISTS idx_analytics_sessions_status  ON analytics_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_analytics_sessions_creator ON analytics_sessions(created_by);
+
+-- Daily aggregates — long-form rows from kernel; Worker pivots into DailyEntry shape.
+CREATE TABLE IF NOT EXISTS analytics_daily (
+  date TEXT NOT NULL,
+  metric TEXT NOT NULL,        -- 'cost' | 'sessions' | 'tokens' | 'spans'
+  dimension TEXT NOT NULL DEFAULT 'total',
+  value REAL NOT NULL,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (date, metric, dimension)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_daily_date ON analytics_daily(date DESC);
+
+-- Cost rollups — denormalized snapshots refreshed on every sync (small).
+CREATE TABLE IF NOT EXISTS analytics_cost_by_model (
+  model TEXT PRIMARY KEY,
+  cost REAL NOT NULL DEFAULT 0,
+  calls INTEGER NOT NULL DEFAULT 0,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS analytics_cost_by_agent (
+  agent TEXT PRIMARY KEY,
+  cost REAL NOT NULL DEFAULT 0,
+  sessions INTEGER NOT NULL DEFAULT 0,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Span type distribution rollup.
+CREATE TABLE IF NOT EXISTS analytics_span_distribution (
+  span_type TEXT PRIMARY KEY,
+  count INTEGER NOT NULL DEFAULT 0,
+  percentage REAL NOT NULL DEFAULT 0,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Score summaries keyed by score name.
+CREATE TABLE IF NOT EXISTS analytics_scores (
+  name TEXT PRIMARY KEY,
+  pass INTEGER NOT NULL DEFAULT 0,
+  fail INTEGER NOT NULL DEFAULT 0,
+  total INTEGER NOT NULL DEFAULT 0,
+  pass_rate REAL NOT NULL DEFAULT 0,
+  avg_value REAL NOT NULL DEFAULT 0,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Alert rules mirror.
+CREATE TABLE IF NOT EXISTS analytics_alerts (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  condition_type TEXT NOT NULL,
+  threshold REAL NOT NULL,
+  action TEXT NOT NULL DEFAULT 'warn',
+  enabled INTEGER NOT NULL DEFAULT 1,
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Sync metadata — last successful kernel pull, for status display + debugging.
+CREATE TABLE IF NOT EXISTS analytics_sync_state (
+  resource TEXT PRIMARY KEY,    -- 'overview' | 'cost' | 'spans' | 'daily' | 'alerts' | 'sessions' | 'scores'
+  last_synced_at TEXT NOT NULL,
+  last_status TEXT NOT NULL,    -- 'ok' | 'error'
+  last_error TEXT
+);

--- a/apps/gctrl-board/src/analytics.ts
+++ b/apps/gctrl-board/src/analytics.ts
@@ -1,0 +1,513 @@
+/**
+ * Analytics — D1-backed read handlers + kernel→D1 sync.
+ *
+ * Read endpoints (/api/analytics, /api/analytics/cost, /daily, etc.) serve
+ * from the analytics_* tables so the dashboard works even when the kernel is
+ * unreachable. The scheduled handler in worker.ts pulls from
+ * KERNEL_URL/api/analytics/* every cron tick and upserts here.
+ *
+ * Latency percentiles stay on the kernel (D1 lacks PERCENTILE_CONT) — that
+ * route is handled by the kernel proxy fallback in worker.ts.
+ */
+import { Context, Effect } from "effect"
+import { D1Client, D1Error } from "./d1.js"
+
+// ── HTTP helpers (kept local so this module has no dep on worker.ts) ──
+
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+  })
+
+// ── Kernel config — runtime view of env.KERNEL_URL ──
+
+export interface KernelConfigShape {
+  readonly kernelUrl: string | undefined
+}
+export class KernelConfig extends Context.Tag("KernelConfig")<KernelConfig, KernelConfigShape>() {}
+
+// ── Handler signature shared with worker.ts ──
+
+type RouteParams = Record<string, string>
+export type AnalyticsHandler = (
+  request: Request,
+  params: RouteParams,
+) => Effect.Effect<Response, D1Error, D1Client | KernelConfig>
+
+// ── Read handlers ──
+
+export const getOverview: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+
+    const totals = yield* db.first<{
+      total_sessions: number
+      total_cost_usd: number
+      total_input_tokens: number
+      total_output_tokens: number
+    }>(
+      `SELECT
+        COUNT(*) AS total_sessions,
+        COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd,
+        COALESCE(SUM(total_input_tokens), 0) AS total_input_tokens,
+        COALESCE(SUM(total_output_tokens), 0) AS total_output_tokens
+      FROM analytics_sessions`,
+    )
+
+    const spanCount = yield* db.first<{ total_spans: number }>(
+      `SELECT COALESCE(SUM(count), 0) AS total_spans FROM analytics_span_distribution`,
+    )
+
+    const byAgent = yield* db.query(
+      `SELECT agent AS agent_name, sessions AS session_count, cost AS total_cost_usd
+       FROM analytics_cost_by_agent ORDER BY cost DESC`,
+    )
+
+    const byModel = yield* db.query(
+      `SELECT model, calls AS span_count, cost AS total_cost_usd,
+              0 AS total_input_tokens, 0 AS total_output_tokens
+       FROM analytics_cost_by_model ORDER BY cost DESC`,
+    )
+
+    return jsonResponse({
+      total_sessions: totals?.total_sessions ?? 0,
+      total_spans: spanCount?.total_spans ?? 0,
+      total_cost_usd: totals?.total_cost_usd ?? 0,
+      total_input_tokens: totals?.total_input_tokens ?? 0,
+      total_output_tokens: totals?.total_output_tokens ?? 0,
+      by_agent: byAgent,
+      by_model: byModel,
+    })
+  })
+
+export const getCost: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const byModel = yield* db.query(
+      `SELECT model, cost, calls FROM analytics_cost_by_model ORDER BY cost DESC`,
+    )
+    const byAgent = yield* db.query(
+      `SELECT agent, cost, sessions FROM analytics_cost_by_agent ORDER BY cost DESC`,
+    )
+    return jsonResponse({ by_model: byModel, by_agent: byAgent })
+  })
+
+export const getSpanDistribution: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const distribution = yield* db.query(
+      `SELECT span_type AS type, count, percentage
+       FROM analytics_span_distribution ORDER BY count DESC`,
+    )
+    return jsonResponse({ distribution })
+  })
+
+export const getDaily: AnalyticsHandler = (req) =>
+  Effect.gen(function* () {
+    const url = new URL(req.url)
+    const days = Math.max(1, Math.min(365, Number(url.searchParams.get("days") ?? "7")))
+
+    const db = yield* D1Client
+    const rows = yield* db.query(
+      `SELECT date, metric, dimension, value
+       FROM analytics_daily
+       WHERE dimension = 'total'
+       ORDER BY date DESC
+       LIMIT ?`,
+      days * 4 + 4,
+    )
+
+    // Pivot long-form (date, metric, value) → DailyEntry shape the frontend expects.
+    const byDate = new Map<string, { date: string; sessions: number; spans: number; cost_usd: number; tokens: number }>()
+    for (const r of rows as Array<{ date: string; metric: string; value: number }>) {
+      const entry = byDate.get(r.date) ?? { date: r.date, sessions: 0, spans: 0, cost_usd: 0, tokens: 0 }
+      if (r.metric === "sessions") entry.sessions = r.value
+      else if (r.metric === "spans") entry.spans = r.value
+      else if (r.metric === "cost") entry.cost_usd = r.value
+      else if (r.metric === "tokens") entry.tokens = r.value
+      byDate.set(r.date, entry)
+    }
+    const out = Array.from(byDate.values())
+      .sort((a, b) => (a.date < b.date ? 1 : -1))
+      .slice(0, days)
+    return jsonResponse(out)
+  })
+
+export const getAlerts: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const rows = yield* db.query(
+      `SELECT id, name, condition_type, threshold, action,
+              CASE enabled WHEN 1 THEN 1 ELSE 0 END AS enabled
+       FROM analytics_alerts WHERE enabled = 1 ORDER BY name`,
+    )
+    return jsonResponse(rows.map((r) => ({ ...r, enabled: r.enabled === 1 })))
+  })
+
+export const getScoreSummary: AnalyticsHandler = (req) =>
+  Effect.gen(function* () {
+    const url = new URL(req.url)
+    const name = url.searchParams.get("name")
+    if (!name) {
+      return new Response(JSON.stringify({ error: "name query param required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      })
+    }
+    const db = yield* D1Client
+    const row = yield* db.first<{
+      name: string
+      pass: number
+      fail: number
+      total: number
+      pass_rate: number
+      avg_value: number
+    }>(
+      `SELECT name, pass, fail, total, pass_rate, avg_value
+       FROM analytics_scores WHERE name = ?`,
+      name,
+    )
+    if (!row) {
+      return jsonResponse({ name, pass: 0, fail: 0, total: 0, pass_rate: 0, avg_value: 0 })
+    }
+    return jsonResponse(row)
+  })
+
+export const listSessions: AnalyticsHandler = (req) =>
+  Effect.gen(function* () {
+    const url = new URL(req.url)
+    const limit = Math.max(1, Math.min(500, Number(url.searchParams.get("limit") ?? "50")))
+    const agent = url.searchParams.get("agent")
+    const status = url.searchParams.get("status")
+    const kind = url.searchParams.get("kind") // 'internal' | 'external' | 'all' | null
+
+    let sql = `SELECT * FROM analytics_sessions WHERE 1=1`
+    const binds: unknown[] = []
+    if (agent) { sql += " AND agent_name = ?"; binds.push(agent) }
+    if (status) { sql += " AND status = ?"; binds.push(status) }
+    if (kind === "internal") sql += " AND created_by IN ('scheduler', 'api')"
+    else if (kind === "external") sql += " AND created_by = 'otel_ingest'"
+    sql += " ORDER BY started_at DESC LIMIT ?"
+    binds.push(limit)
+
+    const db = yield* D1Client
+    const rows = yield* db.query(sql, ...binds)
+    // Strip sync metadata from response
+    return jsonResponse(rows.map((r) => {
+      const { synced_at, ...rest } = r as Record<string, unknown>
+      void synced_at
+      return rest
+    }))
+  })
+
+export const getSession: AnalyticsHandler = (_req, params) =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const row = yield* db.first<Record<string, unknown>>(
+      `SELECT * FROM analytics_sessions WHERE id = ?`,
+      params.id,
+    )
+    if (!row) {
+      return new Response(JSON.stringify({ error: "Session not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      })
+    }
+    const { synced_at, ...rest } = row
+    void synced_at
+    return jsonResponse(rest)
+  })
+
+// ── Sync state types ──
+
+export interface SyncState {
+  resource: string
+  last_synced_at: string
+  last_status: "ok" | "error"
+  last_error: string | null
+}
+
+// GET /api/analytics/sync-status — surfaces sync_state rows + whether KERNEL_URL is set.
+// Frontend uses this to render "last synced 2m ago" / "kernel not configured" / etc.
+export const getSyncStatus: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const db = yield* D1Client
+    const cfg = yield* KernelConfig
+    const rows = (yield* db.query(
+      `SELECT resource, last_synced_at, last_status, last_error
+       FROM analytics_sync_state ORDER BY resource`,
+    )) as unknown as SyncState[]
+    return jsonResponse({
+      kernel_url_configured: Boolean(cfg.kernelUrl),
+      resources: rows,
+    })
+  })
+
+// POST /api/analytics/sync — kicks off syncFromKernel synchronously and returns
+// the resulting state. Useful for `wrangler dev` (where cron requires
+// --test-scheduled) and for ops "force refresh" actions.
+export const triggerSync: AnalyticsHandler = () =>
+  Effect.gen(function* () {
+    const cfg = yield* KernelConfig
+    if (!cfg.kernelUrl) {
+      return new Response(
+        JSON.stringify({ error: "KERNEL_URL not configured" }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+        },
+      )
+    }
+    const db = yield* D1Client
+    yield* Effect.tryPromise({
+      try: () => syncFromKernel(db.raw, makeKernelClient(cfg.kernelUrl!)),
+      catch: (e) => new D1Error({ message: String(e) }),
+    })
+    const rows = (yield* db.query(
+      `SELECT resource, last_synced_at, last_status, last_error
+       FROM analytics_sync_state ORDER BY resource`,
+    )) as unknown as SyncState[]
+    return jsonResponse({ kernel_url_configured: true, resources: rows })
+  })
+
+// ── Kernel→D1 sync (called from scheduled handler) ──
+
+export interface KernelClient {
+  fetchJson: <T>(path: string) => Promise<T>
+}
+
+export const makeKernelClient = (kernelUrl: string): KernelClient => ({
+  fetchJson: async <T>(path: string): Promise<T> => {
+    const res = await fetch(new URL(path, kernelUrl).toString())
+    if (!res.ok) throw new Error(`kernel ${path} → HTTP ${res.status}`)
+    return (await res.json()) as T
+  },
+})
+
+const recordSync = async (
+  db: D1Database,
+  resource: string,
+  status: "ok" | "error",
+  error: string | null,
+): Promise<void> => {
+  await db
+    .prepare(
+      `INSERT INTO analytics_sync_state (resource, last_synced_at, last_status, last_error)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(resource) DO UPDATE SET
+         last_synced_at = excluded.last_synced_at,
+         last_status = excluded.last_status,
+         last_error = excluded.last_error`,
+    )
+    .bind(resource, new Date().toISOString(), status, error)
+    .run()
+}
+
+const syncResource = async (
+  db: D1Database,
+  resource: string,
+  fn: () => Promise<void>,
+): Promise<void> => {
+  try {
+    await fn()
+    await recordSync(db, resource, "ok", null)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    await recordSync(db, resource, "error", msg)
+  }
+}
+
+interface KernelSession {
+  id: string
+  workspace_id: string
+  device_id: string
+  agent_name: string
+  started_at: string
+  ended_at: string | null
+  status: string
+  total_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
+  created_by: string
+}
+
+interface KernelOverview {
+  by_agent: Array<{ agent_name: string; session_count: number; total_cost_usd: number }>
+  by_model: Array<{ model: string; span_count: number; total_cost_usd: number }>
+}
+
+interface KernelCost {
+  by_model: Array<{ model: string; cost: number; calls: number }>
+  by_agent: Array<{ agent: string; cost: number; sessions: number }>
+}
+
+interface KernelSpanDist {
+  distribution: Array<{ type: string; count: number; percentage: number }>
+}
+
+interface KernelDailyRow {
+  date: string
+  metric: string
+  dimension: string
+  value: number
+}
+
+interface KernelAlert {
+  id: string
+  name: string
+  condition_type: string
+  threshold: number
+  action: string
+  enabled: boolean
+}
+
+const upsertSessions = async (db: D1Database, sessions: KernelSession[]): Promise<void> => {
+  if (sessions.length === 0) return
+  const now = new Date().toISOString()
+  const stmts = sessions.map((s) =>
+    db
+      .prepare(
+        `INSERT INTO analytics_sessions
+          (id, workspace_id, device_id, agent_name, started_at, ended_at, status,
+           total_cost_usd, total_input_tokens, total_output_tokens, created_by, synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           ended_at = excluded.ended_at,
+           status = excluded.status,
+           total_cost_usd = excluded.total_cost_usd,
+           total_input_tokens = excluded.total_input_tokens,
+           total_output_tokens = excluded.total_output_tokens,
+           created_by = excluded.created_by,
+           synced_at = excluded.synced_at`,
+      )
+      .bind(
+        s.id, s.workspace_id, s.device_id, s.agent_name, s.started_at,
+        s.ended_at, s.status, s.total_cost_usd, s.total_input_tokens,
+        s.total_output_tokens, s.created_by, now,
+      ),
+  )
+  await db.batch(stmts)
+}
+
+const replaceCostByModel = async (db: D1Database, rows: KernelCost["by_model"]): Promise<void> => {
+  const now = new Date().toISOString()
+  const stmts = [
+    db.prepare(`DELETE FROM analytics_cost_by_model`),
+    ...rows.map((r) =>
+      db
+        .prepare(
+          `INSERT INTO analytics_cost_by_model (model, cost, calls, synced_at) VALUES (?, ?, ?, ?)`,
+        )
+        .bind(r.model, r.cost, r.calls, now),
+    ),
+  ]
+  await db.batch(stmts)
+}
+
+const replaceCostByAgent = async (db: D1Database, rows: KernelCost["by_agent"]): Promise<void> => {
+  const now = new Date().toISOString()
+  const stmts = [
+    db.prepare(`DELETE FROM analytics_cost_by_agent`),
+    ...rows.map((r) =>
+      db
+        .prepare(
+          `INSERT INTO analytics_cost_by_agent (agent, cost, sessions, synced_at) VALUES (?, ?, ?, ?)`,
+        )
+        .bind(r.agent, r.cost, r.sessions, now),
+    ),
+  ]
+  await db.batch(stmts)
+}
+
+const replaceSpanDistribution = async (
+  db: D1Database,
+  rows: KernelSpanDist["distribution"],
+): Promise<void> => {
+  const now = new Date().toISOString()
+  const stmts = [
+    db.prepare(`DELETE FROM analytics_span_distribution`),
+    ...rows.map((r) =>
+      db
+        .prepare(
+          `INSERT INTO analytics_span_distribution (span_type, count, percentage, synced_at) VALUES (?, ?, ?, ?)`,
+        )
+        .bind(r.type, r.count, r.percentage, now),
+    ),
+  ]
+  await db.batch(stmts)
+}
+
+const upsertDaily = async (db: D1Database, rows: KernelDailyRow[]): Promise<void> => {
+  if (rows.length === 0) return
+  const now = new Date().toISOString()
+  const stmts = rows.map((r) =>
+    db
+      .prepare(
+        `INSERT INTO analytics_daily (date, metric, dimension, value, synced_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(date, metric, dimension) DO UPDATE SET
+           value = excluded.value, synced_at = excluded.synced_at`,
+      )
+      .bind(r.date, r.metric, r.dimension, r.value, now),
+  )
+  await db.batch(stmts)
+}
+
+const replaceAlerts = async (db: D1Database, rows: KernelAlert[]): Promise<void> => {
+  const now = new Date().toISOString()
+  const stmts = [
+    db.prepare(`DELETE FROM analytics_alerts`),
+    ...rows.map((r) =>
+      db
+        .prepare(
+          `INSERT INTO analytics_alerts (id, name, condition_type, threshold, action, enabled, synced_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(r.id, r.name, r.condition_type, r.threshold, r.action, r.enabled ? 1 : 0, now),
+    ),
+  ]
+  await db.batch(stmts)
+}
+
+/**
+ * Pull all analytics resources from the kernel and upsert into D1.
+ * Each resource is synced independently — a failure in one doesn't block the others.
+ */
+export const syncFromKernel = async (
+  db: D1Database,
+  kernel: KernelClient,
+): Promise<void> => {
+  await Promise.all([
+    syncResource(db, "sessions", async () => {
+      const sessions = await kernel.fetchJson<KernelSession[]>("/api/sessions?limit=500")
+      await upsertSessions(db, sessions)
+    }),
+    syncResource(db, "overview", async () => {
+      const ov = await kernel.fetchJson<KernelOverview>("/api/analytics")
+      // Overview's by_agent/by_model are subsumed by the cost rollups; nothing
+      // extra to store here. Keep the resource entry so the sync table shows it.
+      void ov
+    }),
+    syncResource(db, "cost", async () => {
+      const cost = await kernel.fetchJson<KernelCost>("/api/analytics/cost")
+      await replaceCostByModel(db, cost.by_model)
+      await replaceCostByAgent(db, cost.by_agent)
+    }),
+    syncResource(db, "spans", async () => {
+      const dist = await kernel.fetchJson<KernelSpanDist>("/api/analytics/spans")
+      await replaceSpanDistribution(db, dist.distribution)
+    }),
+    syncResource(db, "daily", async () => {
+      const rows = await kernel.fetchJson<KernelDailyRow[]>("/api/analytics/daily?days=30")
+      await upsertDaily(db, rows)
+    }),
+    syncResource(db, "alerts", async () => {
+      const alerts = await kernel.fetchJson<KernelAlert[]>("/api/analytics/alerts")
+      await replaceAlerts(db, alerts)
+    }),
+  ])
+}
+
+// Keep KernelClient as a Tag in case the worker wants to inject it later.
+export class KernelClientTag extends Context.Tag("KernelClient")<KernelClientTag, KernelClient>() {}

--- a/apps/gctrl-board/src/d1.ts
+++ b/apps/gctrl-board/src/d1.ts
@@ -34,6 +34,11 @@ export interface D1ClientShape {
     sql: string,
     ...binds: unknown[]
   ) => Effect.Effect<void, D1Error>
+
+  /** Underlying D1Database binding — for callers that need .prepare/.batch
+   *  outside the Effect wrapper (e.g. the scheduled handler / sync code that
+   *  shares logic with non-Effect contexts). */
+  readonly raw: D1Database
 }
 
 export class D1Client extends Context.Tag("D1Client")<D1Client, D1ClientShape>() {}
@@ -81,4 +86,6 @@ export const makeD1Client = (db: D1Database): D1ClientShape => ({
           .then(() => undefined),
       catch: (e) => new D1Error({ message: String(e) }),
     }),
+
+  raw: db,
 })

--- a/apps/gctrl-board/src/worker.ts
+++ b/apps/gctrl-board/src/worker.ts
@@ -4,21 +4,39 @@
  * Routes:
  *   /api/board/*  → D1-backed board API (Effect-TS handlers)
  *   /api/inbox/*  → stub returning empty stats
+ *   /api/*        → proxied to KERNEL_URL when configured (facade over kernel HTTP API)
  *   everything else → static assets (SPA with fallback routing)
  *
  * Each API handler is an Effect program using D1Client, with tagged errors
  * caught and mapped to HTTP responses at the boundary.
  */
 import { Effect } from "effect"
+import {
+  getAlerts,
+  getCost,
+  getDaily,
+  getOverview,
+  getScoreSummary,
+  getSession,
+  getSpanDistribution,
+  getSyncStatus,
+  KernelConfig,
+  listSessions,
+  makeKernelClient,
+  syncFromKernel,
+  triggerSync,
+} from "./analytics.js"
 import { D1Client, D1Error, makeD1Client } from "./d1.js"
 
 interface Env {
   ASSETS: Fetcher
   DB: D1Database
   /**
-   * Optional base URL for the gctrl kernel daemon. When set, the Worker
-   * proxies acceptance-rollup reads to the kernel (kernel is source of
-   * truth). Defaults to localhost for dev.
+   * Base URL for the gctrl kernel daemon. When set, the Worker proxies
+   * unmatched /api/* paths to the kernel and runs the analytics sync cron;
+   * see src/analytics.ts and the proxyToKernel fallback below. Defaults to
+   * localhost for dev — Cloudflare edge cannot reach localhost, so deployed
+   * Workers must point this at a publicly-reachable kernel.
    */
   KERNEL_URL?: string
 }
@@ -94,7 +112,7 @@ type RouteParams = Record<string, string>
 type ApiHandler = (
   request: Request,
   params: RouteParams
-) => Effect.Effect<Response, D1Error, D1Client>
+) => Effect.Effect<Response, D1Error, D1Client | KernelConfig>
 
 interface Route {
   method: string
@@ -539,6 +557,20 @@ const routes: Route[] = [
   defineRoute("GET", "/api/board/projects/:id/gantt", projectGantt),
   defineRoute("GET", "/api/inbox/stats", inboxStats),
   defineRoute("GET", "/api/sync/status", syncStatus),
+
+  // Analytics — D1-backed reads (kept in sync from kernel by the scheduled handler).
+  // /api/analytics/latency stays unmirrored: D1 lacks PERCENTILE_CONT, so it
+  // falls through to the kernel proxy in the fetch handler below.
+  defineRoute("GET", "/api/analytics", getOverview),
+  defineRoute("GET", "/api/analytics/cost", getCost),
+  defineRoute("GET", "/api/analytics/spans", getSpanDistribution),
+  defineRoute("GET", "/api/analytics/daily", getDaily),
+  defineRoute("GET", "/api/analytics/alerts", getAlerts),
+  defineRoute("GET", "/api/analytics/scores", getScoreSummary),
+  defineRoute("GET", "/api/sessions", listSessions),
+  defineRoute("GET", "/api/sessions/:id", getSession),
+  defineRoute("GET", "/api/analytics/sync-status", getSyncStatus),
+  defineRoute("POST", "/api/analytics/sync", triggerSync),
 ]
 
 // ── Route matcher → Effect<Response> ──
@@ -546,7 +578,7 @@ const routes: Route[] = [
 const matchRoute = (
   request: Request,
   pathname: string,
-): Effect.Effect<Response, D1Error, D1Client> | null => {
+): Effect.Effect<Response, D1Error, D1Client | KernelConfig> | null => {
   for (const r of routes) {
     if (request.method !== r.method) continue
     const match = pathname.match(r.pattern)
@@ -557,6 +589,31 @@ const matchRoute = (
     return r.handler(request, params)
   }
   return null
+}
+
+// ── Kernel facade proxy ──
+//
+// For /api/* paths the Worker doesn't handle locally, forward to the kernel
+// HTTP API at KERNEL_URL. Cloudflare edge can't reach localhost, so deployments
+// must point KERNEL_URL at a publicly-reachable kernel (tunnel or hosted).
+const proxyToKernel = async (
+  request: Request,
+  kernelUrl: string,
+  url: URL,
+): Promise<Response> => {
+  const target = new URL(url.pathname + url.search, kernelUrl)
+  const upstream = await fetch(target.toString(), {
+    method: request.method,
+    headers: request.headers,
+    body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+  } as RequestInit)
+  const headers = new Headers(upstream.headers)
+  headers.set("Access-Control-Allow-Origin", "*")
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  })
 }
 
 // ── Main fetch handler ──
@@ -574,7 +631,7 @@ export default {
           headers: {
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
           },
         })
       }
@@ -589,13 +646,24 @@ export default {
       }
 
       const effect = matchRoute(request, url.pathname)
-      if (!effect) return errorResponse("Not found", 404)
+      if (!effect) {
+        if (env.KERNEL_URL) {
+          try {
+            return await proxyToKernel(request, env.KERNEL_URL, url)
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e)
+            return errorResponse(`Kernel unreachable: ${msg}`, 502)
+          }
+        }
+        return errorResponse("Not found", 404)
+      }
 
-      // Provide D1Client and run the Effect
+      // Provide D1Client + KernelConfig and run the Effect
       const d1 = makeD1Client(env.DB)
       return Effect.runPromise(
         effect.pipe(
           Effect.provideService(D1Client, d1),
+          Effect.provideService(KernelConfig, { kernelUrl: env.KERNEL_URL }),
           Effect.catchTag("D1Error", (e) =>
             Effect.succeed(errorResponse(e.message, 500)),
           ),
@@ -613,5 +681,16 @@ export default {
     }
 
     return assetResponse
+  },
+
+  /**
+   * Scheduled handler — pulls analytics from KERNEL_URL into D1 on every cron
+   * tick. Configured in wrangler.toml under [triggers]. No-op when KERNEL_URL
+   * isn't set (e.g. preview without a kernel target).
+   */
+  async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    if (!env.KERNEL_URL) return
+    const kernel = makeKernelClient(env.KERNEL_URL)
+    ctx.waitUntil(syncFromKernel(env.DB, kernel))
   },
 } satisfies ExportedHandler<Env>

--- a/apps/gctrl-board/tests/worker/analytics.test.ts
+++ b/apps/gctrl-board/tests/worker/analytics.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Analytics tests — D1-backed read handlers + kernel→D1 sync.
+ *
+ * Read tests seed analytics_* tables directly (the prod sync path is exercised
+ * separately in the sync tests below) and verify the Worker returns the shapes
+ * the frontend expects.
+ *
+ * Sync tests pass a stub KernelClient into syncFromKernel so we don't need a
+ * live kernel in the test isolate.
+ */
+import { HttpClient } from "@effect/platform"
+import { env } from "cloudflare:test"
+import { Effect } from "effect"
+import { afterEach, describe, expect, it } from "vitest"
+import { syncFromKernel, type KernelClient } from "../../src/analytics"
+import { HOST, runTest } from "./fixtures/http"
+
+const clearAnalytics = async (): Promise<void> => {
+  const tables = [
+    "analytics_sessions",
+    "analytics_daily",
+    "analytics_cost_by_model",
+    "analytics_cost_by_agent",
+    "analytics_span_distribution",
+    "analytics_scores",
+    "analytics_alerts",
+    "analytics_sync_state",
+  ]
+  for (const t of tables) {
+    await env.DB.prepare(`DELETE FROM ${t}`).run()
+  }
+}
+
+afterEach(async () => {
+  await clearAnalytics()
+})
+
+describe("Analytics D1 reads", () => {
+  it("GET /api/analytics returns overview shape from rollup tables", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO analytics_sessions (id, workspace_id, device_id, agent_name, started_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by)
+         VALUES ('s1','w','d','agent-a','2026-04-26T00:00:00Z','completed',1.5,1000,500,'scheduler')`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_sessions (id, workspace_id, device_id, agent_name, started_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by)
+         VALUES ('s2','w','d','agent-b','2026-04-26T01:00:00Z','active',2.0,2000,800,'otel_ingest')`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_cost_by_model (model, cost, calls) VALUES ('gpt-4o', 3.5, 12)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_cost_by_agent (agent, cost, sessions) VALUES ('agent-a', 1.5, 1)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_span_distribution (span_type, count, percentage) VALUES ('generation', 10, 50.0)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_span_distribution (span_type, count, percentage) VALUES ('span', 10, 50.0)`,
+      ),
+    ])
+
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics`)
+        expect(res.status).toBe(200)
+        return (yield* res.json) as Record<string, unknown>
+      }),
+    )
+
+    expect(data.total_sessions).toBe(2)
+    expect(data.total_spans).toBe(20)
+    expect(data.total_cost_usd).toBeCloseTo(3.5)
+    expect(data.total_input_tokens).toBe(3000)
+    expect(data.total_output_tokens).toBe(1300)
+    expect(Array.isArray(data.by_agent)).toBe(true)
+    expect(Array.isArray(data.by_model)).toBe(true)
+  })
+
+  it("GET /api/analytics/cost returns by_model and by_agent rollups", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO analytics_cost_by_model (model, cost, calls) VALUES ('gpt-4o', 5.0, 20)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_cost_by_model (model, cost, calls) VALUES ('claude-opus', 3.0, 10)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_cost_by_agent (agent, cost, sessions) VALUES ('agent-a', 4.0, 2)`,
+      ),
+    ])
+
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/cost`)
+        expect(res.status).toBe(200)
+        return (yield* res.json) as { by_model: unknown[]; by_agent: unknown[] }
+      }),
+    )
+
+    expect(data.by_model).toHaveLength(2)
+    expect(data.by_agent).toHaveLength(1)
+    // Ordered by cost DESC
+    expect((data.by_model[0] as { model: string }).model).toBe("gpt-4o")
+  })
+
+  it("GET /api/analytics/daily pivots long-form rows into DailyEntry shape", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO analytics_daily (date, metric, dimension, value) VALUES ('2026-04-25', 'sessions', 'total', 5)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_daily (date, metric, dimension, value) VALUES ('2026-04-25', 'spans', 'total', 50)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_daily (date, metric, dimension, value) VALUES ('2026-04-25', 'cost', 'total', 1.25)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_daily (date, metric, dimension, value) VALUES ('2026-04-25', 'tokens', 'total', 1500)`,
+      ),
+    ])
+
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/daily?days=7`)
+        expect(res.status).toBe(200)
+        return (yield* res.json) as Array<Record<string, unknown>>
+      }),
+    )
+
+    expect(data).toHaveLength(1)
+    expect(data[0]).toMatchObject({
+      date: "2026-04-25",
+      sessions: 5,
+      spans: 50,
+      cost_usd: 1.25,
+    })
+  })
+
+  it("GET /api/analytics/alerts returns enabled alerts as JSON booleans", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO analytics_alerts (id, name, condition_type, threshold, action, enabled)
+         VALUES ('a1', 'high-cost', 'cost_per_session_gt', 5.0, 'warn', 1)`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_alerts (id, name, condition_type, threshold, action, enabled)
+         VALUES ('a2', 'disabled-rule', 'foo', 1.0, 'warn', 0)`,
+      ),
+    ])
+
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/alerts`)
+        return (yield* res.json) as Array<Record<string, unknown>>
+      }),
+    )
+
+    expect(data).toHaveLength(1)
+    expect(data[0].name).toBe("high-cost")
+    expect(data[0].enabled).toBe(true)
+  })
+
+  it("GET /api/analytics/scores requires name and returns zeros when missing", async () => {
+    const data400 = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/scores`)
+        expect(res.status).toBe(400)
+        return (yield* res.json) as { error: string }
+      }),
+    )
+    expect(data400.error).toMatch(/name/)
+
+    const data200 = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/scores?name=nonexistent`)
+        expect(res.status).toBe(200)
+        return (yield* res.json) as Record<string, unknown>
+      }),
+    )
+    expect(data200.total).toBe(0)
+    expect(data200.pass_rate).toBe(0)
+  })
+
+  it("GET /api/sessions filters by kind=internal/external", async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO analytics_sessions (id, workspace_id, device_id, agent_name, started_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by)
+         VALUES ('s-int','w','d','sched','2026-04-26T00:00:00Z','completed',0,0,0,'scheduler')`,
+      ),
+      env.DB.prepare(
+        `INSERT INTO analytics_sessions (id, workspace_id, device_id, agent_name, started_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by)
+         VALUES ('s-ext','w','d','ext','2026-04-26T01:00:00Z','completed',0,0,0,'otel_ingest')`,
+      ),
+    ])
+
+    const internal = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/sessions?kind=internal`)
+        return (yield* res.json) as Array<{ id: string }>
+      }),
+    )
+    expect(internal.map((s) => s.id)).toEqual(["s-int"])
+
+    const external = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/sessions?kind=external`)
+        return (yield* res.json) as Array<{ id: string }>
+      }),
+    )
+    expect(external.map((s) => s.id)).toEqual(["s-ext"])
+  })
+})
+
+describe("syncFromKernel", () => {
+  const fixedKernel = (): KernelClient => ({
+    fetchJson: async <T>(path: string): Promise<T> => {
+      if (path === "/api/sessions?limit=500") {
+        return [
+          {
+            id: "s1",
+            workspace_id: "w",
+            device_id: "d",
+            agent_name: "agent-a",
+            started_at: "2026-04-26T00:00:00Z",
+            ended_at: null,
+            status: "active",
+            total_cost_usd: 1.0,
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            created_by: "scheduler",
+          },
+        ] as T
+      }
+      if (path === "/api/analytics") {
+        return { by_agent: [], by_model: [] } as T
+      }
+      if (path === "/api/analytics/cost") {
+        return {
+          by_model: [{ model: "gpt-4o", cost: 1.0, calls: 5 }],
+          by_agent: [{ agent: "agent-a", cost: 1.0, sessions: 1 }],
+        } as T
+      }
+      if (path === "/api/analytics/spans") {
+        return {
+          distribution: [
+            { type: "generation", count: 5, percentage: 100.0 },
+          ],
+        } as T
+      }
+      if (path === "/api/analytics/daily?days=30") {
+        return [
+          { date: "2026-04-26", metric: "sessions", dimension: "total", value: 1 },
+          { date: "2026-04-26", metric: "spans", dimension: "total", value: 5 },
+          { date: "2026-04-26", metric: "cost", dimension: "total", value: 1.0 },
+          { date: "2026-04-26", metric: "tokens", dimension: "total", value: 150 },
+        ] as T
+      }
+      if (path === "/api/analytics/alerts") {
+        return [] as T
+      }
+      throw new Error(`unexpected path: ${path}`)
+    },
+  })
+
+  it("populates all analytics tables from kernel responses", async () => {
+    await syncFromKernel(env.DB, fixedKernel())
+
+    const sessions = await env.DB.prepare(`SELECT id, agent_name FROM analytics_sessions`).all()
+    expect(sessions.results).toHaveLength(1)
+
+    const cost = await env.DB.prepare(`SELECT model FROM analytics_cost_by_model`).all()
+    expect(cost.results).toHaveLength(1)
+
+    const dist = await env.DB.prepare(`SELECT span_type FROM analytics_span_distribution`).all()
+    expect(dist.results).toHaveLength(1)
+
+    const daily = await env.DB.prepare(`SELECT date, metric FROM analytics_daily`).all()
+    expect(daily.results).toHaveLength(4)
+  })
+
+  it("records ok status in sync_state for every resource", async () => {
+    await syncFromKernel(env.DB, fixedKernel())
+
+    const states = await env.DB
+      .prepare(`SELECT resource, last_status FROM analytics_sync_state ORDER BY resource`)
+      .all<{ resource: string; last_status: string }>()
+    const map = new Map((states.results ?? []).map((r) => [r.resource, r.last_status]))
+    expect(map.get("sessions")).toBe("ok")
+    expect(map.get("overview")).toBe("ok")
+    expect(map.get("cost")).toBe("ok")
+    expect(map.get("spans")).toBe("ok")
+    expect(map.get("daily")).toBe("ok")
+    expect(map.get("alerts")).toBe("ok")
+  })
+
+  it("isolates failures — one resource failing doesn't block others", async () => {
+    const flaky: KernelClient = {
+      fetchJson: async <T>(path: string): Promise<T> => {
+        if (path === "/api/analytics/cost") throw new Error("kernel cost endpoint down")
+        return fixedKernel().fetchJson<T>(path)
+      },
+    }
+    await syncFromKernel(env.DB, flaky)
+
+    const states = await env.DB
+      .prepare(`SELECT resource, last_status, last_error FROM analytics_sync_state`)
+      .all<{ resource: string; last_status: string; last_error: string | null }>()
+    const map = new Map((states.results ?? []).map((r) => [r.resource, r]))
+    expect(map.get("cost")?.last_status).toBe("error")
+    expect(map.get("cost")?.last_error).toMatch(/kernel cost endpoint down/)
+    // Others still succeeded
+    expect(map.get("sessions")?.last_status).toBe("ok")
+    expect(map.get("daily")?.last_status).toBe("ok")
+  })
+
+  it("GET /api/analytics/sync-status returns kernel_url_configured + sync rows", async () => {
+    await env.DB
+      .prepare(
+        `INSERT INTO analytics_sync_state (resource, last_synced_at, last_status, last_error)
+         VALUES ('sessions', '2026-04-26T00:00:00Z', 'ok', NULL)`,
+      )
+      .run()
+
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${HOST}/api/analytics/sync-status`)
+        expect(res.status).toBe(200)
+        return (yield* res.json) as { kernel_url_configured: boolean; resources: Array<{ resource: string }> }
+      }),
+    )
+
+    // KERNEL_URL is unset in the test environment
+    expect(data.kernel_url_configured).toBe(false)
+    expect(data.resources).toHaveLength(1)
+    expect(data.resources[0].resource).toBe("sessions")
+  })
+
+  it("POST /api/analytics/sync returns 503 when KERNEL_URL is unset", async () => {
+    const data = await runTest(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.post(`${HOST}/api/analytics/sync`)
+        expect(res.status).toBe(503)
+        return (yield* res.json) as { error: string }
+      }),
+    )
+    expect(data.error).toMatch(/KERNEL_URL/)
+  })
+
+  it("upserts on resync — re-running with new data updates existing rows", async () => {
+    await syncFromKernel(env.DB, fixedKernel())
+
+    const updated: KernelClient = {
+      fetchJson: async <T>(path: string): Promise<T> => {
+        if (path === "/api/sessions?limit=500") {
+          return [
+            {
+              id: "s1",
+              workspace_id: "w",
+              device_id: "d",
+              agent_name: "agent-a",
+              started_at: "2026-04-26T00:00:00Z",
+              ended_at: "2026-04-26T01:00:00Z",
+              status: "completed",
+              total_cost_usd: 2.5,
+              total_input_tokens: 200,
+              total_output_tokens: 100,
+              created_by: "scheduler",
+            },
+          ] as T
+        }
+        return fixedKernel().fetchJson<T>(path)
+      },
+    }
+    await syncFromKernel(env.DB, updated)
+
+    const row = await env.DB
+      .prepare(`SELECT status, total_cost_usd, ended_at FROM analytics_sessions WHERE id = 's1'`)
+      .first<{ status: string; total_cost_usd: number; ended_at: string }>()
+    expect(row?.status).toBe("completed")
+    expect(row?.total_cost_usd).toBe(2.5)
+    expect(row?.ended_at).toBe("2026-04-26T01:00:00Z")
+  })
+})

--- a/apps/gctrl-board/tests/worker/apply-migrations.ts
+++ b/apps/gctrl-board/tests/worker/apply-migrations.ts
@@ -28,6 +28,28 @@ const statements = [
   `CREATE TABLE IF NOT EXISTS issue_events (id TEXT PRIMARY KEY, issue_id TEXT NOT NULL REFERENCES issues(id), event_type TEXT NOT NULL, actor_id TEXT NOT NULL, actor_name TEXT NOT NULL, actor_type TEXT NOT NULL DEFAULT 'human', timestamp TEXT NOT NULL DEFAULT (datetime('now')), data TEXT NOT NULL DEFAULT '{}')`,
 
   `CREATE INDEX IF NOT EXISTS idx_events_issue ON issue_events(issue_id)`,
+
+  // 0004_analytics.sql — analytics mirror tables
+  `CREATE TABLE IF NOT EXISTS analytics_sessions (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL, device_id TEXT NOT NULL, agent_name TEXT NOT NULL, started_at TEXT NOT NULL, ended_at TEXT, status TEXT NOT NULL DEFAULT 'active', total_cost_usd REAL NOT NULL DEFAULT 0, total_input_tokens INTEGER NOT NULL DEFAULT 0, total_output_tokens INTEGER NOT NULL DEFAULT 0, created_by TEXT NOT NULL DEFAULT 'unknown', synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+  `CREATE INDEX IF NOT EXISTS idx_analytics_sessions_started ON analytics_sessions(started_at DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_analytics_sessions_agent ON analytics_sessions(agent_name)`,
+  `CREATE INDEX IF NOT EXISTS idx_analytics_sessions_status ON analytics_sessions(status)`,
+  `CREATE INDEX IF NOT EXISTS idx_analytics_sessions_creator ON analytics_sessions(created_by)`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_daily (date TEXT NOT NULL, metric TEXT NOT NULL, dimension TEXT NOT NULL DEFAULT 'total', value REAL NOT NULL, synced_at TEXT NOT NULL DEFAULT (datetime('now')), PRIMARY KEY (date, metric, dimension))`,
+  `CREATE INDEX IF NOT EXISTS idx_analytics_daily_date ON analytics_daily(date DESC)`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_cost_by_model (model TEXT PRIMARY KEY, cost REAL NOT NULL DEFAULT 0, calls INTEGER NOT NULL DEFAULT 0, synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_cost_by_agent (agent TEXT PRIMARY KEY, cost REAL NOT NULL DEFAULT 0, sessions INTEGER NOT NULL DEFAULT 0, synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_span_distribution (span_type TEXT PRIMARY KEY, count INTEGER NOT NULL DEFAULT 0, percentage REAL NOT NULL DEFAULT 0, synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_scores (name TEXT PRIMARY KEY, pass INTEGER NOT NULL DEFAULT 0, fail INTEGER NOT NULL DEFAULT 0, total INTEGER NOT NULL DEFAULT 0, pass_rate REAL NOT NULL DEFAULT 0, avg_value REAL NOT NULL DEFAULT 0, synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_alerts (id TEXT PRIMARY KEY, name TEXT NOT NULL, condition_type TEXT NOT NULL, threshold REAL NOT NULL, action TEXT NOT NULL DEFAULT 'warn', enabled INTEGER NOT NULL DEFAULT 1, synced_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+
+  `CREATE TABLE IF NOT EXISTS analytics_sync_state (resource TEXT PRIMARY KEY, last_synced_at TEXT NOT NULL, last_status TEXT NOT NULL, last_error TEXT)`,
 ]
 
 for (const sql of statements) {

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -273,5 +273,20 @@ export const api = {
         `/api/analytics/scores?name=${encodeURIComponent(name)}`,
       ),
     alerts: () => request<AlertRule[]>("/api/analytics/alerts"),
+    syncStatus: () => request<AnalyticsSyncStatus>("/api/analytics/sync-status"),
+    sync: () =>
+      request<AnalyticsSyncStatus>("/api/analytics/sync", { method: "POST" }),
   },
+}
+
+export interface AnalyticsSyncResource {
+  resource: string
+  last_synced_at: string
+  last_status: "ok" | "error"
+  last_error: string | null
+}
+
+export interface AnalyticsSyncStatus {
+  kernel_url_configured: boolean
+  resources: AnalyticsSyncResource[]
 }

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react"
-import { api } from "@/api/client"
+import { api, type AnalyticsSyncStatus } from "@/api/client"
 import type {
   AnalyticsOverview,
   CostAnalytics,
@@ -161,6 +161,7 @@ function OverviewTab({ kind }: { kind: SessionKind }) {
   const [cost, setCost] = useState<CostAnalytics | null>(null)
   const [liveCount, setLiveCount] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [syncStatus, setSyncStatus] = useState<AnalyticsSyncStatus | null>(null)
 
   // Live count respects the kind filter — operators expect "live
   // sessions now" to track the same population as the rest of the page.
@@ -169,14 +170,18 @@ function OverviewTab({ kind }: { kind: SessionKind }) {
   // that out in the KPI label rather than silently fudging.
   const refresh = useCallback(async () => {
     try {
-      const [o, c, live] = await Promise.all([
+      const [o, c, live, sync] = await Promise.all([
         api.analytics.overview(),
         api.analytics.cost(),
+        // Kernel's /api/analytics rollup has no active_sessions field;
+        // count from sessions.list?status=active instead.
         api.sessions.list({ status: "active", limit: 200, kind }),
+        api.analytics.syncStatus().catch(() => null),
       ])
       setOverview(o)
       setCost(c)
       setLiveCount(live.length)
+      setSyncStatus(sync)
       setError(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -213,12 +218,59 @@ function OverviewTab({ kind }: { kind: SessionKind }) {
   })
 
   if (error) {
+    // Hint depends on deployment shape: in dev (Vite) the page hits the kernel
+    // directly via :4318; in preview/prod the Worker serves from D1 and pulls
+    // from KERNEL_URL on a cron. Surface whichever is relevant.
+    const hint =
+      syncStatus === null
+        ? "Is the kernel running on :4318? (or the Worker on the configured host)"
+        : !syncStatus.kernel_url_configured
+          ? "Worker is running but KERNEL_URL is not configured — set it via `wrangler secret put KERNEL_URL`."
+          : "Last sync state is below — check resources marked `error`."
     return (
       <div className="p-8 text-rose-400 font-mono text-sm">
         Failed to load overview: {error}
-        <div className="mt-2 text-zinc-500">
-          Is the kernel running on :4318?
-        </div>
+        <div className="mt-2 text-zinc-500">{hint}</div>
+        {syncStatus && <SyncStatusPanel status={syncStatus} />}
+      </div>
+    )
+  }
+
+  // Empty state — analytics tables exist but never synced. The Worker returns
+  // zeros rather than 404, so we detect "never synced" via sync-status.
+  const neverSynced =
+    overview.total_sessions === 0 &&
+    syncStatus !== null &&
+    syncStatus.resources.length === 0
+  if (neverSynced) {
+    return (
+      <div className="p-8 text-zinc-400 font-mono text-sm space-y-3">
+        <div className="text-zinc-200">No analytics data yet.</div>
+        {syncStatus.kernel_url_configured ? (
+          <>
+            <div>The kernel sync hasn't run yet — it ticks every 2 minutes.</div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={async () => {
+                try {
+                  const s = await api.analytics.sync()
+                  setSyncStatus(s)
+                  refresh()
+                } catch (e) {
+                  setError(e instanceof Error ? e.message : String(e))
+                }
+              }}
+            >
+              Sync now
+            </Button>
+          </>
+        ) : (
+          <div>
+            KERNEL_URL is not configured on this Worker — analytics will stay
+            empty until it's set.
+          </div>
+        )}
       </div>
     )
   }
@@ -1313,5 +1365,36 @@ function ScoreKpi({
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+function SyncStatusPanel({ status }: { status: AnalyticsSyncStatus }) {
+  if (status.resources.length === 0) {
+    return (
+      <div className="mt-4 text-zinc-500 text-xs">
+        No sync attempts recorded yet.
+      </div>
+    )
+  }
+  return (
+    <div className="mt-4 text-xs">
+      <div className="text-zinc-400 mb-1">Sync state by resource:</div>
+      <ul className="space-y-0.5">
+        {status.resources.map((r) => (
+          <li key={r.resource} className="flex gap-2">
+            <span
+              className={cn(
+                "font-mono",
+                r.last_status === "ok" ? "text-emerald-400" : "text-rose-400",
+              )}
+            >
+              {r.last_status === "ok" ? "✓" : "✗"} {r.resource}
+            </span>
+            <span className="text-zinc-500">{r.last_synced_at}</span>
+            {r.last_error && <span className="text-rose-400">{r.last_error}</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/apps/gctrl-board/wrangler.toml
+++ b/apps/gctrl-board/wrangler.toml
@@ -3,6 +3,18 @@ compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 main = "src/worker.ts"
 
+# Kernel facade — unmatched /api/* paths are proxied to KERNEL_URL.
+# Set per-env via `wrangler secret put KERNEL_URL --env <env>` so the Worker
+# can reach a publicly-routable kernel (tunnel, hosted instance, etc.).
+# Leave unset to keep returning 404 for unmatched API paths.
+[vars]
+# KERNEL_URL = "https://kernel.example.com"
+
+# Analytics sync cron — pulls /api/analytics/* + /api/sessions from KERNEL_URL
+# into D1 every 2 minutes. No-op when KERNEL_URL is unset.
+[triggers]
+crons = ["*/2 * * * *"]
+
 # Workers Static Assets — serves the Vite SPA build output
 [assets]
 directory = "dist-web"
@@ -23,6 +35,9 @@ migrations_dir = "migrations"
 # ── Preview environment (PR deploys) ──
 [env.preview]
 name = "gctrl-board-preview"
+
+[env.preview.vars]
+# KERNEL_URL = "https://kernel-preview.example.com"
 
 [[env.preview.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

- Worker now proxies unmatched `/api/*` paths to `KERNEL_URL` (when set), turning it into a real facade over the kernel HTTP API. Cloudflare edge can't reach `localhost:4318`, so deployments must point `KERNEL_URL` at a publicly-reachable kernel (tunnel or hosted).
- Analytics reads are served from D1 mirror tables instead of round-tripping to the kernel — the dashboard works even when the kernel is offline. A scheduled cron pulls `/api/analytics/*` + `/api/sessions` from `KERNEL_URL` into D1 every 2 minutes.
- Adds operational endpoints (`GET /api/analytics/sync-status`, `POST /api/analytics/sync`) and updates the frontend's error copy + empty state to match the new architecture.

Closes the 404 the user originally hit at `https://gctrl-board-preview…workers.dev/analytics/overview` — that endpoint had no Worker route and there was no proxy fallback.

## How it works

```
GET /api/board/*           → D1 (board state, unchanged)
GET /api/analytics/*       → D1 (analytics_* tables, kept fresh by cron)
GET /api/sessions(/:id)    → D1 (analytics_sessions)
POST /api/analytics/sync   → triggers sync now (503 if KERNEL_URL unset)
GET  /api/analytics/sync-status → last sync state per resource

Anything else under /api/*:
  KERNEL_URL set     → proxy fetch to ${KERNEL_URL}${path} with body+headers
  KERNEL_URL unset   → 404 (preserves existing test behavior)

Cron tick (every 2 min):
  KERNEL_URL set   → syncFromKernel(env.DB, makeKernelClient(KERNEL_URL))
  KERNEL_URL unset → no-op
```

`/api/analytics/latency` stays kernel-proxied because D1 has no `PERCENTILE_CONT`. Pre-computing percentiles is a follow-up (kernel-side change).

## What's in the diff

- `migrations/0004_analytics.sql` — D1 schema for `analytics_sessions`, `analytics_daily` (long-form), `analytics_cost_by_{model,agent}`, `analytics_span_distribution`, `analytics_scores`, `analytics_alerts`, `analytics_sync_state`.
- `src/analytics.ts` (new) — Effect-TS read handlers + `syncFromKernel(db, kernel)` with per-resource error isolation. Pivots long-form `daily` rows into the `DailyEntry` shape the frontend expects.
- `src/worker.ts` — registers analytics routes, adds `proxyToKernel` fallback, adds `scheduled` handler, threads a new `KernelConfig` Context.Tag through Effect handlers.
- `src/d1.ts` — exposes the raw `D1Database` on `D1ClientShape` so handlers can call `db.batch()` paths shared with the cron.
- `wrangler.toml` — adds `[vars]` placeholder for `KERNEL_URL` (default + preview env) and `[triggers]` cron `*/2 * * * *`.
- `web/src/api/client.ts` — `analytics.syncStatus()` / `analytics.sync()` and the response types.
- `web/src/pages/AnalyticsPage.tsx` — replaces the misleading "is the kernel running on :4318?" hint with sync-aware copy; never-synced empty state with a "Sync now" button.
- `tests/worker/analytics.test.ts` (new) — 12 tests: D1 reads, daily pivot, kind=internal/external filter, sync upsert, sync error isolation, resync idempotency, sync-status response, sync 503 path.

## Configuration

After merging, set `KERNEL_URL` per env so the facade has somewhere to proxy + sync from:

```sh
wrangler secret put KERNEL_URL                 # default env
wrangler secret put KERNEL_URL --env preview   # preview env
```

Leave it unset to keep the existing 404 behavior (analytics will show empty state until a kernel is wired up).

## Notes

- Cloudflare crons only tick on deployed Workers. For `wrangler dev`, use `wrangler dev --test-scheduled` and `curl /__scheduled?cron=*/2+*+*+*+*` — or just hit `POST /api/analytics/sync` to trigger it on demand.
- `KernelConfig` Context.Tag is now provided alongside `D1Client` at the fetch boundary, so any future handler can read `env.KERNEL_URL` without changing the route signature.

## Test plan

- [x] `pnpm vitest run --config apps/gctrl-board/vitest.config.workers.ts` → 56/56 (12 new + 44 existing)
- [x] `pnpm vitest run` (unit pool) → 41/41
- [x] `pnpm tsc --noEmit -p apps/gctrl-board/tsconfig.json` clean
- [ ] Browser smoke: load `/analytics` against a Worker with no `KERNEL_URL` → never-synced empty state
- [ ] Browser smoke: load `/analytics` after `POST /api/analytics/sync` against a wired kernel → KPIs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
