### PR TITLE
docs(specs): codify Effect-TS rules from refactor audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,8 @@ Detailed programming patterns, code examples, and how-to guides live under `vaul
 | Directory / File | Scope | Content that belongs here |
 |-----------------|-------|--------------------------|
 | `vault/specs/implementation/kernel/` | Kernel implementation | Rust crate map, dependency graph, subsystem details (OTel, guardrails, context, proxy, sync, net, scheduler), kernel style guide, orchestrator, tracker. |
-| `vault/specs/implementation/shell/` | Shell implementation | Effect-TS CLI (`@effect/cli`), KernelClient/GitHubClient adapters, kernel↔shell HTTP communication patterns. |
-| `vault/specs/implementation/apps/` | Application implementation | Effect-TS package structure, gctrl-board details, app style guide, integration modes (sidecar, embedded). |
+| `vault/specs/implementation/shell/` | Shell implementation | Effect-TS CLI (`@effect/cli`), KernelClient/GitHubClient adapters, kernel↔shell HTTP communication patterns. Includes `style.md` (shell-specific Effect-TS rules — `ExecError` for subprocesses, `Option.match` for optional args, no dynamic `require`). |
+| `vault/specs/implementation/apps/` | Application implementation | Effect-TS package structure, gctrl-board details, app style guide (`style.md` — Bad/Good examples for tagged errors, Schema decode, no barrel re-exports), integration modes (sidecar, embedded). |
 | `vault/specs/implementation/formal/` | Formal spec conventions | Lean 4 style: Mathlib, generic theorems, state machine file structure, proof style, naming conventions. |
 | `vault/specs/implementation/repo.md` | Monorepo structure | Nx + Cargo workspace setup, directory layout, cross-language orchestration. |
 | `vault/specs/implementation/kernel/orchestrator.md` | Orchestration implementation | gctrl-orch Rust crate, agent adapters, retry constants, conformance testing. |
@@ -124,7 +124,7 @@ Detailed programming patterns, code examples, and how-to guides live under `vaul
 1. Dependencies MUST flow inward: Shell → Kernel → Domain, never reverse.
 2. DuckDB is single-writer: the daemon MUST hold the lock; shell and apps MUST use the HTTP API.
 3. Application tables MUST use namespaced prefixes (`board_*`, `eval_*`, `capacity_*`, `inbox_*`).
-4. Code MUST NOT access Effect-TS `._tag` directly — use combinators (`Effect.catchTag`, `Match.tag`).
+4. Code MUST NOT access Effect-TS `._tag` directly — use combinators (`Effect.catchTag`, `Match.tag`, `Option.match`). Also: no bare `new Error` in Effect contexts (use `Schema.TaggedError`), no `as any` on external JSON (use `Schema.decodeUnknown`), no `export *` barrels, no dynamic `require` inside Effect generators. Full list with Bad/Good examples: `vault/specs/principles.md` § Effect-TS Invariants and `vault/specs/implementation/{apps,shell}/style.md`. Reviewer sweep: `rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts`.
 5. **TDD is the default.** Write a failing test first, then make it pass, then refactor. No production code without a pre-existing test.
 6. Every new public function MUST have at least one test. Coverage: storage CRUD + HTTP routes (happy + error) + shell commands.
 7. Contributors MUST use feature branches — MUST NOT push directly to main.

--- a/vault/specs/implementation/apps/style.md
+++ b/vault/specs/implementation/apps/style.md
@@ -1,4 +1,9 @@
-# Applications Style Guide (Effect-TS — `packages/`)
+# Applications Style Guide (Effect-TS — `apps/`)
+
+The rules below are enforced via review and the ripgrep sweep documented
+in `vault/specs/principles.md` § Effect-TS Invariants. Each rule shows
+**Bad** (what the audit caught in this repo) and **Good** (the idiomatic
+fix) so reviewers can pattern-match.
 
 ## Tag Access
 
@@ -7,34 +12,195 @@ Never access `._tag` directly. Use proper combinators:
 - `Effect.catchTag` / `Effect.catchTags` for error handling
 - `Match.tag` + `Match.exhaustive` for pattern matching
 - `Schema.TaggedError` / `Schema.TaggedClass` for defining tagged types
+- `Exit.match`, `Either.match`, `Option.match` for branching
 
-## Tagged Errors
-
-Define domain errors as tagged error classes with structured fields:
-
+**Bad:**
 ```typescript
-class IssueNotFoundError extends Schema.TaggedError<IssueNotFoundError>()(
-  "IssueNotFoundError", { issueId: Schema.String }
-) {}
+const seed = fromSeed._tag === "Some" ? resolve(fromSeed.value) : FIXTURE_ROOT
 ```
 
-## Service Definitions (Ports as Context.Tag)
+**Good:**
+```typescript
+const seed = Option.match(fromSeed, {
+  onSome: (v) => resolve(v),
+  onNone: () => FIXTURE_ROOT,
+})
+```
 
-Model service ports as `Context.Tag`. Each method returns `Effect` with typed errors:
+## Tagged Errors (no bare `new Error`)
+
+Define domain errors as `Schema.TaggedError` with structured fields.
+Inside an Effect context, **never** `Effect.fail(new Error(...))` and
+**never** `throw new Error(...)` from a function the Effect runtime
+will wrap.
+
+**Bad:**
+```typescript
+yield* Effect.fail(new Error(`${issues.length} validation issue(s)`))
+// or
+catch: (e) => new Error(String(e))
+// or, inside a sync helper called from an Effect:
+if (Number.isNaN(d.getTime())) throw new Error(`invalid starts_at: ${startsAt}`)
+```
+
+**Good:**
+```typescript
+class ProfileError extends Schema.TaggedError<ProfileError>()(
+  "ProfileError",
+  { message: Schema.String, issues: Schema.optional(Schema.Array(Schema.String)) }
+) {}
+
+yield* Effect.fail(new ProfileError({
+  message: `${issues.length} validation issue(s)`, issues,
+}))
+
+// For sync helpers, return Either instead of throwing:
+const datePart = (s: string): Either.Either<string, string> =>
+  Number.isNaN(new Date(s).getTime())
+    ? Either.left(`invalid starts_at: ${s}`)
+    : Either.right(/* … */)
+```
+
+## Decode External JSON (no `as any`)
+
+HTTP / kernel responses MUST flow through `Schema.decodeUnknown` so a
+malformed payload becomes a tagged error, not a runtime
+`cannot read property of undefined`. The wire schema is local to the
+adapter; the domain type is what the rest of the codebase sees.
+
+**Bad:**
+```typescript
+const mapIssue = (raw: any): Issue => ({ id: raw.id, projectId: raw.project_id, /* … */ })
+const issues = (raw as any[]).map(mapIssue)
+const envelope = raw as { issue: unknown }
+```
+
+**Good:**
+```typescript
+const KernelIssue = Schema.Struct({
+  id: Schema.String,
+  project_id: Schema.String,
+  status: IssueStatus,
+  /* … */
+})
+const decodeIssue = (raw: unknown, ctx: string) =>
+  Schema.decodeUnknown(KernelIssue)(raw).pipe(
+    Effect.map(toIssue),
+    Effect.mapError((e) => new KernelError({
+      message: `${ctx}: invalid kernel response — ${String(e)}`,
+    })),
+  )
+```
+
+## No Barrel Re-exports
+
+Wildcard re-exports defeat tree-shaking and let new internal symbols
+silently leak into the package's public API. List exports explicitly.
+
+**Bad:**
+```typescript
+// src/schema/index.ts
+export * from "./Issue.js"
+export * from "./IssueEvent.js"
+export * from "./Board.js"
+```
+
+**Good:**
+```typescript
+// src/schema/index.ts
+export {
+  Assignee, AssigneeType, CreateIssueInput, Issue,
+  IssueFilter, IssueId, IssueStatus, Priority, ProjectId,
+} from "./Issue.js"
+export { Comment, IssueEvent, IssueEventType } from "./IssueEvent.js"
+export { Board, BoardId, Project } from "./Board.js"
+```
+
+When in doubt, prefer importing directly from the leaf module — barrels
+are only justified when a package has a deliberate, curated public API.
+
+## No Dynamic `require` Inside Effect
+
+Dynamic `require()` defeats bundlers and obscures the dependency graph.
+Use a static `import` and wrap the call site in `Effect.try` (or
+`Effect.sync` for code that cannot throw).
+
+**Bad:**
+```typescript
+const { readFileSync } = yield* Effect.sync(() => require("node:fs"))
+let content: string
+try {
+  content = readFileSync(filePath, "utf-8")
+} catch {
+  yield* Console.error(`Cannot read file: ${filePath}`)
+  return
+}
+```
+
+**Good:**
+```typescript
+import { readFileSync } from "node:fs"
+
+const maybeContent = yield* Effect.try(() => readFileSync(filePath, "utf-8")).pipe(
+  Effect.option,
+)
+if (Option.isNone(maybeContent)) {
+  yield* Console.error(`Cannot read file: ${filePath}`)
+  return
+}
+const content = maybeContent.value
+```
+
+## Recover with `catchTag`, not `catchAll`
+
+`Effect.catchAll((e) => …)` swallows the error type and lands `e` as
+`unknown`. Use `Effect.catchTag(<TagName>, …)` so the recovered error
+is statically known. Reserve `catchAll` for top-level entrypoints where
+the program is about to exit.
+
+**Bad:**
+```typescript
+return runWork().pipe(
+  Effect.catchAll((e) => Console.error(`Error: ${e}`))
+)
+```
+
+**Good:**
+```typescript
+class ExecError extends Schema.TaggedError<ExecError>()(
+  "ExecError",
+  { message: Schema.String, bin: Schema.String, args: Schema.Array(Schema.String) }
+) {}
+
+return runWork().pipe(
+  Effect.catchTag("ExecError", (e) =>
+    Console.error(`Error: ${e.message}. Is ${e.bin} installed?`)
+  )
+)
+```
+
+## Service Definitions (Ports as `Context.Tag`)
+
+Model service ports as `Context.Tag`. Each method returns `Effect` with
+typed errors:
 
 ```typescript
 class BoardService extends Context.Tag("BoardService")<
   BoardService,
   {
     readonly createIssue: (input: CreateIssueInput) => Effect.Effect<Issue, BoardError>
-    readonly moveIssue: (id: IssueId, status: IssueStatus) => Effect.Effect<Issue, BoardError | IssueNotFoundError>
+    readonly moveIssue: (id: IssueId, status: IssueStatus) =>
+      Effect.Effect<Issue, BoardError | IssueNotFoundError>
   }
 >() {}
 ```
 
 ## Layer Composition
 
-Wire adapters via Effect Layers at the edge (entrypoint), keeping domain logic pure.
+Wire adapters via Effect Layers at the entrypoint, keeping domain logic
+pure. Centralize repeated layer wiring in a `provideAllLayers(...)`
+factory rather than re-pasting the same `Effect.provide(...)` chain in
+every command.
 
 ## Branded Types (Value Objects)
 
@@ -47,7 +213,10 @@ const ProjectId = Schema.String.pipe(Schema.brand("ProjectId"))
 
 ## General Rules
 
-- Prefer `pipe` / `Effect.gen` generators over imperative chains
-- No `any` types — use `unknown` + Schema decode
-- No mutable global state — use Effect Ref or Context
-- No barrel exports (`index.ts` re-exporting everything) — import directly
+- Prefer `pipe` / `Effect.gen` generators over imperative chains.
+- No `any` types — use `unknown` + Schema decode (see above).
+- No mutable global state — use `Effect.Ref` or `Context`.
+- No barrel exports — list each name explicitly (see above).
+- Imperative loops mutating shared state (e.g. a worker pool with
+  `let next = 0`) MUST be replaced with `Effect.forEach(items, fn,
+  { concurrency })` + `Ref` for accumulators.

--- a/vault/specs/implementation/shell/style.md
+++ b/vault/specs/implementation/shell/style.md
@@ -1,0 +1,134 @@
+# Shell Style Guide (Effect-TS — `shell/gctrl-shell/`)
+
+The shell is an `@effect/cli` program. Most rules from
+`vault/specs/implementation/apps/style.md` apply verbatim — this file
+captures the shell-specific specializations.
+
+## All Apps Rules Apply
+
+Read `apps/style.md` first. Every rule there (no `._tag`, tagged errors
+over bare `new Error`, `Schema.decodeUnknown` over `as any`, no barrel
+re-exports, no dynamic `require`, `catchTag` over `catchAll`) applies
+to commands, adapters, and services in `shell/gctrl-shell/src/`.
+
+## KernelClient is the Only HTTP Adapter
+
+Commands MUST NOT call `fetch` directly. Use the `KernelClient` service
+port:
+
+```typescript
+const cmd = Command.make("foo", {}, () =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const data = yield* kernel.get("/api/foo", FooSchema)
+    yield* Console.log(data.bar)
+  })
+)
+```
+
+Tests inject a mock `KernelClient` Layer (see
+`test/helpers/mock-kernel.ts`) — there is no real HTTP in unit tests.
+
+## External APIs Go Through Kernel Drivers
+
+The shell MUST NOT depend on `ccli`, `gh`, `linear-cli`, or call
+GitHub / Linear / Slack APIs directly. All external access goes through
+kernel driver routes (`/api/github/*`, `/api/linear/*`, …) so
+authentication and rate-limiting are centralized.
+
+The one carve-out is the `gctrl` Rust binary for filesystem-backed
+spider operations (`net fetch/crawl/list/show/compact`). That call
+SHOULD use the typed `ExecError` pattern below, not bare `new Error`.
+
+## Subprocess Calls Use `ExecError`
+
+When the shell shells out (e.g. invoking the `gctrl` Rust binary),
+failure MUST surface as a tagged `ExecError`, not a bare Error.
+
+**Bad:**
+```typescript
+if (!result.ok) {
+  return yield* Effect.fail(new Error(`gctrl ${args[0]} failed`))
+}
+```
+
+**Good:**
+```typescript
+import { ExecError } from "../errors"
+
+if (!result.ok) {
+  return yield* Effect.fail(new ExecError({
+    message: `gctrl ${args[0]} failed`,
+    bin: GCTRL_BIN,
+    args,
+    output: result.output,
+  }))
+}
+```
+
+Recovery uses `Effect.catchTag("ExecError", …)` so the error fields are
+statically available to the handler.
+
+## Optional Args: `Option.match`, not `._tag`
+
+`@effect/cli` `Options.optional()` returns an `Option`. Branch with
+`Option.match` / `Option.isSome` / `Option.getOrElse` — never
+`opt._tag === "Some"`.
+
+**Bad:**
+```typescript
+const seed = fromSeed._tag === "Some" ? resolve(fromSeed.value) : DEFAULT
+```
+
+**Good:**
+```typescript
+const seed = Option.match(fromSeed, {
+  onSome: (v) => resolve(v),
+  onNone: () => DEFAULT,
+})
+```
+
+## File I/O: Static Import + `Effect.try`
+
+The `node:fs` builtins MUST be imported statically. Wrap the call in
+`Effect.try` and recover with `Option`/`Either` rather than imperative
+`try/catch`.
+
+**Bad:**
+```typescript
+const { readFileSync } = yield* Effect.sync(() => require("node:fs"))
+try {
+  content = readFileSync(filePath, "utf-8")
+} catch {
+  yield* Console.error(`Cannot read file: ${filePath}`)
+  return
+}
+```
+
+**Good:**
+```typescript
+import { readFileSync } from "node:fs"
+
+const maybe = yield* Effect.try(() => readFileSync(filePath, "utf-8")).pipe(
+  Effect.option,
+)
+if (Option.isNone(maybe)) {
+  yield* Console.error(`Cannot read file: ${filePath}`)
+  return
+}
+const content = maybe.value
+```
+
+## Quality Gate: `AuditError` for the audit command
+
+The `audit` command MUST fail with a tagged `AuditError` carrying
+structured `{ failed, passed }` counts so callers (CI scripts, skills)
+can branch on the structured fields rather than parse a stringified
+message.
+
+## Test Helpers
+
+Mock `KernelClient` factories live in `test/helpers/mock-kernel.ts`.
+Per-command tests SHOULD reuse the shared factory rather than spinning
+up bespoke `Layer.succeed` blocks. New mock helpers MUST be exported
+from that file (no barrel re-exports — list them explicitly).

--- a/vault/specs/principles.md
+++ b/vault/specs/principles.md
@@ -70,6 +70,25 @@ When modifying code, respect crate boundaries:
    - `Schema.TaggedError` / `Schema.TaggedClass` for defining tagged types
    - `Exit.match`, `Either.match`, `Option.match` for branching
 2. **MUST follow idiomatic Effect-TS:** use `pipe`/generators (`Effect.gen`), Layer composition, and built-in combinators instead of imperative escape hatches.
+3. **MUST NOT throw or fail with bare `new Error(...)`.** Inside Effect contexts (including `Effect.tryPromise.catch` and `Effect.fail`), failures MUST construct a `Schema.TaggedError` carrying structured fields. Reviewer search: `rg -n 'new Error\(|Effect\.fail\(new Error' shell apps`.
+4. **MUST NOT use `as any` to read external JSON.** Kernel/HTTP responses MUST be validated via `Schema.decodeUnknown(WireSchema)`. Decode failures convert to a tagged error so a malformed payload surfaces as a structured failure, not `cannot read property of undefined`. Reviewer search: `rg -n 'as any|: any\b' shell apps --type ts`.
+5. **MUST NOT use `export *` barrel re-exports** in `index.ts` files. List each export by name. Wildcard re-exports defeat tree-shaking and silently leak new internal symbols into a package's public API. Reviewer search: `rg -n '^export \*' shell apps`.
+6. **MUST NOT use dynamic `require(...)` inside an Effect context.** Use a static `import` at the top of the module; wrap the call site in `Effect.try` (or `Effect.sync` for known-pure code). Reviewer search: `rg -n 'require\(' shell apps --type ts`.
+7. **MUST NOT recover with `Effect.catchAll(e => ...)` over an untyped error.** Use `Effect.catchTag(<TagName>, ...)` so the recovered error type is preserved. Untyped `catchAll` is reserved for top-level entrypoints where the program is exiting.
+8. **MUST NOT keep mutable module-level state** (`let` at top level, mutable singletons). Use `Effect.Ref` or `Context` for shared state.
+
+### Quick enforcement
+
+The above rules can be checked in CI / pre-review with a single ripgrep
+sweep over `shell/` and `apps/`:
+
+```sh
+rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts
+```
+
+A clean run is required before merge. Existing legitimate exceptions
+MUST be documented inline with a `// effect-ts-allow: <reason>` comment
+so the sweep can be filtered without weakening the rule.
 
 ## Testing Invariants
 


### PR DESCRIPTION
## Summary

Codify the Effect-TS anti-patterns surfaced by the audit that drove PRs #90–#94 so they're enforceable on future PRs (review checklist + ripgrep sweep), not just fixed once.

The audit ran three Explore agents over `shell/gctrl-shell/`, `apps/uebermensch/`, and `apps/gctrl-board/` + `apps/gctrl-inbox/`. Across all three packages it found six categories of violation that PR #90–#94 cleaned up:

| Category | Caught in audit | Fixed in PR |
|---|---|---|
| `._tag === "Some"` | uebermensch `vault-init.ts:37` | #90 |
| Bare `new Error` / `Effect.fail(new Error(...))` | 6 sites across uebermensch + shell | #90, #91 |
| Imperative `try/catch` + dynamic `require` in Effect.gen | shell `persona.ts` | #91 |
| `export *` barrel re-exports | gctrl-board `src/index.ts`, `schema/index.ts`, `services/index.ts` | #93 |
| `as any` on external JSON | gctrl-board `BoardServiceLive.ts` (4 sites) | #94 |
| `Effect.catchAll(e => …)` over untyped errors | shell `net.ts`, `audit.ts` | #91 |

This PR moves the rules into the spec layer with concrete Bad/Good examples lifted from the actual audit, so reviewers can pattern-match.

### Changes

- **`vault/specs/principles.md` § Effect-TS Invariants** — add rules 3–8 covering each category, plus a single reviewer ripgrep sweep:
  ```sh
  rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts
  ```
- **`vault/specs/implementation/apps/style.md`** — rewrite with Bad/Good examples for every rule. Each example is the exact violation the audit caught.
- **`vault/specs/implementation/shell/style.md` (new)** — shell-specific specializations: `KernelClient` is the only HTTP adapter, `ExecError` for subprocess failures, `Option.match` for `@effect/cli` optional args, no dynamic `require` inside `Effect.gen`.
- **`AGENTS.md`** — expand invariant #4 with the full rule list and the reviewer sweep; link to the two style guides.

## Test plan

- [x] No code changes — docs / specs only
- [ ] CI green
- [ ] Manual: run the ripgrep sweep on `main` after PRs #90–#94 land — should print zero hits
