### PR TITLE
fix(storage): backfill start_date/due_date on existing SQLite DBs

### DIFF
--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -435,6 +435,8 @@ impl SqliteStore {
             "ALTER TABLE board_issues ADD COLUMN device_id TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE board_issues ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE board_issues ADD COLUMN acceptance_criteria TEXT",
+            "ALTER TABLE board_issues ADD COLUMN start_date TEXT",
+            "ALTER TABLE board_issues ADD COLUMN due_date TEXT",
             "ALTER TABLE board_events ADD COLUMN device_id TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE board_events ADD COLUMN updated_at TEXT NOT NULL DEFAULT (datetime('now'))",
             "ALTER TABLE board_events ADD COLUMN synced INTEGER NOT NULL DEFAULT 0",


### PR DESCRIPTION
## Summary

Fixes a startup crash on `gctrld serve` (and `gctrld serve --proxy`) for any kernel database that predates #56 (Gantt view).

```
Error: storage error: migration: no such column: start_date in
CREATE INDEX IF NOT EXISTS idx_board_issues_start_date ON board_issues(start_date) at offset 71
```

## Root cause

#56 added `start_date` / `due_date` to `board_issues` and created indexes over both columns, but only updated the `CREATE TABLE IF NOT EXISTS` block. Old databases keep the pre-#56 shape, so when `run_migrations()` reaches the `CREATE INDEX` step the columns are missing and rusqlite errors out.

## Fix

Two idempotent `ALTER TABLE board_issues ADD COLUMN` statements alongside the existing backwards-compat ALTERs in `kernel/crates/gctrl-storage/src/sqlite_store.rs`. The existing `if !msg.contains("duplicate column name")` guard makes this a no-op for fresh databases.

## Test plan

- [x] `cargo build -p gctrl-storage` — clean
- [x] `cargo test -p gctrl-storage --lib` — 98 passed, 0 failed
- [ ] Manual: reproduce on an old kernel DB, run `gctrld serve --proxy`, confirm startup succeeds
