### PR TITLE
feat(proxy): tee SSE streaming responses through LLM relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "bytes",
  "chrono",
+ "futures-util",
  "gctrl-core",
  "gctrl-storage",
  "hudsucker",
@@ -1744,6 +1746,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
  "url",
@@ -3757,12 +3760,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -4623,6 +4628,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +5077,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-core = "0.3"
 clap = { version = "4", features = ["derive"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/kernel/crates/gctrl-proxy/Cargo.toml
+++ b/kernel/crates/gctrl-proxy/Cargo.toml
@@ -19,6 +19,9 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
+futures-util = "0.3"
+tokio-stream = "0.1"
+bytes = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/kernel/crates/gctrl-proxy/src/capture.rs
+++ b/kernel/crates/gctrl-proxy/src/capture.rs
@@ -165,6 +165,120 @@ fn stringify_content(v: &serde_json::Value) -> String {
     }
 }
 
+// --- SSE streaming response shapes ---
+//
+// Streaming chat completions arrive as `data: {json}\n\n` lines, each carrying
+// a partial choice (`delta.content`) and (per OpenAI 2024-04 onward) an
+// optional final `usage` chunk. LMStudio sends usage by default; OpenAI cloud
+// requires `stream_options.include_usage: true`. The relay does not require
+// usage to capture turns — it just leaves `tokens` NULL when absent.
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionsChunk {
+    #[serde(default)]
+    choices: Vec<ChatChunkChoice>,
+    #[serde(default)]
+    usage: Option<ChatUsage>,
+    #[serde(default)]
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChunkChoice {
+    #[serde(default)]
+    index: u32,
+    #[serde(default)]
+    delta: Option<ChatChunkDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChunkDelta {
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+}
+
+/// Parse an OpenAI-compatible SSE `text/event-stream` body into a synthetic
+/// non-streaming [`ChatCompletionsResponse`] suitable for [`extract_turns`].
+///
+/// Returns `None` if no parseable `data:` chunks are found (caller should
+/// fall back to JSON parsing). `data: [DONE]` is treated as terminator and
+/// non-JSON `data:` lines (LMStudio occasionally emits keepalives) are
+/// skipped silently — telemetry must never reject an otherwise-valid stream.
+pub fn parse_sse_to_response(body: &str) -> Option<ChatCompletionsResponse> {
+    use std::collections::BTreeMap;
+
+    let mut content_by_choice: BTreeMap<u32, String> = BTreeMap::new();
+    let mut role_by_choice: BTreeMap<u32, String> = BTreeMap::new();
+    let mut usage: Option<ChatUsage> = None;
+    let mut model: Option<String> = None;
+    let mut saw_chunk = false;
+
+    for line in body.lines() {
+        let payload = match line.strip_prefix("data:").map(str::trim) {
+            Some(p) => p,
+            None => continue,
+        };
+        if payload.is_empty() || payload == "[DONE]" {
+            continue;
+        }
+        let chunk: ChatCompletionsChunk = match serde_json::from_str(payload) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        saw_chunk = true;
+        if let Some(m) = chunk.model {
+            if model.is_none() {
+                model = Some(m);
+            }
+        }
+        if let Some(u) = chunk.usage {
+            usage = Some(u);
+        }
+        for choice in chunk.choices {
+            if let Some(delta) = choice.delta {
+                if let Some(role) = delta.role {
+                    role_by_choice
+                        .entry(choice.index)
+                        .or_insert(role);
+                }
+                if let Some(content) = delta.content {
+                    content_by_choice
+                        .entry(choice.index)
+                        .or_default()
+                        .push_str(&content);
+                }
+            }
+        }
+    }
+
+    if !saw_chunk {
+        return None;
+    }
+
+    let choices = content_by_choice
+        .into_iter()
+        .map(|(idx, content)| {
+            let role = role_by_choice
+                .remove(&idx)
+                .unwrap_or_else(|| "assistant".to_string());
+            ChatChoice {
+                message: Some(ChatMessage {
+                    role,
+                    content: serde_json::Value::String(content),
+                }),
+            }
+        })
+        .collect();
+
+    Some(ChatCompletionsResponse {
+        choices,
+        usage,
+        model,
+    })
+}
+
 // --- Capture sink: storage + OTLP ---
 
 pub struct Capture {
@@ -412,6 +526,50 @@ mod tests {
             tokens: None,
         };
         assert_eq!(t1.fingerprint(), t2.fingerprint());
+    }
+
+    #[test]
+    fn parse_sse_assembles_content_and_usage() {
+        // LMStudio-style stream: role on first delta, content deltas in
+        // the middle, usage on the final pre-[DONE] chunk.
+        let sse = "\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}],\"model\":\"google/gemma-4-31b\"}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"po\"}}]}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ng\"}}]}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2}}\n\n\
+data: [DONE]\n\n";
+
+        let resp = parse_sse_to_response(sse).expect("parses");
+        assert_eq!(resp.choices.len(), 1);
+        let msg = resp.choices[0].message.as_ref().unwrap();
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(stringify_content(&msg.content), "pong");
+        assert_eq!(resp.usage.as_ref().unwrap().prompt_tokens, Some(7));
+        assert_eq!(resp.usage.as_ref().unwrap().completion_tokens, Some(2));
+        assert_eq!(resp.model.as_deref(), Some("google/gemma-4-31b"));
+    }
+
+    #[test]
+    fn parse_sse_returns_none_for_non_sse_body() {
+        // Non-streaming JSON should yield None so the caller falls back
+        // to the regular ChatCompletionsResponse parser.
+        let body = r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#;
+        assert!(parse_sse_to_response(body).is_none());
+    }
+
+    #[test]
+    fn parse_sse_skips_keepalive_and_malformed_chunks() {
+        // OpenAI sends `: ping` keepalives; LMStudio occasionally emits
+        // `data: ` with an empty payload. Neither should derail capture.
+        let sse = "\
+: keepalive\n\n\
+data: \n\n\
+data: not-json\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"}}]}\n\n\
+data: [DONE]\n\n";
+
+        let resp = parse_sse_to_response(sse).expect("parses");
+        assert_eq!(stringify_content(&resp.choices[0].message.as_ref().unwrap().content), "ok");
     }
 
     #[test]

--- a/kernel/crates/gctrl-proxy/src/relay.rs
+++ b/kernel/crates/gctrl-proxy/src/relay.rs
@@ -9,17 +9,23 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use axum::{
+    body::Body,
     extract::State,
-    http::{HeaderMap, StatusCode},
-    response::IntoResponse,
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
     routing::post,
     Json, Router,
 };
+use bytes::Bytes;
+use futures_util::StreamExt;
 use serde_json::Value as JsonValue;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use crate::capture::{
-    extract_turns, Capture, ChatCompletionsRequest, ChatCompletionsResponse, OtlpSpanInputs,
+    extract_turns, parse_sse_to_response, Capture, ChatCompletionsRequest,
+    ChatCompletionsResponse, OtlpSpanInputs,
 };
 
 #[derive(Debug, Clone)]
@@ -73,7 +79,7 @@ async fn handle_chat_completions(
     State(relay): State<LlmRelay>,
     headers: HeaderMap,
     body: String,
-) -> impl IntoResponse {
+) -> Response {
     let session_id = extract_header(&headers, &relay.cfg.session_header);
     let service_name = extract_header(&headers, &relay.cfg.service_header);
 
@@ -90,54 +96,168 @@ async fn handle_chat_completions(
         .send()
         .await;
 
-    match upstream_resp {
-        Ok(resp) => {
-            let status = resp.status();
-            let resp_text = resp.text().await.unwrap_or_default();
-            let parsed_resp: Option<ChatCompletionsResponse> =
-                serde_json::from_str(&resp_text).ok();
-
-            if let (Some(req), Some(rsp), Some(sid)) =
-                (parsed_req, parsed_resp.as_ref(), session_id.clone())
-            {
-                let trace_id = format!("{:032x}", Uuid::new_v4().as_u128());
-                let span_id = format!("{:016x}", (Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff));
-                let turns = extract_turns(&req, rsp, &sid, &trace_id, &span_id);
-                if let Err(e) = relay.capture.persist(&turns) {
-                    tracing::warn!(error = %e, "prompt body persist failed");
-                }
-
-                let end_at = SystemTime::now();
-                let span_inputs = OtlpSpanInputs {
-                    session_id: sid,
-                    trace_id,
-                    span_id,
-                    model: req.model.clone(),
-                    gen_ai_system: derive_gen_ai_system(&relay.cfg.upstream_url),
-                    prompt_tokens: rsp.usage.as_ref().and_then(|u| u.prompt_tokens),
-                    completion_tokens: rsp.usage.as_ref().and_then(|u| u.completion_tokens),
-                    start_unix_nano: unix_nanos(started_at),
-                    end_unix_nano: unix_nanos(end_at),
-                    status_ok: status.is_success(),
-                };
-                let _ = relay.capture.emit_otlp_with_service(&span_inputs, service_name.as_deref()).await;
-            }
-
-            let json: JsonValue =
-                serde_json::from_str(&resp_text).unwrap_or(JsonValue::String(resp_text));
-            (status, Json(json)).into_response()
-        }
+    let resp = match upstream_resp {
+        Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "upstream relay failed");
-            (
+            return (
                 StatusCode::BAD_GATEWAY,
                 Json(serde_json::json!({
                     "error": { "message": format!("relay upstream failed: {e}") }
                 })),
             )
-                .into_response()
+                .into_response();
         }
+    };
+
+    let status = resp.status();
+    let upstream_content_type = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .cloned();
+    let is_sse = upstream_content_type
+        .as_ref()
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.contains("text/event-stream"))
+        .unwrap_or(false);
+
+    if is_sse {
+        // Streaming response: tee bytes through to the client live, and
+        // accumulate a copy server-side. Once the upstream stream ends,
+        // parse the accumulated SSE buffer into a synthetic response and
+        // run the same capture path the non-streaming branch uses. This
+        // keeps the agent's UX (token-by-token output) intact while
+        // making opencode + any other AI-SDK client visible to analytics.
+        let (tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(32);
+        let relay_for_task = relay.clone();
+        let parsed_req_for_task = parsed_req;
+        let session_id_for_task = session_id;
+        let service_name_for_task = service_name;
+        tokio::spawn(async move {
+            let mut buf: Vec<u8> = Vec::new();
+            let mut stream = resp.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                match chunk {
+                    Ok(bytes) => {
+                        buf.extend_from_slice(&bytes);
+                        if tx.send(Ok(bytes)).await.is_err() {
+                            // Client hung up — keep accumulating so we
+                            // still capture what the upstream produced,
+                            // but stop trying to forward.
+                            while let Some(c) = stream.next().await {
+                                if let Ok(b) = c {
+                                    buf.extend_from_slice(&b);
+                                }
+                            }
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(std::io::Error::other(e.to_string())))
+                            .await;
+                        return;
+                    }
+                }
+            }
+            drop(tx);
+
+            let resp_text = String::from_utf8_lossy(&buf).to_string();
+            let parsed_resp = parse_sse_to_response(&resp_text);
+            run_capture(
+                &relay_for_task,
+                parsed_req_for_task,
+                parsed_resp,
+                session_id_for_task,
+                service_name_for_task,
+                started_at,
+                status.as_u16(),
+            )
+            .await;
+        });
+
+        let body_stream = Body::from_stream(ReceiverStream::new(rx));
+        let mut response = Response::new(body_stream);
+        *response.status_mut() = status;
+        if let Some(ct) = upstream_content_type {
+            response.headers_mut().insert(header::CONTENT_TYPE, ct);
+        } else {
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/event-stream"),
+            );
+        }
+        // SSE clients (and intermediaries) do better with explicit
+        // no-cache + identity transfer hints.
+        response
+            .headers_mut()
+            .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        return response;
     }
+
+    // Non-streaming path: collect, parse JSON, capture, return JSON verbatim.
+    let resp_text = resp.text().await.unwrap_or_default();
+    let parsed_resp: Option<ChatCompletionsResponse> = serde_json::from_str(&resp_text).ok();
+
+    run_capture(
+        &relay,
+        parsed_req,
+        parsed_resp,
+        session_id,
+        service_name,
+        started_at,
+        status.as_u16(),
+    )
+    .await;
+
+    let json: JsonValue =
+        serde_json::from_str(&resp_text).unwrap_or(JsonValue::String(resp_text));
+    (status, Json(json)).into_response()
+}
+
+/// Run the capture path (storage + OTLP) when all the inputs needed for
+/// a captured turn are present. Shared by the streaming and
+/// non-streaming branches so the same set of attributes always lands.
+async fn run_capture(
+    relay: &LlmRelay,
+    req: Option<ChatCompletionsRequest>,
+    resp: Option<ChatCompletionsResponse>,
+    session_id: Option<String>,
+    service_name: Option<String>,
+    started_at: SystemTime,
+    status_code: u16,
+) {
+    let (Some(req), Some(rsp), Some(sid)) = (req, resp, session_id) else {
+        return;
+    };
+
+    let trace_id = format!("{:032x}", Uuid::new_v4().as_u128());
+    let span_id = format!(
+        "{:016x}",
+        (Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff)
+    );
+    let turns = extract_turns(&req, &rsp, &sid, &trace_id, &span_id);
+    if let Err(e) = relay.capture.persist(&turns) {
+        tracing::warn!(error = %e, "prompt body persist failed");
+    }
+
+    let end_at = SystemTime::now();
+    let span_inputs = OtlpSpanInputs {
+        session_id: sid,
+        trace_id,
+        span_id,
+        model: req.model.clone(),
+        gen_ai_system: derive_gen_ai_system(&relay.cfg.upstream_url),
+        prompt_tokens: rsp.usage.as_ref().and_then(|u| u.prompt_tokens),
+        completion_tokens: rsp.usage.as_ref().and_then(|u| u.completion_tokens),
+        start_unix_nano: unix_nanos(started_at),
+        end_unix_nano: unix_nanos(end_at),
+        status_ok: (200..300).contains(&status_code),
+    };
+    let _ = relay
+        .capture
+        .emit_otlp_with_service(&span_inputs, service_name.as_deref())
+        .await;
 }
 
 async fn handle_unimplemented() -> impl IntoResponse {
@@ -300,6 +420,102 @@ mod tests {
         assert_eq!(rows[0].role, "user");
         assert_eq!(rows[1].role, "assistant");
         assert_eq!(rows[1].tokens, Some(3));
+    }
+
+    #[tokio::test]
+    async fn relay_captures_streaming_sse_response() {
+        // Simulates an LMStudio-style streaming chat completion. The
+        // upstream emits SSE chunks; the relay must pass the bytes
+        // through unchanged AND capture turns from the assembled
+        // content once the stream ends.
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_url = format!("http://{}/v1/chat/completions", upstream_addr);
+
+        tokio::spawn(async move {
+            let upstream_app: Router = Router::new().route(
+                "/v1/chat/completions",
+                post(|| async {
+                    let sse = "\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}],\"model\":\"google/gemma-4-31b\"}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"po\"}}]}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ng\"}}]}\n\n\
+data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2}}\n\n\
+data: [DONE]\n\n";
+                    (
+                        [(header::CONTENT_TYPE, "text/event-stream")],
+                        sse,
+                    )
+                }),
+            );
+            axum::serve(upstream, upstream_app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (relay, store) = test_relay(&upstream_url);
+        let app = relay.router();
+
+        let req_body = serde_json::json!({
+            "model": "google/gemma-4-31b",
+            "stream": true,
+            "messages": [{ "role": "user", "content": "ping" }]
+        });
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("x-session-id", "sess-stream")
+                    .header("x-service-name", "opencode")
+                    .body(Body::from(serde_json::to_vec(&req_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            ct.contains("text/event-stream"),
+            "expected streaming content-type, got {ct:?}"
+        );
+
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&bytes);
+        // Bytes are forwarded verbatim — opencode keeps its streaming UX.
+        assert!(body_str.contains("\"po\""));
+        assert!(body_str.contains("\"ng\""));
+        assert!(body_str.contains("[DONE]"));
+
+        // Capture happens in a spawned task after the stream ends.
+        // Poll briefly so the test isn't a flake on slow runners.
+        let mut rows = Vec::new();
+        for _ in 0..40 {
+            rows = store.list_prompt_bodies_for_session("sess-stream").unwrap();
+            if !rows.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(rows.len(), 2, "user prompt + assembled assistant reply");
+        assert_eq!(rows[0].role, "user");
+        assert_eq!(rows[0].content, "ping");
+        assert_eq!(rows[1].role, "assistant");
+        assert_eq!(
+            rows[1].content, "pong",
+            "deltas should be concatenated into the full reply"
+        );
+        assert_eq!(rows[1].tokens, Some(2));
+        assert_eq!(rows[0].tokens, Some(7));
     }
 
     #[tokio::test]

--- a/vault/specs/implementation/llm-relay.md
+++ b/vault/specs/implementation/llm-relay.md
@@ -102,7 +102,13 @@ In `kernel/crates/gctrl-proxy/`:
   1. Read body, parse `model`, `messages`. Forward verbatim to the
      upstream URL with original headers minus `Host`.
   2. On response, parse `choices[0].message`, `usage.prompt_tokens`,
-     `usage.completion_tokens`.
+     `usage.completion_tokens`. **Streaming responses** (upstream
+     `Content-Type: text/event-stream`) are tee'd: bytes pass through
+     to the client live so the agent's UX is preserved, while the
+     relay accumulates a copy and reassembles it via
+     `parse_sse_to_response` (concatenates per-choice `delta.content`,
+     reads `usage` from the final chunk, ignores `[DONE]` and
+     keepalives) before running the same capture path.
   3. Emit one OTLP span to `/v1/traces` with attributes:
      `service.name=<x-service-name or default>`, `session.id=<x-session-id>`,
      `gen_ai.request.model`, `gen_ai.usage.prompt_tokens`,


### PR DESCRIPTION
## Summary

Unblocks opencode (and any `@ai-sdk/openai-compatible` agent) for analytics. Before this PR, the relay forwarded streaming chat completions correctly but **silently dropped capture** — `serde_json::from_str::<ChatCompletionsResponse>` can't parse SSE, so `parsed_resp` was `None` and the entire `extract_turns` / `persist` / `emit_otlp` branch was skipped. Result: bytes flowed end-to-end but no session, prompt body, or generation span ever landed in DuckDB.

`vault/specs/implementation/llm-relay.md` and the existing acceptance fixture (`mock-llm-server.cjs`) only exercised single-shot JSON, so the gap wasn't caught at PR #84/#87.

## How it works

`handle_chat_completions` now splits on the upstream `Content-Type`:

- **`text/event-stream`** → spawn a fan-out task that:
  1. forwards each `bytes_stream()` chunk to the client over an `mpsc`-backed `Body::from_stream` (preserves opencode's token-by-token UX),
  2. accumulates a copy server-side,
  3. once the upstream stream closes, feeds the buffer through a new pure `parse_sse_to_response` (concat `delta.content` per choice index, read `usage` from any chunk that has it, skip `[DONE]` and keepalives) and runs the existing capture path.
- **anything else** → unchanged collect-then-JSON path.

Capture inputs are shared via a new `run_capture` helper so streaming and non-streaming sessions store identical rows.

`reqwest` gains the `stream` feature; `gctrl-proxy` gains `bytes`, `tokio-stream`, `futures-util`.

## Test plan

- [x] `cargo test -p gctrl-proxy` — 28 passed (3 new SSE parser unit tests + 1 new streaming integration test that asserts both pass-through bytes and assembled capture rows)
- [x] Acceptance: `pnpm exec playwright test tests/acceptance/analytics-llm-relay.spec.ts tests/acceptance/analytics-dashboard.spec.ts` — 15/15 pass against the rebuilt kernel (non-streaming path regression check)
- [x] Live verification with real opencode: `OC_SESSION_ID=$(uuidgen) opencode run "..."` → captured session lands in `/api/sessions` with `agent_name=opencode`, populated `total_input_tokens` / `total_output_tokens`, and full conversation bodies in `/api/sessions/{id}/prompts`
- [ ] Add a Playwright e2e that drives the streaming path through a mock LMStudio (follow-up — requires extending `fixtures/mock-llm-server.cjs` to emit SSE)
