### PR TITLE
specs(eval): kernel-storage DDL for M4 eval primitives schema

### DIFF
--- a/vault/specs/architecture/apps/observe-eval.md
+++ b/vault/specs/architecture/apps/observe-eval.md
@@ -146,5 +146,6 @@ The runner calls the substrate `POST /api/eval/score` for every case. There is n
 - [PRD § Native Applications](../../gctrl/PRD.md) — product positioning
 - [ROADMAP § M4](../../gctrl/ROADMAP.md) — delivery milestones
 - [domain-model § 5.3](../domain-model.md#53-eval-application-tables) — table DDL and ownership
+- [implementation/kernel/eval-storage.md](../../implementation/kernel/eval-storage.md) — column-level DDL, JSON shapes, indexes, migration order
 - [os.md § 3](../os.md) — application invariants
 - [glossary](../../glossary.md) — Metric, Judge, Eval Run, Eval Score

--- a/vault/specs/architecture/domain-model.md
+++ b/vault/specs/architecture/domain-model.md
@@ -379,7 +379,7 @@ The Observe & Eval application owns evaluation primitives across the full produc
 | `eval_cases` | Cases belonging to datasets — `input`, `expected`, `context` (JSON-typed; permissive schema) |
 | `eval_runs` | Run-level metadata grouping a batch of `Score`s: suite name, `baseline_run_id`, `git_sha`, env, model, prompt version |
 
-DDL lands in `kernel/crates/gctrl-storage/src/schema.rs` under `CREATE_EVAL_*_TABLE` constants when M4 implementation begins.
+DDL lands in `kernel/crates/gctrl-storage/src/schema.rs` under `CREATE_EVAL_*_TABLE` constants when M4 implementation begins. See [implementation/kernel/eval-storage.md](../implementation/kernel/eval-storage.md) for column-level shapes, JSON column conventions, indexes, and migration order.
 
 The earlier `eval_scores` prefix was folded into the kernel-owned `scores` table for the continuity reasons above; the `eval_*` namespace is reserved for app-owned tables that the kernel does not need to know about.
 

--- a/vault/specs/gctrl/ROADMAP.md
+++ b/vault/specs/gctrl/ROADMAP.md
@@ -79,7 +79,7 @@ Observe & Eval owns both the **substrate** (metrics, prompts, judges, datasets, 
 
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
-| Eval primitives schema | `eval_metrics`, `eval_datasets`, `eval_cases`, `eval_runs` tables; extend `scores.target_type` for `eval_case`/`eval_run` | P1 | M1 Storage | TBD |
+| Eval primitives schema | `eval_metrics`, `eval_datasets`, `eval_cases`, `eval_runs` tables; extend `scores.target_type` for `eval_case`/`eval_run` and add `scores.eval_run_id` FK. See [implementation/kernel/eval-storage.md](../implementation/kernel/eval-storage.md) | P1 | M1 Storage | TBD |
 | Substrate API | `POST /api/eval/score`, `/metrics`, `/datasets`, `/cases`, `/runs` — applications call directly from their own loops | P1 | Eval primitives schema | TBD |
 | Built-in judge metrics | Curated set: `faithfulness`, `tool_correctness`, `json_correctness`, `hallucination`, generic `g_eval` | P1 | Substrate API, M1 Model router | TBD |
 | Harness runner | `gctrl eval run <suite>` end-to-end runner; thin client of the substrate API | P1 | Substrate API | TBD |

--- a/vault/specs/implementation/kernel/eval-storage.md
+++ b/vault/specs/implementation/kernel/eval-storage.md
@@ -1,0 +1,236 @@
+# Eval Primitives Storage — Implementation Details
+
+Implementation details for the eval primitives defined in [vault/specs/architecture/apps/observe-eval.md](../../architecture/apps/observe-eval.md). This file specifies the kernel-storage-level DDL, JSON column shapes, indexes, and migration order for the M4 deliverable **Eval primitives schema**.
+
+It is the foundation every other M4 deliverable depends on:
+
+- **Substrate API** (`POST /api/eval/*`) writes rows defined here.
+- **Harness runner** (`gctrl eval run`) reads `eval_datasets`/`eval_cases`, opens `eval_runs`, posts to the substrate.
+- **Baseline & CI gating** diffs `scores` rows joined on `eval_runs.baseline_run_id`.
+- **gctrl-board surface** subscribes to `EvalRunCompleted` and reads `eval_runs` summaries.
+
+## Ownership and Layering
+
+Per [domain-model § 5.3](../../architecture/domain-model.md#53-eval-application-tables) and the namespacing invariant in [os.md § 3](../../architecture/os.md):
+
+| Table | Owner | Layer | Why |
+|---|---|---|---|
+| `scores` | Kernel (existing) | `gctrl-storage` | Single sink for substrate + harness, dev + prod. The metric-continuity property depends on this. |
+| `prompt_versions` | Kernel (existing) | `gctrl-storage` | Reused for judge prompts; content-addressed by hash. |
+| `eval_metrics` | Observe & Eval app | `gctrl-storage` | Metric-name resolution must be available to *any* writer (substrate API or harness), so DDL lives in the kernel storage crate even though the table is app-namespaced. |
+| `eval_datasets` | Observe & Eval app | `gctrl-storage` | Same rationale. |
+| `eval_cases` | Observe & Eval app | `gctrl-storage` | Same rationale. |
+| `eval_runs` | Observe & Eval app | `gctrl-storage` | Same rationale. |
+
+The `eval_*` tables are **app-namespaced** (Invariant #3) but their DDL is co-located with kernel schema — same pattern as `board_*` tables, which the kernel does not interpret but does host.
+
+## DDL
+
+DDL lands in `kernel/crates/gctrl-storage/src/schema.rs` under `CREATE_EVAL_*_TABLE` constants and is appended to `all_migrations()` in the order shown below.
+
+### `eval_metrics`
+
+```sql
+CREATE TABLE IF NOT EXISTS eval_metrics (
+    name VARCHAR PRIMARY KEY,
+    kind VARCHAR NOT NULL,                        -- 'deterministic' | 'judge' | 'composite'
+    prompt_hash VARCHAR,                          -- FK → prompt_versions.hash; required when kind='judge'
+    threshold DOUBLE,                             -- pass/fail cutoff; NULL means "score-only, no gate"
+    higher_is_better BOOLEAN NOT NULL DEFAULT TRUE,
+    schema_json VARCHAR,                          -- optional JSON Schema for the case shape this metric expects
+    description VARCHAR,
+    created_at VARCHAR NOT NULL,
+    updated_at VARCHAR NOT NULL
+)
+```
+
+`name` is the primary key — the same string an app passes to `POST /api/eval/score` and the same string written to `scores.name`. This is the load-bearing identifier: register `faithfulness` once, reference it everywhere.
+
+`kind` invariants:
+- `deterministic` — pure function (regex match, JSON-validity, latency threshold). No `prompt_hash`.
+- `judge` — LLM-as-judge. `prompt_hash` MUST resolve in `prompt_versions`.
+- `composite` — combines other metrics (e.g., weighted average). `prompt_hash` NULL; the composition graph lives in `schema_json`.
+
+`schema_json` is **advisory**, not enforced. The substrate API never rejects a case for failing the schema; the metric's evaluator decides what to do with malformed input.
+
+### `eval_datasets`
+
+```sql
+CREATE TABLE IF NOT EXISTS eval_datasets (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR NOT NULL UNIQUE,
+    description VARCHAR,
+    created_at VARCHAR NOT NULL,
+    updated_at VARCHAR NOT NULL
+)
+```
+
+Datasets are optional — the substrate accepts inline cases without registration. They become important in harness mode and for replayable baselines.
+
+### `eval_cases`
+
+```sql
+CREATE TABLE IF NOT EXISTS eval_cases (
+    id VARCHAR PRIMARY KEY,
+    dataset_id VARCHAR NOT NULL,                  -- FK → eval_datasets.id
+    input VARCHAR NOT NULL,                       -- JSON
+    expected VARCHAR,                             -- JSON, optional (some metrics are reference-free)
+    context VARCHAR,                              -- JSON, optional (e.g., RAG retrieved docs)
+    tags VARCHAR,                                 -- JSON array of strings, optional
+    created_at VARCHAR NOT NULL
+)
+```
+
+JSON columns store DuckDB `VARCHAR` (not `JSON`) for portability with the existing schema style — the storage layer treats them as opaque strings; the substrate API decodes/validates.
+
+`input`/`expected`/`context` shapes are **permissive** (per spec non-goal: "no mandatory test-case schema"). Apps pass whatever shape their metric understands.
+
+### `eval_runs`
+
+```sql
+CREATE TABLE IF NOT EXISTS eval_runs (
+    id VARCHAR PRIMARY KEY,
+    suite_name VARCHAR NOT NULL,                  -- harness suite name OR app-supplied label for substrate batches
+    status VARCHAR NOT NULL,                      -- 'open' | 'completed' | 'aborted'
+    baseline_run_id VARCHAR,                      -- FK → eval_runs.id; for diff/regression
+    git_sha VARCHAR,
+    env VARCHAR,                                  -- 'dev' | 'ci' | 'staging' | 'prod' | <custom>
+    model VARCHAR,                                -- model under test (not the judge model)
+    prompt_hash VARCHAR,                          -- prompt under test; FK → prompt_versions.hash
+    judge_model VARCHAR,                          -- model used by judge metrics in this run
+    metadata VARCHAR,                             -- JSON, free-form
+    started_at VARCHAR NOT NULL,
+    completed_at VARCHAR,
+    pass_count INTEGER NOT NULL DEFAULT 0,
+    fail_count INTEGER NOT NULL DEFAULT 0,
+    error_count INTEGER NOT NULL DEFAULT 0
+)
+```
+
+`pass_count` / `fail_count` / `error_count` are denormalised counters maintained by the substrate as scores are written, so run summaries don't require aggregation over `scores` for the common case.
+
+`status` transitions: `open → completed` (normal), `open → aborted` (cancelled). Once non-`open`, the row is immutable except for trailing telemetry.
+
+### `scores` extension
+
+The existing `scores` table requires no schema change. The `target_type` enum-by-convention extends:
+
+| `target_type` | `target_id` references | Set by |
+|---|---|---|
+| `session` (existing) | `sessions.id` | Auto-scoring + manual scoring |
+| `span` (existing) | `spans.span_id` | Manual scoring |
+| `task` (existing) | `tasks.id` | Manual scoring |
+| `eval_case` *(new)* | `eval_cases.id` | Substrate + harness |
+| `eval_run` *(new)* | `eval_runs.id` | Aggregate scores (composite metrics, run-level rollups) |
+
+Score writes from eval runs MUST set `scores.source = 'eval_substrate'` or `'eval_harness'` so analytics can attribute origin without joining `eval_runs`. The kernel does not enforce this string — it is an Observe & Eval convention, documented here so writers stay consistent.
+
+Eval scores additionally need to join back to their parent run. `scores.target_id` already references `eval_cases.id` (or `eval_runs.id` for run-level aggregates), but cases are templates — many runs can score the same case — so the parent run is not derivable from `target_id` alone. Add an explicit FK column:
+
+```sql
+ALTER TABLE scores ADD COLUMN IF NOT EXISTS eval_run_id VARCHAR;
+```
+
+NULL for non-eval scores (sessions, spans, tasks). When set, it joins to `eval_runs.id`. This is the only structural change to `scores`; everything else is enum-by-convention on `target_type`.
+
+## Indexes
+
+Append to `CREATE_INDEXES`:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_eval_cases_dataset ON eval_cases(dataset_id);
+CREATE INDEX IF NOT EXISTS idx_eval_runs_suite ON eval_runs(suite_name, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eval_runs_baseline ON eval_runs(baseline_run_id);
+CREATE INDEX IF NOT EXISTS idx_eval_runs_status ON eval_runs(status);
+CREATE INDEX IF NOT EXISTS idx_scores_eval_run ON scores(eval_run_id);
+CREATE INDEX IF NOT EXISTS idx_eval_metrics_kind ON eval_metrics(kind);
+```
+
+`idx_eval_runs_suite` is the hot path for the board's "show me runs of suite X over the last 30 days" query — descending `started_at` matches the access pattern.
+
+`idx_scores_eval_run` is the hot path for run summary queries (`SELECT name, avg(value) FROM scores WHERE eval_run_id = ? GROUP BY name`).
+
+## Migration Order
+
+In `all_migrations()`, append after the persona/inbox/schedule blocks:
+
+```rust
+CREATE_EVAL_METRICS_TABLE,
+CREATE_EVAL_DATASETS_TABLE,
+CREATE_EVAL_CASES_TABLE,
+CREATE_EVAL_RUNS_TABLE,
+ADD_SCORES_EVAL_RUN_ID,    // ALTER TABLE — idempotent column add
+```
+
+Datasets must precede cases (FK). Runs come last so baseline_run_id self-FK is well-defined at every point in a fresh-schema build.
+
+## JSON Column Shapes (advisory)
+
+Recommended canonical shapes for app interop. The kernel does not enforce these; the substrate API and built-in metrics rely on them.
+
+### `eval_cases.input`
+
+```json
+{ "prompt": "<user message>", "history": [{"role": "...", "content": "..."}] }
+```
+
+For non-LLM metrics (e.g., a deterministic check on a function), `input` is whatever the function takes:
+
+```json
+{ "args": [1, 2, 3], "kwargs": {"flag": true} }
+```
+
+### `eval_cases.expected`
+
+```json
+{ "answer": "<reference>", "tool_calls": [...], "rubric": "<judge guidance>" }
+```
+
+Reference-free metrics (e.g., `faithfulness` against retrieved context) leave `expected` NULL.
+
+### `eval_cases.context`
+
+```json
+{ "retrieved_docs": ["..."], "tools_available": [...], "system_state": {...} }
+```
+
+### `eval_runs.metadata`
+
+```json
+{
+  "ci_run_url": "https://github.com/.../actions/runs/12345",
+  "branch": "feature/x",
+  "triggered_by": "user@example.com",
+  "extra": {}
+}
+```
+
+Keep it small — large blobs belong in the linked CI run, not here.
+
+## Tests
+
+In `kernel/crates/gctrl-storage/tests/`:
+
+| Test | What it asserts |
+|---|---|
+| `eval_schema.rs::creates_all_tables` | Fresh DB build creates all five eval objects (4 tables + 1 column) |
+| `eval_schema.rs::scores_eval_run_id_column_added_idempotently` | Running migrations twice doesn't error |
+| `eval_schema.rs::eval_run_baseline_self_fk_resolves` | A run with `baseline_run_id` pointing at another run inserts cleanly |
+| `eval_schema.rs::scores_join_eval_runs` | `SELECT … FROM scores JOIN eval_runs ON scores.eval_run_id = eval_runs.id` returns expected rows |
+| `eval_schema.rs::indexes_present` | All `idx_eval_*` indexes appear in `SHOW INDEXES` |
+
+Use `DuckDbStore::open(":memory:")` per the existing test convention.
+
+## Out of Scope (deferred to other M4 specs)
+
+- **Substrate API request/response schemas** — covered in a separate spec under `vault/specs/architecture/apps/eval-substrate-api.md`.
+- **Harness runner CLI surface** — covered in `vault/specs/architecture/apps/eval-harness.md`.
+- **Built-in judge metric prompts** — content of judge prompts (faithfulness, tool_correctness, etc.) is content, not schema; lives in a metric catalog doc.
+- **`EvalRunCompleted` event payload** — covered in event-bus spec under kernel.
+
+## References
+
+- [vault/specs/architecture/apps/observe-eval.md](../../architecture/apps/observe-eval.md) — architectural position, primitives, lifecycle
+- [vault/specs/architecture/domain-model.md § 5.3](../../architecture/domain-model.md#53-eval-application-tables) — table ownership, kernel-shared vs app-namespaced
+- [vault/specs/gctrl/ROADMAP.md § M4](../../gctrl/ROADMAP.md#m4-eval-capacity--intelligence--planned) — milestone delivery
+- [`kernel/crates/gctrl-storage/src/schema.rs`](../../../../kernel/crates/gctrl-storage/src/schema.rs) — where `CREATE_EVAL_*_TABLE` constants land


### PR DESCRIPTION
## Summary

- First M4 deliverable from the Observe & Eval architecture (#67): kernel-storage DDL for the eval primitives schema, the foundation every other M4 row depends on (substrate API, harness runner, baseline gating, board surface, TS SDK).
- Spec-only PR. New file: `vault/specs/implementation/kernel/eval-storage.md`. No code yet.
- Cross-links added from the architecture spec, domain-model § 5.3, and ROADMAP M4 row.

## What changed

- **New** `vault/specs/implementation/kernel/eval-storage.md` — DDL for `eval_metrics` / `eval_datasets` / `eval_cases` / `eval_runs`, the `scores.eval_run_id` column add (`target_type` extends to `eval_case` / `eval_run` by convention), index list, migration order, JSON column shapes, test plan, and out-of-scope items deferred to other M4 specs.
- **`vault/specs/architecture/domain-model.md` § 5.3** — link out to the new implementation spec next to the existing "DDL lands in `schema.rs`" sentence.
- **`vault/specs/architecture/apps/observe-eval.md`** References section — link out to the new implementation spec.
- **`vault/specs/gctrl/ROADMAP.md` M4 row** — add `scores.eval_run_id` to the deliverable description and link the implementation spec.

## Decisions worth review

1. **`eval_metrics` keyed by `name`** (PK), not a synthetic id. The metric name is the load-bearing identifier across substrate, harness, and `scores.name`; a synthetic id would need a uniqueness constraint on `name` anyway.
2. **JSON columns stored as `VARCHAR`** (not DuckDB `JSON` type) for consistency with the existing schema style. Validation is the substrate API's job, not the storage layer's.
3. **`scores.eval_run_id` as a real column** rather than encoding the run-id in `comment` or relying on join-through-`eval_cases`. Cases are templates — many runs score the same case — so the parent run is not derivable from `target_id` alone.
4. **Denormalised `pass_count` / `fail_count` / `error_count` on `eval_runs`** so run summaries don't require aggregation over `scores` for the common case.
5. **Datasets are optional.** Substrate-mode evals can pass cases inline without registering a dataset; this matches the architecture spec's "permissive case schema" non-goal.

## Out of scope (subsequent M4 PRs)

- Substrate API request/response schemas
- Harness runner CLI surface
- Built-in judge metric prompt content
- `EvalRunCompleted` event payload (event-bus spec)

## Test plan

- [ ] Spec-only PR — no code, no tests.
- [ ] Cross-references resolve (observe-eval.md → eval-storage.md, domain-model § 5.3 → eval-storage.md, ROADMAP M4 → eval-storage.md, eval-storage.md → observe-eval.md / domain-model § 5.3 / ROADMAP / `schema.rs`).
- [ ] DDL is concrete enough that the M4 implementation PR can copy the SQL into `schema.rs` with no further design.
- [ ] Index list covers the access patterns called out (run summary, suite-over-time, baseline diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
