### PR TITLE
feat(uebermensch): person topics — alias matching + Google News discovery

### DIFF
--- a/apps/uebermensch/src/commands/ingest.ts
+++ b/apps/uebermensch/src/commands/ingest.ts
@@ -5,6 +5,7 @@ import { FileSystemVaultLive } from "../adapters/FileSystemVault.js";
 import { HttpFeedDefaultConfig, HttpFeedLive } from "../adapters/HttpFeed.js";
 import { HttpIngestDefaultConfig, HttpIngestLive } from "../adapters/HttpIngest.js";
 import { KernelLlmLive } from "../adapters/KernelLlm.js";
+import { personFeedUrls } from "../lib/discovery.js";
 import { resolveVaultDir } from "../lib/env.js";
 import { FeedService } from "../services/FeedService.js";
 import { IngestService } from "../services/IngestService.js";
@@ -181,7 +182,12 @@ const sources = Command.make(
         const allTopicSlugs = profile.topics.topics.map((t) => t.slug);
         const topicWatchlists: Record<string, ReadonlyArray<string>> = {};
         for (const t of profile.topics.topics) {
-          topicWatchlists[t.slug] = t.watchlist ?? [];
+          // Person topics treat aliases as watchlist terms so a page that
+          // mentions "Sam Altman" or "@sama" classifies onto the
+          // `sam-altman` topic without forcing the user to also slugify
+          // those forms into `watchlist`.
+          const merged = [...(t.watchlist ?? []), ...(t.aliases ?? [])];
+          topicWatchlists[t.slug] = merged;
         }
         const selected = profile.sources.sources.filter((s) => {
           if (onlySlug !== null) return s.slug === onlySlug;
@@ -296,7 +302,213 @@ const sources = Command.make(
   ),
 );
 
+// --- ingest person ----------------------------------------------------------
+// Walk topics with `kind: person`, build their candidate feeds (Google News +
+// any author-supplied feed URLs), fetch each, and ingest recent items. Each
+// ingested page is force-tagged with the person's topic slug so it shows up
+// in candidate selection and briefs.
+
+const personSlugOpt = Options.text("topic").pipe(
+  Options.withDescription("Restrict to a single person topic slug"),
+  Options.optional,
+);
+
+const personSinceHoursOpt = Options.integer("since-hours").pipe(
+  Options.withDescription("Only ingest items published within the last N hours"),
+  Options.withDefault(168),
+);
+
+const personLimitOpt = Options.integer("limit").pipe(
+  Options.withDescription("Max items per discovered feed"),
+  Options.withDefault(10),
+);
+
+const personMinWordsOpt = Options.integer("min-words").pipe(
+  Options.withDescription("Reject ingested pages with fewer words (default 50)"),
+  Options.withDefault(50),
+);
+
+const personOverwriteOpt = Options.boolean("overwrite").pipe(
+  Options.withDescription("Overwrite existing pages (default: skip on collision)"),
+  Options.withDefault(false),
+);
+
+const personDryRunOpt = Options.boolean("dry-run").pipe(
+  Options.withDescription("Show what would be ingested without writing"),
+  Options.withDefault(false),
+);
+
+const personSummarizeOpt = Options.boolean("summarize").pipe(
+  Options.withDescription(
+    "Replace each stored body with an LLM-generated key-insights summary (default on; set UBER_INGEST_SUMMARIZE=0 to disable)",
+  ),
+  Options.withDefault(summarizeDefaultFromEnv()),
+);
+
+const person = Command.make(
+  "person",
+  {
+    personSlugOpt,
+    personSinceHoursOpt,
+    personLimitOpt,
+    personMinWordsOpt,
+    personOverwriteOpt,
+    personDryRunOpt,
+    personSummarizeOpt,
+  },
+  ({
+    personSlugOpt: onlySlugVal,
+    personSinceHoursOpt: sinceHours,
+    personLimitOpt: limit,
+    personMinWordsOpt: minWords,
+    personOverwriteOpt: overwrite,
+    personDryRunOpt: dryRun,
+    personSummarizeOpt: summarize,
+  }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir();
+      const onlySlug = Option.getOrNull(onlySlugVal);
+      const now = new Date();
+      const cutoff = new Date(now.getTime() - sinceHours * 3_600_000);
+      const date = now.toISOString().slice(0, 10);
+
+      yield* Console.log(
+        `discovering person sources from ${vaultDir} (since ${cutoff.toISOString()})`,
+      );
+
+      const program = Effect.gen(function* () {
+        const profileSvc = yield* ProfileService;
+        const feedSvc = yield* FeedService;
+        const ingestSvc = yield* IngestService;
+        const profile = yield* profileSvc.load();
+
+        const allTopicSlugs = profile.topics.topics.map((t) => t.slug);
+        const topicWatchlists: Record<string, ReadonlyArray<string>> = {};
+        for (const t of profile.topics.topics) {
+          topicWatchlists[t.slug] = [...(t.watchlist ?? []), ...(t.aliases ?? [])];
+        }
+
+        const persons = profile.topics.topics.filter((t) => {
+          if (t.kind !== "person") return false;
+          if (onlySlug !== null) return t.slug === onlySlug;
+          return true;
+        });
+        if (persons.length === 0) {
+          yield* Console.log(
+            onlySlug !== null
+              ? `  no person topic with slug "${onlySlug}"`
+              : `  no topics with kind=person`,
+          );
+          return;
+        }
+        yield* Console.log(`  ${persons.length} person topic(s) selected`);
+
+        let totalFetched = 0;
+        let totalIngested = 0;
+        let totalSkipped = 0;
+        let totalFailed = 0;
+
+        for (const p of persons) {
+          const feeds = personFeedUrls(p);
+          if (feeds.length === 0) {
+            yield* Console.log(`  - ${p.slug}: discovery disabled, skipping`);
+            continue;
+          }
+          yield* Console.log(`  - ${p.slug} (${p.title}): ${feeds.length} feed(s)`);
+
+          for (const feedUrl of feeds) {
+            const fetched = yield* feedSvc.fetchFeed(feedUrl).pipe(
+              Effect.tap((f) =>
+                Console.log(`    ${f.format} "${f.title}" — ${f.items.length} item(s)`),
+              ),
+              Effect.tapError((e) => Console.log(`    feed fetch failed — ${e.kind}: ${e.message}`)),
+              Effect.either,
+            );
+            const feed = Either.getOrNull(fetched);
+            if (feed === null) {
+              totalFailed += 1;
+              continue;
+            }
+            const windowItems = feed.items.filter((it) => {
+              if (!it.link) return false;
+              if (!it.publishedAt) return true;
+              return it.publishedAt >= cutoff;
+            });
+            const batch = windowItems.slice(0, limit);
+            totalFetched += batch.length;
+            yield* Console.log(
+              `      ${batch.length}/${windowItems.length} within window (limit=${limit})`,
+            );
+            for (const item of batch) {
+              if (dryRun) {
+                yield* Console.log(`      [dry-run] ${item.link}`);
+                continue;
+              }
+              const result = yield* ingestSvc
+                .ingestUrl({
+                  url: item.link,
+                  date,
+                  topicSlugs: allTopicSlugs,
+                  minWordCount: minWords,
+                  overwrite,
+                  // Pin the person's slug so the page lands on this topic
+                  // even when the article body uses a partial/last-name form
+                  // that the classifier alone might miss.
+                  forceTopics: [p.slug],
+                  topicWatchlists,
+                  descriptionFromFeed: item.description ?? undefined,
+                  summarize,
+                })
+                .pipe(
+                  Effect.tap((r) =>
+                    Console.log(
+                      `      ✓ ${r.relPath} (${r.wordCount}w${r.paywalled ? ", paywalled" : ""}${r.bodySource === "rss_description" ? ", rss-desc" : r.bodySource === "llm_insights" ? ", insights" : ""}, topics=[${r.topicsMatched.join(", ")}])`,
+                    ),
+                  ),
+                  Effect.tapError((e) => Console.log(`      ✗ ${item.link} — ${e.kind}: ${e.message}`)),
+                  Effect.either,
+                );
+              Either.match(result, {
+                onLeft: (e) => {
+                  if (e.kind === "collision") totalSkipped += 1;
+                  else totalFailed += 1;
+                },
+                onRight: () => {
+                  totalIngested += 1;
+                },
+              });
+            }
+          }
+        }
+        yield* Console.log(
+          `\ntotals: fetched=${totalFetched} ingested=${totalIngested} skipped=${totalSkipped} failed=${totalFailed}`,
+        );
+      });
+
+      const vaultLayer = FileSystemVaultLive(vaultDir);
+      const ingestLayer = HttpIngestLive.pipe(
+        Layer.provide(Layer.mergeAll(vaultLayer, HttpIngestDefaultConfig)),
+      );
+      const feedLayer = HttpFeedLive.pipe(Layer.provide(HttpFeedDefaultConfig));
+      yield* program.pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            FileSystemProfileLive(vaultDir),
+            vaultLayer,
+            ingestLayer,
+            feedLayer,
+            KernelLlmLive,
+          ),
+        ),
+      );
+    }),
+).pipe(
+  Command.withDescription(
+    "Discover and ingest news + interviews for topics with kind: person",
+  ),
+);
+
 export const ingest = Command.make("ingest").pipe(
-  Command.withSubcommands([url, sources]),
+  Command.withSubcommands([url, sources, person]),
   Command.withDescription("Ingest external sources into the vault"),
 );

--- a/apps/uebermensch/src/lib/discovery.ts
+++ b/apps/uebermensch/src/lib/discovery.ts
@@ -1,0 +1,57 @@
+import type { Schema } from "effect"
+import type { TopicEntry } from "../schemas.js"
+
+type Topic = Schema.Schema.Type<typeof TopicEntry>
+
+// Google News exposes a stable RSS endpoint that takes any search query.
+// We URL-encode the query and pin hl=en-US&gl=US&ceid=US:en so the result
+// shape is deterministic across machines.
+const GOOGLE_NEWS_BASE = "https://news.google.com/rss/search"
+
+export const googleNewsUrl = (query: string): string => {
+  const params = new URLSearchParams({
+    q: query,
+    hl: "en-US",
+    gl: "US",
+    ceid: "US:en",
+  })
+  return `${GOOGLE_NEWS_BASE}?${params.toString()}`
+}
+
+const quote = (s: string) => `"${s.replace(/"/g, "")}"`
+
+// Build the candidate feed URLs for a person topic. Returns an empty list
+// for non-person topics or when discovery is explicitly disabled.
+//
+// The "interviews" flag adds a second Google News query scoped to interview-
+// flavored terms — these turn up podcast appearances and Q&A transcripts
+// that the bare-name query tends to miss.
+export const personFeedUrls = (topic: Topic): ReadonlyArray<string> => {
+  if (topic.kind !== "person") return []
+  const discovery = topic.discovery ?? {}
+  const enabled = discovery.google_news ?? true
+  const urls: Array<string> = []
+
+  if (enabled) {
+    const aliases = topic.aliases ?? []
+    // Quote the primary name so Google News treats "Sam Altman" as a phrase
+    // instead of two loose tokens. Aliases are joined with OR so any surface
+    // form qualifies a hit.
+    const nameTerms = [topic.title, ...aliases].filter((s) => s.trim().length > 0)
+    const dedup = Array.from(new Set(nameTerms))
+    const nameClause =
+      dedup.length === 1 ? quote(dedup[0]!) : dedup.map(quote).join(" OR ")
+    urls.push(googleNewsUrl(nameClause))
+
+    if (discovery.interviews ?? true) {
+      // Mirror the BBC/Karpathy gist heuristic: interviews surface under
+      // "interview", "podcast", or "talk" near the name.
+      urls.push(googleNewsUrl(`${nameClause} (interview OR podcast OR talk)`))
+    }
+  }
+
+  for (const f of discovery.feeds ?? []) {
+    if (f.trim().length > 0) urls.push(f.trim())
+  }
+  return urls
+}

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -55,12 +55,36 @@ export const ProfileConfig = Schema.Struct({
   delivery: Delivery,
 })
 
+// Person topics open up name/alias matching and feed discovery.
+// `kind` defaults to "topic"; vault files written before this field landed
+// continue to load.
+export const TopicKind = Schema.Literal("topic", "person")
+export type TopicKind = typeof TopicKind.Type
+
+// Discovery config — currently only meaningful for person topics. When
+// `google_news` is true, `gctrl uber ingest person` auto-builds a Google News
+// RSS query from `title` (and optionally aliases) and ingests recent items.
+// `feeds` is a list of pre-built RSS/Atom URLs (e.g. a personal blog feed,
+// substack, or a curated YouTube interview channel).
+export const TopicDiscovery = Schema.Struct({
+  google_news: Schema.optional(Schema.Boolean),
+  interviews: Schema.optional(Schema.Boolean),
+  feeds: Schema.optional(Schema.Array(Schema.String)),
+})
+export type TopicDiscovery = typeof TopicDiscovery.Type
+
 export const TopicEntry = Schema.Struct({
   slug: Slug,
   title: Schema.String,
   horizon: Schema.Literal("short", "long", "both"),
   weight: Schema.Number,
+  kind: Schema.optional(TopicKind),
+  // Free-text surface forms used during classification: full name, handles,
+  // common short forms. Unlike `watchlist` (which is slug-shaped), aliases
+  // accept spaces, punctuation, and mixed case — "Sam Altman", "@sama".
+  aliases: Schema.optional(Schema.Array(Schema.String)),
   watchlist: Schema.optional(Schema.Array(Slug)),
+  discovery: Schema.optional(TopicDiscovery),
 })
 
 export const TopicsConfig = Schema.Struct({

--- a/apps/uebermensch/tests/person-topics.test.ts
+++ b/apps/uebermensch/tests/person-topics.test.ts
@@ -1,0 +1,173 @@
+import { Schema } from "effect"
+import { describe, expect, it } from "vitest"
+import { classifyTopics } from "../src/adapters/HttpIngest.js"
+import { googleNewsUrl, personFeedUrls } from "../src/lib/discovery.js"
+import { TopicEntry, TopicsConfig } from "../src/schemas.js"
+
+describe("TopicEntry — person kind + aliases", () => {
+  it("decodes a topic without kind (legacy default)", () => {
+    const out = Schema.decodeUnknownSync(TopicEntry)({
+      slug: "ai-dev-workflows",
+      title: "AI dev workflows",
+      horizon: "both",
+      weight: 1.0,
+    })
+    expect(out.kind).toBeUndefined()
+    expect(out.aliases).toBeUndefined()
+  })
+
+  it("decodes a person topic with aliases + discovery", () => {
+    const out = Schema.decodeUnknownSync(TopicEntry)({
+      slug: "sam-altman",
+      title: "Sam Altman",
+      kind: "person",
+      horizon: "both",
+      weight: 0.8,
+      aliases: ["Sam Altman", "@sama"],
+      discovery: { google_news: true, interviews: true },
+    })
+    expect(out.kind).toBe("person")
+    expect(out.aliases).toEqual(["Sam Altman", "@sama"])
+    expect(out.discovery?.interviews).toBe(true)
+  })
+
+  it("rejects unknown kinds", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(TopicEntry)({
+        slug: "x",
+        title: "X",
+        kind: "company",
+        horizon: "both",
+        weight: 1,
+      }),
+    ).toThrow()
+  })
+
+  it("decodes a TopicsConfig that mixes kinds", () => {
+    const out = Schema.decodeUnknownSync(TopicsConfig)({
+      topics: [
+        { slug: "macro", title: "Macro", horizon: "long", weight: 0.5 },
+        {
+          slug: "sam-altman",
+          title: "Sam Altman",
+          kind: "person",
+          horizon: "both",
+          weight: 0.7,
+          aliases: ["@sama"],
+        },
+      ],
+    })
+    expect(out.topics).toHaveLength(2)
+  })
+})
+
+describe("classifyTopics — alias matching for person topics", () => {
+  // The CLI merges aliases into the per-topic watchlist before calling
+  // classifyTopics. This test mirrors that contract.
+  it("matches a multi-word alias with spaces", () => {
+    const text = "In a recent interview, Sam Altman said the company..."
+    const hits = classifyTopics(text, ["sam-altman"], {
+      "sam-altman": ["Sam Altman", "@sama"],
+    })
+    expect(hits).toEqual(["sam-altman"])
+  })
+
+  it("matches the @handle form of an alias", () => {
+    const text = "thread by @sama on launch day"
+    const hits = classifyTopics(text, ["sam-altman"], {
+      "sam-altman": ["Sam Altman", "@sama"],
+    })
+    expect(hits).toEqual(["sam-altman"])
+  })
+
+  it("does not match when neither slug-phrase nor alias appears", () => {
+    const text = "story about other people in tech"
+    const hits = classifyTopics(text, ["sam-altman"], {
+      "sam-altman": ["Sam Altman", "@sama"],
+    })
+    expect(hits).toEqual([])
+  })
+
+  it("still matches the kebab→space slug form", () => {
+    // Person slug doubles as a watchlist seed: "sam-altman" → "sam altman".
+    const text = "essay by sam altman on agi"
+    const hits = classifyTopics(text, ["sam-altman"], { "sam-altman": [] })
+    expect(hits).toEqual(["sam-altman"])
+  })
+})
+
+describe("personFeedUrls + googleNewsUrl", () => {
+  const baseTopic = {
+    slug: "sam-altman",
+    title: "Sam Altman",
+    horizon: "both" as const,
+    weight: 0.8,
+  }
+
+  it("returns [] for a non-person topic", () => {
+    expect(personFeedUrls({ ...baseTopic, kind: "topic" })).toEqual([])
+    expect(personFeedUrls(baseTopic)).toEqual([])
+  })
+
+  it("builds a Google News query quoting the title", () => {
+    const urls = personFeedUrls({
+      ...baseTopic,
+      kind: "person",
+      discovery: { google_news: true, interviews: false },
+    })
+    expect(urls).toHaveLength(1)
+    const u = new URL(urls[0]!)
+    expect(u.host).toBe("news.google.com")
+    expect(u.pathname).toBe("/rss/search")
+    expect(u.searchParams.get("q")).toBe('"Sam Altman"')
+    expect(u.searchParams.get("hl")).toBe("en-US")
+  })
+
+  it("appends an interview-flavored query when interviews=true", () => {
+    const urls = personFeedUrls({
+      ...baseTopic,
+      kind: "person",
+      discovery: { google_news: true, interviews: true },
+    })
+    expect(urls).toHaveLength(2)
+    expect(new URL(urls[1]!).searchParams.get("q")).toBe(
+      '"Sam Altman" (interview OR podcast OR talk)',
+    )
+  })
+
+  it("ORs aliases into the name clause", () => {
+    const urls = personFeedUrls({
+      ...baseTopic,
+      kind: "person",
+      aliases: ["Sam Altman", "@sama"],
+      discovery: { google_news: true, interviews: false },
+    })
+    const q = new URL(urls[0]!).searchParams.get("q")!
+    expect(q).toContain('"Sam Altman"')
+    expect(q).toContain('"@sama"')
+    expect(q).toContain(" OR ")
+  })
+
+  it("appends author-supplied feeds verbatim", () => {
+    const urls = personFeedUrls({
+      ...baseTopic,
+      kind: "person",
+      discovery: {
+        google_news: false,
+        interviews: false,
+        feeds: ["https://blog.samaltman.com/posts.atom"],
+      },
+    })
+    expect(urls).toEqual(["https://blog.samaltman.com/posts.atom"])
+  })
+
+  it("defaults google_news + interviews to true when discovery is omitted", () => {
+    const urls = personFeedUrls({ ...baseTopic, kind: "person" })
+    expect(urls).toHaveLength(2)
+  })
+
+  it("googleNewsUrl percent-encodes special chars", () => {
+    const u = googleNewsUrl('"Yann LeCun" interview')
+    expect(u).toContain("q=%22Yann+LeCun%22+interview")
+  })
+})

--- a/apps/uebermensch/vault/specs/profile.md
+++ b/apps/uebermensch/vault/specs/profile.md
@@ -321,6 +321,23 @@ topics:
     horizon: "long"
     weight: 0.6
     watchlist: ["vllm", "dspy", "effect-ts"]
+
+  # A topic can also be a person. `kind: person` opens up two affordances:
+  #   1. `aliases` are matched in source bodies in addition to the slug —
+  #      so the topic catches "Sam Altman" and "@sama" without slug-shaping.
+  #   2. `gctrl uber ingest person` discovers Google News RSS for the title
+  #      (and an "interview OR podcast OR talk" variant), plus any explicit
+  #      `discovery.feeds`, and ingests recent items tagged with this slug.
+  - slug: "sam-altman"
+    title: "Sam Altman"
+    kind: "person"
+    horizon: "both"
+    weight: 0.7
+    aliases: ["Sam Altman", "@sama"]
+    discovery:
+      google_news: true
+      interviews: true
+      feeds: ["https://blog.samaltman.com/posts.atom"]
 ```
 
 Maps to: `Profile.topics`. Slugs are the lingua franca — they appear in theses, source topic filters, brief item tags, and rank priors.


### PR DESCRIPTION
## Summary

Topics in uebermensch can now be **people**. Adds `kind: person` to `TopicEntry` plus the discovery affordances that make a person topic useful:

- **Alias matching** — `aliases: ["Sam Altman", "@sama"]` are merged into the per-topic watchlist during ingest, so the classifier catches surface forms that don't fit the slug pattern (spaces, handles, mixed case).
- **Auto-discovery** — new `gctrl uber ingest person [--topic <slug>]` walks every `kind: person` topic, builds a Google News RSS query for the title + aliases (joined with `OR`), adds a second `(interview OR podcast OR talk)` variant, also pulls any explicit `discovery.feeds`, and ingests recent items force-tagged with the person's slug.

Schema is backward-compatible — `kind`, `aliases`, and `discovery` are all optional, and existing topics.md files load unchanged.

### Example

```yaml
- slug: "sam-altman"
  title: "Sam Altman"
  kind: "person"
  horizon: "both"
  weight: 0.7
  aliases: ["Sam Altman", "@sama"]
  discovery:
    google_news: true
    interviews: true
    feeds: ["https://blog.samaltman.com/posts.atom"]
```

```sh
gctrl uber ingest person --topic sam-altman --since-hours 168 --limit 10
```

### Files

- `apps/uebermensch/src/schemas.ts` — `TopicKind`, `TopicDiscovery`; new optional fields on `TopicEntry`.
- `apps/uebermensch/src/lib/discovery.ts` — `googleNewsUrl` + `personFeedUrls` helpers.
- `apps/uebermensch/src/commands/ingest.ts` — `sources` flow merges aliases into watchlists; new `person` subcommand.
- `apps/uebermensch/tests/person-topics.test.ts` — 15 new tests (schema decode, classifier alias matching, discovery URL construction).
- `apps/uebermensch/vault/specs/profile.md` — example person topic added to the topics.md spec.

## Test plan

- [x] `pnpm test` — 135 passed (was 120; +15 new)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] CLI smoke: `uber ingest` lists `person` subcommand with all flags
- [x] End-to-end dry run against live Google News + a personal Atom feed:
      `uber ingest person --topic sam-altman --dry-run` resolved 3 feeds (100 + 100 + 30 items), correctly windowed and listed candidates without writing
- [x] `uber profile validate` against a real vault with mixed legacy + person topics — clean
