### PR TITLE
feat(driver-llm): capture /api/llm/completions exchanges (uebermensch in analytics)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "gctrl-context",
  "gctrl-core",
  "gctrl-net",
+ "gctrl-proxy",
  "gctrl-scheduler",
  "gctrl-storage",
  "gctrl-sync",

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -46,6 +46,29 @@ const isWorkersAiModel = (model: string): boolean => !isAnthropicModel(model);
 const kernelBase = (): string =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
 
+// Identity headers consumed by the kernel's driver-llm capture path
+// (vault/specs/implementation/llm-relay.md § "Convergence with driver-llm").
+// Setting `x-session-id` makes the kernel persist a `prompt_bodies` row
+// per turn and emit a generation span — uebermensch then shows up in
+// /api/sessions and the analytics dashboard alongside opencode and the
+// rest. `UBER_SESSION_ID` is the operator's hook for tying a logical run
+// (e.g. one daily-brief invocation, one profile cycle) to a single
+// session; the fallback is a process-lifetime UUID so a forgotten env
+// var still produces *some* aggregated session rather than orphans.
+const SERVICE_NAME = "uebermensch";
+let processSessionId: string | null = null;
+const sessionIdFor = (): string => {
+  const explicit = process.env.UBER_SESSION_ID;
+  if (explicit && explicit.length > 0) return explicit;
+  if (processSessionId === null) {
+    processSessionId =
+      typeof globalThis.crypto?.randomUUID === "function"
+        ? globalThis.crypto.randomUUID()
+        : `uber-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+  return processSessionId;
+};
+
 const excerptOf = (body: string, max: number): string => {
   const trimmed = body.trim();
   if (trimmed.length <= max) return trimmed;
@@ -222,7 +245,11 @@ const fetchKernel = (
       try: () =>
         fetch(`${kernelBase()}${path}`, {
           method: "POST",
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            "x-session-id": sessionIdFor(),
+            "x-service-name": SERVICE_NAME,
+          },
           body: JSON.stringify(body),
         }),
       catch: (e) =>
@@ -830,6 +857,8 @@ export const _internal = {
   DEFAULT_SUMMARY_MODEL,
   modelFor,
   summaryModelFor,
+  sessionIdFor,
+  SERVICE_NAME,
   isAnthropicModel,
   isWorkersAiModel,
 };

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -334,6 +334,47 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     }
   })
 
+  it("attaches x-session-id + x-service-name=uebermensch on every kernel call", async () => {
+    // Capture headers fed into the kernel. The kernel reads these to
+    // tag prompt_bodies + sessions for the analytics dashboard
+    // (vault/specs/implementation/llm-relay.md § Convergence with
+    // driver-llm). Pin UBER_SESSION_ID so the assertion is exact —
+    // without it we'd just check that *some* uuid was set.
+    const prevSession = process.env.UBER_SESSION_ID
+    process.env.UBER_SESSION_ID = "uber-test-session-fixed"
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify(
+          anthropicJson({ items: [], topicsCovered: [], thesesCovered: [] }),
+        ),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: ["alpha"],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 3,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      const [, init] = fetchMock.mock.calls[0]!
+      const headers = (init as { headers: Record<string, string> }).headers
+      expect(headers["x-session-id"]).toBe("uber-test-session-fixed")
+      expect(headers["x-service-name"]).toBe("uebermensch")
+    } finally {
+      if (prevSession === undefined) delete process.env.UBER_SESSION_ID
+      else process.env.UBER_SESSION_ID = prevSession
+    }
+  })
+
   it("default model (no UBER_LLM_MODEL) routes to /api/llm/completions for LM Studio", async () => {
     // Clear the pinned anthropic model so the live default kicks in.
     delete process.env.UBER_LLM_MODEL

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -10,6 +10,10 @@ gctrl-context = { path = "../gctrl-context" }
 gctrl-sync = { path = "../gctrl-sync" }
 gctrl-net = { path = "../gctrl-net" }
 gctrl-scheduler = { path = "../gctrl-scheduler" }
+# Reuses the LLM-relay capture path so /api/llm/completions calls
+# (e.g. driver-llm clients like uebermensch) write the same prompt_bodies
+# rows + OTLP spans the relay does.
+gctrl-proxy = { path = "../gctrl-proxy" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -37,6 +37,15 @@ pub struct AppState {
     /// Live session-event bus (broadcast + replay ring) consumed by the
     /// SSE stream handlers — see spec/architecture/apps/gctrl-analytics.md §5.
     pub event_bus: Arc<EventBus>,
+    /// Shared capture sink for `/api/llm/{completions,messages}` exchanges.
+    /// Persists `prompt_bodies` rows and emits an OTLP generation span back
+    /// at this same kernel — same write path the LLM relay uses, so
+    /// driver-llm clients (uebermensch, anything calling `/api/llm/*`)
+    /// land in /api/sessions and the analytics dashboard with no extra
+    /// glue beyond setting `x-session-id` + `x-service-name` headers.
+    /// See vault/specs/implementation/llm-relay.md § "Convergence with
+    /// driver-llm".
+    pub llm_capture: Arc<gctrl_proxy::Capture>,
 }
 
 pub fn create_router(store: DuckDbStore) -> Router {
@@ -46,6 +55,7 @@ pub fn create_router(store: DuckDbStore) -> Router {
 /// Create router from a pre-shared Arc<DuckDbStore> (used when store is shared with other tasks).
 pub fn create_router_from_arc(store: Arc<DuckDbStore>) -> Router {
     let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite open"));
+    let llm_capture = build_llm_capture(Arc::clone(&store));
     let state = Arc::new(AppState {
         store: Arc::clone(&store),
         sqlite,
@@ -55,6 +65,7 @@ pub fn create_router_from_arc(store: Arc<DuckDbStore>) -> Router {
         net_config: Arc::new(NetConfig::default()),
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
+        llm_capture,
     });
     build_router(state)
 }
@@ -86,6 +97,7 @@ pub fn create_router_full(
     sync_config: Option<Arc<SyncConfig>>,
     net_config: Arc<NetConfig>,
 ) -> Router {
+    let llm_capture = build_llm_capture(Arc::clone(&store));
     let state = Arc::new(AppState {
         store,
         sqlite: Arc::clone(&sqlite),
@@ -95,14 +107,17 @@ pub fn create_router_full(
         net_config,
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
+        llm_capture,
     });
     build_router(state).merge(gctrl_scheduler::http::router(sqlite))
 }
 
 pub fn create_router_with_context(store: DuckDbStore, context: Option<ContextManager>) -> Router {
     let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite open"));
+    let store = Arc::new(store);
+    let llm_capture = build_llm_capture(Arc::clone(&store));
     let state = Arc::new(AppState {
-        store: Arc::new(store),
+        store,
         sqlite,
         context,
         started_at: std::time::Instant::now(),
@@ -110,8 +125,26 @@ pub fn create_router_with_context(store: DuckDbStore, context: Option<ContextMan
         net_config: Arc::new(NetConfig::default()),
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
+        llm_capture,
     });
     build_router(state)
+}
+
+/// Build the shared LLM capture sink. Sends OTLP back at this same kernel
+/// (the same daemon already terminates `/v1/traces`), and falls back to a
+/// neutral `service.name` when a caller doesn't supply `x-service-name`.
+/// `GCTRL_KERNEL_OTLP_URL` lets ops point at a sibling kernel for
+/// cross-machine analytics aggregation.
+fn build_llm_capture(store: Arc<DuckDbStore>) -> Arc<gctrl_proxy::Capture> {
+    let kernel_otlp_url = std::env::var("GCTRL_KERNEL_OTLP_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:4318/v1/traces".to_string());
+    Arc::new(gctrl_proxy::Capture::new(
+        store,
+        gctrl_proxy::CaptureConfig {
+            kernel_otlp_url,
+            default_service_name: "llm-client".to_string(),
+        },
+    ))
 }
 
 fn build_router(state: Arc<AppState>) -> Router {
@@ -4145,12 +4178,24 @@ const LMSTUDIO_DEFAULT_URL: &str = "http://127.0.0.1:1234/v1/chat/completions";
 
 async fn llm_completions(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     // Local-first: anything other than `GCTRL_LLM_PROVIDER=cloudflare` routes
     // to a local OpenAI-compat backend.
     let provider =
         std::env::var("GCTRL_LLM_PROVIDER").unwrap_or_else(|_| "lmstudio".to_string());
+
+    // Capture identity headers — the kernel is the relay's twin here. When
+    // a client (e.g. uebermensch via KernelLlm.ts) supplies x-session-id +
+    // x-service-name, this exchange will land in `prompt_bodies` and the
+    // sessions/cost/latency rollups exactly like a relay-routed call.
+    // Missing headers ⇒ no capture (we don't write orphan rows), request
+    // still served. Spec: vault/specs/implementation/llm-relay.md.
+    let session_id = llm_capture_header(&headers, "x-session-id");
+    let service_name = llm_capture_header(&headers, "x-service-name");
+    let req_body_text = serde_json::to_string(&body).unwrap_or_default();
+    let started_at = std::time::SystemTime::now();
 
     if provider != "cloudflare" {
         let local_url = std::env::var("GCTRL_LLM_LOCAL_URL")
@@ -4167,6 +4212,17 @@ async fn llm_completions(
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
                 if status.is_success() {
+                    gctrl_proxy::capture_oai_exchange(
+                        &state.llm_capture,
+                        &local_url,
+                        &req_body_text,
+                        &text,
+                        session_id.as_deref(),
+                        service_name.as_deref(),
+                        started_at,
+                        status.as_u16(),
+                    )
+                    .await;
                     match serde_json::from_str::<serde_json::Value>(&text) {
                         Ok(v) => Json(v).into_response(),
                         Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
@@ -4216,6 +4272,17 @@ async fn llm_completions(
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
             if status.is_success() {
+                gctrl_proxy::capture_oai_exchange(
+                    &state.llm_capture,
+                    &url,
+                    &req_body_text,
+                    &text,
+                    session_id.as_deref(),
+                    service_name.as_deref(),
+                    started_at,
+                    status.as_u16(),
+                )
+                .await;
                 match serde_json::from_str::<serde_json::Value>(&text) {
                     Ok(v) => Json(v).into_response(),
                     Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
@@ -4230,6 +4297,13 @@ async fn llm_completions(
         )
             .into_response(),
     }
+}
+
+fn llm_capture_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
 }
 
 #[cfg(test)]

--- a/kernel/crates/gctrl-otel/tests/llm_completions_capture.rs
+++ b/kernel/crates/gctrl-otel/tests/llm_completions_capture.rs
@@ -1,0 +1,152 @@
+//! Integration test for `/api/llm/completions` driver-llm capture.
+//!
+//! Spec: `vault/specs/implementation/llm-relay.md` § "Convergence with
+//! driver-llm". When the kernel forwards a chat-completions request to a
+//! local upstream, an `x-session-id` + `x-service-name` header pair on
+//! the inbound call should make the exchange land in `prompt_bodies`
+//! and, by way of the OTLP self-emit, in `/api/sessions`. Without the
+//! headers, the request still completes but no rows are written.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::body::Body;
+use axum::routing::post;
+use axum::{Json, Router};
+use gctrl_otel::create_router_from_arc;
+use gctrl_storage::DuckDbStore;
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+/// Both tests below mutate `GCTRL_LLM_LOCAL_URL` and `GCTRL_LLM_PROVIDER`,
+/// which are process-global. Cargo runs tests in a binary in parallel by
+/// default, so without serialization the second test's `set_var` could
+/// race the first test's in-flight `oneshot`. Take this lock for the
+/// whole duration of any test that depends on those env vars.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
+
+/// Spawn a tiny stand-in LMStudio that returns a deterministic response.
+/// We point the kernel at it with `GCTRL_LLM_LOCAL_URL`, then route the
+/// receiver's `/api/llm/completions` through `oneshot`.
+async fn spawn_mock_upstream() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}/v1/chat/completions");
+    tokio::spawn(async move {
+        let app: Router = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                Json(serde_json::json!({
+                    "id": "cmpl-driver",
+                    "model": "google/gemma-4-31b",
+                    "choices": [{
+                        "index": 0,
+                        "message": { "role": "assistant", "content": "ok" }
+                    }],
+                    "usage": { "prompt_tokens": 11, "completion_tokens": 1 }
+                }))
+            }),
+        );
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    url
+}
+
+#[tokio::test]
+async fn llm_completions_with_session_headers_captures_prompt_bodies() {
+    let _guard = env_lock();
+    let upstream = spawn_mock_upstream().await;
+
+    // Force the local-first branch and point at our stand-in. The
+    // `env_lock` above ensures we don't race the sibling test on the
+    // shared GCTRL_LLM_* env vars.
+    unsafe {
+        std::env::set_var("GCTRL_LLM_PROVIDER", "lmstudio");
+        std::env::set_var("GCTRL_LLM_LOCAL_URL", &upstream);
+    }
+
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let app = create_router_from_arc(Arc::clone(&store));
+
+    let body = serde_json::json!({
+        "model": "google/gemma-4-31b",
+        "messages": [
+            { "role": "system", "content": "be terse" },
+            { "role": "user", "content": "ping" }
+        ]
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/llm/completions")
+                .header("content-type", "application/json")
+                .header("x-session-id", "drvl-sess-1")
+                .header("x-service-name", "uebermensch")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["choices"][0]["message"]["content"], "ok");
+
+    // Capture is awaited inside the handler, so by the time the response
+    // returns the rows are committed.
+    let rows = store.list_prompt_bodies_for_session("drvl-sess-1").unwrap();
+    assert_eq!(rows.len(), 3, "system + user + assistant");
+    assert_eq!(rows[0].role, "system");
+    assert_eq!(rows[0].content, "be terse");
+    assert_eq!(rows[1].role, "user");
+    assert_eq!(rows[1].content, "ping");
+    assert_eq!(rows[1].tokens, Some(11));
+    assert_eq!(rows[2].role, "assistant");
+    assert_eq!(rows[2].content, "ok");
+    assert_eq!(rows[2].tokens, Some(1));
+}
+
+#[tokio::test]
+async fn llm_completions_without_session_header_still_serves_no_capture() {
+    let _guard = env_lock();
+    let upstream = spawn_mock_upstream().await;
+    unsafe {
+        std::env::set_var("GCTRL_LLM_PROVIDER", "lmstudio");
+        std::env::set_var("GCTRL_LLM_LOCAL_URL", &upstream);
+    }
+
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let app = create_router_from_arc(Arc::clone(&store));
+
+    let body = serde_json::json!({
+        "model": "google/gemma-4-31b",
+        "messages": [{ "role": "user", "content": "no-session" }]
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/llm/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    // No session header → no orphan rows. Spec: relay/driver-llm both
+    // skip capture rather than write under a synthetic id.
+    let any_rows = store.list_prompt_bodies_for_session("").unwrap();
+    assert!(any_rows.is_empty());
+}

--- a/kernel/crates/gctrl-proxy/src/capture.rs
+++ b/kernel/crates/gctrl-proxy/src/capture.rs
@@ -279,6 +279,99 @@ pub fn parse_sse_to_response(body: &str) -> Option<ChatCompletionsResponse> {
     })
 }
 
+// --- Generic OpenAI-compat exchange capture (relay + driver-llm) ---
+//
+// Both the LLM relay and the kernel's `driver-llm` HTTP route forward
+// OpenAI-compat `/v1/chat/completions` calls to a configurable upstream.
+// They share the same capture target — `prompt_bodies` rows + a single
+// OTLP generation span — so the persist/emit logic lives here, not in
+// either caller. Skipping capture is silent and never blocks the agent
+// loop: missing session id, unparseable JSON, or a downstream OTLP failure
+// all degrade to "request still served, telemetry quietly dropped."
+
+use std::time::SystemTime;
+
+/// Run the capture path for one OpenAI-compat chat-completions exchange.
+///
+/// All fields that block capture are passed as `Option`/`Result` so a
+/// caller never has to short-circuit upstream — the function decides
+/// internally whether enough is present to write a row. This is the
+/// single entry point the relay and `driver-llm` both call.
+///
+/// `upstream_url` is used only for `gen_ai.system` heuristics
+/// (`lmstudio`/`ollama`/`openai`/...); pass the URL the request was
+/// forwarded to, not the URL the client called.
+pub async fn capture_oai_exchange(
+    capture: &Capture,
+    upstream_url: &str,
+    req_body_text: &str,
+    resp_body_text: &str,
+    session_id: Option<&str>,
+    service_name: Option<&str>,
+    started_at: SystemTime,
+    status_code: u16,
+) {
+    let Some(sid) = session_id else { return };
+    let Ok(req) = serde_json::from_str::<ChatCompletionsRequest>(req_body_text) else {
+        return;
+    };
+    let Ok(rsp) = serde_json::from_str::<ChatCompletionsResponse>(resp_body_text) else {
+        return;
+    };
+
+    let trace_id = format!("{:032x}", Uuid::new_v4().as_u128());
+    let span_id = format!(
+        "{:016x}",
+        (Uuid::new_v4().as_u128() & 0xffff_ffff_ffff_ffff)
+    );
+    let turns = extract_turns(&req, &rsp, sid, &trace_id, &span_id);
+    if let Err(e) = capture.persist(&turns) {
+        tracing::warn!(error = %e, "prompt body persist failed");
+    }
+
+    let span_inputs = OtlpSpanInputs {
+        session_id: sid.to_string(),
+        trace_id,
+        span_id,
+        model: req.model.clone(),
+        gen_ai_system: derive_gen_ai_system_from_url(upstream_url),
+        prompt_tokens: rsp.usage.as_ref().and_then(|u| u.prompt_tokens),
+        completion_tokens: rsp.usage.as_ref().and_then(|u| u.completion_tokens),
+        start_unix_nano: unix_nanos(started_at),
+        end_unix_nano: unix_nanos(SystemTime::now()),
+        status_ok: (200..300).contains(&status_code),
+    };
+    let _ = capture
+        .emit_otlp_with_service(&span_inputs, service_name)
+        .await;
+}
+
+/// Best-effort `gen_ai.system` derivation from the upstream URL host.
+/// Returns `None` rather than guessing wrong — operators can always
+/// add a per-request override later.
+pub fn derive_gen_ai_system_from_url(upstream_url: &str) -> Option<String> {
+    let lower = upstream_url.to_lowercase();
+    if lower.contains("127.0.0.1:1234") || lower.contains("localhost:1234") {
+        Some("lmstudio".into())
+    } else if lower.contains("api.openai.com") {
+        Some("openai".into())
+    } else if lower.contains("api.anthropic.com") {
+        Some("anthropic".into())
+    } else if lower.contains("ollama") || lower.contains(":11434") {
+        Some("ollama".into())
+    } else if lower.contains("gateway.ai.cloudflare.com") {
+        Some("cloudflare-ai-gateway".into())
+    } else {
+        None
+    }
+}
+
+fn unix_nanos(t: SystemTime) -> u64 {
+    t.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
 // --- Capture sink: storage + OTLP ---
 
 pub struct Capture {

--- a/kernel/crates/gctrl-proxy/src/lib.rs
+++ b/kernel/crates/gctrl-proxy/src/lib.rs
@@ -37,7 +37,9 @@ use hudsucker::{
 };
 
 pub use ca::{ensure_ca_cert, CaPaths};
-pub use capture::{Capture, CaptureConfig, CapturedTurn};
+pub use capture::{
+    capture_oai_exchange, derive_gen_ai_system_from_url, Capture, CaptureConfig, CapturedTurn,
+};
 pub use handler::TrafficLogger;
 pub use redact::redact_url;
 pub use relay::{LlmRelay, RelayConfig};


### PR DESCRIPTION
## Summary

Closes the "Convergence with driver-llm" gap in `vault/specs/implementation/llm-relay.md`. Until this PR, requests through `/api/llm/completions` (the kernel's driver-llm route, called by uebermensch and any other internal Effect-TS app) were forwarded to LMStudio / Cloudflare AI Gateway with **no analytics capture** — bytes flowed through but no `prompt_bodies` rows, no generation span, nothing in `/api/sessions`. The relay already captured opencode-style external traffic; this PR extends the same capture path to the kernel's own LLM gateway so internal apps land in analytics on equal footing.

Trigger: uebermensch runs daily and was completely invisible to the analytics dashboard.

## How it works

1. **Shared capture helper** — hoisted the relay's persist + OTLP-emit core out of `relay.rs::run_capture` into `gctrl_proxy::capture_oai_exchange` (pure function over a `Capture` sink). `Capture` and `derive_gen_ai_system_from_url` are now `pub use` re-exports. `gen_ai.system` heuristics gain a `cloudflare-ai-gateway` mapping.
2. **Receiver wiring** — `AppState` gets a single shared `Capture` (built once from the same `DuckDbStore`; OTLP self-emits at `GCTRL_KERNEL_OTLP_URL`, default `http://127.0.0.1:4318/v1/traces`). `llm_completions` now takes a `HeaderMap`, reads `x-session-id` + `x-service-name`, and runs the helper after a successful upstream response. Missing headers ⇒ no capture, request still served (same fail-quiet contract as the relay).
3. **uebermensch headers** — `KernelLlm.ts::fetchKernel` always sets `x-service-name: uebermensch` and an `x-session-id` from `UBER_SESSION_ID` (operator hook for "one cycle = one session"), falling back to a process-lifetime UUID so a forgotten env var still aggregates to *some* session instead of producing a swarm of one-turn orphans.

### What's deferred

- Anthropic-shape `/api/llm/messages` capture — needs a parser for `{ content: [...], usage: { input_tokens, output_tokens } }`. Currently uebermensch's Anthropic-routed calls (Claude models) skip capture; OpenAI-shape calls (the LMStudio/CF Workers AI default) capture cleanly. Tracked under M3 of the relay spec.
- Streaming through driver-llm — the kernel's existing `llm_completions` already collects the full response before returning, so SSE handling isn't relevant here. PR [#88](https://github.com/OpenHackersClub/gctrl/pull/88)'s SSE tee can be lifted in if/when driver-llm grows streaming.

## Test plan

- [x] `cargo test -p gctrl-proxy -p gctrl-otel` — all green (existing 28 proxy + new 2 driver-llm capture integration tests + the rest of the otel suite).
- [x] New `tests/llm_completions_capture.rs` — drives a request through `/api/llm/completions` against a stand-in upstream, asserts both that capture happens with the headers (3 prompt_bodies rows, correct content/tokens) and is silently skipped without them.
- [x] `pnpm --filter uebermensch test` — 142/142 including a new test that pins `UBER_SESSION_ID` and asserts the headers are set on every fetched kernel call.
- [x] Live smoke against the launchd kernel + LMStudio: `curl -X POST :4318/api/llm/completions -H "x-session-id: $(uuidgen)" -H "x-service-name: uebermensch-smoke"` → session lands in `/api/sessions` with the right `agent_name` and token totals.
- [ ] Real uebermensch CLI run after merge → session visible in `/api/sessions?agent=uebermensch` and the dashboard's Sessions tab.
