### PR TITLE
test(analytics): acceptance suite for dashboard + LLM relay e2e

### DIFF
--- a/apps/gctrl-board/playwright.config.ts
+++ b/apps/gctrl-board/playwright.config.ts
@@ -23,6 +23,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const KERNEL_PORT = Number(process.env.GCTRL_KERNEL_PORT ?? 14318)
 const VITE_PORT = Number(process.env.GCTRL_VITE_PORT ?? 14200)
+// LLM relay path: kernel forwards /v1/chat/completions to a mock OpenAI-compat
+// server we boot alongside the kernel. Tests POST through the relay port and
+// assert the captured prompt/span lands in /api/sessions + /api/analytics.
+const RELAY_PORT = Number(process.env.GCTRL_RELAY_PORT ?? 14319)
+const MOCK_LLM_PORT = Number(process.env.MOCK_LLM_PORT ?? 14299)
 
 // Remote mode: drive a (deployed) Worker at PREVIEW_URL. Browser is either
 // local Chromium (fallback) or Cloudflare Browser Rendering CDP (set
@@ -33,9 +38,10 @@ const isRemoteCDP = isRemote && !!process.env.CDP_ENDPOINT
 
 // In CI, use the pre-built kernel binary to avoid needing cargo/Rust toolchain.
 // Set GCTRL_KERNEL_BIN to the absolute path of the gctrl binary.
+const kernelBaseArgs = `--db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT} --relay-port ${RELAY_PORT} --relay-upstream http://127.0.0.1:${MOCK_LLM_PORT}/v1/chat/completions`
 const kernelCommand = process.env.GCTRL_KERNEL_BIN
-  ? `${process.env.GCTRL_KERNEL_BIN} --db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT}`
-  : `cargo run -p gctrl-cli -- --db :memory: serve --host 127.0.0.1 --port ${KERNEL_PORT}`
+  ? `${process.env.GCTRL_KERNEL_BIN} ${kernelBaseArgs}`
+  : `cargo run -p gctrl-cli -- ${kernelBaseArgs}`
 
 export default defineConfig({
   testDir: "./tests/acceptance",
@@ -46,6 +52,13 @@ export default defineConfig({
         testIgnore: [
           "**/agent-integration.spec.ts",
           "**/markdown-sync.spec.ts",
+          // Remote Workers don't expose /v1/traces or the LLM relay port,
+          // and the mock-llm-server is only booted by the local webServer.
+          "**/analytics-llm-relay.spec.ts",
+          // Analytics dashboard tests seed via /v1/traces, which is
+          // kernel-only. Skip in remote mode for the same reason as
+          // agent-integration above.
+          "**/analytics-dashboard.spec.ts",
         ],
       }
     : {}),
@@ -95,6 +108,19 @@ export default defineConfig({
     ? {}
     : {
         webServer: [
+          {
+            // Mock OpenAI-compat upstream for the kernel LLM relay. Must
+            // start before the kernel so the relay's first request to
+            // it succeeds; playwright launches webServers in parallel,
+            // but we use `port` health checks so the kernel only waits
+            // on its own port and bringup ordering doesn't matter as
+            // long as both ports come up before the first test.
+            command: `node tests/acceptance/fixtures/mock-llm-server.cjs`,
+            port: MOCK_LLM_PORT,
+            reuseExistingServer: !process.env.CI,
+            env: { MOCK_LLM_PORT: String(MOCK_LLM_PORT) },
+            timeout: 30_000,
+          },
           {
             // Kernel: in-memory DuckDB for full test isolation
             command: kernelCommand,

--- a/apps/gctrl-board/tests/acceptance/analytics-dashboard.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/analytics-dashboard.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * Analytics Dashboard — acceptance tests
+ *
+ * Drives the /analytics/* page tree against a live kernel:
+ *
+ *   Overview     — KPIs + cost-by-model/cost-by-agent tables
+ *   Sessions     — list / timeline / heatmap views, detail pane
+ *   Usage        — providers / tools / latency / span distribution
+ *   Evals        — alert rules + score lookup form
+ *   Contributions — PR table (graceful when `gh` is unavailable)
+ *
+ * Data is seeded via direct kernel HTTP (`/v1/traces`) bypassing the UI.
+ * Each test creates its own session ids so the in-memory kernel — which is
+ * shared across the suite by the playwright webServer — stays loosely
+ * isolated. Filters are kind-aware: traces ingested through `/v1/traces`
+ * land as `created_by=otel_ingest` ⇒ `kind=external`.
+ */
+import { test, expect } from "./fixtures/test"
+import { hexId } from "./fixtures/kernel"
+
+interface SeededSession {
+  sessionId: string
+  agentName: string
+  model: string
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+}
+
+/**
+ * Seed a single completed external session with one Generation span.
+ * Returns the params so tests can assert on agent name / model / cost.
+ */
+async function seedExternalSession(
+  kernel: import("./fixtures/kernel").KernelTestClient,
+  overrides?: Partial<SeededSession>,
+): Promise<SeededSession> {
+  const stamp = Date.now().toString(36).slice(-4)
+  const seeded: SeededSession = {
+    sessionId: overrides?.sessionId ?? `sess-${stamp}-${hexId(6)}`,
+    agentName: overrides?.agentName ?? `analytics-agent-${stamp}`,
+    model: overrides?.model ?? "test-model-v1",
+    costUsd: overrides?.costUsd ?? 0.1234,
+    inputTokens: overrides?.inputTokens ?? 1500,
+    outputTokens: overrides?.outputTokens ?? 850,
+  }
+  await kernel.ingestTrace({
+    traceId: hexId(32),
+    spanId: hexId(16),
+    sessionId: seeded.sessionId,
+    agentName: seeded.agentName,
+    spanName: "chat.completion",
+    model: seeded.model,
+    costUsd: seeded.costUsd,
+    inputTokens: seeded.inputTokens,
+    outputTokens: seeded.outputTokens,
+    durationMs: 1200,
+  })
+  // End the session so it shows up as `completed` in the list, which
+  // matches what the dashboard renders by default. Live sessions are
+  // exercised separately by the timeline view test below.
+  await kernel.endSession(seeded.sessionId, "completed")
+  return seeded
+}
+
+test.describe("Analytics Dashboard", () => {
+  test("renders all five tabs and routes update via the URL", async ({ page }) => {
+    await page.goto("/analytics")
+    await expect(page.getByRole("tab", { name: "Overview" })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Sessions" })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Usage" })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Evals" })).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Contributions" })).toBeVisible()
+
+    // Click each tab and confirm the URL pushed and the tab body changed.
+    await page.getByRole("tab", { name: "Sessions" }).click()
+    await expect(page).toHaveURL(/\/analytics\/sessions/)
+    await expect(
+      page.locator('[data-testid="sessions-view-list"]'),
+    ).toBeVisible()
+
+    await page.getByRole("tab", { name: "Usage" }).click()
+    await expect(page).toHaveURL(/\/analytics\/usage/)
+    // Usage tab loads three rollups in parallel; the first heading is enough
+    // to confirm the body switched even if the data is empty.
+    await expect(
+      page.getByText(/Providers — cost by model/i),
+    ).toBeVisible()
+
+    await page.getByRole("tab", { name: "Evals" }).click()
+    await expect(page).toHaveURL(/\/analytics\/evals/)
+    await expect(page.getByText(/Score lookup/i)).toBeVisible()
+    // The page renders an "Alert rules" panel header AND, when empty,
+    // a "No alert rules configured." body. Either is sufficient — the
+    // heading is the more stable signal that the panel mounted.
+    await expect(
+      page.getByRole("heading", { name: /Alert rules/i }),
+    ).toBeVisible()
+
+    await page.getByRole("tab", { name: "Contributions" }).click()
+    await expect(page).toHaveURL(/\/analytics\/contributions/)
+    await expect(page.getByPlaceholder("owner/repo")).toBeVisible()
+
+    await page.getByRole("tab", { name: "Overview" }).click()
+    await expect(page).toHaveURL(/\/analytics\/overview/)
+  })
+
+  test("Overview KPIs reflect seeded sessions", async ({ page, kernel }) => {
+    const before = await kernel.getAnalytics()
+    const seeded = await seedExternalSession(kernel)
+
+    await page.goto("/analytics/overview")
+
+    // total sessions and total spans must each have grown by at least 1.
+    await expect
+      .poll(
+        async () => {
+          const a = await kernel.getAnalytics()
+          return (
+            a.total_sessions >= before.total_sessions + 1 &&
+            a.total_spans >= before.total_spans + 1
+          )
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(true)
+
+    // The cost is rolled up into the total. The label is `Total cost` (no
+    // suffix) when kind=all is active, which is the default. We use a
+    // partial regex because the exact value depends on suite ordering.
+    const totalCard = page
+      .locator("div", { hasText: /Total cost$/ })
+      .first()
+    await expect(totalCard).toBeVisible()
+
+    // Cost by agent table should include the seeded service name once
+    // /api/analytics/cost has caught up with the ingest. The page polls
+    // its own state via the SSE stream, so a hard reload is the simplest
+    // way to force a deterministic re-fetch under test conditions.
+    await page.reload()
+    await expect(
+      page.getByRole("cell", { name: seeded.agentName }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test("Sessions tab list view shows the seeded row with model + cost", async ({
+    page,
+    kernel,
+  }) => {
+    const seeded = await seedExternalSession(kernel)
+
+    await page.goto("/analytics/sessions")
+
+    // Wait for the row keyed by agent name. The list is virtualized only
+    // implicitly (no windowing component), so a substring match is fine.
+    const row = page
+      .getByRole("row")
+      .filter({ hasText: seeded.agentName })
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await expect(row).toContainText(`$${seeded.costUsd.toFixed(4)}`)
+    const totalTokens = (
+      seeded.inputTokens + seeded.outputTokens
+    ).toLocaleString()
+    await expect(row).toContainText(totalTokens)
+  })
+
+  test("Sessions view-mode switcher cycles through list / timeline / heatmap", async ({
+    page,
+    kernel,
+  }) => {
+    await seedExternalSession(kernel)
+
+    await page.goto("/analytics/sessions")
+    await expect(
+      page.locator('[data-testid="sessions-view-list"]'),
+    ).toBeVisible()
+
+    await page.locator('[data-testid="sessions-view-timeline"]').click()
+    // Timeline body has no role=table; the toggle going pressed is enough
+    // to confirm the renderer switched. Radix sets data-state=on on press.
+    await expect(
+      page.locator('[data-testid="sessions-view-timeline"]'),
+    ).toHaveAttribute("data-state", "on")
+
+    await page.locator('[data-testid="sessions-view-heatmap"]').click()
+    await expect(
+      page.locator('[data-testid="sessions-view-heatmap"]'),
+    ).toHaveAttribute("data-state", "on")
+
+    await page.locator('[data-testid="sessions-view-list"]').click()
+    await expect(
+      page.locator('[data-testid="sessions-view-list"]'),
+    ).toHaveAttribute("data-state", "on")
+  })
+
+  test("Usage tab surfaces cost-by-model and span distribution", async ({
+    page,
+    kernel,
+  }) => {
+    const seeded = await seedExternalSession(kernel, {
+      model: `usage-model-${Date.now().toString(36).slice(-4)}`,
+    })
+
+    await page.goto("/analytics/usage")
+
+    // Cost-by-model is the first panel; the seeded model + its formatted
+    // cost should appear once /api/analytics/cost has the row. The model
+    // label also shows up in latency-by-model below, hence `.first()`.
+    await expect(
+      page.getByRole("cell", { name: seeded.model }).first(),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(
+      page
+        .getByRole("row")
+        .filter({ hasText: seeded.model })
+        .getByText(`$${seeded.costUsd.toFixed(4)}`)
+        .first(),
+    ).toBeVisible()
+
+    // The Generation span type should appear in the distribution. The
+    // exact percentage depends on suite ordering — only check the row
+    // exists.
+    await expect(
+      page.getByText("generation", { exact: false }),
+    ).toBeVisible()
+  })
+
+  test("kind filter narrows totals to external", async ({ page, kernel }) => {
+    await seedExternalSession(kernel)
+
+    await page.goto("/analytics/overview")
+    await page.locator('[data-testid="kind-external"]').click()
+
+    // KPIs re-fetch with ?kind=external — total_sessions for external
+    // must equal what /api/analytics?kind=external reports (which is at
+    // least 1 since we just seeded an external row).
+    await expect
+      .poll(
+        async () => {
+          const a = await kernel.getAnalytics("external")
+          return a.total_sessions >= 1
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(true)
+
+    // The "Total sessions (external)" KPI label appears once the filter
+    // applies — it's the same Kpi component, just with a kind suffix.
+    await expect(
+      page.getByText(/Total sessions \(external\)/i),
+    ).toBeVisible()
+  })
+
+  test("Evals tab — score lookup renders zeros for an unknown rule", async ({
+    page,
+  }) => {
+    await page.goto("/analytics/evals")
+
+    const form = page.locator("form").filter({
+      has: page.getByPlaceholder(/score name/i),
+    })
+    await form.getByPlaceholder(/score name/i).fill("definitely_no_such_score")
+    await form.getByRole("button", { name: /lookup/i }).click()
+
+    // The kernel returns 200 + a zero-filled summary for an unknown name
+    // (rather than 404), so the panel renders the four KPI cards with
+    // zeros and a 0.0% pass rate.
+    const passRateCard = page
+      .locator("div")
+      .filter({ hasText: /^Pass rate$/ })
+      .first()
+    await expect(passRateCard).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText("0.0%")).toBeVisible()
+  })
+
+  test("Contributions tab renders the repo selector and table shell", async ({
+    page,
+  }) => {
+    await page.goto("/analytics/contributions")
+    await expect(page.getByPlaceholder("owner/repo")).toBeVisible()
+    // The default repo is OpenHackersClub/gctrl; the input is pre-filled
+    // either with that or the localStorage override. Either way the
+    // value should look like owner/repo.
+    const input = page.getByPlaceholder("owner/repo")
+    const value = await input.inputValue()
+    expect(value).toMatch(/^[\w-]+\/[\w-]+$/)
+    // The table either renders rows or an empty-state — both are valid
+    // depending on whether `gh` is authed on the host. Just confirm the
+    // page didn't crash.
+    await expect(page.getByText(/Contributions/i).first()).toBeVisible()
+  })
+})
+
+test.describe("Analytics Dashboard — CDP observability", () => {
+  test("no console errors while clicking through every tab", async ({
+    page,
+    cdp,
+    kernel,
+  }) => {
+    await seedExternalSession(kernel)
+
+    await page.goto("/analytics/overview")
+    cdp.clearConsole()
+
+    for (const tab of ["Sessions", "Usage", "Evals", "Contributions", "Overview"]) {
+      await page.getByRole("tab", { name: tab }).click()
+      // Give each tab a beat to load its data — purely to flush any
+      // promise-rejection noise into the console capture.
+      await page.waitForTimeout(250)
+    }
+
+    const errors = cdp.getConsoleErrors()
+    // Filter out noise from analytics_sync_status: in local dev there's
+    // no Worker, so the route 404s. The page swallows it via .catch and
+    // it produces a network 404 (not a console error), so this filter
+    // is defensive — if it fires, we still want to know.
+    const realErrors = errors.filter(
+      (e) => !e.text.includes("/api/analytics/sync-status"),
+    )
+    expect(realErrors).toHaveLength(0)
+  })
+
+  test("all analytics requests are JSON and complete with 2xx", async ({
+    page,
+    cdp,
+    kernel,
+  }) => {
+    await seedExternalSession(kernel)
+
+    await page.goto("/analytics/overview")
+    await expect(
+      page.getByRole("tab", { name: "Overview" }),
+    ).toHaveAttribute("data-state", "active")
+    await page.getByRole("tab", { name: "Usage" }).click()
+    await page.waitForTimeout(500)
+
+    const analyticsReqs = cdp
+      .getRequests()
+      .filter((r) => {
+        try {
+          const url = new URL(r.url)
+          return (
+            url.pathname.startsWith("/api/analytics") ||
+            url.pathname.startsWith("/api/sessions") ||
+            url.pathname.startsWith("/api/net")
+          )
+        } catch {
+          return false
+        }
+      })
+
+    expect(analyticsReqs.length).toBeGreaterThan(0)
+
+    for (const req of analyticsReqs) {
+      // sync-status is a Worker-only endpoint and 404s in local dev. The
+      // page tolerates that explicitly. Skip it for the 2xx assertion.
+      if (req.url.includes("/api/analytics/sync-status")) continue
+
+      // SSE long-polls don't carry a final status here; only assert when
+      // a status was captured.
+      if (req.responseStatus != null) {
+        expect(
+          req.responseStatus,
+          `${req.url} returned ${req.responseStatus}`,
+        ).toBeLessThan(400)
+      }
+    }
+  })
+})

--- a/apps/gctrl-board/tests/acceptance/analytics-llm-relay.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/analytics-llm-relay.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Analytics — Local LLM relay end-to-end
+ *
+ * Drives a real prompt through the kernel's LLM relay and asserts the
+ * resulting span/cost/prompt is captured AND surfaces in the analytics
+ * dashboard.
+ *
+ * Wiring (set up by playwright.config.ts):
+ *
+ *     test → :RELAY_PORT/v1/chat/completions   (gctrl-proxy LlmRelay)
+ *           ↓ forwards to
+ *     mock LM Studio on :MOCK_LLM_PORT          (fixtures/mock-llm-server.cjs)
+ *           ↓ relay captures + emits OTLP span back to
+ *     kernel :KERNEL_PORT/v1/traces             (gctrl-otel receiver)
+ *           ↓ persists prompt body + span row in DuckDB :memory:
+ *     /api/sessions, /api/analytics, /api/sessions/{id}/prompts
+ *           ↓ rendered by Worker / Vite proxy at /analytics/*
+ *     dashboard
+ *
+ * The relay's `derive_gen_ai_system` returns "lmstudio" for upstream URLs
+ * containing 127.0.0.1:1234 — our mock listens on a different port, so the
+ * `gen_ai.system` attribute will be absent. That's fine: cost-by-model and
+ * the sessions table key off `model` and `service.name`, both of which we
+ * control via the request body / x-service-name header.
+ */
+import { test, expect } from "./fixtures/test"
+
+const RELAY_PORT = Number(process.env.GCTRL_RELAY_PORT ?? 14319)
+const RELAY_URL = `http://127.0.0.1:${RELAY_PORT}/v1/chat/completions`
+const MOCK_LLM_PORT = Number(process.env.MOCK_LLM_PORT ?? 14299)
+
+interface RelayCallResult {
+  sessionId: string
+  serviceName: string
+  model: string
+  responseStatus: number
+  responseBody: any
+}
+
+async function callRelay(opts?: {
+  sessionId?: string
+  serviceName?: string
+  model?: string
+  prompt?: string
+}): Promise<RelayCallResult> {
+  const stamp = Date.now().toString(36).slice(-5)
+  const sessionId = opts?.sessionId ?? `relay-sess-${stamp}`
+  const serviceName = opts?.serviceName ?? `relay-svc-${stamp}`
+  const model = opts?.model ?? `mock-llm-model-${stamp}`
+  const prompt = opts?.prompt ?? "Hello relay — please record this turn."
+
+  const res = await fetch(RELAY_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-session-id": sessionId,
+      "x-service-name": serviceName,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: "You are a deterministic test stand-in." },
+        { role: "user", content: prompt },
+      ],
+    }),
+  })
+  const responseBody = await res.json()
+  return { sessionId, serviceName, model, responseStatus: res.status, responseBody }
+}
+
+test.describe("LLM relay → kernel → analytics dashboard", () => {
+  test("relay forwards to the mock upstream and returns a 200 chat completion", async () => {
+    const result = await callRelay()
+    expect(result.responseStatus).toBe(200)
+    expect(result.responseBody?.choices?.[0]?.message?.content).toMatch(/mock reply/)
+    // Mock pins usage counts so we can verify the relay is talking to the
+    // right upstream (and not a stale local LM Studio that happens to run
+    // on the same machine).
+    expect(result.responseBody?.usage?.prompt_tokens).toBe(42)
+    expect(result.responseBody?.usage?.completion_tokens).toBe(17)
+  })
+
+  test("captured prompt + span land in kernel storage", async ({ kernel }) => {
+    const result = await callRelay()
+    expect(result.responseStatus).toBe(200)
+
+    // Relay emits OTLP asynchronously after the response — poll until the
+    // session row exists.
+    await expect
+      .poll(
+        async () => {
+          const sessions = await kernel.getSessions({ limit: 50 })
+          return sessions.find((s: any) => s.id === result.sessionId)
+        },
+        { timeout: 10_000, message: "session never appeared in /api/sessions" },
+      )
+      .toBeTruthy()
+
+    const sessions = await kernel.getSessions({ limit: 50 })
+    const row = sessions.find((s: any) => s.id === result.sessionId)
+    expect(row?.agent_name).toBe(result.serviceName)
+    // Tokens come from the mock's pinned usage block.
+    expect(row?.total_input_tokens + row?.total_output_tokens).toBeGreaterThanOrEqual(
+      42 + 17,
+    )
+
+    const prompts = await kernel.listSessionPrompts(result.sessionId)
+    expect(prompts.prompts.length).toBeGreaterThan(0)
+  })
+
+  test("/api/analytics rolls up the relay-driven generation span", async ({
+    kernel,
+  }) => {
+    const before = await kernel.getAnalytics()
+    const result = await callRelay()
+    expect(result.responseStatus).toBe(200)
+
+    await expect
+      .poll(
+        async () => {
+          const a = await kernel.getAnalytics()
+          return (
+            a.total_sessions >= before.total_sessions + 1 &&
+            a.total_spans >= before.total_spans + 1
+          )
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(true)
+
+    // cost-by-model uses span.model. The relay emits ai.model.id from the
+    // request body, so the mock's `model` field flows all the way through.
+    const cost = await kernel.getCostAnalytics()
+    const modelRow = cost.by_model.find((m) => m.model === result.model)
+    expect(modelRow, `cost-by-model missing ${result.model}`).toBeTruthy()
+    expect(modelRow!.calls).toBeGreaterThanOrEqual(1)
+
+    const agentRow = cost.by_agent.find((a) => a.agent === result.serviceName)
+    expect(agentRow, `cost-by-agent missing ${result.serviceName}`).toBeTruthy()
+  })
+
+  test("dashboard Sessions tab shows the relay row; Usage tab shows the model", async ({
+    page,
+    kernel,
+  }) => {
+    const result = await callRelay()
+    expect(result.responseStatus).toBe(200)
+
+    // Wait for the kernel to have the session before opening the page —
+    // otherwise the first render would see an empty list and require us
+    // to wait on the SSE stream to push it in.
+    await expect
+      .poll(
+        async () => {
+          const sessions = await kernel.getSessions({ limit: 50 })
+          return sessions.some((s: any) => s.id === result.sessionId)
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(true)
+
+    await page.goto("/analytics/sessions")
+    await expect(
+      page.getByRole("row").filter({ hasText: result.serviceName }),
+    ).toBeVisible({ timeout: 10_000 })
+
+    await page.getByRole("tab", { name: "Usage" }).click()
+    // The model appears in both cost-by-model AND latency-by-model
+    // tables; either is fine for this assertion, hence `.first()`.
+    await expect(
+      page.getByRole("cell", { name: result.model }).first(),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test("relay path config — mock LLM server is reachable", async () => {
+    // Sanity check that the mock is up. Doing this last so that if the
+    // earlier tests fail we know whether it's a relay bug or an upstream
+    // bug. A failure here means the playwright webServer didn't start
+    // the mock — check playwright.config.ts.
+    const res = await fetch(`http://127.0.0.1:${MOCK_LLM_PORT}/health`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+  })
+})

--- a/apps/gctrl-board/tests/acceptance/fixtures/kernel.ts
+++ b/apps/gctrl-board/tests/acceptance/fixtures/kernel.ts
@@ -261,6 +261,12 @@ export class KernelTestClient {
   /**
    * Ingest an OTLP trace into the kernel telemetry pipeline.
    * Simulates an agent session for end-to-end testing.
+   *
+   * Attribute keys match what gctrl-otel/span_processor.rs reads:
+   *   - `ai.model.id`         → model (also flips span_type to Generation)
+   *   - `ai.tokens.input`     → input tokens
+   *   - `ai.tokens.output`    → output tokens
+   *   - `ai.cost.usd`         → per-span cost (rolls up to session totals)
    */
   async ingestTrace(params: {
     traceId: string
@@ -270,20 +276,40 @@ export class KernelTestClient {
     spanName?: string
     costUsd?: number
     durationMs?: number
+    /** Setting model flips span_type → Generation, which feeds cost-by-model. */
+    model?: string
+    inputTokens?: number
+    outputTokens?: number
   }): Promise<void> {
     const now = Date.now() * 1_000_000
     const duration = (params.durationMs ?? 1000) * 1_000_000
 
-    const attributes = [
-      {
-        key: "session.id",
-        value: { stringValue: params.sessionId },
-      },
-    ]
+    // Span-level attributes — model + tokens + cost. The kernel reads
+    // `session.id` from the *resource* attributes (see span_processor.rs),
+    // so we set it on the resource block below, not here.
+    const attributes: Array<{ key: string; value: any }> = []
     if (params.costUsd != null) {
       attributes.push({
-        key: "gctrl.cost.usd",
-        value: { doubleValue: params.costUsd } as any,
+        key: "ai.cost.usd",
+        value: { doubleValue: params.costUsd },
+      })
+    }
+    if (params.model) {
+      attributes.push({
+        key: "ai.model.id",
+        value: { stringValue: params.model },
+      })
+    }
+    if (params.inputTokens != null) {
+      attributes.push({
+        key: "ai.tokens.input",
+        value: { intValue: params.inputTokens },
+      })
+    }
+    if (params.outputTokens != null) {
+      attributes.push({
+        key: "ai.tokens.output",
+        value: { intValue: params.outputTokens },
       })
     }
 
@@ -295,6 +321,10 @@ export class KernelTestClient {
               {
                 key: "service.name",
                 value: { stringValue: params.agentName },
+              },
+              {
+                key: "session.id",
+                value: { stringValue: params.sessionId },
               },
             ],
           },
@@ -336,8 +366,45 @@ export class KernelTestClient {
     return this.request(`/api/sessions${q ? `?${q}` : ""}`)
   }
 
-  async getAnalytics(): Promise<any> {
-    return this.request("/api/analytics")
+  async getAnalytics(kind?: "internal" | "external"): Promise<{
+    total_sessions: number
+    total_spans: number
+    total_cost_usd: number
+    total_input_tokens: number
+    total_output_tokens: number
+  }> {
+    const q = kind ? `?kind=${kind}` : ""
+    return this.request(`/api/analytics${q}`)
+  }
+
+  async getCostAnalytics(): Promise<{
+    by_model: Array<{ model: string; cost: number; calls: number }>
+    by_agent: Array<{ agent: string; cost: number; sessions: number }>
+  }> {
+    return this.request("/api/analytics/cost")
+  }
+
+  async getSpanAnalytics(): Promise<{
+    distribution: Array<{ type: string; count: number; percentage: number }>
+  }> {
+    return this.request("/api/analytics/spans")
+  }
+
+  async listSessionPrompts(sessionId: string): Promise<{
+    prompts: Array<Record<string, unknown>>
+  }> {
+    return this.request(`/api/sessions/${sessionId}/prompts`)
+  }
+
+  /**
+   * Mark a session as ended so it transitions out of the live state.
+   * The kernel auto-scores on session end, which feeds the Evals tab.
+   */
+  async endSession(sessionId: string, status = "completed"): Promise<void> {
+    return this.request(`/api/sessions/${sessionId}/end`, {
+      method: "POST",
+      body: JSON.stringify({ status }),
+    })
   }
 
   // ── Sync ──

--- a/apps/gctrl-board/tests/acceptance/fixtures/mock-llm-server.cjs
+++ b/apps/gctrl-board/tests/acceptance/fixtures/mock-llm-server.cjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Mock OpenAI-compat /v1/chat/completions upstream for the LLM relay
+ * acceptance tests. Standing in for LM Studio / Ollama / etc. so the test
+ * suite has a deterministic, offline endpoint to drive the kernel relay
+ * against.
+ *
+ * Listens on 127.0.0.1:$MOCK_LLM_PORT (default 14299) and answers exactly
+ * one shape of request — POST /v1/chat/completions — with a fixed body
+ * that includes a `usage` block (the relay needs this to emit cost +
+ * token spans). Anything else returns 404.
+ *
+ * Run standalone:
+ *   MOCK_LLM_PORT=14299 node fixtures/mock-llm-server.cjs
+ */
+const http = require("node:http")
+
+const PORT = Number(process.env.MOCK_LLM_PORT ?? 14299)
+const HOST = process.env.MOCK_LLM_HOST ?? "127.0.0.1"
+
+const server = http.createServer((req, res) => {
+  if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    let body = ""
+    req.on("data", (chunk) => {
+      body += chunk
+    })
+    req.on("end", () => {
+      let parsed = null
+      try {
+        parsed = JSON.parse(body)
+      } catch {
+        // fall through — we'll still answer with a generic completion
+      }
+      const requestedModel =
+        (parsed && parsed.model) || "mock-llm/test-model-v1"
+      const userText =
+        (parsed &&
+          Array.isArray(parsed.messages) &&
+          parsed.messages
+            .filter((m) => m.role === "user")
+            .map((m) => (typeof m.content === "string" ? m.content : ""))
+            .join(" ")) ||
+        ""
+
+      const response = {
+        id: `chatcmpl-mock-${Date.now()}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: requestedModel,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: `mock reply (echo: ${userText.slice(0, 64)})`,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        // The relay reads usage.prompt_tokens / usage.completion_tokens to
+        // populate the OTel span. Pinning these makes the assertions
+        // deterministic.
+        usage: {
+          prompt_tokens: 42,
+          completion_tokens: 17,
+          total_tokens: 59,
+        },
+      }
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(JSON.stringify(response))
+    })
+    return
+  }
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" })
+    res.end(JSON.stringify({ ok: true, port: PORT }))
+    return
+  }
+  res.writeHead(404, { "Content-Type": "application/json" })
+  res.end(
+    JSON.stringify({
+      error: { message: `mock-llm-server only serves POST /v1/chat/completions; got ${req.method} ${req.url}` },
+    }),
+  )
+})
+
+server.listen(PORT, HOST, () => {
+  process.stderr.write(`[mock-llm] listening on http://${HOST}:${PORT}\n`)
+})
+
+const shutdown = () => {
+  server.close(() => process.exit(0))
+}
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -242,6 +242,10 @@ function OverviewTab({ kind }: { kind: SessionKind }) {
     )
   }
 
+  if (!overview) {
+    return <div className="p-8 text-zinc-500 font-mono text-sm">Loading…</div>
+  }
+
   // Empty state — analytics tables exist but never synced. The Worker returns
   // zeros rather than 404, so we detect "never synced" via sync-status.
   const neverSynced =
@@ -279,10 +283,6 @@ function OverviewTab({ kind }: { kind: SessionKind }) {
         )}
       </div>
     )
-  }
-
-  if (!overview) {
-    return <div className="p-8 text-zinc-500 font-mono text-sm">Loading…</div>
   }
 
   // Every KPI now reflects the active kind filter — no more split label.


### PR DESCRIPTION
## Summary

Adds two Playwright acceptance specs against the analytics dashboard, driven by a real kernel + a mock OpenAI-compat upstream so the LLM relay path is exercised end-to-end (relay → mock → OTLP capture → DuckDB → `/api/*` → dashboard render).

- **`analytics-dashboard.spec.ts`** — tab routing, Overview KPIs after seed, Sessions list/timeline/heatmap, Usage cost-by-model + span dist, kind filter, Evals score lookup, Contributions shell. Plus two CDP-observability checks: no console errors across tabs, all analytics requests JSON+2xx.
- **`analytics-llm-relay.spec.ts`** — POSTs through the kernel relay, asserts the captured prompt + span land in `/api/sessions`, `/api/sessions/{id}/prompts`, and `/api/analytics`, then verifies the dashboard surfaces the row.
- **`fixtures/mock-llm-server.cjs`** — pinned-usage OpenAI-compat stub so the relay path is deterministic and offline.

### Fixture + config wiring

- `KernelTestClient.ingestTrace` gains `model` / `inputTokens` / `outputTokens` using the kernel's actual span attribute keys (`ai.model.id`, `ai.tokens.input/output`, `ai.cost.usd`). `session.id` moves to the **resource** block where `span_processor` reads it — without this the kernel was filing every ingested session under `id="unknown"`, so the existing fixture was silently broken for analytics.
- New helpers: `getCostAnalytics`, `getSpanAnalytics`, `listSessionPrompts`, `endSession`.
- `playwright.config.ts` boots the mock-llm webServer on `:14299` and points the kernel at it via `--relay-port 14319 --relay-upstream http://127.0.0.1:14299/v1/chat/completions`. Both new specs are skipped in remote/preview mode (kernel-only endpoints).

### App fix

- `web/src/pages/AnalyticsPage.tsx` dereferenced `overview.total_sessions` before the null guard, so the page white-screened on first paint when `/api/analytics` was slow. Moved the loading early-return ahead of `neverSynced`.

## Test plan

- [x] `pnpm exec playwright test tests/acceptance/analytics-dashboard.spec.ts tests/acceptance/analytics-llm-relay.spec.ts` — 15/15 pass (~7.6s)
- [x] Full acceptance suite — 64 passed / 3 skipped (~28.5s) using rebuilt `target/debug/gctrld`
- [ ] CI green on `acceptance/analytics-dashboard-llm-relay`
