### PR TITLE
refactor(uebermensch): tagged errors + Option/Either over bare Error

### DIFF
--- a/apps/uebermensch/src/adapters/FileSystemCalendar.ts
+++ b/apps/uebermensch/src/adapters/FileSystemCalendar.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
 import { extname, join, relative } from "node:path"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Either, Layer, Schema } from "effect"
 import matter from "gray-matter"
 import { VaultError, vaultIo } from "../errors.js"
 import { matchesFilter, sortByStart } from "../lib/calendar-filter.js"
@@ -28,17 +28,17 @@ const slugify = (s: string): string =>
     .replace(/^-+|-+$/g, "")
     .slice(0, 60)
 
-const datePart = (startsAt: string): string => {
+const datePart = (startsAt: string): Either.Either<string, string> => {
   const bare = startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
-  if (bare) return bare[1]
+  if (bare) return Either.right(bare[1])
   const d = new Date(startsAt)
   if (Number.isNaN(d.getTime())) {
-    throw new Error(`invalid starts_at: ${startsAt}`)
+    return Either.left(`invalid starts_at: ${startsAt}`)
   }
   const y = d.getUTCFullYear()
   const m = String(d.getUTCMonth() + 1).padStart(2, "0")
   const day = String(d.getUTCDate()).padStart(2, "0")
-  return `${y}-${m}-${day}`
+  return Either.right(`${y}-${m}-${day}`)
 }
 
 const failVault = (
@@ -223,16 +223,10 @@ export const FileSystemCalendarLive = (vaultDir: string) =>
           )
         }
 
-        let datePrefix: string
-        try {
-          datePrefix = datePart(input.startsAt)
-        } catch {
-          return yield* failVault(
-            `invalid starts_at: ${input.startsAt}`,
-            calRoot,
-            "parse_failure",
-          )
-        }
+        const datePrefix = yield* Either.match(datePart(input.startsAt), {
+          onLeft: (msg) => failVault(msg, calRoot, "parse_failure"),
+          onRight: (v) => Effect.succeed(v),
+        })
         const relPath = `${CALENDAR_DIR}/${datePrefix}--${slug}.md`
         const absPath = join(vaultDir, relPath)
         const body = (input.body ?? "").trimEnd()

--- a/apps/uebermensch/src/commands/profile-validate.ts
+++ b/apps/uebermensch/src/commands/profile-validate.ts
@@ -1,6 +1,7 @@
 import { Command } from "@effect/cli"
 import { Console, Effect } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
+import { ProfileError } from "../errors.js"
 import { resolveVaultDir } from "../lib/env.js"
 import { ProfileService } from "../services/ProfileService.js"
 
@@ -18,7 +19,12 @@ const validate = Command.make("validate", {}, () =>
     }
     yield* Console.error("✗ validation issues:")
     for (const issue of issues) yield* Console.error(`  - ${issue}`)
-    yield* Effect.fail(new Error(`${issues.length} validation issue(s)`))
+    yield* Effect.fail(
+      new ProfileError({
+        message: `${issues.length} validation issue(s)`,
+        issues,
+      }),
+    )
   }),
 ).pipe(Command.withDescription("Validate profile.md + topics.md + sources.md frontmatter"))
 

--- a/apps/uebermensch/src/commands/vault-init.ts
+++ b/apps/uebermensch/src/commands/vault-init.ts
@@ -2,7 +2,8 @@ import { cp, mkdir, rename, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Args, Command, Options } from "@effect/cli"
-import { Console, Effect } from "effect"
+import { Console, Effect, Option } from "effect"
+import { VaultError, vaultIo } from "../errors.js"
 
 const here = dirname(fileURLToPath(import.meta.url))
 const FIXTURE_ROOT = resolve(here, "../../tests/fixtures/vault")
@@ -19,8 +20,8 @@ const fromSeed = Options.text("from-seed").pipe(
 export const vaultInit = Command.make("init", { target, fromSeed }, ({ target, fromSeed }) =>
   Effect.gen(function* () {
     const abs = resolve(target)
-    const exists = yield* Effect.tryPromise({
-      try: async () => {
+    const exists = yield* vaultIo(
+      async () => {
         try {
           const s = await stat(abs)
           return s.isDirectory()
@@ -28,15 +29,20 @@ export const vaultInit = Command.make("init", { target, fromSeed }, ({ target, f
           return false
         }
       },
-      catch: (e) => new Error(String(e)),
-    })
+      { message: "stat target failed", path: abs },
+    )
     if (exists) {
       yield* Console.error(`target ${abs} already exists — refusing to overwrite`)
-      return yield* Effect.fail(new Error("target exists"))
+      return yield* Effect.fail(
+        new VaultError({ message: "target exists", path: abs, kind: "collision" }),
+      )
     }
-    const seed = fromSeed._tag === "Some" ? resolve(fromSeed.value) : FIXTURE_ROOT
-    yield* Effect.tryPromise({
-      try: async () => {
+    const seed = Option.match(fromSeed, {
+      onSome: (v) => resolve(v),
+      onNone: () => FIXTURE_ROOT,
+    })
+    yield* vaultIo(
+      async () => {
         await mkdir(dirname(abs), { recursive: true })
         await cp(seed, abs, { recursive: true })
         const tmpl = join(abs, "gitignore.template")
@@ -46,8 +52,8 @@ export const vaultInit = Command.make("init", { target, fromSeed }, ({ target, f
           // no template — fine
         }
       },
-      catch: (e) => new Error(`init failed: ${String(e)}`),
-    })
+      { message: "init failed", path: abs },
+    )
     yield* Console.log(`✓ initialized vault at ${abs} from ${seed}`)
     yield* Console.log(`  Set UBER_VAULT_DIR=${abs} and open it in Obsidian.`)
   }),


### PR DESCRIPTION
## Summary

Replace `._tag === "Some"` and bare `new Error` constructions with idiomatic Effect-TS combinators in three uebermensch call sites.

- **`vault-init.ts`** — switch to `Option.match` for the `fromSeed` flag; route both `stat` and the copy through the existing `vaultIo` helper so the command fails with `VaultError` (kind: `collision` / `io_failure`) instead of an untyped `Error`.
- **`profile-validate.ts`** — fail with `ProfileError` carrying the structured `issues` array instead of a generic `new Error`.
- **`FileSystemCalendar.ts`** — `datePart` returns `Either<string, string>` and the `add` call site uses `Either.match` to fail with `VaultError(parse_failure)`, removing the imperative `try/catch` around `datePart` and the bare `throw new Error` inside it.

Why: the project's CLAUDE.md / arch-taste rules prohibit `._tag` access and require tagged errors over plain `Error`. These were the three remaining offenders flagged by an Effect-TS audit of `apps/uebermensch/`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (141/141)
- [ ] CI green
