### PR TITLE
refactor(shell): tagged errors + static fs import for persona seed

### DIFF
--- a/shell/gctrl-shell/src/commands/audit.ts
+++ b/shell/gctrl-shell/src/commands/audit.ts
@@ -6,6 +6,7 @@
  */
 import { Command, Options } from "@effect/cli"
 import { Console, Effect } from "effect"
+import { AuditError } from "../errors"
 import { execPromise, type CheckResult } from "../lib/exec"
 
 const runCheck = (
@@ -119,13 +120,15 @@ export const auditCommand = Command.make(
 
       if (failed > 0) {
         yield* Console.log("Audit FAILED — fix issues before PR.")
-        return yield* Effect.fail(new Error("Audit failed"))
+        return yield* Effect.fail(
+          new AuditError({ message: "Audit failed", failed, passed })
+        )
       }
 
       yield* Console.log("Audit PASSED — ready for PR.")
     }).pipe(
-      Effect.catchAll((e) =>
-        Console.error(String(e)).pipe(Effect.flatMap(() => Effect.fail(e)))
+      Effect.catchTag("AuditError", (e) =>
+        Console.error(e.message).pipe(Effect.flatMap(() => Effect.fail(e)))
       )
     )
 )

--- a/shell/gctrl-shell/src/commands/net.ts
+++ b/shell/gctrl-shell/src/commands/net.ts
@@ -8,6 +8,7 @@
  */
 import { Command, Options, Args } from "@effect/cli"
 import { Console, Effect, Option, Schema } from "effect"
+import { ExecError } from "../errors"
 import { execFilePromise } from "../lib/exec"
 import { KernelClient } from "../services/KernelClient"
 
@@ -26,12 +27,21 @@ const runGctl = (args: string[]) =>
     const result = yield* execFilePromise(GCTRL_BIN, args, process.cwd())
     if (!result.ok) {
       yield* Console.error(result.output || `gctrl ${args[0]} failed`)
-      return yield* Effect.fail(new Error(`gctrl ${args[0]} failed`))
+      return yield* Effect.fail(
+        new ExecError({
+          message: `gctrl ${args[0]} failed`,
+          bin: GCTRL_BIN,
+          args,
+          output: result.output,
+        })
+      )
     }
     if (result.output) yield* Console.log(result.output)
   }).pipe(
-    Effect.catchAll((e) =>
-      Console.error(`Error: ${e}. Is the gctrl Rust binary installed? (cargo install gctrl)`)
+    Effect.catchTag("ExecError", (e) =>
+      Console.error(
+        `Error: ${e.message}. Is the gctrl Rust binary installed? (cargo install gctrl)`
+      )
     )
   )
 

--- a/shell/gctrl-shell/src/commands/persona.ts
+++ b/shell/gctrl-shell/src/commands/persona.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { Command, Options, Args } from "@effect/cli"
 import { Console, Effect, Option, Schema } from "effect"
 import { KernelClient } from "../services/KernelClient"
@@ -91,15 +92,16 @@ const seedCommand = Command.make("seed", { file: seedFile }, ({ file }) =>
     const kernel = yield* KernelClient
     const filePath = Option.getOrElse(file, () => "vault/specs/team/personas.md")
 
-    // Read and parse the markdown file
-    const { readFileSync } = yield* Effect.sync(() => require("node:fs"))
-    let content: string
-    try {
-      content = readFileSync(filePath, "utf-8")
-    } catch {
+    // Read and parse the markdown file. Treat read failure as a recoverable
+    // None so the command exits cleanly with a friendly message.
+    const maybeContent = yield* Effect.try(() => readFileSync(filePath, "utf-8")).pipe(
+      Effect.option,
+    )
+    if (Option.isNone(maybeContent)) {
       yield* Console.error(`Cannot read file: ${filePath}`)
       return
     }
+    const content = maybeContent.value
 
     const { personas, reviewRules } = parsePersonasMarkdown(content)
 

--- a/shell/gctrl-shell/src/errors.ts
+++ b/shell/gctrl-shell/src/errors.ts
@@ -9,3 +9,24 @@ export class KernelUnavailableError extends Schema.TaggedError<KernelUnavailable
   "KernelUnavailableError",
   { message: Schema.String }
 ) {}
+
+// Failure of a subprocess invoked by the shell (e.g. `gctrl net fetch`).
+export class ExecError extends Schema.TaggedError<ExecError>()(
+  "ExecError",
+  {
+    message: Schema.String,
+    bin: Schema.String,
+    args: Schema.Array(Schema.String),
+    output: Schema.optional(Schema.String),
+  }
+) {}
+
+// Failure of a quality-gate audit check (build/lint/tests/acceptance).
+export class AuditError extends Schema.TaggedError<AuditError>()(
+  "AuditError",
+  {
+    message: Schema.String,
+    failed: Schema.Number,
+    passed: Schema.Number,
+  }
+) {}


### PR DESCRIPTION
## Summary

Replace bare `new Error` and a dynamic `require("node:fs")` + `try/catch` with idiomatic Effect-TS combinators in three shell commands.

- **`errors.ts`** — introduce two new tagged errors: `ExecError` (subprocess failure carrying `bin`, `args`, `output`) and `AuditError` (carries `failed` / `passed` counts).
- **`net.ts`** — `runGctl` now fails with `ExecError` and recovers via `Effect.catchTag("ExecError", …)` instead of `Effect.catchAll(e => …)` over an untyped error.
- **`audit.ts`** — fails with `AuditError` carrying the structured summary; recovery via `catchTag` so the error type is propagated, not stringified.
- **`persona.ts`** — drop `require("node:fs")` for a static `import`; replace imperative `try/catch` around `readFileSync` with `Effect.try(...).pipe(Effect.option)` + `Option.isNone` early return.

Why: the project's `arch-taste.md` rules require `Schema.TaggedError` over plain `Error` and prohibit imperative escape hatches inside Effect contexts. These were the three offenders flagged by an Effect-TS audit of `shell/gctrl-shell/`.

## Test plan

- [x] `pnpm test` passes (135/135)
- [ ] CI green
