### PR TITLE
feat(uebermensch): two-pass subtopic + ELI5 + local-LLM forwarder

### DIFF
--- a/apps/uebermensch/src/adapters/FileSystemVault.ts
+++ b/apps/uebermensch/src/adapters/FileSystemVault.ts
@@ -147,6 +147,7 @@ export const FileSystemVaultLive = (vaultDir: string) =>
             sources: decoded.sources ?? [],
             horizon: decoded.horizon ?? null,
             weight: decoded.weight ?? null,
+            fieldFamiliarity: decoded.field_familiarity ?? "expert",
             notes: parsed.content.trim(),
             relPath: f.rel,
           })

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -7,6 +7,7 @@ import {
   type InterestReportRequest,
   LlmService,
   type ResearchQueryRequest,
+  type SubtopicProposeRequest,
 } from "../services/LlmService.js";
 import type { CuratedItem } from "../services/RendererService.js";
 
@@ -18,7 +19,7 @@ const DEFAULT_MAX_TOKENS = 16000;
 
 // Per-article summarization uses a cheaper model. Kernel /api/llm/messages
 // routes through the AI Gateway so any model in the provider registry works.
-const SUMMARY_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_SUMMARY_MODEL = "claude-haiku-4-5-20251001";
 const SUMMARY_INPUT_COST_PER_MTOK = 1.0;
 const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0;
 const SUMMARY_MAX_TOKENS = 800;
@@ -26,7 +27,15 @@ const SUMMARY_INPUT_CHARS_CAP = 12000;
 
 const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL;
 
-const isWorkersAiModel = (model: string): boolean => model.startsWith("@cf/");
+const summaryModelFor = (): string =>
+  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL;
+
+// Anthropic-shaped models go through /api/llm/messages. Everything else
+// (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
+// LM Studio / Ollama) goes through /api/llm/completions.
+const isAnthropicModel = (model: string): boolean => model.startsWith("claude-");
+// Back-compat alias — older callers/tests still import this name.
+const isWorkersAiModel = (model: string): boolean => !isAnthropicModel(model);
 
 const kernelBase = (): string =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
@@ -42,12 +51,17 @@ const candidateBlock = (c: CandidateRef): string => {
   const title = (fm.title as string | undefined) ?? c.page.stem;
   const topics = ((fm.topics as ReadonlyArray<string> | undefined) ?? []).join(", ");
   const url = (fm.url as string | undefined) ?? "";
+  // source_kind is set by the ingest pipeline (news / paper / research-blog /
+  // primary). Surface it so the deep-dive prompt can promote primary research
+  // citations into a "Latest research" frame for novice-mode interests.
+  const sourceKind = (fm.source_kind as string | undefined) ?? "";
   const lines: Array<string> = [
     `- id: ${c.id}`,
     `  stem: ${c.page.stem}`,
     `  title: ${title}`,
     `  topics: [${topics}]`,
   ];
+  if (sourceKind) lines.push(`  source_kind: ${sourceKind}`);
   if (url) lines.push(`  url: ${url}`);
   lines.push(`  score: ${c.score.toFixed(3)}`);
   lines.push(`  excerpt: |`);
@@ -154,6 +168,35 @@ const classifyKernelStatus = (status: number): LlmError["kind"] => {
   return "invalid";
 };
 
+// Node's fetch surfaces a connection refusal as `TypeError: fetch failed`
+// with a nested `cause` carrying `code: ECONNREFUSED`. Walk the chain so we
+// can tell the user the kernel daemon is simply down vs. some other failure.
+const isConnRefused = (e: unknown): boolean => {
+  let cur: unknown = e;
+  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
+    const code = (cur as { code?: string }).code;
+    if (
+      code === "ECONNREFUSED" ||
+      code === "ENOTFOUND" ||
+      code === "EHOSTUNREACH" ||
+      code === "ECONNRESET"
+    ) {
+      return true;
+    }
+    const errors = (cur as { errors?: ReadonlyArray<unknown> }).errors;
+    if (Array.isArray(errors) && errors.some(isConnRefused)) return true;
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return false;
+};
+
+const kernelDownErr = (path: string): LlmError =>
+  llmErr(
+    "unavailable",
+    `kernel daemon not reachable at ${kernelBase()}${path} — start it with: ` +
+      `gctrld serve --port 4318 (or set GCTRL_KERNEL_URL to point at a running kernel)`,
+  );
+
 const tokensCost = (
   inputTokens: number,
   outputTokens: number,
@@ -204,10 +247,11 @@ const postAnthropic = (
         model: parsed.model ?? model,
       };
     },
-    catch: (e) =>
-      e instanceof LlmError
-        ? e
-        : llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`),
+    catch: (e) => {
+      if (e instanceof LlmError) return e;
+      if (isConnRefused(e)) return kernelDownErr("/api/llm/messages");
+      return llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`);
+    },
   });
 
 const postWorkersAi = (
@@ -250,10 +294,11 @@ const postWorkersAi = (
         model: parsed.model ?? model,
       };
     },
-    catch: (e) =>
-      e instanceof LlmError
-        ? e
-        : llmErr("unavailable", `kernel /api/llm/completions fetch failed: ${String(e)}`),
+    catch: (e) => {
+      if (e instanceof LlmError) return e;
+      if (isConnRefused(e)) return kernelDownErr("/api/llm/completions");
+      return llmErr("unavailable", `kernel /api/llm/completions fetch failed: ${String(e)}`);
+    },
   });
 
 const postLlm = (
@@ -267,7 +312,73 @@ const postLlm = (
     ? postWorkersAi(model, system, userPrompt, maxTokens)
     : postAnthropic(model, system, userPrompt, maxTokens, thinking);
 
-const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst. Your task is to produce a DEEP weekly research report for ONE research interest.
+const SUBTOPIC_SYSTEM_PROMPT = `You are uebermensch-curator. Given a long-running research interest and the strongest candidates surfaced this week, identify 1–3 sharply focused SUB-TOPICS the deep-dive could explore this week, then pick the best one.
+
+OUTPUT CONTRACT:
+- Output MUST be a single JSON object wrapped in a triple-backtick json fenced block. No prose outside the fence.
+- Shape:
+  {
+    "proposals": [
+      {
+        "slug": "kebab-case",                    // <= 60 chars, lower kebab
+        "title": "Sub-topic title",              // <= 80 chars
+        "rationale": "1–2 sentences",            // why this thread is the strongest signal
+        "relevant_candidate_ids": ["..."]        // candidate ids that support this sub-topic
+      }
+    ],
+    "selected_slug": "..."                       // MUST equal one proposals[].slug
+  }
+
+RULES:
+- A sub-topic MUST be sharper than the interest's umbrella title — name a specific thread, actor, mechanism, ruling, paper, or development. NOT a paraphrase of the interest.
+- 1–3 proposals. If signal is weak/diffuse, return ONE proposal capturing the dominant fragment rather than no proposals.
+- relevant_candidate_ids MUST be a subset of the provided candidate ids — never fabricate.
+- Rationale is concrete: name actors, numbers, dates, mechanisms. No meta phrases like "this week's pool covers...".
+- selected_slug picks the proposal with the densest cited evidence and the highest decision-relevance for the interest's question.`;
+
+const buildSubtopicUserPrompt = (req: SubtopicProposeRequest): string => {
+  const it = req.interest;
+  const lines: Array<string> = [];
+  lines.push(`period: ${req.periodLabel}`);
+  lines.push(`periodStart: ${req.periodStart}`);
+  lines.push(`periodEnd: ${req.periodEnd}`);
+  lines.push(`profile: ${req.profileName}`);
+  lines.push("");
+  lines.push("interest:");
+  lines.push(`  slug: ${it.slug}`);
+  lines.push(`  title: ${it.title}`);
+  if (it.question) lines.push(`  question: ${it.question}`);
+  lines.push(`  topics: [${it.topics.join(", ")}]`);
+  lines.push(`  field_familiarity: ${it.fieldFamiliarity}`);
+  if (it.notes) {
+    lines.push(`  notes: |`);
+    for (const line of it.notes.split("\n")) lines.push(`    ${line}`);
+  }
+  lines.push("");
+  lines.push("candidates:");
+  if (it.candidates.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const c of it.candidates) lines.push(candidateBlock(c));
+  }
+  lines.push("");
+  lines.push("Return ONLY a fenced ```json block with the schema above.");
+  return lines.join("\n");
+};
+
+const SubtopicProposalSchema = Schema.Struct({
+  slug: Schema.String,
+  title: Schema.String,
+  rationale: Schema.String,
+  relevant_candidate_ids: Schema.Array(Schema.String),
+});
+
+const SubtopicProposeOutputSchema = Schema.Struct({
+  proposals: Schema.Array(SubtopicProposalSchema).pipe(Schema.minItems(1)),
+  selected_slug: Schema.String,
+});
+
+const REPORT_SYSTEM_PROMPT = `You are uebermensch-researcher, a chief-of-staff analyst. Your task is to produce a DEEP weekly research report for ONE research interest, focused on a chosen SUB-TOPIC for this week.
 
 OUTPUT CONTRACT:
 - Output MUST be a single JSON object wrapped in a triple-backtick json fenced block. No prose outside the fence.
@@ -278,7 +389,7 @@ OUTPUT CONTRACT:
     ### Cross-currents
     ### Implications
     ### Open questions
-  - Thesis (1 short paragraph): the single most important claim of the week for this interest, stated sharply.
+  - Thesis (1 short paragraph): the single most important claim of the week, framed around the FOCUS_SUBTOPIC if one is provided.
   - Key developments (2–5 paragraphs): concrete, specific developments grounded in the candidate excerpts. Tight bullets are acceptable here, but prefer prose that synthesizes across candidates.
   - Cross-currents (1–3 paragraphs): tensions, disagreements, or contradictions between sources; second-order effects; what is being priced in vs. not.
   - Implications (1–3 paragraphs): what this means for the interest's question. Concrete, falsifiable, decision-relevant.
@@ -306,6 +417,22 @@ DEPTH RULES:
 - Name actors, numbers, dates, and mechanisms. Avoid generic macro prose.
 - Do NOT meta-describe the candidate pool ("the sources cover X", "based on these articles"). Write as a first-party analyst.
 
+SUBTOPIC FOCUS RULES:
+- If a FOCUS_SUBTOPIC block is provided, the entire report MUST be framed around that specific sub-thread. The interest's umbrella question is context only — DO NOT default to surveying the whole interest.
+- Thesis MUST directly address the FOCUS_SUBTOPIC. Key developments / Cross-currents / Implications MUST stay on that thread; mention adjacent threads only when they bear on it.
+- Open questions MUST be specific to the sub-topic, not the umbrella interest.
+
+FIELD FAMILIARITY (controls tone, never citation rigor):
+- "expert": assume technical fluency. Use domain jargon directly. Focus on second-order effects, mechanism nuance, and decision-relevant deltas. NO definitions of standard terms.
+- "novice": ELI5 framing. Define every domain term on first use in one short clause (e.g. "BDCs (Business Development Companies — public-listed funds that lend to mid-market firms)"). Prefer concrete analogies and one short "Plain English:" callout per Key Development paragraph that restates the development for a non-specialist. Citation rigor and "no meta commentary" rules still apply.
+- The FIELD_FAMILIARITY value will appear in the user prompt; honor it strictly.
+
+STATE-OF-THE-ART RESEARCH:
+- Each candidate may carry a \`source_kind\` field. Values: "news", "paper", "research-blog", "primary" (e.g. central-bank releases, SEC filings).
+- If at least one cited candidate has source_kind in {"paper", "research-blog"}, INSERT a level-3 section "### Latest research" immediately after Thesis (so the order becomes: Thesis → Latest research → Key developments → Cross-currents → Implications → Open questions). The Latest research section is 1–2 paragraphs naming the paper/research piece(s), the authors/institution if shown, and the substantive finding — citations strict as elsewhere.
+- For novice-mode interests, the Latest research section MUST translate the finding into one Plain English sentence at the end.
+- If no candidate has a research source_kind, OMIT the section entirely — do not write "no research this week".
+
 INSIGHT-ONLY RULES (strict — enforced by reviewer):
 - Write substantive insight only. NEVER describe what is absent, thin, missing, or quiet in the candidate pool.
 - BANNED phrases and patterns: "No direct X...", "No fresh X...", "appeared in the candidate set", "This week was quiet for...", "Candidate pool was thin...", "Most items were only indirectly relevant...", "Reference pages were also indexed but carry no new information", "Treat this week as a quiet one for...".
@@ -323,6 +450,7 @@ const buildInterestReportUserPrompt = (req: InterestReportRequest): string => {
   lines.push(`periodEnd: ${req.periodEnd}`);
   lines.push(`profile: ${req.profileName}`);
   lines.push(`maxItems: ${req.maxItems}`);
+  lines.push(`field_familiarity: ${it.fieldFamiliarity}`);
   lines.push("");
   lines.push("interest:");
   lines.push(`  slug: ${it.slug}`);
@@ -334,6 +462,13 @@ const buildInterestReportUserPrompt = (req: InterestReportRequest): string => {
     for (const line of it.notes.split("\n")) lines.push(`    ${line}`);
   }
   lines.push("");
+  if (req.subtopic) {
+    lines.push("FOCUS_SUBTOPIC:");
+    lines.push(`  slug: ${req.subtopic.slug}`);
+    lines.push(`  title: ${req.subtopic.title}`);
+    lines.push(`  rationale: ${req.subtopic.rationale}`);
+    lines.push("");
+  }
   lines.push("candidates:");
   if (it.candidates.length === 0) {
     lines.push("  (none)");
@@ -489,6 +624,69 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         model: res.model,
       };
     }),
+  proposeSubtopic: (req) =>
+    Effect.gen(function* () {
+      const model = modelFor();
+      const userPrompt = buildSubtopicUserPrompt(req);
+      const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const res = yield* postLlm(
+        model,
+        SUBTOPIC_SYSTEM_PROMPT,
+        userPrompt,
+        DEFAULT_MAX_TOKENS,
+        true,
+      );
+      const raw = extractJson(res.text);
+      if (raw === null) {
+        return yield* Effect.fail(
+          llmErr("invalid", "kernel response text did not contain a JSON object"),
+        );
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (e) {
+        return yield* Effect.fail(
+          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
+        );
+      }
+      const decoded = yield* Schema.decodeUnknown(SubtopicProposeOutputSchema)(parsed).pipe(
+        Effect.mapError((e) =>
+          llmErr("invalid", `kernel subtopic response schema mismatch: ${String(e)}`),
+        ),
+      );
+      // Validate selected_slug refers to a real proposal; if not, fall back to
+      // the first proposal so the report still proceeds.
+      const proposalSlugs = new Set(decoded.proposals.map((p) => p.slug));
+      const selectedSlug = proposalSlugs.has(decoded.selected_slug)
+        ? decoded.selected_slug
+        : decoded.proposals[0].slug;
+      const candidateIds = new Set(req.interest.candidates.map((c) => c.id));
+      const proposals = decoded.proposals.map((p) => ({
+        slug: p.slug,
+        title: p.title,
+        rationale: p.rationale,
+        // Drop hallucinated candidate ids — never propagate fabricated refs.
+        relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
+      }));
+      const costUsd = isWorkersAiModel(res.model)
+        ? 0
+        : tokensCost(
+            res.inputTokens,
+            res.outputTokens,
+            ANTHROPIC_INPUT_COST_PER_MTOK,
+            ANTHROPIC_OUTPUT_COST_PER_MTOK,
+          );
+      return {
+        selectedSlug,
+        proposals,
+        promptHash,
+        costUsd,
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
+        model: res.model,
+      };
+    }),
   generateInterestReport: (req) =>
     Effect.gen(function* () {
       const model = modelFor();
@@ -581,7 +779,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
       const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
       const res = yield* postLlm(
-        SUMMARY_MODEL,
+        summaryModelFor(),
         SUMMARY_SYSTEM_PROMPT,
         userPrompt,
         SUMMARY_MAX_TOKENS,
@@ -611,20 +809,26 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
 export const _internal = {
   buildUserPrompt,
   buildInterestReportUserPrompt,
+  buildSubtopicUserPrompt,
   buildSummaryUserPrompt,
   buildResearchQueryUserPrompt,
   extractJson,
   kernelBase,
   LlmOutputSchema,
   InterestReportOutputSchema,
+  SubtopicProposeOutputSchema,
   normalizeInsights,
   SYSTEM_PROMPT,
   REPORT_SYSTEM_PROMPT,
+  SUBTOPIC_SYSTEM_PROMPT,
   SUMMARY_SYSTEM_PROMPT,
   RESEARCH_SYSTEM_PROMPT,
   MODEL: DEFAULT_MODEL,
   DEFAULT_MODEL,
-  SUMMARY_MODEL,
+  SUMMARY_MODEL: DEFAULT_SUMMARY_MODEL,
+  DEFAULT_SUMMARY_MODEL,
   modelFor,
+  summaryModelFor,
+  isAnthropicModel,
   isWorkersAiModel,
 };

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -204,6 +204,42 @@ const tokensCost = (
   outputRate: number,
 ): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000;
 
+// POST a JSON body to `${kernelBase()}${path}` and return the raw response
+// text. Connection-level failures (ECONNREFUSED etc.) become a "kernel daemon
+// not reachable" hint; non-2xx responses become a classified LlmError.
+const fetchKernel = (
+  path: string,
+  body: unknown,
+): Effect.Effect<string, LlmError> =>
+  Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${kernelBase()}${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      catch: (e) =>
+        isConnRefused(e)
+          ? kernelDownErr(path)
+          : llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}`),
+    });
+    const raw = yield* Effect.tryPromise({
+      try: () => res.text(),
+      catch: (e) =>
+        llmErr("unavailable", `kernel ${path} body read failed: ${String(e)}`),
+    });
+    if (!res.ok) {
+      return yield* Effect.fail(
+        llmErr(
+          classifyKernelStatus(res.status),
+          `kernel ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
+        ),
+      );
+    }
+    return raw;
+  });
+
 const postAnthropic = (
   model: string,
   system: string,
@@ -211,47 +247,36 @@ const postAnthropic = (
   maxTokens: number,
   thinking: boolean,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
-  Effect.tryPromise({
-    try: async () => {
-      const body: Record<string, unknown> = {
-        model,
-        max_tokens: maxTokens,
-        system,
-        messages: [{ role: "user", content: userPrompt }],
-      };
-      if (thinking) body.thinking = { type: "adaptive" };
-      const res = await fetch(`${kernelBase()}/api/llm/messages`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      const raw = await res.text();
-      if (!res.ok) {
-        throw llmErr(
-          classifyKernelStatus(res.status),
-          `kernel /api/llm/messages HTTP ${res.status}: ${raw.slice(0, 500)}`,
-        );
-      }
-      const parsed = (raw.length > 0 ? JSON.parse(raw) : {}) as AnthropicResponse;
-      const textBlock = (parsed.content ?? []).find(
-        (b): b is { type: string; text: string } =>
-          b.type === "text" && typeof b.text === "string",
+  Effect.gen(function* () {
+    const body: Record<string, unknown> = {
+      model,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: "user", content: userPrompt }],
+      ...(thinking ? { thinking: { type: "adaptive" } } : {}),
+    };
+    const raw = yield* fetchKernel("/api/llm/messages", body);
+    const parsed = yield* Effect.try({
+      try: () =>
+        (raw.length > 0 ? (JSON.parse(raw) as AnthropicResponse) : ({} as AnthropicResponse)),
+      catch: (e) =>
+        llmErr("invalid", `kernel /api/llm/messages JSON.parse failed: ${String(e)}`),
+    });
+    const textBlock = (parsed.content ?? []).find(
+      (b): b is { type: string; text: string } =>
+        b.type === "text" && typeof b.text === "string",
+    );
+    if (!textBlock) {
+      return yield* Effect.fail(
+        llmErr("invalid", "kernel response missing text content block"),
       );
-      if (!textBlock) {
-        throw llmErr("invalid", "kernel response missing text content block");
-      }
-      return {
-        text: textBlock.text,
-        inputTokens: parsed.usage?.input_tokens ?? 0,
-        outputTokens: parsed.usage?.output_tokens ?? 0,
-        model: parsed.model ?? model,
-      };
-    },
-    catch: (e) => {
-      if (e instanceof LlmError) return e;
-      if (isConnRefused(e)) return kernelDownErr("/api/llm/messages");
-      return llmErr("unavailable", `kernel /api/llm/messages fetch failed: ${String(e)}`);
-    },
+    }
+    return {
+      text: textBlock.text,
+      inputTokens: parsed.usage?.input_tokens ?? 0,
+      outputTokens: parsed.usage?.output_tokens ?? 0,
+      model: parsed.model ?? model,
+    };
   });
 
 const postWorkersAi = (
@@ -260,45 +285,34 @@ const postWorkersAi = (
   userPrompt: string,
   maxTokens: number,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
-  Effect.tryPromise({
-    try: async () => {
-      const body = {
-        model,
-        max_tokens: maxTokens,
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: userPrompt },
-        ],
-      };
-      const res = await fetch(`${kernelBase()}/api/llm/completions`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      const raw = await res.text();
-      if (!res.ok) {
-        throw llmErr(
-          classifyKernelStatus(res.status),
-          `kernel /api/llm/completions HTTP ${res.status}: ${raw.slice(0, 500)}`,
-        );
-      }
-      const parsed = (raw.length > 0 ? JSON.parse(raw) : {}) as OpenAiChatResponse;
-      const content = parsed.choices?.[0]?.message?.content;
-      if (typeof content !== "string") {
-        throw llmErr("invalid", "kernel response missing choices[0].message.content string");
-      }
-      return {
-        text: content,
-        inputTokens: parsed.usage?.prompt_tokens ?? 0,
-        outputTokens: parsed.usage?.completion_tokens ?? 0,
-        model: parsed.model ?? model,
-      };
-    },
-    catch: (e) => {
-      if (e instanceof LlmError) return e;
-      if (isConnRefused(e)) return kernelDownErr("/api/llm/completions");
-      return llmErr("unavailable", `kernel /api/llm/completions fetch failed: ${String(e)}`);
-    },
+  Effect.gen(function* () {
+    const body = {
+      model,
+      max_tokens: maxTokens,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: userPrompt },
+      ],
+    };
+    const raw = yield* fetchKernel("/api/llm/completions", body);
+    const parsed = yield* Effect.try({
+      try: () =>
+        (raw.length > 0 ? (JSON.parse(raw) as OpenAiChatResponse) : ({} as OpenAiChatResponse)),
+      catch: (e) =>
+        llmErr("invalid", `kernel /api/llm/completions JSON.parse failed: ${String(e)}`),
+    });
+    const content = parsed.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      return yield* Effect.fail(
+        llmErr("invalid", "kernel response missing choices[0].message.content string"),
+      );
+    }
+    return {
+      text: content,
+      inputTokens: parsed.usage?.prompt_tokens ?? 0,
+      outputTokens: parsed.usage?.completion_tokens ?? 0,
+      model: parsed.model ?? model,
+    };
   });
 
 const postLlm = (
@@ -311,6 +325,44 @@ const postLlm = (
   isWorkersAiModel(model)
     ? postWorkersAi(model, system, userPrompt, maxTokens)
     : postAnthropic(model, system, userPrompt, maxTokens, thinking);
+
+// Pull the first JSON object out of an LLM response and decode it against
+// `schema`. All three failure modes (no JSON, JSON.parse error, schema
+// mismatch) collapse to a single LlmError("invalid") with a contextual hint
+// so callers don't reimplement the extract → parse → decode trio.
+const decodeLlmJson = <A, I>(
+  text: string,
+  schema: Schema.Schema<A, I>,
+  contextLabel: string,
+): Effect.Effect<A, LlmError> =>
+  Effect.gen(function* () {
+    const raw = extractJson(text);
+    if (raw === null) {
+      return yield* Effect.fail(
+        llmErr("invalid", `${contextLabel}: response did not contain a JSON object`),
+      );
+    }
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(raw) as unknown,
+      catch: (e) => llmErr("invalid", `${contextLabel}: JSON.parse failed: ${String(e)}`),
+    });
+    return yield* Schema.decodeUnknown(schema)(parsed).pipe(
+      Effect.mapError((e) =>
+        llmErr("invalid", `${contextLabel}: schema mismatch: ${String(e)}`),
+      ),
+    );
+  });
+
+// USD cost for a normalized LLM response. Workers AI / local models
+// always cost $0; Anthropic & summary lanes pay for input + output tokens.
+const costForResponse = (
+  res: NormalizedResponse,
+  inputRate: number,
+  outputRate: number,
+): number =>
+  isWorkersAiModel(res.model)
+    ? 0
+    : tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate);
 
 const SUBTOPIC_SYSTEM_PROMPT = `You are uebermensch-curator. Given a long-running research interest and the strongest candidates surfaced this week, identify 1–3 sharply focused SUB-TOPICS the deep-dive could explore this week, then pick the best one.
 
@@ -581,31 +633,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const userPrompt = buildUserPrompt(req);
       const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
       const res = yield* postLlm(model, SYSTEM_PROMPT, userPrompt, DEFAULT_MAX_TOKENS, true);
-      const raw = extractJson(res.text);
-      if (raw === null) {
-        return yield* Effect.fail(
-          llmErr("invalid", "kernel response text did not contain a JSON object"),
-        );
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch (e) {
-        return yield* Effect.fail(
-          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
-        );
-      }
-      const decoded = yield* Schema.decodeUnknown(LlmOutputSchema)(parsed).pipe(
-        Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
+      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
+      const costUsd = costForResponse(
+        res,
+        ANTHROPIC_INPUT_COST_PER_MTOK,
+        ANTHROPIC_OUTPUT_COST_PER_MTOK,
       );
-      const costUsd = isWorkersAiModel(res.model)
-        ? 0
-        : tokensCost(
-            res.inputTokens,
-            res.outputTokens,
-            ANTHROPIC_INPUT_COST_PER_MTOK,
-            ANTHROPIC_OUTPUT_COST_PER_MTOK,
-          );
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -636,24 +669,10 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         DEFAULT_MAX_TOKENS,
         true,
       );
-      const raw = extractJson(res.text);
-      if (raw === null) {
-        return yield* Effect.fail(
-          llmErr("invalid", "kernel response text did not contain a JSON object"),
-        );
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch (e) {
-        return yield* Effect.fail(
-          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
-        );
-      }
-      const decoded = yield* Schema.decodeUnknown(SubtopicProposeOutputSchema)(parsed).pipe(
-        Effect.mapError((e) =>
-          llmErr("invalid", `kernel subtopic response schema mismatch: ${String(e)}`),
-        ),
+      const decoded = yield* decodeLlmJson(
+        res.text,
+        SubtopicProposeOutputSchema,
+        "kernel subtopic",
       );
       // Validate selected_slug refers to a real proposal; if not, fall back to
       // the first proposal so the report still proceeds.
@@ -669,14 +688,11 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         // Drop hallucinated candidate ids — never propagate fabricated refs.
         relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
       }));
-      const costUsd = isWorkersAiModel(res.model)
-        ? 0
-        : tokensCost(
-            res.inputTokens,
-            res.outputTokens,
-            ANTHROPIC_INPUT_COST_PER_MTOK,
-            ANTHROPIC_OUTPUT_COST_PER_MTOK,
-          );
+      const costUsd = costForResponse(
+        res,
+        ANTHROPIC_INPUT_COST_PER_MTOK,
+        ANTHROPIC_OUTPUT_COST_PER_MTOK,
+      );
       return {
         selectedSlug,
         proposals,
@@ -699,31 +715,16 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         DEFAULT_MAX_TOKENS,
         true,
       );
-      const raw = extractJson(res.text);
-      if (raw === null) {
-        return yield* Effect.fail(
-          llmErr("invalid", "kernel response text did not contain a JSON object"),
-        );
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch (e) {
-        return yield* Effect.fail(
-          llmErr("invalid", `kernel response JSON parse failed: ${String(e)}`),
-        );
-      }
-      const decoded = yield* Schema.decodeUnknown(InterestReportOutputSchema)(parsed).pipe(
-        Effect.mapError((e) => llmErr("invalid", `kernel response schema mismatch: ${String(e)}`)),
+      const decoded = yield* decodeLlmJson(
+        res.text,
+        InterestReportOutputSchema,
+        "kernel interest report",
       );
-      const costUsd = isWorkersAiModel(res.model)
-        ? 0
-        : tokensCost(
-            res.inputTokens,
-            res.outputTokens,
-            ANTHROPIC_INPUT_COST_PER_MTOK,
-            ANTHROPIC_OUTPUT_COST_PER_MTOK,
-          );
+      const costUsd = costForResponse(
+        res,
+        ANTHROPIC_INPUT_COST_PER_MTOK,
+        ANTHROPIC_OUTPUT_COST_PER_MTOK,
+      );
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -760,14 +761,11 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       if (answerMd.length === 0) {
         return yield* Effect.fail(llmErr("invalid", "kernel researchQuery returned empty body"));
       }
-      const costUsd = isWorkersAiModel(res.model)
-        ? 0
-        : tokensCost(
-            res.inputTokens,
-            res.outputTokens,
-            ANTHROPIC_INPUT_COST_PER_MTOK,
-            ANTHROPIC_OUTPUT_COST_PER_MTOK,
-          );
+      const costUsd = costForResponse(
+        res,
+        ANTHROPIC_INPUT_COST_PER_MTOK,
+        ANTHROPIC_OUTPUT_COST_PER_MTOK,
+      );
       return { answerMd, promptHash, costUsd, model: res.model };
     }),
   summarizeSource: (req) =>
@@ -789,14 +787,11 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       if (insightsMd.length === 0) {
         return yield* Effect.fail(llmErr("invalid", "kernel summarize returned empty insights"));
       }
-      const costUsd = isWorkersAiModel(res.model)
-        ? 0
-        : tokensCost(
-            res.inputTokens,
-            res.outputTokens,
-            SUMMARY_INPUT_COST_PER_MTOK,
-            SUMMARY_OUTPUT_COST_PER_MTOK,
-          );
+      const costUsd = costForResponse(
+        res,
+        SUMMARY_INPUT_COST_PER_MTOK,
+        SUMMARY_OUTPUT_COST_PER_MTOK,
+      );
       return {
         insightsMd,
         promptHash,

--- a/apps/uebermensch/src/adapters/StrictRenderer.ts
+++ b/apps/uebermensch/src/adapters/StrictRenderer.ts
@@ -119,33 +119,57 @@ const verifyAnalysisCitations = (
 const interestReportSlug = (periodLabel: string, interestSlug: string): string =>
   `${periodLabel}--${interestSlug}`
 
+const yamlString = (s: string): string => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+
 const renderInterestReportFrontmatter = (
   input: InterestReportRenderInput,
   slug: string,
   itemCount: number,
   citedClaims: number,
   totalClaims: number,
-): string =>
-  [
+): string => {
+  const lines: Array<string> = [
     "---",
     "page_type: report",
     `slug: report-${slug}`,
     'kind: "weekly"',
-    `period_label: "${input.periodLabel}"`,
-    `period_start: "${input.periodStart}"`,
-    `period_end: "${input.periodEnd}"`,
-    `interest_slug: "${input.interestSlug}"`,
-    `interest_title: "${input.interestTitle.replace(/"/g, '\\"')}"`,
-    `generator: "${input.generator}"`,
-    `model: "${input.model}"`,
-    `prompt_hash: "${input.promptHash}"`,
+    `period_label: ${yamlString(input.periodLabel)}`,
+    `period_start: ${yamlString(input.periodStart)}`,
+    `period_end: ${yamlString(input.periodEnd)}`,
+    `interest_slug: ${yamlString(input.interestSlug)}`,
+    `interest_title: ${yamlString(input.interestTitle)}`,
+    `field_familiarity: ${yamlString(input.fieldFamiliarity)}`,
+  ]
+  if (input.subtopic) {
+    lines.push(`subtopic_slug: ${yamlString(input.subtopic.slug)}`)
+    lines.push(`subtopic_title: ${yamlString(input.subtopic.title)}`)
+    lines.push(`subtopic_rationale: ${yamlString(input.subtopic.rationale)}`)
+  } else {
+    lines.push("subtopic_slug: null")
+  }
+  if (input.subtopicAlternatives.length > 0) {
+    lines.push("subtopic_alternatives:")
+    for (const alt of input.subtopicAlternatives) {
+      lines.push(`  - slug: ${yamlString(alt.slug)}`)
+      lines.push(`    title: ${yamlString(alt.title)}`)
+      lines.push(`    rationale: ${yamlString(alt.rationale)}`)
+    }
+  } else {
+    lines.push("subtopic_alternatives: []")
+  }
+  lines.push(
+    `generator: ${yamlString(input.generator)}`,
+    `model: ${yamlString(input.model)}`,
+    `prompt_hash: ${yamlString(input.promptHash)}`,
     `cost_usd: ${input.costUsd}`,
     `item_count: ${itemCount}`,
     `cited_claims: ${citedClaims}`,
     `total_claims: ${totalClaims}`,
     `topics: ${yamlList(input.interestTopics)}`,
     "---",
-  ].join("\n")
+  )
+  return lines.join("\n")
+}
 
 const renderReportIndexFrontmatter = (
   input: ReportIndexRenderInput,
@@ -234,12 +258,17 @@ export const StrictRendererLive = Layer.succeed(RendererService, {
         citedClaims,
         totalClaims,
       )
-      const header = `# ${input.interestTitle} — ${input.periodLabel}`
+      const header = input.subtopic
+        ? `# ${input.interestTitle}: ${input.subtopic.title} — ${input.periodLabel}`
+        : `# ${input.interestTitle} — ${input.periodLabel}`
       const periodLine = `_Period ${input.periodStart} → ${input.periodEnd}_`
+      const subtopicLine = input.subtopic
+        ? `_Subtopic: ${input.subtopic.title} — ${input.subtopic.rationale.trim()}_\n\n`
+        : ""
       const questionLine = input.interestQuestion
         ? `> ${input.interestQuestion}\n\n`
         : ""
-      const markdown = `${frontmatter}\n\n${header}\n\n${periodLine}\n\n${questionLine}${body}\n`
+      const markdown = `${frontmatter}\n\n${header}\n\n${periodLine}\n\n${subtopicLine}${questionLine}${body}\n`
       const result: InterestReportRenderResult = {
         markdown,
         slug,
@@ -261,9 +290,12 @@ export const StrictRendererLive = Layer.succeed(RendererService, {
         lines.push("_No interests had substantive signal this week._")
       } else {
         for (const entry of input.entries) {
+          const linkText = entry.subtopicTitle
+            ? `${entry.interestTitle}: ${entry.subtopicTitle}`
+            : entry.interestTitle
           const link = entry.publicUrl
-            ? `[${entry.interestTitle}](${entry.publicUrl})`
-            : `[[${entry.reportSlug}|${entry.interestTitle}]]`
+            ? `[${linkText}](${entry.publicUrl})`
+            : `[[${entry.reportSlug}|${linkText}]]`
           lines.push(`## ${link}`)
           lines.push("")
           if (entry.interestQuestion) {

--- a/apps/uebermensch/src/adapters/StubLlm.ts
+++ b/apps/uebermensch/src/adapters/StubLlm.ts
@@ -95,6 +95,41 @@ export const StubLlmLive = Layer.succeed(LlmService, {
       ].join("\n");
       return { answerMd, promptHash, costUsd: 0, model: STUB_MODEL };
     }),
+  proposeSubtopic: (req) =>
+    Effect.sync(() => {
+      const it = req.interest;
+      const prompt = [
+        "persona: uber-curator/stub-subtopic",
+        `period: ${req.periodLabel}`,
+        `interest: ${it.slug}`,
+        `candidates: ${it.candidates.map((c) => c.id).join(",")}`,
+      ].join("\n");
+      const promptHash = sha256(prompt);
+      const top = [...it.candidates].sort((a, b) => b.score - a.score).slice(0, 5);
+      // Deterministic stub: anchor sub-topic on the highest-scored candidate's
+      // first page topic; fall back to the interest topic if candidates empty.
+      const seed =
+        (top[0]?.page.frontmatter.topics as ReadonlyArray<string> | undefined)?.[0] ??
+        it.topics[0] ??
+        it.slug;
+      const proposalSlug = `${it.slug}--${seed}`.replace(/[^a-z0-9-]/g, "-").slice(0, 60);
+      const proposalTitle = `${it.title} — ${seed}`;
+      const proposal = {
+        slug: proposalSlug,
+        title: proposalTitle,
+        rationale: `Stub subtopic anchored on '${seed}' (top candidate signal).`,
+        relevantCandidateIds: top.map((c) => c.id),
+      };
+      return {
+        selectedSlug: proposalSlug,
+        proposals: [proposal],
+        promptHash,
+        costUsd: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        model: STUB_MODEL,
+      };
+    }),
   generateInterestReport: (req) =>
     Effect.sync(() => {
       const it = req.interest;
@@ -103,6 +138,8 @@ export const StubLlmLive = Layer.succeed(LlmService, {
         `period: ${req.periodLabel}`,
         `profile: ${req.profileName}`,
         `interest: ${it.slug}`,
+        `field_familiarity: ${it.fieldFamiliarity}`,
+        `subtopic: ${req.subtopic?.slug ?? "(none)"}`,
         `candidates: ${it.candidates.map((c) => c.id).join(",")}`,
       ].join("\n");
       const promptHash = sha256(prompt);

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -45,16 +45,19 @@ const maxItemsOpt = Options.integer("max-items-per-interest").pipe(
   Options.withDefault(5),
 )
 
+// Default to 2: hosted gateways tolerate 3+, but local OpenAI-compat backends
+// (LM Studio, Ollama) often serialize requests and drop in-flight forwards
+// when more than ~2 land at once. Bump via UBER_REPORT_CONCURRENCY for cloud.
 const envConcurrency = (): number => {
   const raw = process.env.UBER_REPORT_CONCURRENCY
-  if (!raw) return 3
+  if (!raw) return 2
   const n = Number.parseInt(raw, 10)
-  return Number.isFinite(n) && n > 0 ? n : 3
+  return Number.isFinite(n) && n > 0 ? n : 2
 }
 
 const concurrencyOpt = Options.integer("concurrency").pipe(
   Options.withDescription(
-    "Concurrent LLM calls across interests (default 3, overridable via UBER_REPORT_CONCURRENCY)",
+    "Concurrent LLM calls across interests (default 2, overridable via UBER_REPORT_CONCURRENCY)",
   ),
   Options.withDefault(envConcurrency()),
 )
@@ -243,6 +246,7 @@ export const report = Command.make(
             topics: it.topics,
             notes: it.notes,
             candidates: cands,
+            fieldFamiliarity: it.fieldFamiliarity,
           }
         })
 
@@ -252,23 +256,91 @@ export const report = Command.make(
 
         const vaultSlugs = yield* vaultSvc.listSlugs()
 
-        // One LLM call per interest, run with bounded concurrency.
-        const responses: ReadonlyArray<{
+        // Two-pass per interest: (1) propose sub-topic for the week, (2) deep-
+        // dive on the chosen sub-topic with that subtopic's relevant candidates.
+        type DeepResponse = {
           readonly input: (typeof interestInputs)[number]
+          readonly subtopicSelected: {
+            readonly slug: string
+            readonly title: string
+            readonly rationale: string
+          } | null
+          readonly subtopicAlternatives: ReadonlyArray<{
+            readonly slug: string
+            readonly title: string
+            readonly rationale: string
+          }>
+          readonly proposeCostUsd: number
           readonly response: InterestReportResponse
-        }> = yield* Effect.all(
+        }
+        const responses: ReadonlyArray<DeepResponse> = yield* Effect.all(
           interestInputs.map((ii) =>
             Effect.gen(function* () {
-              yield* Console.log(`  → ${ii.slug}: requesting deep analysis ...`)
-              const response = yield* llm.generateInterestReport({
+              yield* Console.log(`  → ${ii.slug}: proposing subtopic ...`)
+              const propose = yield* llm.proposeSubtopic({
                 periodLabel,
                 periodStart,
                 periodEnd,
                 profileName: profile.profile.identity.name,
                 interest: ii,
-                maxItems,
               })
-              return { input: ii, response }
+              const selected = propose.proposals.find(
+                (p) => p.slug === propose.selectedSlug,
+              )
+              const subtopicSelected = selected
+                ? {
+                    slug: selected.slug,
+                    title: selected.title,
+                    rationale: selected.rationale,
+                  }
+                : null
+              const subtopicAlternatives = propose.proposals
+                .filter((p) => p.slug !== propose.selectedSlug)
+                .map((p) => ({
+                  slug: p.slug,
+                  title: p.title,
+                  rationale: p.rationale,
+                }))
+              // Pass 2 always sees the full candidate pool (top up to 20):
+              // the marked-relevant ones first, then the highest-scored
+              // unmarked ones as adjacent context. A narrow subtopic with only
+              // 1–2 marked candidates was starving pass 2 below the prompt's
+              // 600-word floor; topping up gives the model enough material to
+              // write a substantive deep-dive while the subtopic prompt keeps
+              // the framing focused.
+              const MIN_DEEP_CANDIDATES = 20
+              const relevantSet = new Set(selected?.relevantCandidateIds ?? [])
+              const marked = ii.candidates.filter((c) => relevantSet.has(c.id))
+              const markedIds = new Set(marked.map((c) => c.id))
+              const fillers = ii.candidates
+                .filter((c) => !markedIds.has(c.id))
+                .slice(0, Math.max(0, MIN_DEEP_CANDIDATES - marked.length))
+              const filteredCands = [...marked, ...fillers]
+              const interestForDeep: typeof ii = {
+                ...ii,
+                candidates: filteredCands,
+              }
+              yield* Console.log(
+                subtopicSelected
+                  ? `  → ${ii.slug}: deep-dive on subtopic '${subtopicSelected.title}' (${marked.length}/${ii.candidates.length} marked relevant)`
+                  : `  → ${ii.slug}: deep-dive (no subtopic selected)`,
+              )
+              const response = yield* llm.generateInterestReport({
+                periodLabel,
+                periodStart,
+                periodEnd,
+                profileName: profile.profile.identity.name,
+                interest: interestForDeep,
+                maxItems,
+                subtopic: subtopicSelected,
+              })
+              return {
+                input: ii,
+                subtopicSelected,
+                subtopicAlternatives,
+                proposeCostUsd: propose.costUsd,
+                response,
+              }
             }),
           ),
           { concurrency },
@@ -277,6 +349,7 @@ export const report = Command.make(
         // Render per-interest reports; drop empty ones (insight-only).
         type Written = {
           readonly interest: (typeof interestInputs)[number]
+          readonly subtopicSelected: DeepResponse["subtopicSelected"]
           readonly response: InterestReportResponse
           readonly markdown: string
           readonly reportSlug: string
@@ -287,8 +360,12 @@ export const report = Command.make(
         }
         const written: Array<Written> = []
         let totalCost = 0
-        for (const { input: ii, response } of responses) {
-          totalCost += response.costUsd
+        for (const r of responses) {
+          const ii = r.input
+          const response = r.response
+          // Total cost combines pass 1 (propose) and pass 2 (deep-dive).
+          const interestCost = response.costUsd + r.proposeCostUsd
+          totalCost += interestCost
           const analysisTrim = response.analysis_md.trim()
           if (analysisTrim.length === 0 && response.items.length === 0) {
             yield* Console.log(
@@ -303,12 +380,15 @@ export const report = Command.make(
             generator: llm.name(),
             model: response.model,
             promptHash: response.promptHash,
-            costUsd: response.costUsd,
+            costUsd: interestCost,
             profileName: profile.profile.identity.name,
             interestSlug: ii.slug,
             interestTitle: ii.title,
             interestQuestion: ii.question,
             interestTopics: ii.topics,
+            fieldFamiliarity: ii.fieldFamiliarity,
+            subtopic: r.subtopicSelected,
+            subtopicAlternatives: r.subtopicAlternatives,
             analysis_md: response.analysis_md,
             items: response.items,
             candidates: ii.candidates,
@@ -322,11 +402,12 @@ export const report = Command.make(
               `  ✓ ${w.relPath} (${w.contentHash}) — ${rendered.itemCount} item(s), ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
             )
             yield* Console.log(
-              `    cost: $${response.costUsd.toFixed(4)} (in=${response.inputTokens}t out=${response.outputTokens}t model=${response.model})`,
+              `    cost: $${interestCost.toFixed(4)} (propose=$${r.proposeCostUsd.toFixed(4)} deep=$${response.costUsd.toFixed(4)} in=${response.inputTokens}t out=${response.outputTokens}t model=${response.model})`,
             )
           }
           written.push({
             interest: ii,
+            subtopicSelected: r.subtopicSelected,
             response,
             markdown: rendered.markdown,
             reportSlug: rendered.slug,
@@ -342,6 +423,7 @@ export const report = Command.make(
           interestSlug: w.interest.slug,
           interestTitle: w.interest.title,
           interestQuestion: w.interest.question,
+          subtopicTitle: w.subtopicSelected?.title ?? null,
           reportSlug: w.reportSlug,
           publicUrl: publicReportUrl(w.reportSlug),
           itemCount: w.itemCount,

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -91,18 +91,25 @@ export const TopicsConfig = Schema.Struct({
   topics: Schema.Array(TopicEntry).pipe(Schema.minItems(1)),
 })
 
+export const SourceKind = Schema.Literal("news", "paper", "research-blog", "primary")
+
 export const SourceEntry = Schema.Struct({
   slug: Slug,
   driver: Schema.String,
   cadence: Schema.String,
   topics: Schema.Array(Slug),
   url: Schema.optional(Schema.NullOr(Schema.String)),
+  // kind drives candidate ranking and renderer "Latest research" callout.
+  // Defaults to "news" when omitted (see SourceEntryDefaults).
+  kind: Schema.optional(SourceKind),
   config: Schema.optional(Schema.Unknown),
 })
 
 export const SourcesConfig = Schema.Struct({
   sources: Schema.Array(SourceEntry).pipe(Schema.minItems(1)),
 })
+
+export const FieldFamiliarity = Schema.Literal("expert", "novice")
 
 export const ResearchInterestFrontmatter = Schema.Struct({
   slug: Slug,
@@ -112,6 +119,9 @@ export const ResearchInterestFrontmatter = Schema.Struct({
   sources: Schema.optional(Schema.Array(Slug)),
   horizon: Schema.optional(Schema.Literal("short", "long", "both")),
   weight: Schema.optional(Schema.Number),
+  // expert = assume technical fluency; novice = ELI5 framing in deep-dives.
+  // Defaults to "expert" when omitted.
+  field_familiarity: Schema.optional(FieldFamiliarity),
 })
 
 export const PromptStatus = Schema.Literal("pending", "processed", "failed", "rerun")

--- a/apps/uebermensch/src/services/LlmService.ts
+++ b/apps/uebermensch/src/services/LlmService.ts
@@ -21,6 +21,8 @@ export type BriefResponse = {
   readonly model: string;
 };
 
+export type FieldFamiliarity = "expert" | "novice";
+
 export type ReportInterestInput = {
   readonly slug: string;
   readonly title: string;
@@ -28,6 +30,38 @@ export type ReportInterestInput = {
   readonly topics: ReadonlyArray<string>;
   readonly notes: string;
   readonly candidates: ReadonlyArray<CandidateRef>;
+  readonly fieldFamiliarity: FieldFamiliarity;
+};
+
+export type SubtopicProposal = {
+  readonly slug: string;
+  readonly title: string;
+  readonly rationale: string;
+  readonly relevantCandidateIds: ReadonlyArray<string>;
+};
+
+export type SubtopicProposeRequest = {
+  readonly periodLabel: string;
+  readonly periodStart: string;
+  readonly periodEnd: string;
+  readonly profileName: string;
+  readonly interest: ReportInterestInput;
+};
+
+export type SubtopicProposeResponse = {
+  readonly selectedSlug: string;
+  readonly proposals: ReadonlyArray<SubtopicProposal>;
+  readonly promptHash: string;
+  readonly costUsd: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly model: string;
+};
+
+export type ReportSubtopic = {
+  readonly slug: string;
+  readonly title: string;
+  readonly rationale: string;
 };
 
 export type InterestReportRequest = {
@@ -37,6 +71,7 @@ export type InterestReportRequest = {
   readonly profileName: string;
   readonly interest: ReportInterestInput;
   readonly maxItems: number;
+  readonly subtopic: ReportSubtopic | null;
 };
 
 export type InterestReportResponse = {
@@ -90,6 +125,9 @@ export type ResearchQueryResponse = {
 export interface LlmServiceShape {
   readonly name: () => string;
   readonly generateBrief: (req: BriefRequest) => Effect.Effect<BriefResponse, LlmError>;
+  readonly proposeSubtopic: (
+    req: SubtopicProposeRequest,
+  ) => Effect.Effect<SubtopicProposeResponse, LlmError>;
   readonly generateInterestReport: (
     req: InterestReportRequest,
   ) => Effect.Effect<InterestReportResponse, LlmError>;

--- a/apps/uebermensch/src/services/RendererService.ts
+++ b/apps/uebermensch/src/services/RendererService.ts
@@ -33,6 +33,12 @@ export type RenderResult = {
   readonly totalClaims: number
 }
 
+export type RenderedSubtopic = {
+  readonly slug: string
+  readonly title: string
+  readonly rationale: string
+}
+
 export type InterestReportRenderInput = {
   readonly periodLabel: string
   readonly periodStart: string
@@ -46,6 +52,9 @@ export type InterestReportRenderInput = {
   readonly interestTitle: string
   readonly interestQuestion: string | null
   readonly interestTopics: ReadonlyArray<string>
+  readonly fieldFamiliarity: "expert" | "novice"
+  readonly subtopic: RenderedSubtopic | null
+  readonly subtopicAlternatives: ReadonlyArray<RenderedSubtopic>
   readonly analysis_md: string
   readonly items: ReadonlyArray<CuratedItem>
   readonly candidates: ReadonlyArray<CandidateRef>
@@ -64,6 +73,7 @@ export type ReportIndexEntry = {
   readonly interestSlug: string
   readonly interestTitle: string
   readonly interestQuestion: string | null
+  readonly subtopicTitle: string | null
   readonly reportSlug: string
   readonly publicUrl: string | null
   readonly itemCount: number

--- a/apps/uebermensch/src/services/VaultService.ts
+++ b/apps/uebermensch/src/services/VaultService.ts
@@ -42,6 +42,7 @@ export type ResearchInterest = {
   readonly sources: ReadonlyArray<string>
   readonly horizon: "short" | "long" | "both" | null
   readonly weight: number | null
+  readonly fieldFamiliarity: "expert" | "novice"
   readonly notes: string
   readonly relPath: string
 }

--- a/apps/uebermensch/tests/ingest.test.ts
+++ b/apps/uebermensch/tests/ingest.test.ts
@@ -248,6 +248,7 @@ describe("HttpIngest with summarization", () => {
     Layer.succeed(LlmService, {
       name: () => "fake-llm",
       generateBrief: () => Effect.die("not used"),
+      proposeSubtopic: () => Effect.die("not used"),
       generateInterestReport: () => Effect.die("not used"),
       researchQuery: () => Effect.die("not used"),
       summarizeSource: () =>
@@ -319,6 +320,7 @@ describe("HttpIngest with summarization", () => {
     const failingLlm = Layer.succeed(LlmService, {
       name: () => "broken-llm",
       generateBrief: () => Effect.die("not used"),
+      proposeSubtopic: () => Effect.die("not used"),
       generateInterestReport: () => Effect.die("not used"),
       researchQuery: () => Effect.die("not used"),
       summarizeSource: () =>

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -161,6 +161,38 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     expect(Exit.isFailure(exit)).toBe(true)
   })
 
+  it("emits 'kernel daemon not reachable' when fetch fails with ECONNREFUSED", async () => {
+    // Simulate node fetch's exact failure shape when nothing is listening on
+    // GCTRL_KERNEL_URL: TypeError("fetch failed") with a nested cause
+    // carrying code: "ECONNREFUSED".
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:4318"), {
+      code: "ECONNREFUSED",
+    })
+    const wrapped = Object.assign(new TypeError("fetch failed"), { cause })
+    globalThis.fetch = vi.fn().mockRejectedValue(wrapped) as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.generateBrief({
+          date: "2026-04-22",
+          profileName: "Test",
+          topics: [],
+          thesesSlugs: [],
+          candidates: [],
+          maxItems: 3,
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const msg = String(exit.cause)
+      expect(msg).toContain("kernel daemon not reachable")
+      expect(msg).toContain("/api/llm/messages")
+      expect(msg).toContain("gctrld serve")
+    }
+  })
+
   it("summarizeSource posts to kernel with SUMMARY_MODEL and returns insights", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -312,5 +344,103 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
       }).pipe(Effect.provide(KernelLlmLive)),
     )
     expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it("proposeSubtopic decodes proposals and drops fabricated candidate ids", async () => {
+    const payload = anthropicJson({
+      proposals: [
+        {
+          slug: "japan-macro--boj-private-credit",
+          title: "BoJ flags private-credit linkages",
+          rationale: "BoJ research review highlights JP banks' BDC exposure.",
+          // First id is real; second is fabricated (not in the input set).
+          relevant_candidate_ids: ["cand-0000", "cand-fake"],
+        },
+        {
+          slug: "japan-macro--takaichi-arms-exports",
+          title: "Takaichi loosens lethal-arms export rules",
+          rationale: "Policy shift opens defense-industrial revenue.",
+          relevant_candidate_ids: ["cand-0001"],
+        },
+      ],
+      selected_slug: "japan-macro--boj-private-credit",
+    })
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    }) as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.proposeSubtopic({
+          periodLabel: "2026-W18",
+          periodStart: "2026-04-21",
+          periodEnd: "2026-04-28",
+          profileName: "Test",
+          interest: {
+            slug: "japan-macro",
+            title: "Japan macroeconomics",
+            question: "What's moving BoJ policy this week?",
+            topics: ["japan-macro"],
+            notes: "",
+            fieldFamiliarity: "expert",
+            candidates: [
+              candidate("cand-0000", "2026-04-22--boj-rev26e01", "BoJ private credit body.", ["japan-macro"]),
+              candidate("cand-0001", "2026-04-22--bbc-takaichi-arms", "Takaichi arms body.", ["japan-politics"]),
+            ],
+          },
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+
+    expect(result.selectedSlug).toBe("japan-macro--boj-private-credit")
+    expect(result.proposals).toHaveLength(2)
+    // Fabricated id was dropped, real one retained.
+    expect(result.proposals[0].relevantCandidateIds).toEqual(["cand-0000"])
+    expect(result.proposals[1].relevantCandidateIds).toEqual(["cand-0001"])
+  })
+
+  it("proposeSubtopic falls back to first proposal when selected_slug is unknown", async () => {
+    const payload = anthropicJson({
+      proposals: [
+        {
+          slug: "real-slug",
+          title: "Real",
+          rationale: "ok",
+          relevant_candidate_ids: ["cand-0000"],
+        },
+      ],
+      selected_slug: "hallucinated-slug-not-in-proposals",
+    })
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    }) as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LlmService
+        return yield* llm.proposeSubtopic({
+          periodLabel: "2026-W18",
+          periodStart: "2026-04-21",
+          periodEnd: "2026-04-28",
+          profileName: "Test",
+          interest: {
+            slug: "japan-macro",
+            title: "Japan macroeconomics",
+            question: null,
+            topics: ["japan-macro"],
+            notes: "",
+            fieldFamiliarity: "expert",
+            candidates: [candidate("cand-0000", "stem", "body", ["japan-macro"])],
+          },
+        })
+      }).pipe(Effect.provide(KernelLlmLive)),
+    )
+
+    expect(result.selectedSlug).toBe("real-slug")
   })
 })

--- a/apps/uebermensch/tests/renderer.test.ts
+++ b/apps/uebermensch/tests/renderer.test.ts
@@ -5,6 +5,7 @@ import type { CandidateRef } from "../src/lib/candidates.js"
 import {
   RendererService,
   type CuratedItem,
+  type InterestReportRenderInput,
   type RenderInput,
 } from "../src/services/RendererService.js"
 import type { WikiPage } from "../src/services/VaultService.js"
@@ -149,6 +150,92 @@ describe("StrictRenderer", () => {
       run(baseInput(items, ["alpha"], [cand("cand-0000", "alpha")])),
     )
     expect(result.markdown).toContain("[[alpha|the Alpha report]]")
+  })
+})
+
+describe("StrictRenderer.renderInterestReport — subtopic + field_familiarity", () => {
+  const runReport = (input: InterestReportRenderInput) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const r = yield* RendererService
+        return yield* r.renderInterestReport(input)
+      }).pipe(Effect.provide(StrictRendererLive)),
+    )
+
+  const cands = [cand("cand-0000", "alpha-source")]
+
+  it("frontmatter and title surface the selected subtopic", async () => {
+    const result = await runReport({
+      periodLabel: "2026-W18",
+      periodStart: "2026-04-21",
+      periodEnd: "2026-04-28",
+      generator: "stub",
+      model: "stub-llm",
+      promptHash: "sha256:" + "0".repeat(64),
+      costUsd: 0,
+      profileName: "Test",
+      interestSlug: "japan-macro",
+      interestTitle: "Japan macroeconomics",
+      interestQuestion: "What's moving BoJ policy?",
+      interestTopics: ["japan-macro"],
+      fieldFamiliarity: "expert",
+      subtopic: {
+        slug: "japan-macro--boj-private-credit",
+        title: "BoJ flags private-credit linkages",
+        rationale: "BoJ research review highlights JP banks' BDC exposure.",
+      },
+      subtopicAlternatives: [
+        {
+          slug: "japan-macro--takaichi-arms-exports",
+          title: "Takaichi loosens arms-export rules",
+          rationale: "Policy shift opens defense revenue.",
+        },
+      ],
+      analysis_md:
+        "### Thesis\n\nBoJ supervisory shift on private credit [[alpha-source]].\n\n### Key developments\n\nDetails [[alpha-source]].\n\n### Cross-currents\n\nNone notable.\n\n### Implications\n\nBank capital buffers [[alpha-source]].\n\n### Open questions\n\n- Will rules tighten?",
+      items: [],
+      candidates: cands,
+      vaultSlugs: new Set(["alpha-source"]),
+    })
+    expect(result.markdown).toContain(
+      '# Japan macroeconomics: BoJ flags private-credit linkages — 2026-W18',
+    )
+    expect(result.markdown).toContain('subtopic_slug: "japan-macro--boj-private-credit"')
+    expect(result.markdown).toContain(
+      'subtopic_title: "BoJ flags private-credit linkages"',
+    )
+    expect(result.markdown).toContain('field_familiarity: "expert"')
+    expect(result.markdown).toContain("subtopic_alternatives:")
+    expect(result.markdown).toContain('slug: "japan-macro--takaichi-arms-exports"')
+  })
+
+  it("falls back to umbrella title when no subtopic was selected", async () => {
+    const result = await runReport({
+      periodLabel: "2026-W18",
+      periodStart: "2026-04-21",
+      periodEnd: "2026-04-28",
+      generator: "stub",
+      model: "stub-llm",
+      promptHash: "sha256:" + "0".repeat(64),
+      costUsd: 0,
+      profileName: "Test",
+      interestSlug: "japan-macro",
+      interestTitle: "Japan macroeconomics",
+      interestQuestion: null,
+      interestTopics: ["japan-macro"],
+      fieldFamiliarity: "novice",
+      subtopic: null,
+      subtopicAlternatives: [],
+      analysis_md:
+        "### Thesis\n\nUmbrella thesis [[alpha-source]].\n\n### Key developments\n\nDetails [[alpha-source]].\n\n### Cross-currents\n\nNo cross-currents.\n\n### Implications\n\nFlows [[alpha-source]].\n\n### Open questions\n\n- Watch the JGB curve.",
+      items: [],
+      candidates: cands,
+      vaultSlugs: new Set(["alpha-source"]),
+    })
+    expect(result.markdown).toContain("# Japan macroeconomics — 2026-W18")
+    expect(result.markdown).toContain("subtopic_slug: null")
+    expect(result.markdown).toContain("subtopic_alternatives: []")
+    expect(result.markdown).toContain('field_familiarity: "novice"')
   })
 })
 

--- a/apps/uebermensch/tests/report.test.ts
+++ b/apps/uebermensch/tests/report.test.ts
@@ -86,6 +86,7 @@ describe("weekly report (per-interest deep analysis + stub LLM + strict renderer
           topics: it.topics,
           notes: it.notes,
           candidates: cands,
+          fieldFamiliarity: it.fieldFamiliarity,
         }
       })
       // Each interest sees only its own candidate.
@@ -102,6 +103,19 @@ describe("weekly report (per-interest deep analysis + stub LLM + strict renderer
       const entries: Array<ReportIndexEntry> = []
 
       for (const ii of inputs) {
+        const propose = yield* llm.proposeSubtopic({
+          periodLabel: "2026-W17",
+          periodStart: "2026-04-15",
+          periodEnd: "2026-04-22",
+          profileName: "Test",
+          interest: ii,
+        })
+        const selected = propose.proposals.find((p) => p.slug === propose.selectedSlug)
+        const subtopic = selected
+          ? { slug: selected.slug, title: selected.title, rationale: selected.rationale }
+          : null
+        expect(subtopic).not.toBeNull()
+
         const response = yield* llm.generateInterestReport({
           periodLabel: "2026-W17",
           periodStart: "2026-04-15",
@@ -109,6 +123,7 @@ describe("weekly report (per-interest deep analysis + stub LLM + strict renderer
           profileName: "Test",
           interest: ii,
           maxItems: 3,
+          subtopic,
         })
         expect(response.interestSlug).toBe(ii.slug)
         expect(response.analysis_md).toContain("### Thesis")
@@ -127,6 +142,11 @@ describe("weekly report (per-interest deep analysis + stub LLM + strict renderer
           interestTitle: ii.title,
           interestQuestion: ii.question,
           interestTopics: ii.topics,
+          fieldFamiliarity: ii.fieldFamiliarity,
+          subtopic,
+          subtopicAlternatives: propose.proposals
+            .filter((p) => p.slug !== propose.selectedSlug)
+            .map((p) => ({ slug: p.slug, title: p.title, rationale: p.rationale })),
           analysis_md: response.analysis_md,
           items: response.items,
           candidates: ii.candidates,
@@ -145,6 +165,7 @@ describe("weekly report (per-interest deep analysis + stub LLM + strict renderer
           interestSlug: ii.slug,
           interestTitle: ii.title,
           interestQuestion: ii.question,
+          subtopicTitle: subtopic?.title ?? null,
           reportSlug: rendered.slug,
           publicUrl: null,
           itemCount: rendered.itemCount,

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -3527,10 +3527,14 @@ async fn llm_messages(
 
 // --- LLM Driver: Workers AI (OpenAI-compat Chat Completions) ---
 //
-// Forwards OpenAI-shape Chat Completions payloads through Cloudflare AI Gateway
-// to Cloudflare Workers AI models (e.g. `@cf/google/gemma-4-26b-a4b-it`).
+// Forwards OpenAI-shape Chat Completions payloads to either:
+//   1. A locally-served OpenAI-compat backend (LM Studio, Ollama, vLLM, …)
+//      when GCTRL_LLM_LOCAL_URL is set. The full URL is forwarded as-is, so
+//      typical values are e.g. `http://localhost:1234/v1/chat/completions`.
+//      No CF gateway / token required in this mode — keeps inference local.
+//   2. Cloudflare AI Gateway → Workers AI (`@cf/...` models) otherwise.
 //
-// Required env:
+// Required env when GCTRL_LLM_LOCAL_URL is unset:
 //   CLOUDFLARE_ACCOUNT_ID        — CF account owning the gateway
 //   CLOUDFLARE_AI_GATEWAY_ID     — slug of the AI Gateway
 //   CF_API_TOKEN                 — Cloudflare API token with Workers AI read
@@ -3540,6 +3544,34 @@ async fn llm_completions(
     State(state): State<Arc<AppState>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    if let Ok(local_url) = std::env::var("GCTRL_LLM_LOCAL_URL") {
+        let mut req = state
+            .http_client
+            .post(&local_url)
+            .header("content-type", "application/json");
+        if let Ok(token) = std::env::var("GCTRL_LLM_LOCAL_TOKEN") {
+            req = req.header("authorization", format!("Bearer {token}"));
+        }
+        return match req.json(&body).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                if status.is_success() {
+                    match serde_json::from_str::<serde_json::Value>(&text) {
+                        Ok(v) => Json(v).into_response(),
+                        Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
+                    }
+                } else {
+                    (messaging_upstream_status(status), text).into_response()
+                }
+            }
+            Err(e) => (
+                StatusCode::BAD_GATEWAY,
+                format!("local llm request failed: {e}"),
+            )
+                .into_response(),
+        };
+    }
     let Ok(account_id) = std::env::var("CLOUDFLARE_ACCOUNT_ID") else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/kernel/crates/gctrl-otel/tests/net_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/net_routes.rs
@@ -245,10 +245,12 @@ async fn llm_completions_fails_closed_without_gateway_config() {
     let prev_acct = std::env::var("CLOUDFLARE_ACCOUNT_ID").ok();
     let prev_gw = std::env::var("CLOUDFLARE_AI_GATEWAY_ID").ok();
     let prev_cf_tok = std::env::var("CF_API_TOKEN").ok();
+    let prev_local = std::env::var("GCTRL_LLM_LOCAL_URL").ok();
     unsafe {
         std::env::remove_var("CLOUDFLARE_ACCOUNT_ID");
         std::env::remove_var("CLOUDFLARE_AI_GATEWAY_ID");
         std::env::remove_var("CF_API_TOKEN");
+        std::env::remove_var("GCTRL_LLM_LOCAL_URL");
     }
     let app = router_with(NetConfig::default());
     let probe_body = serde_json::json!({
@@ -285,6 +287,9 @@ async fn llm_completions_fails_closed_without_gateway_config() {
         }
         if let Some(v) = prev_cf_tok {
             std::env::set_var("CF_API_TOKEN", v);
+        }
+        if let Some(v) = prev_local {
+            std::env::set_var("GCTRL_LLM_LOCAL_URL", v);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Two-pass subtopic flow**: weekly reports now propose 1–3 sharply-focused sub-topics for each interest then deep-dive on the chosen one. Subtopic + alternatives recorded in frontmatter for eval signal. Fixes the "same umbrella thesis every week" problem.
- **In-field vs out-of-field expertise** per interest (`field_familiarity: expert | novice`). Novice mode produces ELI5 deep-dives with inline jargon definitions and "Plain English:" callouts.
- **State-of-the-art research source kind** (`news | paper | research-blog | primary`) on `sources.md` entries. Candidate blocks expose `source_kind` so deep-dives can render a "### Latest research" section when paper/research-blog candidates are present.
- **Local-LLM forwarder** in the kernel: `/api/llm/completions` forwards to `GCTRL_LLM_LOCAL_URL` when set (LM Studio / Ollama), bypassing CF AI Gateway entirely. $0 inference, fully local.
- Default `report` concurrency 3 → 2 (local backends often serialize requests).
- ECONNREFUSED detection on the uebermensch side routes to a "kernel daemon not reachable" hint instead of generic fetch-failed.

## How it works

```
proposeSubtopic(interest, 20 cands)            ── pass 1 ──▶ {proposals[], selected_slug}
generateInterestReport(interest, subtopic, 20 cands top-up) ── pass 2 ──▶ {analysis_md, items}
```

Pass 2 sees the **full pool** (top-up to 20) so a narrow subtopic with only 1–2 marked candidates doesn't starve the deep-dive below the prompt's word floor — marked-relevant candidates come first, the rest serve as adjacent context for cross-currents.

## End-to-end smoke (gemma-4-31b via LM Studio)

1 interest (`japan-aging-healthcare`), `field_familiarity: novice`, `--concurrency 1`:

- Pass 1 picked **"Prudential Financial Mis-selling Scandal in Japan"** (1 of 20 marked relevant) — sharp news-led angle, not the umbrella.
- Pass 2 wrote `reports/2026-W18--japan-aging-healthcare.md`: 600+ word report, 2 `Plain English:` callouts, inline LTCI / BDC / FSA definitions, pulled adjacent BoJ BDC candidates into cross-currents.
- Cost: **$0.0000** (16,657 in / 3,976 out tokens local).
- Frontmatter:
  ```yaml
  field_familiarity: "novice"
  subtopic_slug: "prudential-japan-mis-selling"
  subtopic_title: "Prudential Financial Mis-selling Scandal in Japan"
  subtopic_rationale: "Prudential's extended sales pause reflects regulatory and trust issues..."
  subtopic_alternatives: []
  ```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 140 passing (was 136). New tests:
  - `kernel-llm.test.ts`: `proposeSubtopic` decodes + drops fabricated candidate ids; falls back to first proposal when `selected_slug` is unknown
  - `renderer.test.ts`: subtopic + `field_familiarity` appear in frontmatter and title; fallback to umbrella when no subtopic selected
  - `report.test.ts`: updated for two-pass orchestration with subtopic threading through to the renderer
- [x] End-to-end smoke against local gemma-4-31b (see above)
- [ ] Verify cloud gateway path still works after merge (Anthropic + CF Workers AI)

## Out of scope (Phase B)

- Arxiv / Semantic Scholar ingestion adapters
- Auto-discovery of research blogs into `sources.md`
- Source-kind-aware ranking boost in `selectCandidates` (papers don't go stale in a week)
