### PR TITLE
refactor(gctrl-board): explicit named exports over export *

### DIFF
--- a/apps/gctrl-board/src/index.ts
+++ b/apps/gctrl-board/src/index.ts
@@ -1,3 +1,39 @@
-export * from "./schema/index.js"
-export * from "./services/index.js"
-export * from "./adapters/index.js"
+// Schema
+export {
+  Assignee,
+  AssigneeType,
+  Board,
+  BoardId,
+  Comment,
+  CreateIssueInput,
+  Issue,
+  IssueEvent,
+  IssueEventType,
+  IssueFilter,
+  IssueId,
+  IssueStatus,
+  Priority,
+  Project,
+  ProjectId,
+} from "./schema/index.js"
+
+// Services
+export {
+  BoardError,
+  BoardService,
+  CyclicDependencyError,
+  DEFAULT_SPAN_DAYS,
+  DependencyResolver,
+  IssueNotFoundError,
+  KernelError,
+  KernelUnavailableError,
+  ProjectNotFoundError,
+  WipLimitExceededError,
+} from "./services/index.js"
+
+// Adapters
+export {
+  BoardServiceLive,
+  KernelClient,
+  KernelClientLive,
+} from "./adapters/index.js"

--- a/apps/gctrl-board/src/schema/index.ts
+++ b/apps/gctrl-board/src/schema/index.ts
@@ -1,3 +1,13 @@
-export * from "./Issue.js"
-export * from "./IssueEvent.js"
-export * from "./Board.js"
+export {
+  Assignee,
+  AssigneeType,
+  CreateIssueInput,
+  Issue,
+  IssueFilter,
+  IssueId,
+  IssueStatus,
+  Priority,
+  ProjectId,
+} from "./Issue.js"
+export { Comment, IssueEvent, IssueEventType } from "./IssueEvent.js"
+export { Board, BoardId, Project } from "./Board.js"

--- a/apps/gctrl-board/src/services/index.ts
+++ b/apps/gctrl-board/src/services/index.ts
@@ -1,4 +1,12 @@
 export { BoardService } from "./BoardService.js"
 export { DependencyResolver } from "./DependencyResolver.js"
-export * from "./errors.js"
+export {
+  BoardError,
+  CyclicDependencyError,
+  IssueNotFoundError,
+  KernelError,
+  KernelUnavailableError,
+  ProjectNotFoundError,
+  WipLimitExceededError,
+} from "./errors.js"
 export { DEFAULT_SPAN_DAYS } from "./constants.js"


### PR DESCRIPTION
## Summary

Replace wildcard `export *` re-exports in three `gctrl-board` barrel files with explicit named exports.

- **`src/schema/index.ts`** — enumerate Issue / IssueEvent / Board exports (was 3× `export *`).
- **`src/services/index.ts`** — enumerate the seven error classes from `errors.js` (was `export * from "./errors.js"`); the other entries were already explicit.
- **`src/index.ts`** — enumerate everything re-exported from `schema` / `services` / `adapters` (was 3× `export *`).

Why: the project's `arch-taste.md` rules call out *"No barrel exports (index.ts re-exporting everything)"* — wildcard re-exports defeat tree-shaking and let new internal symbols silently leak into the package's public API. Explicit lists make the public surface auditable at a glance.

No behavioural change — existing import sites continue to resolve.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` passes (41/41 active)
- [ ] CI green
