### PR TITLE
feat(analytics): Prompts tab + auto-close idle sessions

### DIFF
--- a/apps/gctrl-board/tests/acceptance/analytics-llm-relay.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/analytics-llm-relay.spec.ts
@@ -172,6 +172,48 @@ test.describe("LLM relay → kernel → analytics dashboard", () => {
     ).toBeVisible({ timeout: 10_000 })
   })
 
+  test("dashboard Prompts tab renders captured turns for the relay session", async ({
+    page,
+    kernel,
+  }) => {
+    // Use a recognizable user prompt so we can assert it actually
+    // surfaces in the UI rather than relying on token counts alone.
+    const userPrompt = `dashboard-prompts-probe-${Date.now().toString(36).slice(-5)}`
+    const result = await callRelay({ prompt: userPrompt })
+    expect(result.responseStatus).toBe(200)
+
+    await expect
+      .poll(
+        async () => {
+          const list = await kernel.listSessionPrompts(result.sessionId)
+          return list.prompts.length
+        },
+        {
+          timeout: 10_000,
+          message: "prompt bodies never landed in /api/sessions/{id}/prompts",
+        },
+      )
+      .toBeGreaterThan(0)
+
+    await page.goto(`/analytics/sessions/${result.sessionId}`)
+
+    // Detail pane opens deep-linked. Switch to the Prompts tab.
+    const promptsTab = page.getByTestId("session-tab-prompts")
+    await expect(promptsTab).toBeVisible({ timeout: 10_000 })
+    await promptsTab.click()
+
+    // Prompt rows render with role badges and the user's prompt content.
+    const list = page.getByTestId("prompts-list")
+    await expect(list).toBeVisible({ timeout: 10_000 })
+    // The relay captures the system + user turns from the request plus the
+    // assistant reply from the response — at least three rows.
+    await expect(list.getByTestId("prompt-row")).toHaveCount(3)
+    await expect(list.locator('[data-role="user"]')).toContainText(userPrompt)
+    await expect(list.locator('[data-role="assistant"]')).toContainText(
+      "mock reply",
+    )
+  })
+
   test("relay path config — mock LLM server is reachable", async () => {
     // Sanity check that the mock is up. Doing this last so that if the
     // earlier tests fail we know whether it's a relay bug or an upstream

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -18,6 +18,7 @@ import type {
   CostAnalytics,
   DailyEntry,
   TraceTreeResponse,
+  PromptList,
   LatencyAnalytics,
   SpanAnalytics,
   ScoreSummary,
@@ -270,6 +271,13 @@ export const api = {
 
     tree: (id: string) =>
       request<TraceTreeResponse>(`/api/sessions/${id}/tree`),
+
+    /** Per-turn prompt + completion bodies for one session.
+     *  Returns `{ count, prompts: PromptTurn[] }`, ordered by turn_ordinal.
+     *  Source: `prompt_bodies` table written by the LLM relay (or any
+     *  capture path that targets it). See llm-relay spec §M1. */
+    prompts: (id: string) =>
+      request<PromptList>(`/api/sessions/${id}/prompts`),
   },
 
   analytics: {

--- a/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
+++ b/apps/gctrl-board/web/src/pages/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import type {
   SessionKind,
   TraceTreeNode,
   TraceTreeResponse,
+  PromptTurn,
   LatencyAnalytics,
   SpanAnalytics,
   ScoreSummary,
@@ -744,6 +745,8 @@ function formatDuration(ms: number): string {
   return `${h}h ${m % 60}m`
 }
 
+type DetailPaneTab = "trace" | "prompts"
+
 function SessionDetailPane({
   session,
   onClose,
@@ -752,7 +755,10 @@ function SessionDetailPane({
   onClose: () => void
 }) {
   const [tree, setTree] = useState<TraceTreeResponse | null>(null)
+  const [prompts, setPrompts] = useState<PromptTurn[] | null>(null)
+  const [promptError, setPromptError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<DetailPaneTab>("trace")
 
   const isLive = session.ended_at === null && session.status === "active"
 
@@ -766,23 +772,51 @@ function SessionDetailPane({
     }
   }, [session.id])
 
+  const refreshPrompts = useCallback(async () => {
+    try {
+      const list = await api.sessions.prompts(session.id)
+      setPrompts(list.prompts)
+      setPromptError(null)
+    } catch (e) {
+      setPromptError(e instanceof Error ? e.message : String(e))
+    }
+  }, [session.id])
+
   useEffect(() => {
     refresh()
   }, [refresh])
 
+  // Lazy-load prompts when the user opens the tab; refresh on each
+  // open so a still-streaming session shows its latest assembled turns.
+  useEffect(() => {
+    if (tab === "prompts") {
+      refreshPrompts()
+    }
+  }, [tab, refreshPrompts])
+
   // Per-session stream: refetch the trace tree on every span event for
   // this session. The kernel returns the full tree (root + direct
   // children) cheaply, and this guarantees the UI never reorders or
-  // drops a child relative to a server-side rebuild.
+  // drops a child relative to a server-side rebuild. Also refresh
+  // prompts when visible — relay-driven captures land between span
+  // events, but the OTLP span the relay also emits triggers this hook.
   useSessionStream({
     sessionId: session.id,
     disabled: !isLive,
     onEvent: (ev) => {
       if (ev.type === "session_span") {
         refresh()
+        if (tab === "prompts") {
+          refreshPrompts()
+        }
       }
     },
-    onReplayGap: refresh,
+    onReplayGap: () => {
+      refresh()
+      if (tab === "prompts") {
+        refreshPrompts()
+      }
+    },
   })
 
   return (
@@ -838,24 +872,193 @@ function SessionDetailPane({
         </div>
       </div>
 
-      <div className="px-4 py-2 border-b border-zinc-800 text-[10px] font-mono tracking-wider text-zinc-500 uppercase">
-        Trace
+      <div
+        className="border-b border-zinc-800 flex text-[10px] font-mono tracking-wider uppercase"
+        role="tablist"
+      >
+        <DetailTabBtn
+          label="Trace"
+          active={tab === "trace"}
+          onClick={() => setTab("trace")}
+          testId="session-tab-trace"
+        />
+        <DetailTabBtn
+          label={
+            <>
+              Prompts
+              {prompts && prompts.length > 0 && (
+                <span className="ml-1.5 text-zinc-600 normal-case tracking-normal">
+                  {prompts.length}
+                </span>
+              )}
+            </>
+          }
+          active={tab === "prompts"}
+          onClick={() => setTab("prompts")}
+          testId="session-tab-prompts"
+        />
       </div>
+
       <div className="flex-1 overflow-auto p-3 text-[12px] font-mono">
-        {error && <div className="text-rose-400">Error: {error}</div>}
-        {!error && !tree && <div className="text-zinc-600">Loading…</div>}
-        {tree && (!tree.spans || tree.spans.length === 0) && (
-          <div className="text-zinc-600">No spans yet.</div>
+        {tab === "trace" && (
+          <>
+            {error && <div className="text-rose-400">Error: {error}</div>}
+            {!error && !tree && <div className="text-zinc-600">Loading…</div>}
+            {tree && (!tree.spans || tree.spans.length === 0) && (
+              <div className="text-zinc-600">No spans yet.</div>
+            )}
+            {tree && tree.spans && tree.spans.length > 0 && (
+              <ul className="space-y-1">
+                {tree.spans.map((node) => (
+                  <SpanNode key={node.span_id} node={node} depth={0} />
+                ))}
+              </ul>
+            )}
+          </>
         )}
-        {tree && tree.spans && tree.spans.length > 0 && (
-          <ul className="space-y-1">
-            {tree.spans.map((node) => (
-              <SpanNode key={node.span_id} node={node} depth={0} />
-            ))}
-          </ul>
+        {tab === "prompts" && (
+          <PromptsList
+            prompts={prompts}
+            error={promptError}
+          />
         )}
       </div>
     </aside>
+  )
+}
+
+function DetailTabBtn({
+  label,
+  active,
+  onClick,
+  testId,
+}: {
+  label: ReactNode
+  active: boolean
+  onClick: () => void
+  testId?: string
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        "px-4 py-2 cursor-pointer transition-colors",
+        active
+          ? "text-zinc-200 border-b border-zinc-200 -mb-px"
+          : "text-zinc-500 hover:text-zinc-300",
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+/**
+ * Per-turn list rendered from `prompt_bodies`. Bodies can be hundreds of
+ * KB (full agent system prompts), so each row collapses by default and
+ * the user clicks to expand. We deliberately keep this read-only — copy
+ * is for grepping prompts visually, not editing.
+ */
+function PromptsList({
+  prompts,
+  error,
+}: {
+  prompts: PromptTurn[] | null
+  error: string | null
+}) {
+  if (error) {
+    return <div className="text-rose-400">Error: {error}</div>
+  }
+  if (!prompts) {
+    return <div className="text-zinc-600">Loading…</div>
+  }
+  if (prompts.length === 0) {
+    return (
+      <div className="text-zinc-600 leading-relaxed" data-testid="prompts-empty">
+        No prompt bodies captured for this session.
+        <div className="mt-2 text-zinc-700 text-[11px]">
+          External agents land here once they call through the LLM relay
+          on <span className="text-zinc-500">:4319</span> with an{" "}
+          <span className="text-zinc-500">x-session-id</span> header.
+        </div>
+      </div>
+    )
+  }
+  return (
+    <ul className="space-y-2" data-testid="prompts-list">
+      {prompts.map((turn) => (
+        <PromptRow key={turn.id} turn={turn} />
+      ))}
+    </ul>
+  )
+}
+
+function PromptRow({ turn }: { turn: PromptTurn }) {
+  const [expanded, setExpanded] = useState(false)
+  const isLong = turn.content.length > 300
+  const preview = isLong && !expanded
+    ? turn.content.slice(0, 300) + "…"
+    : turn.content
+  return (
+    <li
+      className="border border-zinc-800 rounded-sm bg-zinc-950/40"
+      data-testid="prompt-row"
+      data-role={turn.role}
+    >
+      <div className="flex items-center gap-2 px-2 py-1 text-[10px] uppercase tracking-wider border-b border-zinc-800">
+        <span className="text-zinc-600 w-6 text-right">
+          {turn.turn_ordinal}
+        </span>
+        <RoleBadge role={turn.role} />
+        {turn.tokens !== null && (
+          <span className="text-zinc-600 normal-case tracking-normal">
+            {turn.tokens.toLocaleString()} tok
+          </span>
+        )}
+        {isLong && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="ml-auto text-zinc-500 hover:text-zinc-200 text-[11px] normal-case tracking-normal cursor-pointer"
+            data-testid="prompt-toggle"
+          >
+            {expanded ? "collapse" : "expand"}
+          </button>
+        )}
+      </div>
+      <pre className="px-2 py-2 whitespace-pre-wrap break-words text-zinc-200 text-[12px] leading-relaxed font-mono">
+        {preview}
+      </pre>
+    </li>
+  )
+}
+
+function RoleBadge({ role }: { role: string }) {
+  // Hard-coded palette; we already use Tailwind utility classes elsewhere
+  // and don't need to lean on the design system's Badge variants here.
+  const tone =
+    role === "user"
+      ? "text-sky-400 border-sky-900"
+      : role === "assistant"
+      ? "text-emerald-400 border-emerald-900"
+      : role === "system"
+      ? "text-amber-400 border-amber-900"
+      : role === "tool"
+      ? "text-violet-400 border-violet-900"
+      : "text-zinc-400 border-zinc-700"
+  return (
+    <span
+      className={cn(
+        "px-1.5 py-px border rounded-sm normal-case tracking-normal text-[10px]",
+        tone,
+      )}
+    >
+      {role}
+    </span>
   )
 }
 

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -126,6 +126,30 @@ export interface TraceTreeResponse {
   tags?: Array<{ key: string; value: string }>
 }
 
+// ── Prompt bodies (llm-relay M2 — per-session turn list) ──
+//
+// Shape returned by `GET /api/sessions/{id}/prompts`. Both relay capture
+// and direct OTLP-attribute capture write into the same `prompt_bodies`
+// table, so the UI doesn't care which path produced the row.
+
+export interface PromptTurn {
+  id: string
+  session_id: string
+  span_id: string | null
+  trace_id: string | null
+  turn_ordinal: number
+  role: string
+  content: string
+  fingerprint: string
+  tokens: number | null
+  created_at: string
+}
+
+export interface PromptList {
+  count: number
+  prompts: PromptTurn[]
+}
+
 // ── Contributions (analytics §M5) ──
 
 /** A single PR (commits will follow when the route adds them) joined

--- a/vault/specs/implementation/llm-relay.md
+++ b/vault/specs/implementation/llm-relay.md
@@ -272,12 +272,18 @@ gctrl analytics latency
    - `gctrl sessions prompts <id>` shell command.
    - *Accept*: routes return rows the M0 capture wrote, with stable
      ordering and fingerprint counts that match a manual SQL `GROUP BY`.
-3. **M2 — Web UI**
-   - Wire the Prompts tab in `gctrl-analytics` against the M1 routes.
-     Pure UI work; closes
-     [gctrl-analytics M2b](../architecture/apps/gctrl-analytics.md#milestones).
+3. **M2 — Web UI** *(shipped)*
+   - Prompts tab in the analytics dashboard's session detail pane —
+     `apps/gctrl-board/web/src/pages/AnalyticsPage.tsx`'s
+     `SessionDetailPane` switches between `Trace` and `Prompts`.
+     Prompts come from `api.sessions.prompts(id)` →
+     `GET /api/sessions/{id}/prompts`. Long bodies collapse to ~300
+     chars with an expand toggle.
    - *Accept*: opening a Sessions detail pane on any external session
-     shows the full prompt + completion turn list with drill-through.
+     shows the full prompt + completion turn list with role badges
+     and per-turn token counts. Verified by
+     `analytics-llm-relay.spec.ts` "dashboard Prompts tab renders
+     captured turns for the relay session".
 4. **M3 — Generalize beyond OpenAI-compat** *(separate spec)*
    - Add `POST /v1/messages` (Anthropic shape) and any other shapes the
      operator's tools actually use. The capture core (turns →


### PR DESCRIPTION
## Summary

Two related fixes to the analytics dashboard so a fresh kernel and a long-running one both render correctly:

1. **Prompts tab** in the session detail pane (closes M2 from `vault/specs/implementation/llm-relay.md`).
2. **Auto-close idle sessions** so OTLP-ingested rows don't sit in `Active` forever.

## Prompts tab

The kernel has been writing `prompt_bodies` rows since M0 (relay capture) and serving them via `GET /api/sessions/{id}/prompts` since M1, but the dashboard had no UI to read them. Operators wanting to see what an agent actually said had to drop down to `curl` or the (currently broken) `gctl sessions prompts` shell command.

`SessionDetailPane` now shows a Trace / Prompts tab switch (read-only, keyboard-friendly, deep-linkable via `/analytics/sessions/{id}`). The Prompts panel:

- Lazy-loads on tab open via the new `api.sessions.prompts(id)` client method.
- Refreshes on incoming `session_span` events for live sessions, since relay-driven captures land in the same window the OTLP span arrives in.
- Renders each turn as a row with an ordinal, a role-coloured badge (`user`/`assistant`/`system`/`tool`), per-turn token count, and the body content.
- Collapses bodies over 300 chars to a preview with an expand toggle, so a 15kb opencode system prompt doesn't blow out the pane.
- Empty state explains the relay path (`:4319` + `x-session-id` header) so a fresh kernel isn't a confusing dead end.

UI deliberately stays read-only — this surface is for visually grepping prompts, not editing them. Fingerprint grouping (the other half of M1's read API) is a separate follow-up.

## Auto-close idle sessions

OTLP-ingested sessions were auto-created as `active` and only ever transitioned to `completed` when a client called `POST /api/sessions/{id}/end`. Most external recorders (opencode, the LLM relay, ad-hoc curl traces) never do — so the analytics dashboard rendered every past session as "live" forever and `liveCount` grew unbounded.

A new `SessionSweeper` fiber spawned alongside the OTel receiver:

- Ticks every 60s.
- Finds `status='active'` sessions whose latest activity (max span `started_at`, falling back to session `started_at` if no spans yet) is older than `GCTRL_SESSION_IDLE_SECS` (default `300` = 5 min).
- Sets `status='completed'` and `ended_at = <last_activity>` so the row reflects when the session actually went quiet, not when the sweeper noticed.
- Publishes `session.ended` lifecycle events on the existing live bus so SSE-subscribed dashboards drop the row from their live count without refetching.

A new `create_router_full_with_bus` variant lets the receiver and sweeper share the same `EventBus`. The original `create_router_full` is preserved for tests that don't need lifecycle observability.

## Test plan

- [x] `cargo test -p gctrl-storage -p gctrl-otel` — all suites green (250+ tests).
- [x] New unit `test_sweep_idle_active_sessions` — covers stale session w/ stale span, recent session w/ recent span, spanless old session, already-completed session.
- [x] New unit `tick_closes_idle_and_publishes_ended` — sweeper closes only the idle row and publishes one `session.ended` event.
- [x] New unit `idle_secs_from_env_clamps_short_values` — ignores values below 30s to avoid closing mid-turn.
- [x] `pnpm exec playwright test tests/acceptance/analytics-dashboard.spec.ts tests/acceptance/analytics-llm-relay.spec.ts` — 16/16 pass (~7.6s).
- [x] New case `dashboard Prompts tab renders captured turns for the relay session` — drives a relay call, deep-links to the session, switches to Prompts, and asserts both the user prompt content and the assistant reply render with their role badges.
- [x] Type-check on touched files (`web/src/types.ts`, `web/src/api/client.ts`, `web/src/pages/AnalyticsPage.tsx`) — clean. (Pre-existing `InboxMessage.source_name` errors in `MessageCard.tsx` and `MessageDetail.tsx` are unrelated.)
- [ ] Manual smoke against a real opencode session captured by [#88](https://github.com/OpenHackersClub/gctrl/pull/88) — can verify post-merge.
