### PR TITLE
feat(uebermensch): calendar timeboxes — multi-event practice plans

### DIFF
--- a/apps/uebermensch/ROADMAP.md
+++ b/apps/uebermensch/ROADMAP.md
@@ -137,6 +137,23 @@
 
 **Done when:** A user can `gctrl uber calendar add` a personal event and see it in tomorrow's brief; `driver-markets` populates earnings dates for the user's ticker watchlist; `gctrl uber calendar list --view personal-week` returns the right shape on stdout and `/api/uber/calendar/feed.ics` is subscribable from Google Calendar; reminders fire idempotently to the configured channel within 60s of the scheduled offset.
 
+## M7: Calendar Timeboxes — Planned
+
+**Goal:** Multi-event practice plans (reading a paper, training for a race, shipping a content series) live as parent vault files that own N child calendar events, with deterministic and LLM-assisted slicing of work into sessions, progress rollup, coaching nudges, and stalled-plan detection. Spec: [vault/specs/calendar-timeboxes.md](vault/specs/calendar-timeboxes.md).
+
+| Task | Description | Priority | Depends On | Issue |
+|------|-------------|----------|------------|-------|
+| Timebox M0: parent files + storage | `calendar/timeboxes/<slug>.md` shape; `uber_timeboxes` table; `timebox_slug`/`step`/`step_total`/`step_units` columns added to `uber_calendar`; `status: superseded` value added to event status enum | P0 | M6 calendar schema | TBD |
+| Timebox M0: deterministic planner + manual lifecycle | `gctrl uber timebox plan` (no `--llm`) with even arithmetic slice; `add-event`, `complete`, `skip`, `pause`/`resume`/`cancel`, `reindex`; dry-run by default; `--apply` commits | P0 | uber_timeboxes table | TBD |
+| Timebox M0: briefing integration | Today's practice events render in "On the calendar today" with `step/step_total`; off-track block fires when stalled and deadline within `stalled_threshold` | P0 | M6 briefing-pipeline calendar block | TBD |
+| Timebox M1: LLM-assisted planner + working-windows | `--llm` flag on `plan` and `replan`; planner reads `profile.timeboxes.working_windows`; pinned-event logic for re-plan (`replan_policy: pin-edited`) | P0 | Timebox M0; M1 driver-llm | TBD |
+| Timebox M1: coaching nudges | `coaching.nudges[]` in timebox frontmatter; on `complete`, crossed thresholds insert reminder rows; idempotency key `(timebox_slug, nudge_index)`; reuses `uber_calendar_reminders` + `DelivererService` | P1 | Timebox M0; M2 Deliverer | TBD |
+| Timebox M1: stalled-timebox alert | Daily check inserts `uber_alerts(kind='timebox_stalled')` with high/medium urgency; auto-clears on next `complete` | P1 | Timebox M0; M4 alert pipeline | TBD |
+| Timebox M2: web UI gantt-lite view | Timeline of child events as bars per timebox; coloured by `status: done / confirmed / superseded`; click-through to the markdown file | P2 | Timebox M0; M2 App web UI | TBD |
+| Timebox M2: `driver-gcal` mirror | Timebox children mirror to Google Calendar with title-prefix convention `[<title> <step>/<step_total>]`; opt-in via the same write-back flag as M6 calendar | P2 | M6 driver-gcal read-only; Timebox M0 | TBD |
+
+**Done when:** A user can `gctrl uber timebox plan --discipline reading --total 64 --unit pages --session-minutes 60 --sessions-per-week 4 --deadline 2026-05-20 --apply` and find the parent file plus all child events in the vault; today's session shows up in the morning brief with progress; `complete` rolls progress up and fires the next coaching nudge; missing two consecutive sessions within the stall window produces a `timebox_stalled` alert and an "Off-track" line in the next brief.
+
 ## Backlog (unprioritized)
 
 1. LLM-as-judge with rubric per dimension (accuracy, depth, freshness)

--- a/apps/uebermensch/src/adapters/FileSystemTimebox.ts
+++ b/apps/uebermensch/src/adapters/FileSystemTimebox.ts
@@ -1,0 +1,838 @@
+// FileSystem-backed Timebox adapter.
+// Spec: apps/uebermensch/vault/specs/calendar-timeboxes.md.
+// Pattern mirrors FileSystemCalendar — vault is source of truth, no SQLite yet.
+
+import { createHash } from "node:crypto"
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises"
+import { extname, join, relative } from "node:path"
+import { Effect, Layer, Schema } from "effect"
+import matter from "gray-matter"
+import { VaultError, vaultIo } from "../errors.js"
+import { plan as runPlanner, composeIsoInTz } from "../lib/timebox-planner.js"
+import {
+  EventFrontmatter,
+  TimeboxFrontmatter,
+  type TimeboxStatus,
+  type TimeboxNudge,
+  type TimeboxWorkingWindow,
+} from "../schemas.js"
+import {
+  TimeboxService,
+  type Timebox,
+  type TimeboxAddEventInput,
+  type TimeboxPlanInput,
+  type TimeboxPlanProposal,
+} from "../services/TimeboxService.js"
+import type { CalendarEvent } from "../services/CalendarService.js"
+
+const CALENDAR_DIR = "calendar"
+const TIMEBOXES_SUBDIR = "timeboxes"
+const RECURRING_SUBDIR = "recurring"
+const GENERATOR = "gctrl-uber-cli"
+
+const hashContent = (s: string): string =>
+  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
+
+const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+
+const failVault = (
+  message: string,
+  path: string,
+  kind: "not_found" | "collision" | "io_failure" | "parse_failure",
+): Effect.Effect<never, VaultError> =>
+  Effect.fail(new VaultError({ message, path, kind }))
+
+const normaliseDates = (v: unknown): unknown => {
+  if (v instanceof Date) return v.toISOString()
+  if (Array.isArray(v)) return v.map(normaliseDates)
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      out[k] = normaliseDates(val)
+    }
+    return out
+  }
+  return v
+}
+
+const omitEmpty = (rec: Record<string, unknown>): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(rec)) {
+    if (v === undefined || v === null) continue
+    if (Array.isArray(v) && v.length === 0) continue
+    out[k] = v
+  }
+  return out
+}
+
+const atomicWrite = async (absPath: string, content: string): Promise<void> => {
+  const tmp = `${absPath}.tmp-${process.pid}-${Date.now()}`
+  await mkdir(join(absPath, ".."), { recursive: true })
+  await writeFile(tmp, content, "utf8")
+  await rename(tmp, absPath)
+}
+
+const renderFrontmatter = (data: Record<string, unknown>, body: string): string =>
+  matter.stringify(body, data)
+
+// --- timebox parent file walking ---
+
+type WalkEntry = { abs: string; rel: string }
+
+const walkTimeboxes = async (vaultDir: string): Promise<ReadonlyArray<WalkEntry>> => {
+  const root = join(vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR)
+  let entries: Array<import("node:fs").Dirent>
+  try {
+    entries = await readdir(root, { recursive: true, withFileTypes: true })
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw e
+  }
+  const out: Array<WalkEntry> = []
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (extname(e.name).toLowerCase() !== ".md") continue
+    const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? root
+    const abs = join(parent, e.name)
+    out.push({ abs, rel: relative(vaultDir, abs) })
+  }
+  return out
+}
+
+// Walk all calendar events (excluding recurring/) so we can find children of a
+// timebox + check for double-bookings during planning. Mirrors FileSystemCalendar.
+const walkCalendarEvents = async (vaultDir: string): Promise<ReadonlyArray<WalkEntry>> => {
+  const root = join(vaultDir, CALENDAR_DIR)
+  let entries: Array<import("node:fs").Dirent>
+  try {
+    entries = await readdir(root, { recursive: true, withFileTypes: true })
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw e
+  }
+  const out: Array<WalkEntry> = []
+  for (const e of entries) {
+    if (!e.isFile()) continue
+    if (extname(e.name).toLowerCase() !== ".md") continue
+    const parent = (e as unknown as { parentPath?: string }).parentPath ?? e.path ?? root
+    const abs = join(parent, e.name)
+    const rel = relative(vaultDir, abs)
+    const segments = rel.split("/")
+    if (segments.includes(RECURRING_SUBDIR)) continue
+    if (segments.includes(TIMEBOXES_SUBDIR)) continue
+    out.push({ abs, rel })
+  }
+  return out
+}
+
+const decodeTimebox = (
+  entry: WalkEntry,
+  raw: string,
+): Effect.Effect<Timebox, VaultError> =>
+  Effect.gen(function* () {
+    const parsed = matter(raw)
+    const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>)
+    const decoded = yield* Schema.decodeUnknown(TimeboxFrontmatter)(data).pipe(
+      Effect.mapError(
+        (e) =>
+          new VaultError({
+            message: `timebox ${entry.rel} invalid frontmatter: ${String(e)}`,
+            path: entry.abs,
+            kind: "parse_failure",
+          }),
+      ),
+    )
+    const nudgesArr = decoded.coaching?.nudges ?? []
+    return {
+      slug: decoded.slug,
+      title: decoded.title,
+      discipline: decoded.discipline,
+      goal: decoded.goal,
+      deadline: decoded.deadline,
+      unit: decoded.unit,
+      total: decoded.total,
+      done: decoded.done ?? 0,
+      sessionMinutes: decoded.session_minutes,
+      sessionsPerWeek: decoded.sessions_per_week,
+      status: decoded.status,
+      taperDaysBeforeDeadline: decoded.taper_days_before_deadline ?? null,
+      relatedPages: decoded.related_pages ?? [],
+      topics: decoded.topics ?? [],
+      tags: decoded.tags ?? [],
+      nudges: nudgesArr as ReadonlyArray<TimeboxNudge>,
+      createdAt: decoded.created_at ?? null,
+      updatedAt: decoded.updated_at ?? null,
+      contentHash: decoded.content_hash ?? null,
+      body: parsed.content,
+      relPath: entry.rel,
+      absPath: entry.abs,
+    }
+  })
+
+const decodeEvent = (
+  entry: WalkEntry,
+  raw: string,
+): Effect.Effect<CalendarEvent, VaultError> =>
+  Effect.gen(function* () {
+    const parsed = matter(raw)
+    const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>)
+    const decoded = yield* Schema.decodeUnknown(EventFrontmatter)(data).pipe(
+      Effect.mapError(
+        (e) =>
+          new VaultError({
+            message: `event ${entry.rel} invalid frontmatter: ${String(e)}`,
+            path: entry.abs,
+            kind: "parse_failure",
+          }),
+      ),
+    )
+    return {
+      slug: decoded.slug,
+      title: decoded.title,
+      kind: decoded.kind,
+      source: decoded.source,
+      startsAt: decoded.starts_at,
+      endsAt: decoded.ends_at ?? null,
+      allDay: decoded.all_day ?? false,
+      tz: decoded.tz,
+      status: decoded.status,
+      location: decoded.location ?? null,
+      tickers: decoded.tickers ?? [],
+      topics: decoded.topics ?? [],
+      theses: decoded.theses ?? [],
+      tags: decoded.tags ?? [],
+      links: (decoded.links ?? []).map((l) => ({ title: l.title, url: l.url })),
+      relatedPages: decoded.related_pages ?? [],
+      reminders: decoded.reminders ?? [],
+      externalId: decoded.external_id ?? null,
+      externalEtag: decoded.external_etag ?? null,
+      generator: decoded.generator ?? null,
+      contentHash: decoded.content_hash ?? null,
+      createdAt: decoded.created_at ?? null,
+      updatedAt: decoded.updated_at ?? null,
+      body: parsed.content,
+      relPath: entry.rel,
+      absPath: entry.abs,
+    }
+  })
+
+const loadTimeboxes = (vaultDir: string): Effect.Effect<ReadonlyArray<Timebox>, VaultError> =>
+  Effect.gen(function* () {
+    const entries = yield* vaultIo(() => walkTimeboxes(vaultDir), {
+      message: "list timeboxes failed",
+      path: vaultDir,
+    })
+    const out: Array<Timebox> = []
+    for (const entry of entries) {
+      const raw = yield* vaultIo(() => readFile(entry.abs, "utf8"), {
+        message: "read timebox failed",
+        path: entry.abs,
+      })
+      out.push(yield* decodeTimebox(entry, raw))
+    }
+    return out
+  })
+
+const loadEvents = (vaultDir: string): Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError> =>
+  Effect.gen(function* () {
+    const entries = yield* vaultIo(() => walkCalendarEvents(vaultDir), {
+      message: "list events failed",
+      path: vaultDir,
+    })
+    const out: Array<CalendarEvent> = []
+    for (const entry of entries) {
+      const raw = yield* vaultIo(() => readFile(entry.abs, "utf8"), {
+        message: "read event failed",
+        path: entry.abs,
+      })
+      out.push(yield* decodeEvent(entry, raw))
+    }
+    return out
+  })
+
+// --- write helpers ---
+
+const writeTimeboxFile = (vaultDir: string, slug: string, fmInput: Record<string, unknown>, body: string) =>
+  Effect.gen(function* () {
+    const relPath = `${CALENDAR_DIR}/${TIMEBOXES_SUBDIR}/${slug}.md`
+    const absPath = join(vaultDir, relPath)
+    const draft = renderFrontmatter(fmInput, body)
+    const contentHash = hashContent(draft)
+    const final = renderFrontmatter({ ...fmInput, content_hash: contentHash }, body)
+    yield* vaultIo(() => atomicWrite(absPath, final), {
+      message: "write timebox failed",
+      path: absPath,
+    })
+    return { absPath, relPath, contentHash }
+  })
+
+const writeChildEventFile = (
+  vaultDir: string,
+  date: string,
+  parentSlug: string,
+  ordinal: number,
+  fmInput: Record<string, unknown>,
+  body: string,
+) =>
+  Effect.gen(function* () {
+    // Suffix sessions same-day: -a, -b, -c... (most plans don't pack same-day,
+    // so the bare form is the common case.)
+    const suffix = ordinal > 0 ? `-${String.fromCharCode("a".charCodeAt(0) + ordinal)}` : ""
+    const childSlug = `${date}--${parentSlug}${suffix}`
+    const relPath = `${CALENDAR_DIR}/${childSlug}.md`
+    const absPath = join(vaultDir, relPath)
+    const draft = renderFrontmatter({ ...fmInput, slug: childSlug }, body)
+    const contentHash = hashContent(draft)
+    const final = renderFrontmatter({ ...fmInput, slug: childSlug, content_hash: contentHash }, body)
+    yield* vaultIo(() => atomicWrite(absPath, final), {
+      message: "write child event failed",
+      path: absPath,
+    })
+    return { childSlug, absPath, relPath }
+  })
+
+// --- service config ---
+
+export type FileSystemTimeboxConfig = {
+  readonly vaultDir: string
+  readonly tz: string                                // profile identity tz; used for child events
+  readonly workingWindows: ReadonlyArray<TimeboxWorkingWindow>
+  readonly defaultSessionMinutes: number
+  readonly defaultSessionsPerWeek: number
+  readonly now?: () => Date                          // injectable for tests
+}
+
+const fallbackWindows: ReadonlyArray<TimeboxWorkingWindow> = [
+  { days: ["mon", "tue", "wed", "thu", "fri"], start: "09:00", end: "10:00" },
+  { days: ["sat", "sun"], start: "09:00", end: "11:00" },
+]
+
+export const FileSystemTimeboxLive = (config: FileSystemTimeboxConfig) => {
+  const now = config.now ?? (() => new Date())
+  const workingWindows =
+    config.workingWindows.length > 0 ? config.workingWindows : fallbackWindows
+
+  const childrenOf = (events: ReadonlyArray<CalendarEvent>, slug: string) =>
+    events
+      .filter((e) => (e as unknown as { /* schema decoded */ } & { _step?: number }))
+      // The frontmatter `timebox` field rides through EventFrontmatter; since
+      // CalendarEvent doesn't model it as a typed field, we reach into the
+      // raw vault file's frontmatter via a parallel lookup. Easier: the
+      // adapter loads events using the same EventFrontmatter schema, and we
+      // re-decode child fields here from the matter parse. For simplicity in
+      // M0 we keep two helpers:
+      //   - listChildEventSlugsForTimebox: lightweight re-walk + frontmatter scan
+      //   - re-read individual files when mutating
+      .filter(() => false)  // placeholder; never used directly — see scanChildren below
+
+  // Scan all calendar events and return raw frontmatter records keyed by slug
+  // for any event whose `timebox` field matches. We do this by reading the
+  // YAML directly so we get `step`/`step_total` without widening CalendarEvent.
+  const scanChildren = (vaultDir: string, parentSlug: string) =>
+    Effect.gen(function* () {
+      const entries = yield* vaultIo(() => walkCalendarEvents(vaultDir), {
+        message: "list events failed",
+        path: vaultDir,
+      })
+      type Child = {
+        rel: string
+        abs: string
+        raw: string
+        data: Record<string, unknown>
+        body: string
+        step: number
+        stepTotal: number
+        status: string
+      }
+      const out: Array<Child> = []
+      for (const entry of entries) {
+        const raw = yield* vaultIo(() => readFile(entry.abs, "utf8"), {
+          message: "read event failed",
+          path: entry.abs,
+        })
+        const parsed = matter(raw)
+        const data = normaliseDates((parsed.data ?? {}) as Record<string, unknown>) as Record<string, unknown>
+        if (data.timebox !== parentSlug) continue
+        const step = Number(data.step ?? 0)
+        const stepTotal = Number(data.step_total ?? 0)
+        const status = String(data.status ?? "confirmed")
+        out.push({
+          rel: entry.rel,
+          abs: entry.abs,
+          raw,
+          data,
+          body: parsed.content,
+          step,
+          stepTotal,
+          status,
+        })
+      }
+      out.sort((a, b) => a.step - b.step)
+      return out
+    })
+
+  const writeProposalAsChildren = (
+    vaultDir: string,
+    parentSlug: string,
+    parentTitle: string,
+    proposal: TimeboxPlanProposal,
+    tz: string,
+    sessionMinutes: number,
+  ) =>
+    Effect.gen(function* () {
+      const childSlugs: Array<string> = []
+      const stepTotal = proposal.sessions.length
+      // Group by date so we can suffix collisions if a plan stacks multiple per day.
+      const sameDayCounter = new Map<string, number>()
+      for (let i = 0; i < proposal.sessions.length; i++) {
+        const s = proposal.sessions[i]
+        const ordinal = sameDayCounter.get(s.date) ?? 0
+        sameDayCounter.set(s.date, ordinal + 1)
+
+        const startsAt = composeIsoInTz(s.date, s.start, tz)
+        const endsAt = composeIsoInTz(s.date, s.end, tz)
+        const step = i + 1
+
+        const fm = omitEmpty({
+          title: `${parentTitle} · ${s.units} · session ${step}/${stepTotal}`,
+          kind: "practice",
+          source: "user",
+          starts_at: startsAt,
+          ends_at: endsAt,
+          tz,
+          status: "confirmed",
+          all_day: false,
+          generator: GENERATOR,
+          created_at: now().toISOString(),
+          updated_at: now().toISOString(),
+          timebox: parentSlug,
+          step,
+          step_total: stepTotal,
+          step_units: s.units,
+        })
+
+        // Validate child shape before write
+        yield* Schema.decodeUnknown(EventFrontmatter)({ ...fm, slug: `${s.date}--${parentSlug}` }).pipe(
+          Effect.mapError(
+            (e) =>
+              new VaultError({
+                message: `child event invalid frontmatter: ${String(e)}`,
+                path: vaultDir,
+                kind: "parse_failure",
+              }),
+          ),
+        )
+
+        const written = yield* writeChildEventFile(vaultDir, s.date, parentSlug, ordinal, fm, "")
+        childSlugs.push(written.childSlug)
+      }
+      return childSlugs
+    })
+
+  const stampParentDone = (
+    vaultDir: string,
+    timebox: Timebox,
+    newDone: number,
+    newStatus?: TimeboxStatus,
+  ) =>
+    Effect.gen(function* () {
+      const raw = yield* vaultIo(() => readFile(timebox.absPath, "utf8"), {
+        message: "read timebox failed",
+        path: timebox.absPath,
+      })
+      const parsed = matter(raw)
+      const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
+      data.done = newDone
+      if (newStatus) data.status = newStatus
+      data.updated_at = now().toISOString()
+      // Recompute hash
+      const draft = renderFrontmatter(data, parsed.content)
+      const newHash = hashContent(draft)
+      data.content_hash = newHash
+      const final = renderFrontmatter(data, parsed.content)
+      yield* vaultIo(() => atomicWrite(timebox.absPath, final), {
+        message: "stamp timebox failed",
+        path: timebox.absPath,
+      })
+    })
+
+  const stampChildStatus = (abs: string, body: string, data: Record<string, unknown>, status: string) =>
+    Effect.gen(function* () {
+      const next = { ...data, status, updated_at: now().toISOString() }
+      const draft = renderFrontmatter(next, body)
+      const hash = hashContent(draft)
+      const final = renderFrontmatter({ ...next, content_hash: hash }, body)
+      yield* vaultIo(() => atomicWrite(abs, final), {
+        message: "stamp child failed",
+        path: abs,
+      })
+    })
+
+  return Layer.succeed(TimeboxService, {
+    list: (filter) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        return all.filter((t) => {
+          if (filter?.status && filter.status.length > 0 && !filter.status.includes(t.status)) return false
+          if (filter?.discipline && t.discipline !== filter.discipline) return false
+          return true
+        })
+      }),
+
+    get: (slug) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const found = all.find((t) => t.slug === slug)
+        if (found) return found
+        return yield* failVault(
+          `timebox not found: ${slug}`,
+          join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+          "not_found",
+        )
+      }),
+
+    plan: (input: TimeboxPlanInput) =>
+      Effect.gen(function* () {
+        const slug = input.slug ?? slugify(input.title)
+        if (slug.length === 0) {
+          return yield* failVault(
+            `cannot derive slug from title: ${input.title}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "parse_failure",
+          )
+        }
+        const events = yield* loadEvents(config.vaultDir)
+        const proposal = runPlanner({
+          slug,
+          remainingUnits: input.total,                      // brand-new plan: done == 0
+          unit: input.unit,
+          sessionMinutes: input.sessionMinutes,
+          sessionsPerWeek: input.sessionsPerWeek,
+          deadline: input.deadline,
+          taperDays: input.taperDays ?? 0,
+          today: now(),
+          workingWindows,
+          existingEvents: events,
+        })
+        return proposal
+      }),
+
+    apply: (input: TimeboxPlanInput, proposal: TimeboxPlanProposal) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const slug = input.slug ?? slugify(input.title)
+        if (all.some((t) => t.slug === slug)) {
+          return yield* failVault(
+            `timebox slug already exists: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "collision",
+          )
+        }
+        const nowIso = now().toISOString()
+        const fm = omitEmpty({
+          slug,
+          kind: "practice",
+          discipline: input.discipline,
+          title: input.title,
+          goal: input.goal ?? input.title,
+          deadline: input.deadline,
+          unit: input.unit,
+          total: input.total,
+          done: 0,
+          session_minutes: input.sessionMinutes,
+          sessions_per_week: input.sessionsPerWeek,
+          status: "active",
+          taper_days_before_deadline: input.taperDays,
+          related_pages: input.relatedPages,
+          topics: input.topics,
+          tags: input.tags,
+          coaching: input.nudges && input.nudges.length > 0 ? { nudges: input.nudges } : undefined,
+          created_at: nowIso,
+          updated_at: nowIso,
+        })
+        // Validate before write
+        yield* Schema.decodeUnknown(TimeboxFrontmatter)(fm).pipe(
+          Effect.mapError(
+            (e) =>
+              new VaultError({
+                message: `timebox invalid frontmatter: ${String(e)}`,
+                path: join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+                kind: "parse_failure",
+              }),
+          ),
+        )
+        const body = `## Goal\n\n${input.goal ?? input.title}\n`
+        yield* writeTimeboxFile(config.vaultDir, slug, fm, body)
+
+        const childSlugs = yield* writeProposalAsChildren(
+          config.vaultDir,
+          slug,
+          input.title,
+          proposal,
+          input.tz,
+          input.sessionMinutes,
+        )
+
+        // Re-read parent
+        const reloaded = yield* loadTimeboxes(config.vaultDir)
+        const tb = reloaded.find((t) => t.slug === slug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox written but not loadable: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "io_failure",
+          )
+        }
+        return { timebox: tb, childSlugs }
+      }),
+
+    replan: (slug: string) =>
+      Effect.gen(function* () {
+        const tb = yield* loadTimeboxes(config.vaultDir).pipe(
+          Effect.flatMap((all) => {
+            const t = all.find((x) => x.slug === slug)
+            if (!t) {
+              return failVault(
+                `timebox not found: ${slug}`,
+                join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+                "not_found",
+              )
+            }
+            return Effect.succeed(t)
+          }),
+        )
+        const events = yield* loadEvents(config.vaultDir)
+        // Existing events for double-booking exclude this timebox's own pending children
+        const otherEvents = events.filter((e) => {
+          // We can't see `timebox:` in CalendarEvent type, so re-read on the fly
+          // would be expensive; for M0 we accept that re-plan won't double-book
+          // against own pending children (those are about to be superseded).
+          return true
+        })
+        const remainingUnits = Math.max(0, tb.total - tb.done)
+        const proposal = runPlanner({
+          slug: tb.slug,
+          remainingUnits,
+          unit: tb.unit,
+          sessionMinutes: tb.sessionMinutes,
+          sessionsPerWeek: tb.sessionsPerWeek,
+          deadline: tb.deadline,
+          taperDays: tb.taperDaysBeforeDeadline ?? 0,
+          today: now(),
+          workingWindows,
+          existingEvents: otherEvents,
+        })
+        return proposal
+      }),
+
+    applyReplan: (slug: string, proposal: TimeboxPlanProposal) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const tb = all.find((t) => t.slug === slug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox not found: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "not_found",
+          )
+        }
+        // Mark all non-done, non-cancelled children as superseded.
+        // M0 policy: pin user-edited children where `updated_at > created_at + 60s`.
+        const children = yield* scanChildren(config.vaultDir, slug)
+        const supersededSlugs: Array<string> = []
+        for (const c of children) {
+          if (c.status === "cancelled" || c.status === "superseded") continue
+          // Treat anything with `updated_at` clearly later than `created_at` as user-edited
+          const created = c.data.created_at ? Date.parse(String(c.data.created_at)) : 0
+          const updated = c.data.updated_at ? Date.parse(String(c.data.updated_at)) : 0
+          const isPinned = updated > 0 && created > 0 && updated - created > 60_000
+          if (isPinned) continue
+          // Don't supersede ones already complete
+          if (c.data.step_units && c.data.step && c.status === "confirmed" && c.data.completed_at) continue
+          yield* stampChildStatus(c.abs, c.body, c.data, "superseded")
+          supersededSlugs.push(String(c.data.slug ?? c.rel))
+        }
+
+        const childSlugs = yield* writeProposalAsChildren(
+          config.vaultDir,
+          slug,
+          tb.title,
+          proposal,
+          // re-use the tz of the first existing child if any, else fallback to UTC
+          children[0] ? String(children[0].data.tz ?? "UTC") : "UTC",
+          tb.sessionMinutes,
+        )
+        const reloaded = yield* loadTimeboxes(config.vaultDir)
+        const tb2 = reloaded.find((t) => t.slug === slug)
+        if (!tb2) {
+          return yield* failVault(
+            `timebox vanished after replan: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "io_failure",
+          )
+        }
+        return { timebox: tb2, childSlugs, supersededSlugs }
+      }),
+
+    addEvent: (input: TimeboxAddEventInput) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const tb = all.find((t) => t.slug === input.timeboxSlug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox not found: ${input.timeboxSlug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "not_found",
+          )
+        }
+        const children = yield* scanChildren(config.vaultDir, input.timeboxSlug)
+        const activeChildren = children.filter((c) => c.status !== "cancelled" && c.status !== "superseded")
+        const stepTotal = activeChildren.length + 1
+        const step = stepTotal
+        const dateMatch = input.startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
+        if (!dateMatch) {
+          return yield* failVault(
+            `invalid starts_at: ${input.startsAt}`,
+            join(config.vaultDir, CALENDAR_DIR),
+            "parse_failure",
+          )
+        }
+        const date = dateMatch[1]
+        const ordinal = activeChildren.filter(
+          (c) => String(c.data.starts_at ?? "").startsWith(date),
+        ).length
+        const fm = omitEmpty({
+          title: `${tb.title} · ${input.units} · session ${step}/${stepTotal}`,
+          kind: "practice",
+          source: "user",
+          starts_at: input.startsAt,
+          ends_at: input.endsAt,
+          tz: input.tz,
+          status: input.status ?? "confirmed",
+          all_day: false,
+          generator: GENERATOR,
+          created_at: now().toISOString(),
+          updated_at: now().toISOString(),
+          timebox: input.timeboxSlug,
+          step,
+          step_total: stepTotal,
+          step_units: input.units,
+        })
+        const written = yield* writeChildEventFile(
+          config.vaultDir,
+          date,
+          input.timeboxSlug,
+          ordinal,
+          fm,
+          "",
+        )
+        return { slug: written.childSlug, step, stepTotal }
+      }),
+
+    complete: (slug: string, step: number) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const tb = all.find((t) => t.slug === slug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox not found: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "not_found",
+          )
+        }
+        const children = yield* scanChildren(config.vaultDir, slug)
+        const target = children.find((c) => c.step === step)
+        if (!target) {
+          return yield* failVault(
+            `step not found: ${slug}:${step}`,
+            join(config.vaultDir, CALENDAR_DIR),
+            "not_found",
+          )
+        }
+        if (target.data.completed_at) {
+          // Idempotent — already complete.
+          return tb
+        }
+        // Parse units from step_units to credit `done`. For ranges (`pages 30-40`)
+        // we credit (end - start + 1); for "12km" we extract the leading number;
+        // for "1 episode"/"3 sessions" we credit the leading number; otherwise 0.
+        const units = String(target.data.step_units ?? "")
+        const credit = parseUnitsCredit(units, tb.unit, tb.total / Math.max(1, target.stepTotal))
+        const newDone = Math.min(tb.total, tb.done + credit)
+
+        // Stamp child as completed (still status: confirmed but with completed_at)
+        const childData = { ...target.data, completed_at: now().toISOString() }
+        yield* stampChildStatus(target.abs, target.body, childData, "confirmed")
+
+        const newStatus: TimeboxStatus | undefined = newDone >= tb.total ? "done" : undefined
+        yield* stampParentDone(config.vaultDir, tb, newDone, newStatus)
+        const reloaded = yield* loadTimeboxes(config.vaultDir)
+        return reloaded.find((t) => t.slug === slug)!
+      }),
+
+    skip: (slug: string, step: number) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const tb = all.find((t) => t.slug === slug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox not found: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "not_found",
+          )
+        }
+        const children = yield* scanChildren(config.vaultDir, slug)
+        const target = children.find((c) => c.step === step)
+        if (!target) {
+          return yield* failVault(
+            `step not found: ${slug}:${step}`,
+            join(config.vaultDir, CALENDAR_DIR),
+            "not_found",
+          )
+        }
+        yield* stampChildStatus(target.abs, target.body, target.data, "cancelled")
+        return tb
+      }),
+
+    setStatus: (slug: string, status: TimeboxStatus) =>
+      Effect.gen(function* () {
+        const all = yield* loadTimeboxes(config.vaultDir)
+        const tb = all.find((t) => t.slug === slug)
+        if (!tb) {
+          return yield* failVault(
+            `timebox not found: ${slug}`,
+            join(config.vaultDir, CALENDAR_DIR, TIMEBOXES_SUBDIR),
+            "not_found",
+          )
+        }
+        yield* stampParentDone(config.vaultDir, tb, tb.done, status)
+        const reloaded = yield* loadTimeboxes(config.vaultDir)
+        return reloaded.find((t) => t.slug === slug)!
+      }),
+  })
+}
+
+// Extract a numeric credit from a `step_units` string. Conventions:
+//  - `pages 30-40` → 11 (40 - 30 + 1)
+//  - `12km` / `12 km` → 12
+//  - `1 episode` / `3 sessions` → leading number
+//  - falls back to evenSlice when nothing parses (so `complete` always credits something)
+const parseUnitsCredit = (units: string, _unit: string, evenSlice: number): number => {
+  const range = units.match(/(\d+(?:\.\d+)?)\s*[–-]\s*(\d+(?:\.\d+)?)/)
+  if (range) {
+    const a = Number(range[1])
+    const b = Number(range[2])
+    return Math.max(0, b - a + 1)
+  }
+  const lead = units.match(/^(\d+(?:\.\d+)?)/)
+  if (lead) return Number(lead[1])
+  return Math.max(0.001, evenSlice)
+}
+
+export const _internal = { slugify, hashContent, parseUnitsCredit }

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -9,10 +9,11 @@ import { prompts } from "../commands/prompts.js"
 import { report } from "../commands/report.js"
 import { send } from "../commands/send.js"
 import { sync } from "../commands/sync.js"
+import { timebox } from "../commands/timebox.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, calendar, sync]),
+  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, calendar, timebox, sync]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/commands/timebox.ts
+++ b/apps/uebermensch/src/commands/timebox.ts
@@ -1,0 +1,438 @@
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Option } from "effect"
+import { FileSystemTimeboxLive } from "../adapters/FileSystemTimebox.js"
+import { resolveVaultDir } from "../lib/env.js"
+import {
+  TimeboxService,
+  type Timebox,
+  type TimeboxPlanInput,
+  type TimeboxPlanProposal,
+} from "../services/TimeboxService.js"
+import type { TimeboxStatus, TimeboxWorkingWindow } from "../schemas.js"
+
+// === defaults ===
+// In M0 we don't read profile.timeboxes yet — the CLI takes flags directly and
+// falls back to a sensible weekday-mornings window. Wiring profile-driven
+// defaults follows when M1 lands the planner --llm path.
+const DEFAULT_WINDOWS: ReadonlyArray<TimeboxWorkingWindow> = [
+  { days: ["mon", "tue", "wed", "thu", "fri"], start: "07:00", end: "08:00" },
+  { days: ["sat", "sun"], start: "08:00", end: "10:00" },
+]
+
+const STATUSES: ReadonlyArray<TimeboxStatus> = ["active", "paused", "done", "cancelled"]
+
+// === shared options ===
+
+const tzOpt = Options.text("tz").pipe(
+  Options.withDescription("IANA tz for child events (e.g. Asia/Hong_Kong)"),
+  Options.withDefault("UTC"),
+)
+
+// === list ===
+
+const listStatusOpt = Options.choice("status", [...STATUSES]).pipe(
+  Options.withDescription("filter by status"),
+  Options.optional,
+)
+const listDisciplineOpt = Options.text("discipline").pipe(
+  Options.withDescription("filter by discipline (reading, running, writing, …)"),
+  Options.optional,
+)
+
+const formatTimeboxLine = (t: Timebox): string => {
+  const pct = t.total > 0 ? Math.floor((t.done / t.total) * 100) : 0
+  const progress = `${t.done}/${t.total}${t.unit}`.padEnd(14)
+  return `${t.status.padEnd(9)} ${t.discipline.padEnd(12)} ${progress} ${String(pct).padStart(3)}%  ${t.deadline.slice(0, 10)}  ${t.title}  #${t.slug}`
+}
+
+const list = Command.make(
+  "list",
+  { listStatusOpt, listDisciplineOpt },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const status = Option.getOrUndefined(opts.listStatusOpt)
+        const discipline = Option.getOrUndefined(opts.listDisciplineOpt)
+        const items = yield* svc.list({
+          ...(status ? { status: [status] } : {}),
+          ...(discipline ? { discipline } : {}),
+        })
+        if (items.length === 0) {
+          yield* Console.log(`(no timeboxes in ${vaultDir}/calendar/timeboxes/)`)
+          return
+        }
+        for (const t of items) yield* Console.log(formatTimeboxLine(t))
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("List timeboxes (optionally filtered by status / discipline)"))
+
+// === show ===
+
+const show = Command.make(
+  "show",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const t = yield* svc.get(slug)
+        const pct = t.total > 0 ? Math.floor((t.done / t.total) * 100) : 0
+        yield* Console.log(`# ${t.title}`)
+        yield* Console.log(
+          `slug: ${t.slug}  discipline: ${t.discipline}  status: ${t.status}`,
+        )
+        yield* Console.log(
+          `progress: ${t.done}/${t.total} ${t.unit}  (${pct}%)  deadline: ${t.deadline.slice(0, 10)}`,
+        )
+        yield* Console.log(
+          `cadence: ${t.sessionMinutes} min × ${t.sessionsPerWeek}/wk` +
+            (t.taperDaysBeforeDeadline ? `  taper: ${t.taperDaysBeforeDeadline}d` : ""),
+        )
+        if (t.relatedPages.length > 0) {
+          yield* Console.log(
+            `related: ${t.relatedPages.map((p) => `[[${p}]]`).join("  ")}`,
+          )
+        }
+        if (t.tags.length > 0) yield* Console.log(`tags: ${t.tags.join(", ")}`)
+        yield* Console.log("")
+        yield* Console.log("--- goal ---")
+        yield* Console.log(t.goal)
+        if (t.body.trim().length > 0) {
+          yield* Console.log("")
+          yield* Console.log("--- body ---")
+          yield* Console.log(t.body.trim())
+        }
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Show one timebox with progress + goal"))
+
+// === plan / apply ===
+
+const titleOpt = Options.text("title").pipe(Options.withDescription("plan title"))
+const disciplineOpt = Options.text("discipline").pipe(
+  Options.withDescription("discipline (reading, running, writing, …)"),
+)
+const goalOpt = Options.text("goal").pipe(
+  Options.withDescription("plain-language goal (defaults to title)"),
+  Options.optional,
+)
+const totalOpt = Options.float("total").pipe(
+  Options.withDescription("total units to complete (e.g. 64)"),
+)
+const unitOpt = Options.text("unit").pipe(
+  Options.withDescription("unit string (pages, km, episodes, posts, …)"),
+)
+const sessionMinutesOpt = Options.integer("session-minutes").pipe(
+  Options.withDescription("typical session duration"),
+  Options.withDefault(60),
+)
+const sessionsPerWeekOpt = Options.float("sessions-per-week").pipe(
+  Options.withDescription("cadence hint"),
+  Options.withDefault(3),
+)
+const deadlineOpt = Options.text("deadline").pipe(
+  Options.withDescription("ISO 8601 date (e.g. 2026-09-27)"),
+)
+const taperDaysOpt = Options.integer("taper-days").pipe(
+  Options.withDescription("leave the final N days clear of new sessions"),
+  Options.optional,
+)
+const relatedPageOpt = Options.text("related-page").pipe(
+  Options.withDescription("repeatable: bare slug for a wiki page (paper-constitutional-ai, running-log, …)"),
+  Options.repeated,
+)
+const slugOverrideOpt = Options.text("slug").pipe(
+  Options.withDescription("explicit timebox slug (otherwise derived from title)"),
+  Options.optional,
+)
+const applyOpt = Options.boolean("apply").pipe(
+  Options.withDescription("commit the plan (writes parent file + child events). Without --apply, prints a dry-run."),
+  Options.withDefault(false),
+)
+
+const renderProposal = (p: TimeboxPlanProposal) =>
+  Effect.gen(function* () {
+    if (p.sessions.length === 0) {
+      yield* Console.log(`(no sessions to schedule)`)
+      for (const n of p.notes) yield* Console.log(`  · ${n}`)
+      return
+    }
+    yield* Console.log(
+      `proposed: ${p.sessions.length}/${p.sessionsNeeded} sessions  ~${p.unitsPerSession} units each  remaining: ${p.remainingUnits}`,
+    )
+    for (const s of p.sessions) {
+      yield* Console.log(`  ${s.date}  ${s.start}-${s.end}  ${s.units}`)
+    }
+    if (p.notes.length > 0) {
+      yield* Console.log(`notes:`)
+      for (const n of p.notes) yield* Console.log(`  · ${n}`)
+    }
+  })
+
+const plan = Command.make(
+  "plan",
+  {
+    titleOpt,
+    disciplineOpt,
+    goalOpt,
+    totalOpt,
+    unitOpt,
+    sessionMinutesOpt,
+    sessionsPerWeekOpt,
+    deadlineOpt,
+    taperDaysOpt,
+    tzOpt,
+    relatedPageOpt,
+    slugOverrideOpt,
+    applyOpt,
+  },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const input: TimeboxPlanInput = {
+        title: opts.titleOpt,
+        discipline: opts.disciplineOpt,
+        goal: Option.getOrUndefined(opts.goalOpt),
+        total: opts.totalOpt,
+        unit: opts.unitOpt,
+        sessionMinutes: opts.sessionMinutesOpt,
+        sessionsPerWeek: opts.sessionsPerWeekOpt,
+        deadline: opts.deadlineOpt,
+        tz: opts.tzOpt,
+        taperDays: Option.getOrUndefined(opts.taperDaysOpt),
+        relatedPages: opts.relatedPageOpt as ReadonlyArray<string>,
+        slug: Option.getOrUndefined(opts.slugOverrideOpt),
+      }
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(input)
+        yield* renderProposal(proposal)
+        if (opts.applyOpt) {
+          const { timebox, childSlugs } = yield* svc.apply(input, proposal)
+          yield* Console.log("")
+          yield* Console.log(`✓ wrote ${timebox.relPath}`)
+          yield* Console.log(`✓ wrote ${childSlugs.length} child events`)
+        } else {
+          yield* Console.log("")
+          yield* Console.log(`(dry-run — pass --apply to commit)`)
+        }
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: opts.tzOpt,
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: opts.sessionMinutesOpt,
+            defaultSessionsPerWeek: opts.sessionsPerWeekOpt,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Plan a new timebox; dry-run by default, --apply to commit"))
+
+// === replan ===
+
+const replan = Command.make(
+  "replan",
+  { slug: Args.text({ name: "slug" }), applyOpt },
+  ({ slug, applyOpt }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.replan(slug)
+        yield* renderProposal(proposal)
+        if (applyOpt) {
+          const result = yield* svc.applyReplan(slug, proposal)
+          yield* Console.log("")
+          yield* Console.log(`✓ wrote ${result.childSlugs.length} new child events`)
+          if (result.supersededSlugs.length > 0) {
+            yield* Console.log(`✓ superseded ${result.supersededSlugs.length} prior events`)
+          }
+        } else {
+          yield* Console.log("")
+          yield* Console.log(`(dry-run — pass --apply to commit)`)
+        }
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Re-plan remaining sessions for a timebox"))
+
+// === add-event ===
+
+const addEventStartOpt = Options.text("start").pipe(
+  Options.withDescription("ISO 8601 start (e.g. 2026-05-15T07:00:00+08:00)"),
+)
+const addEventEndOpt = Options.text("end").pipe(
+  Options.withDescription("ISO 8601 end (optional)"),
+  Options.optional,
+)
+const addEventUnitsOpt = Options.text("units").pipe(
+  Options.withDescription("step description (e.g. \"12km easy\", \"pages 30-40\")"),
+)
+
+const addEvent = Command.make(
+  "add-event",
+  {
+    slug: Args.text({ name: "slug" }),
+    addEventStartOpt,
+    addEventEndOpt,
+    tzOpt,
+    addEventUnitsOpt,
+  },
+  ({ slug, addEventStartOpt, addEventEndOpt, tzOpt, addEventUnitsOpt }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const result = yield* svc.addEvent({
+          timeboxSlug: slug,
+          startsAt: addEventStartOpt,
+          endsAt: Option.getOrUndefined(addEventEndOpt),
+          tz: tzOpt,
+          units: addEventUnitsOpt,
+        })
+        yield* Console.log(`✓ session ${result.step}/${result.stepTotal}  #${result.slug}`)
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: tzOpt,
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Add a single session to an existing timebox"))
+
+// === complete / skip ===
+
+const stepArg = Args.integer({ name: "step" })
+
+const complete = Command.make(
+  "complete",
+  { slug: Args.text({ name: "slug" }), step: stepArg },
+  ({ slug, step }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const t = yield* svc.complete(slug, step)
+        const pct = t.total > 0 ? Math.floor((t.done / t.total) * 100) : 0
+        yield* Console.log(`✓ ${slug}:${step} complete — progress ${t.done}/${t.total} ${t.unit} (${pct}%)`)
+        if (t.status === "done") yield* Console.log(`✓ timebox done`)
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Mark a step complete and roll progress up"))
+
+const skip = Command.make(
+  "skip",
+  { slug: Args.text({ name: "slug" }), step: stepArg },
+  ({ slug, step }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        yield* svc.skip(slug, step)
+        yield* Console.log(`✓ ${slug}:${step} skipped`)
+      })
+      yield* program.pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: DEFAULT_WINDOWS,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 3,
+          }),
+        ),
+      )
+    }),
+).pipe(Command.withDescription("Mark a step skipped (does not credit progress)"))
+
+// === lifecycle ===
+
+const lifecycleCommand = (name: TimeboxStatus, description: string) =>
+  Command.make(
+    name === "active" ? "resume" : name,
+    { slug: Args.text({ name: "slug" }) },
+    ({ slug }) =>
+      Effect.gen(function* () {
+        const vaultDir = yield* resolveVaultDir()
+        const program = Effect.gen(function* () {
+          const svc = yield* TimeboxService
+          const t = yield* svc.setStatus(slug, name)
+          yield* Console.log(`✓ ${t.slug} → ${t.status}`)
+        })
+        yield* program.pipe(
+          Effect.provide(
+            FileSystemTimeboxLive({
+              vaultDir,
+              tz: "UTC",
+              workingWindows: DEFAULT_WINDOWS,
+              defaultSessionMinutes: 60,
+              defaultSessionsPerWeek: 3,
+            }),
+          ),
+        )
+      }),
+  ).pipe(Command.withDescription(description))
+
+const pause = lifecycleCommand("paused", "Pause an active timebox")
+const resume = lifecycleCommand("active", "Resume a paused timebox")
+const cancel = lifecycleCommand("cancelled", "Cancel a timebox")
+
+export const timebox = Command.make("timebox").pipe(
+  Command.withSubcommands([list, show, plan, replan, addEvent, complete, skip, pause, resume, cancel]),
+  Command.withDescription("Manage timeboxes — multi-event practice plans under $UBER_VAULT_DIR/calendar/timeboxes/"),
+)

--- a/apps/uebermensch/src/lib/timebox-planner.ts
+++ b/apps/uebermensch/src/lib/timebox-planner.ts
@@ -1,0 +1,262 @@
+// Pure deterministic planner for timeboxes.
+// Spec: apps/uebermensch/vault/specs/calendar-timeboxes.md § Planner.
+//
+// Inputs: timebox (or planning input) + working_windows + existing events to avoid.
+// Output: proposal with N sessions placed in working windows, ending by deadline
+// (minus optional taper). No I/O, no LLM — that's the M1 extension.
+
+import type { CalendarEvent } from "../services/CalendarService.js"
+import type {
+  PlannedSession,
+  TimeboxPlanProposal,
+} from "../services/TimeboxService.js"
+import type { TimeboxWorkingWindow } from "../schemas.js"
+
+const DAY_MS = 86_400_000
+const WEEKDAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const
+type Weekday = (typeof WEEKDAY_NAMES)[number]
+
+export type PlannerInputs = {
+  readonly slug: string
+  readonly remainingUnits: number
+  readonly unit: string
+  readonly sessionMinutes: number
+  readonly sessionsPerWeek: number
+  readonly deadline: string                // ISO date or datetime
+  readonly taperDays: number
+  readonly today: Date                     // injectable for tests
+  readonly workingWindows: ReadonlyArray<TimeboxWorkingWindow>
+  readonly existingEvents: ReadonlyArray<CalendarEvent>
+}
+
+const startOfUtcDay = (d: Date): Date =>
+  new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+
+const parseHM = (hm: string): { h: number; m: number } => {
+  const [h, m] = hm.split(":").map((s) => Number.parseInt(s, 10))
+  return { h, m }
+}
+
+const fmtHM = (h: number, m: number): string =>
+  `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`
+
+const isoDate = (d: Date): string => {
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(d.getUTCDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+const weekdayOf = (d: Date): Weekday => WEEKDAY_NAMES[d.getUTCDay()]
+
+// Round units to a reasonable precision (1 decimal for fractional units like km;
+// integer for naturally-discrete units like pages — but we keep 1dp to be safe).
+const roundUnits = (n: number): number => Math.round(n * 10) / 10
+
+// "12km easy" / "pages 30-40" / "1 episode" — single-unit-per-session description.
+// Range form for monotonic countable units (pages, chapters); duration form otherwise.
+const formatUnits = (
+  unit: string,
+  unitsThisSession: number,
+  cumulativeBefore: number,
+  isLastSession: boolean,
+  totalRemaining: number,
+): string => {
+  // Final session absorbs rounding remainder
+  const u = isLastSession ? roundUnits(totalRemaining - cumulativeBefore) : roundUnits(unitsThisSession)
+  if (unit === "pages" || unit === "chapters") {
+    const start = Math.floor(cumulativeBefore) + 1
+    const end = Math.floor(cumulativeBefore + u)
+    if (start >= end) return `${unit.slice(0, -1)} ${start}`
+    return `${unit} ${start}–${end}`
+  }
+  if (unit === "km" || unit === "miles") {
+    return `${u}${unit}`
+  }
+  if (unit === "episodes" || unit === "posts" || unit === "sessions") {
+    return `${u} ${u === 1 ? unit.slice(0, -1) : unit}`
+  }
+  return `${u} ${unit}`
+}
+
+const overlapsExistingEvent = (
+  startMs: number,
+  endMs: number,
+  existing: ReadonlyArray<CalendarEvent>,
+): boolean => {
+  for (const e of existing) {
+    if (e.status === "cancelled" || e.status === "superseded") continue
+    const eStart = Date.parse(e.startsAt)
+    if (Number.isNaN(eStart)) continue
+    const eEnd = e.endsAt ? Date.parse(e.endsAt) : eStart + 30 * 60_000
+    if (startMs < eEnd && endMs > eStart) return true
+  }
+  return false
+}
+
+// Walk forward from `today + 1d` placing sessions one at a time. For each day:
+//  1. Check the day falls within a working_windows entry (matched by weekday).
+//  2. For each matching window, attempt to allocate a slot of `sessionMinutes`.
+//  3. Skip if the slot overlaps an existing confirmed/tentative event.
+//  4. Stop when sessionsNeeded met or deadline (minus taper) reached.
+export const plan = (inputs: PlannerInputs): TimeboxPlanProposal => {
+  const notes: Array<string> = []
+  const remaining = Math.max(0, inputs.remainingUnits)
+  if (remaining === 0) {
+    return {
+      timeboxSlug: inputs.slug,
+      sessionsNeeded: 0,
+      remainingUnits: 0,
+      unitsPerSession: 0,
+      sessions: [],
+      notes: ["nothing to plan: done == total"],
+    }
+  }
+
+  const deadlineMs = Date.parse(inputs.deadline)
+  if (Number.isNaN(deadlineMs)) {
+    return {
+      timeboxSlug: inputs.slug,
+      sessionsNeeded: 0,
+      remainingUnits: remaining,
+      unitsPerSession: 0,
+      sessions: [],
+      notes: [`invalid deadline: ${inputs.deadline}`],
+    }
+  }
+  const taperMs = inputs.taperDays * DAY_MS
+  const planEndMs = deadlineMs - taperMs
+  const todayMs = startOfUtcDay(inputs.today).getTime()
+  if (planEndMs <= todayMs) {
+    return {
+      timeboxSlug: inputs.slug,
+      sessionsNeeded: 0,
+      remainingUnits: remaining,
+      unitsPerSession: 0,
+      sessions: [],
+      notes: ["deadline (minus taper) is in the past"],
+    }
+  }
+
+  const weeksRemaining = Math.max(1 / 7, (planEndMs - todayMs) / (7 * DAY_MS))
+  const sessionsNeeded = Math.max(1, Math.ceil(weeksRemaining * inputs.sessionsPerWeek))
+  const unitsPerSession = remaining / sessionsNeeded
+
+  const sessions: Array<PlannedSession> = []
+  let cumulativeBefore = 0
+
+  // Walk days from tomorrow up to plan-end.
+  for (
+    let dMs = todayMs + DAY_MS;
+    dMs <= planEndMs && sessions.length < sessionsNeeded;
+    dMs += DAY_MS
+  ) {
+    const d = new Date(dMs)
+    const weekday = weekdayOf(d)
+    const matchingWindows = inputs.workingWindows.filter((w) =>
+      (w.days as ReadonlyArray<string>).includes(weekday),
+    )
+    if (matchingWindows.length === 0) continue
+
+    // For each window on this day, try to fit one session at the window start.
+    // We don't pack multiple sessions per day — sessions_per_week shapes cadence.
+    for (const window of matchingWindows) {
+      if (sessions.length >= sessionsNeeded) break
+
+      const { h: sh, m: sm } = parseHM(window.start)
+      const { h: eh, m: em } = parseHM(window.end)
+      const windowStartMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), sh, sm)
+      const windowEndMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), eh, em)
+      const sessionEndMs = windowStartMs + inputs.sessionMinutes * 60_000
+
+      if (sessionEndMs > windowEndMs) {
+        notes.push(
+          `${isoDate(d)}: window ${window.start}-${window.end} too short for ${inputs.sessionMinutes}min session`,
+        )
+        continue
+      }
+
+      if (overlapsExistingEvent(windowStartMs, sessionEndMs, inputs.existingEvents)) {
+        notes.push(`${isoDate(d)}: ${window.start} clashes with existing event — skipped`)
+        continue
+      }
+
+      const isLast = sessions.length === sessionsNeeded - 1
+      const units = formatUnits(inputs.unit, unitsPerSession, cumulativeBefore, isLast, remaining)
+      sessions.push({
+        date: isoDate(d),
+        start: window.start,
+        end: fmtHM(
+          Math.floor(sessionEndMs / 3_600_000) % 24,
+          Math.floor(sessionEndMs / 60_000) % 60,
+        ),
+        units,
+      })
+      cumulativeBefore += isLast ? remaining - cumulativeBefore : unitsPerSession
+      // Only one session per day in this pass.
+      break
+    }
+  }
+
+  if (sessions.length < sessionsNeeded) {
+    notes.push(
+      `placed ${sessions.length} of ${sessionsNeeded} sessions — widen working_windows or shorten deadline`,
+    )
+  }
+
+  return {
+    timeboxSlug: inputs.slug,
+    sessionsNeeded,
+    remainingUnits: remaining,
+    unitsPerSession: roundUnits(unitsPerSession),
+    sessions,
+    notes,
+  }
+}
+
+// Build absolute ISO 8601 datetime in the given IANA tz from date + HH:MM.
+// Best-effort: we emit a wall-clock-with-offset string by interpreting the
+// HH:MM as the tz's local time. The kernel calendar adapter accepts any
+// IsoLike pattern, so a "+HH:MM" offset is sufficient for storage.
+//
+// We compute the offset for the given date by formatting it in the tz and
+// reading the offset back. If Intl.DateTimeFormat doesn't know the tz we
+// fall back to UTC (with a `Z` suffix).
+export const composeIsoInTz = (date: string, hm: string, tz: string): string => {
+  const [h, m] = hm.split(":").map((s) => Number.parseInt(s, 10))
+  const [Y, Mo, D] = date.split("-").map((s) => Number.parseInt(s, 10))
+  const utc = Date.UTC(Y, Mo - 1, D, h, m)
+
+  let offsetMin: number
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      timeZoneName: "shortOffset",
+    })
+    const parts = fmt.formatToParts(new Date(utc))
+    const offsetPart = parts.find((p) => p.type === "timeZoneName")?.value ?? "GMT"
+    const match = offsetPart.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/)
+    if (!match) {
+      offsetMin = 0
+    } else {
+      const sign = match[1] === "-" ? -1 : 1
+      offsetMin = sign * (Number.parseInt(match[2], 10) * 60 + Number.parseInt(match[3] ?? "0", 10))
+    }
+  } catch {
+    offsetMin = 0
+  }
+
+  const localMs = utc - offsetMin * 60_000
+  const out = new Date(localMs)
+  const yyyy = out.getUTCFullYear()
+  const mo = String(out.getUTCMonth() + 1).padStart(2, "0")
+  const dd = String(out.getUTCDate()).padStart(2, "0")
+  const hh = String(out.getUTCHours()).padStart(2, "0")
+  const mm = String(out.getUTCMinutes()).padStart(2, "0")
+  if (offsetMin === 0) return `${yyyy}-${mo}-${dd}T${hh}:${mm}:00Z`
+  const sign = offsetMin >= 0 ? "+" : "-"
+  const absMin = Math.abs(offsetMin)
+  const oh = String(Math.floor(absMin / 60)).padStart(2, "0")
+  const om = String(absMin % 60).padStart(2, "0")
+  return `${yyyy}-${mo}-${dd}T${hh}:${mm}:00${sign}${oh}:${om}`
+}

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -153,6 +153,7 @@ export const EventKind = Schema.Literal(
   "political",
   "prediction-market",
   "industry",
+  "practice",
   "other",
 )
 export type EventKind = typeof EventKind.Type
@@ -166,7 +167,12 @@ export const EventSource = Schema.Literal(
 )
 export type EventSource = typeof EventSource.Type
 
-export const EventStatus = Schema.Literal("confirmed", "tentative", "cancelled")
+export const EventStatus = Schema.Literal(
+  "confirmed",
+  "tentative",
+  "cancelled",
+  "superseded",
+)
 export type EventStatus = typeof EventStatus.Type
 
 // Uppercase ticker per spec § Validation Rules #5
@@ -214,5 +220,86 @@ export const EventFrontmatter = Schema.Struct({
   updated_at: Schema.optional(IsoLike),
   generator: Schema.optional(Schema.String),
   content_hash: Schema.optional(Schema.String),
+  // Timebox child fields — present when this event belongs to a parent timebox.
+  // Validation rule: if `timebox` is set, `step`/`step_total`/`step_units` MUST be set.
+  // See vault/specs/calendar-timeboxes.md § Child Event Frontmatter Additions.
+  timebox: Schema.optional(Slug),
+  step: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(1))),
+  step_total: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(1))),
+  step_units: Schema.optional(Schema.String),
 })
 export type EventFrontmatter = typeof EventFrontmatter.Type
+
+// === Timebox (calendar-timeboxes.md) ===
+
+// Open enum — the planner only needs `unit` + `session_minutes`; discipline drives
+// display and downstream filtering. New values valid immediately, no migration.
+export const Discipline = Schema.String.pipe(Schema.pattern(/^[a-z][a-z0-9-]*$/))
+export type Discipline = typeof Discipline.Type
+
+export const TimeboxStatus = Schema.Literal("active", "paused", "done", "cancelled")
+export type TimeboxStatus = typeof TimeboxStatus.Type
+
+// `at` is a fraction in (0, 1] for progress-triggered nudges, or an ISO 8601
+// date for absolute-time nudges. Validated as union of number-in-range or IsoLike.
+export const TimeboxNudge = Schema.Struct({
+  at: Schema.Union(
+    Schema.Number.pipe(Schema.greaterThan(0), Schema.lessThanOrEqualTo(1)),
+    IsoLike,
+  ),
+  template: Schema.String,
+})
+export type TimeboxNudge = typeof TimeboxNudge.Type
+
+export const TimeboxCoaching = Schema.Struct({
+  nudges: Schema.optional(Schema.Array(TimeboxNudge)),
+})
+
+// Spec § Timebox Frontmatter — required: slug, kind, discipline, title, goal,
+// deadline, unit, total, session_minutes, sessions_per_week, status,
+// created_at, updated_at, content_hash. `done` is rolled up by `complete` and
+// MUST NOT be set by hand (validation enforces 0 default at create time).
+export const TimeboxFrontmatter = Schema.Struct({
+  slug: Slug,
+  kind: Schema.Literal("practice"),
+  discipline: Discipline,
+  title: Schema.String,
+  goal: Schema.String,
+  deadline: IsoLike,                              // ISO date or datetime
+  unit: Schema.String.pipe(Schema.minLength(1)),  // pages | km | episodes | posts | ...
+  total: Schema.Number.pipe(Schema.greaterThan(0)),
+  done: Schema.optional(Schema.Number.pipe(Schema.greaterThanOrEqualTo(0))),
+  session_minutes: Schema.Int.pipe(Schema.greaterThan(0)),
+  sessions_per_week: Schema.Number.pipe(Schema.greaterThan(0)),
+  status: TimeboxStatus,
+  taper_days_before_deadline: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(0))),
+  related_pages: Schema.optional(Schema.Array(Slug)),
+  topics: Schema.optional(Schema.Array(Slug)),
+  tags: Schema.optional(Schema.Array(Schema.String)),
+  coaching: Schema.optional(TimeboxCoaching),
+  created_at: Schema.optional(IsoLike),
+  updated_at: Schema.optional(IsoLike),
+  content_hash: Schema.optional(Schema.String),
+})
+export type TimeboxFrontmatter = typeof TimeboxFrontmatter.Type
+
+// Profile timebox config — see calendar-timeboxes.md § Profile Schema Additions.
+// All fields optional in profile.md; defaults (60 min, 3/wk, P14D) are app-side.
+export const TimeboxWorkingWindow = Schema.Struct({
+  days: Schema.Array(Schema.Literal("mon", "tue", "wed", "thu", "fri", "sat", "sun")),
+  start: Schema.String.pipe(Schema.pattern(/^\d{2}:\d{2}$/)),
+  end: Schema.String.pipe(Schema.pattern(/^\d{2}:\d{2}$/)),
+})
+export type TimeboxWorkingWindow = typeof TimeboxWorkingWindow.Type
+
+export const TimeboxProfileConfig = Schema.Struct({
+  working_windows: Schema.optional(Schema.Array(TimeboxWorkingWindow)),
+  default_session_minutes: Schema.optional(Schema.Int.pipe(Schema.greaterThan(0))),
+  default_sessions_per_week: Schema.optional(Schema.Number.pipe(Schema.greaterThan(0))),
+  stalled_threshold: Schema.optional(Schema.String),  // ISO 8601 duration
+  replan_policy: Schema.optional(Schema.Literal("pin-edited", "redistribute-all")),
+  coaching: Schema.optional(Schema.Struct({
+    default_channel: Schema.optional(Schema.String),
+  })),
+})
+export type TimeboxProfileConfig = typeof TimeboxProfileConfig.Type

--- a/apps/uebermensch/src/services/TimeboxService.ts
+++ b/apps/uebermensch/src/services/TimeboxService.ts
@@ -1,0 +1,126 @@
+import { Context, type Effect } from "effect"
+import type { VaultError } from "../errors.js"
+import type {
+  Discipline,
+  TimeboxNudge,
+  TimeboxStatus,
+} from "../schemas.js"
+
+// === Domain shapes (camelCase projection of TimeboxFrontmatter) ===
+
+export type Timebox = {
+  readonly slug: string
+  readonly title: string
+  readonly discipline: Discipline
+  readonly goal: string
+  readonly deadline: string                  // ISO date or datetime
+  readonly unit: string                      // pages | km | episodes | posts | ...
+  readonly total: number
+  readonly done: number                      // rolled up from completed children
+  readonly sessionMinutes: number
+  readonly sessionsPerWeek: number
+  readonly status: TimeboxStatus
+  readonly taperDaysBeforeDeadline: number | null
+  readonly relatedPages: ReadonlyArray<string>
+  readonly topics: ReadonlyArray<string>
+  readonly tags: ReadonlyArray<string>
+  readonly nudges: ReadonlyArray<TimeboxNudge>
+  readonly createdAt: string | null
+  readonly updatedAt: string | null
+  readonly contentHash: string | null
+  readonly body: string
+  readonly relPath: string
+  readonly absPath: string
+}
+
+// One proposed session in a planner dry-run; date is YYYY-MM-DD in profile tz.
+export type PlannedSession = {
+  readonly date: string
+  readonly start: string                     // HH:MM, profile-local
+  readonly end: string                       // HH:MM, profile-local
+  readonly units: string                     // human-readable description (e.g. "12km easy")
+}
+
+// Proposal returned by `plan` / `replan` before `apply`.
+export type TimeboxPlanProposal = {
+  readonly timeboxSlug: string
+  readonly sessionsNeeded: number
+  readonly remainingUnits: number
+  readonly unitsPerSession: number
+  readonly sessions: ReadonlyArray<PlannedSession>
+  readonly notes: ReadonlyArray<string>      // diagnostics (e.g. "skipped 2026-05-08 — already booked")
+}
+
+// === Inputs ===
+
+export type TimeboxPlanInput = {
+  readonly title: string
+  readonly discipline: Discipline
+  readonly goal?: string
+  readonly total: number
+  readonly unit: string
+  readonly sessionMinutes: number
+  readonly sessionsPerWeek: number
+  readonly deadline: string                  // ISO 8601 date
+  readonly tz: string                        // profile identity tz (used for child events)
+  readonly taperDays?: number
+  readonly relatedPages?: ReadonlyArray<string>
+  readonly topics?: ReadonlyArray<string>
+  readonly tags?: ReadonlyArray<string>
+  readonly nudges?: ReadonlyArray<TimeboxNudge>
+  readonly slug?: string                     // user override; otherwise derived from title
+}
+
+export type TimeboxAddEventInput = {
+  readonly timeboxSlug: string
+  readonly startsAt: string                  // ISO datetime
+  readonly endsAt?: string
+  readonly tz: string
+  readonly units: string
+  readonly status?: "confirmed" | "tentative"
+}
+
+// === Service ===
+
+export interface TimeboxServiceShape {
+  readonly list: (filter?: { status?: ReadonlyArray<TimeboxStatus>; discipline?: string })
+    => Effect.Effect<ReadonlyArray<Timebox>, VaultError>
+
+  readonly get: (slug: string) => Effect.Effect<Timebox, VaultError>
+
+  // Plan + apply are split so callers can show a dry-run before committing.
+  readonly plan: (input: TimeboxPlanInput) => Effect.Effect<TimeboxPlanProposal, VaultError>
+
+  readonly apply: (input: TimeboxPlanInput, proposal: TimeboxPlanProposal)
+    => Effect.Effect<{ timebox: Timebox; childSlugs: ReadonlyArray<string> }, VaultError>
+
+  // Re-plan against remaining work + remaining time. User-edited child events
+  // are pinned (kept in place); the planner redistributes the rest. Spec § Re-plan.
+  readonly replan: (slug: string)
+    => Effect.Effect<TimeboxPlanProposal, VaultError>
+
+  readonly applyReplan: (slug: string, proposal: TimeboxPlanProposal)
+    => Effect.Effect<{ timebox: Timebox; childSlugs: ReadonlyArray<string>; supersededSlugs: ReadonlyArray<string> }, VaultError>
+
+  // Add a single child event outside the planner's automatic schedule.
+  readonly addEvent: (input: TimeboxAddEventInput)
+    => Effect.Effect<{ slug: string; step: number; stepTotal: number }, VaultError>
+
+  // Mark a step done — flips the child event status to a terminal "done" form
+  // (we encode as `status: confirmed` with metadata) and rolls `done` up on the parent.
+  readonly complete: (slug: string, step: number)
+    => Effect.Effect<Timebox, VaultError>
+
+  // Mark a step skipped — does NOT increment `done`; child status becomes `cancelled`.
+  readonly skip: (slug: string, step: number)
+    => Effect.Effect<Timebox, VaultError>
+
+  // Lifecycle: pause / resume / cancel / done.
+  readonly setStatus: (slug: string, status: TimeboxStatus)
+    => Effect.Effect<Timebox, VaultError>
+}
+
+export class TimeboxService extends Context.Tag("uebermensch/TimeboxService")<
+  TimeboxService,
+  TimeboxServiceShape
+>() {}

--- a/apps/uebermensch/tests/timebox.test.ts
+++ b/apps/uebermensch/tests/timebox.test.ts
@@ -1,0 +1,644 @@
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Either, Schema } from "effect"
+import matter from "gray-matter"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileSystemTimeboxLive } from "../src/adapters/FileSystemTimebox.js"
+import { plan as runPlanner } from "../src/lib/timebox-planner.js"
+import { TimeboxFrontmatter, type TimeboxWorkingWindow } from "../src/schemas.js"
+import {
+  TimeboxService,
+  type TimeboxPlanInput,
+} from "../src/services/TimeboxService.js"
+import type { CalendarEvent } from "../src/services/CalendarService.js"
+
+const ALL_DAYS_WINDOW: ReadonlyArray<TimeboxWorkingWindow> = [
+  { days: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"], start: "07:00", end: "09:00" },
+]
+
+const WEEKDAYS_ONLY: ReadonlyArray<TimeboxWorkingWindow> = [
+  { days: ["mon", "tue", "wed", "thu", "fri"], start: "07:00", end: "08:00" },
+]
+
+const stubEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+  slug: overrides.slug ?? "x",
+  title: "x",
+  kind: "personal",
+  source: "user",
+  startsAt: "2026-05-04T07:00:00Z",
+  endsAt: "2026-05-04T08:00:00Z",
+  allDay: false,
+  tz: "UTC",
+  status: "confirmed",
+  location: null,
+  tickers: [],
+  topics: [],
+  theses: [],
+  tags: [],
+  links: [],
+  relatedPages: [],
+  reminders: [],
+  externalId: null,
+  externalEtag: null,
+  generator: null,
+  contentHash: null,
+  createdAt: null,
+  updatedAt: null,
+  body: "",
+  relPath: "",
+  absPath: "",
+  ...overrides,
+})
+
+describe("timebox schemas", () => {
+  it("TimeboxFrontmatter round-trips a valid practice plan", async () => {
+    const sample = {
+      slug: "sub-3-berlin",
+      kind: "practice" as const,
+      discipline: "running",
+      title: "Sub-3 Berlin",
+      goal: "Sub-3 marathon at Berlin",
+      deadline: "2026-09-27",
+      unit: "km",
+      total: 600,
+      done: 0,
+      session_minutes: 60,
+      sessions_per_week: 4,
+      status: "active" as const,
+      taper_days_before_deadline: 14,
+      created_at: "2026-04-29T08:00:00+08:00",
+      updated_at: "2026-04-29T08:00:00+08:00",
+    }
+    const decoded = await Effect.runPromise(Schema.decodeUnknown(TimeboxFrontmatter)(sample))
+    expect(decoded.slug).toBe("sub-3-berlin")
+    expect(decoded.discipline).toBe("running")
+    expect(decoded.total).toBe(600)
+  })
+
+  it("rejects invalid status", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Schema.decodeUnknown(TimeboxFrontmatter)({
+          slug: "x",
+          kind: "practice",
+          discipline: "reading",
+          title: "x",
+          goal: "x",
+          deadline: "2026-09-27",
+          unit: "pages",
+          total: 10,
+          session_minutes: 60,
+          sessions_per_week: 1,
+          status: "wibbly",
+        }),
+      ),
+    )
+    Either.match(result, {
+      onLeft: () => expect(true).toBe(true),
+      onRight: () => {
+        throw new Error("expected decode to fail on invalid status")
+      },
+    })
+  })
+
+  it("rejects total <= 0", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Schema.decodeUnknown(TimeboxFrontmatter)({
+          slug: "x",
+          kind: "practice",
+          discipline: "reading",
+          title: "x",
+          goal: "x",
+          deadline: "2026-09-27",
+          unit: "pages",
+          total: 0,
+          session_minutes: 60,
+          sessions_per_week: 1,
+          status: "active",
+        }),
+      ),
+    )
+    Either.match(result, {
+      onLeft: () => expect(true).toBe(true),
+      onRight: () => {
+        throw new Error("expected decode to fail on total=0")
+      },
+    })
+  })
+})
+
+describe("timebox planner — pure", () => {
+  it("slices remaining work evenly into the right number of sessions", () => {
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 60,
+      unit: "pages",
+      sessionMinutes: 60,
+      sessionsPerWeek: 4,
+      deadline: "2026-05-29",
+      taperDays: 0,
+      today: new Date("2026-05-01T00:00:00Z"),  // Friday
+      workingWindows: ALL_DAYS_WINDOW,
+      existingEvents: [],
+    })
+    // 4 weeks remaining (May 1 → May 29), 4/wk → ~16 sessions, 60 pages / 16 ≈ 3.75
+    expect(proposal.sessionsNeeded).toBeGreaterThanOrEqual(15)
+    expect(proposal.sessionsNeeded).toBeLessThanOrEqual(17)
+    expect(proposal.sessions.length).toBeGreaterThan(0)
+    // First session is on or after tomorrow
+    expect(proposal.sessions[0].date >= "2026-05-02").toBe(true)
+  })
+
+  it("respects working_windows — weekday-only excludes Sat/Sun", () => {
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 100,
+      unit: "pages",
+      sessionMinutes: 60,
+      sessionsPerWeek: 5,
+      deadline: "2026-05-22",
+      taperDays: 0,
+      today: new Date("2026-05-01T00:00:00Z"),
+      workingWindows: WEEKDAYS_ONLY,
+      existingEvents: [],
+    })
+    for (const s of proposal.sessions) {
+      const d = new Date(`${s.date}T00:00:00Z`)
+      expect(d.getUTCDay()).not.toBe(0)  // Sun
+      expect(d.getUTCDay()).not.toBe(6)  // Sat
+    }
+  })
+
+  it("honours taper_days_before_deadline — no sessions in the final N days", () => {
+    const taper = 7
+    const deadline = "2026-06-30"
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 50,
+      unit: "km",
+      sessionMinutes: 60,
+      sessionsPerWeek: 3,
+      deadline,
+      taperDays: taper,
+      today: new Date("2026-05-15T00:00:00Z"),
+      workingWindows: ALL_DAYS_WINDOW,
+      existingEvents: [],
+    })
+    const cutoffMs = Date.parse(deadline) - taper * 86_400_000
+    for (const s of proposal.sessions) {
+      const sMs = Date.parse(`${s.date}T00:00:00Z`)
+      expect(sMs).toBeLessThan(cutoffMs)
+    }
+  })
+
+  it("skips slots that overlap an existing event (double-booking guard)", () => {
+    // Existing 07:00-08:00 event on Mon May 4
+    const existing = stubEvent({
+      slug: "blocker",
+      startsAt: "2026-05-04T07:00:00Z",
+      endsAt: "2026-05-04T08:00:00Z",
+    })
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 30,
+      unit: "pages",
+      sessionMinutes: 60,
+      sessionsPerWeek: 7,
+      deadline: "2026-05-15",
+      taperDays: 0,
+      today: new Date("2026-05-03T00:00:00Z"),
+      workingWindows: ALL_DAYS_WINDOW,
+      existingEvents: [existing],
+    })
+    const may4 = proposal.sessions.find((s) => s.date === "2026-05-04")
+    expect(may4).toBeUndefined()
+    expect(proposal.notes.some((n) => n.includes("2026-05-04") && n.includes("clashes"))).toBe(true)
+  })
+
+  it("emits empty proposal + note when nothing remains to plan", () => {
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 0,
+      unit: "pages",
+      sessionMinutes: 60,
+      sessionsPerWeek: 4,
+      deadline: "2026-05-29",
+      taperDays: 0,
+      today: new Date("2026-05-01T00:00:00Z"),
+      workingWindows: ALL_DAYS_WINDOW,
+      existingEvents: [],
+    })
+    expect(proposal.sessions).toEqual([])
+    expect(proposal.notes[0]).toContain("nothing to plan")
+  })
+
+  it("emits warning when deadline (after taper) is in the past", () => {
+    const proposal = runPlanner({
+      slug: "x",
+      remainingUnits: 10,
+      unit: "pages",
+      sessionMinutes: 60,
+      sessionsPerWeek: 4,
+      deadline: "2026-04-01",
+      taperDays: 0,
+      today: new Date("2026-05-01T00:00:00Z"),
+      workingWindows: ALL_DAYS_WINDOW,
+      existingEvents: [],
+    })
+    expect(proposal.sessions).toEqual([])
+    expect(proposal.notes.some((n) => n.includes("past"))).toBe(true)
+  })
+})
+
+// === filesystem adapter tests ===
+
+const READ_INPUT = (vaultDir: string): TimeboxPlanInput => ({
+  title: "Constitutional AI paper",
+  discipline: "reading",
+  goal: "Read all 64 pages",
+  total: 64,
+  unit: "pages",
+  sessionMinutes: 60,
+  sessionsPerWeek: 4,
+  deadline: "2026-05-29",
+  tz: "UTC",
+  relatedPages: ["paper-constitutional-ai"],
+})
+
+const fixedNow = () => new Date("2026-05-01T00:00:00Z")  // Friday
+
+describe("FileSystemTimebox — plan/apply/list/get", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-timebox-"))
+    await mkdir(join(vaultDir, "calendar"), { recursive: true })
+  })
+
+  it("plan returns a dry-run proposal without writing", async () => {
+    const proposal = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.plan(READ_INPUT(vaultDir))
+      }).pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: ALL_DAYS_WINDOW,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 4,
+            now: fixedNow,
+          }),
+        ),
+      ),
+    )
+    expect(proposal.sessions.length).toBeGreaterThan(0)
+    // Nothing on disk yet — confirm timeboxes/ wasn't created
+    const entries = await readdir(join(vaultDir, "calendar"), { withFileTypes: true })
+    expect(entries.find((e) => e.name === "timeboxes")).toBeUndefined()
+  })
+
+  it("apply writes parent + N child events", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+        return yield* svc.apply(READ_INPUT(vaultDir), proposal)
+      }).pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: ALL_DAYS_WINDOW,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 4,
+            now: fixedNow,
+          }),
+        ),
+      ),
+    )
+    expect(result.timebox.slug).toBe("constitutional-ai-paper")
+    expect(result.childSlugs.length).toBeGreaterThan(0)
+
+    // Parent file exists with valid frontmatter
+    const parentRaw = await readFile(
+      join(vaultDir, "calendar/timeboxes/constitutional-ai-paper.md"),
+      "utf8",
+    )
+    const parsed = matter(parentRaw)
+    expect((parsed.data as { slug: string }).slug).toBe("constitutional-ai-paper")
+    expect((parsed.data as { discipline: string }).discipline).toBe("reading")
+    expect((parsed.data as { content_hash: string }).content_hash).toMatch(/^sha256:/)
+
+    // Each child file has timebox + step + step_units
+    for (const childSlug of result.childSlugs) {
+      const raw = await readFile(join(vaultDir, "calendar", `${childSlug}.md`), "utf8")
+      const cm = matter(raw)
+      const data = cm.data as { timebox: string; step: number; step_total: number; step_units: string; kind: string }
+      expect(data.timebox).toBe("constitutional-ai-paper")
+      expect(data.kind).toBe("practice")
+      expect(data.step).toBeGreaterThanOrEqual(1)
+      expect(data.step_total).toBe(result.childSlugs.length)
+      expect(data.step_units).toBeTruthy()
+    }
+  })
+
+  it("list returns the freshly applied timebox", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+        yield* svc.apply(READ_INPUT(vaultDir), proposal)
+      }).pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: ALL_DAYS_WINDOW,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 4,
+            now: fixedNow,
+          }),
+        ),
+      ),
+    )
+    const items = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.list()
+      }).pipe(
+        Effect.provide(
+          FileSystemTimeboxLive({
+            vaultDir,
+            tz: "UTC",
+            workingWindows: ALL_DAYS_WINDOW,
+            defaultSessionMinutes: 60,
+            defaultSessionsPerWeek: 4,
+            now: fixedNow,
+          }),
+        ),
+      ),
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0].slug).toBe("constitutional-ai-paper")
+    expect(items[0].done).toBe(0)
+  })
+
+  it("apply twice with the same slug fails with collision", async () => {
+    const layer = FileSystemTimeboxLive({
+      vaultDir,
+      tz: "UTC",
+      workingWindows: ALL_DAYS_WINDOW,
+      defaultSessionMinutes: 60,
+      defaultSessionsPerWeek: 4,
+      now: fixedNow,
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+        yield* svc.apply(READ_INPUT(vaultDir), proposal)
+      }).pipe(Effect.provide(layer)),
+    )
+    const second = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const svc = yield* TimeboxService
+          const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+          return yield* svc.apply(READ_INPUT(vaultDir), proposal)
+        }).pipe(Effect.provide(layer)),
+      ),
+    )
+    Either.match(second, {
+      onLeft: (e) => expect(e.kind).toBe("collision"),
+      onRight: () => {
+        throw new Error("expected second apply to fail with collision")
+      },
+    })
+  })
+})
+
+describe("FileSystemTimebox — complete / skip / setStatus", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-timebox-"))
+    await mkdir(join(vaultDir, "calendar"), { recursive: true })
+  })
+
+  const setupLayer = () =>
+    FileSystemTimeboxLive({
+      vaultDir,
+      tz: "UTC",
+      workingWindows: ALL_DAYS_WINDOW,
+      defaultSessionMinutes: 60,
+      defaultSessionsPerWeek: 4,
+      now: fixedNow,
+    })
+
+  const seed = () =>
+    Effect.gen(function* () {
+      const svc = yield* TimeboxService
+      const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+      return yield* svc.apply(READ_INPUT(vaultDir), proposal)
+    }).pipe(Effect.provide(setupLayer()))
+
+  it("complete rolls done up using parsed step_units (pages range)", async () => {
+    const applied = await Effect.runPromise(seed())
+    expect(applied.timebox.done).toBe(0)
+
+    // Find step 1's step_units to know what we expect to credit
+    const firstChildRaw = await readFile(
+      join(vaultDir, "calendar", `${applied.childSlugs[0]}.md`),
+      "utf8",
+    )
+    const firstChildData = matter(firstChildRaw).data as { step_units: string }
+    // Planner format: "pages 1-4" for multi-page sessions, "page 1" for sub-1 sessions.
+    // 64 pages / ~16 sessions = 4 pages/session, so we expect a range form.
+    expect(firstChildData.step_units).toMatch(/pages? \d/)
+
+    const after = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.complete(applied.timebox.slug, 1)
+      }).pipe(Effect.provide(setupLayer())),
+    )
+    expect(after.done).toBeGreaterThan(0)
+    expect(after.done).toBeLessThanOrEqual(applied.timebox.total)
+  })
+
+  it("complete twice on same step is idempotent (no double credit)", async () => {
+    const applied = await Effect.runPromise(seed())
+    const layer = setupLayer()
+
+    const first = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.complete(applied.timebox.slug, 1)
+      }).pipe(Effect.provide(layer)),
+    )
+    const second = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.complete(applied.timebox.slug, 1)
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(second.done).toBe(first.done)
+  })
+
+  it("skip marks the child cancelled and does NOT credit done", async () => {
+    const applied = await Effect.runPromise(seed())
+    const layer = setupLayer()
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.skip(applied.timebox.slug, 1)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    // Re-read the parent — done should still be 0
+    const reloaded = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.get(applied.timebox.slug)
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(reloaded.done).toBe(0)
+
+    // First child file must be marked cancelled
+    const childRaw = await readFile(
+      join(vaultDir, "calendar", `${applied.childSlugs[0]}.md`),
+      "utf8",
+    )
+    expect((matter(childRaw).data as { status: string }).status).toBe("cancelled")
+  })
+
+  it("setStatus pause then resume round-trips status", async () => {
+    const applied = await Effect.runPromise(seed())
+    const layer = setupLayer()
+
+    const paused = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.setStatus(applied.timebox.slug, "paused")
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(paused.status).toBe("paused")
+
+    const resumed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.setStatus(applied.timebox.slug, "active")
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(resumed.status).toBe("active")
+  })
+
+  it("get fails not_found for missing slug", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        Effect.gen(function* () {
+          const svc = yield* TimeboxService
+          return yield* svc.get("does-not-exist")
+        }).pipe(Effect.provide(setupLayer())),
+      ),
+    )
+    Either.match(result, {
+      onLeft: (e) => expect(e.kind).toBe("not_found"),
+      onRight: () => {
+        throw new Error("expected get to fail with not_found")
+      },
+    })
+  })
+})
+
+describe("FileSystemTimebox — replan", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), "uber-timebox-"))
+    await mkdir(join(vaultDir, "calendar"), { recursive: true })
+  })
+
+  it("replan supersedes pending children and writes a new schedule", async () => {
+    const layer = FileSystemTimeboxLive({
+      vaultDir,
+      tz: "UTC",
+      workingWindows: ALL_DAYS_WINDOW,
+      defaultSessionMinutes: 60,
+      defaultSessionsPerWeek: 4,
+      now: fixedNow,
+    })
+
+    const applied = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+        return yield* svc.apply(READ_INPUT(vaultDir), proposal)
+      }).pipe(Effect.provide(layer)),
+    )
+    const originalChildCount = applied.childSlugs.length
+
+    // Re-plan
+    const replanResult = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.replan(applied.timebox.slug)
+        return yield* svc.applyReplan(applied.timebox.slug, proposal)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    // The original children should be marked superseded
+    expect(replanResult.supersededSlugs.length).toBe(originalChildCount)
+    expect(replanResult.childSlugs.length).toBeGreaterThan(0)
+
+    // Spot-check: first original child file's status is now superseded
+    const supersededRaw = await readFile(
+      join(vaultDir, "calendar", `${applied.childSlugs[0]}.md`),
+      "utf8",
+    )
+    expect((matter(supersededRaw).data as { status: string }).status).toBe("superseded")
+  })
+})
+
+describe("FileSystemTimebox — addEvent", () => {
+  it("appends a child event and increments step_total of new entries", async () => {
+    const vaultDir = await mkdtemp(join(tmpdir(), "uber-timebox-"))
+    await mkdir(join(vaultDir, "calendar"), { recursive: true })
+    const layer = FileSystemTimeboxLive({
+      vaultDir,
+      tz: "UTC",
+      workingWindows: ALL_DAYS_WINDOW,
+      defaultSessionMinutes: 60,
+      defaultSessionsPerWeek: 4,
+      now: fixedNow,
+    })
+
+    const applied = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        const proposal = yield* svc.plan(READ_INPUT(vaultDir))
+        return yield* svc.apply(READ_INPUT(vaultDir), proposal)
+      }).pipe(Effect.provide(layer)),
+    )
+    const originalCount = applied.childSlugs.length
+
+    const added = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TimeboxService
+        return yield* svc.addEvent({
+          timeboxSlug: applied.timebox.slug,
+          startsAt: "2026-05-30T07:00:00Z",
+          tz: "UTC",
+          units: "pages 11-12",
+        })
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(added.step).toBe(originalCount + 1)
+    expect(added.stepTotal).toBe(originalCount + 1)
+  })
+})

--- a/apps/uebermensch/vault/specs/architecture.md
+++ b/apps/uebermensch/vault/specs/architecture.md
@@ -81,6 +81,7 @@ Dependencies MUST flow inward only (see [principles.md § Architectural Invarian
 | Brief delivery | L4 | `DelivererService` | Renders per channel, writes `uber_deliveries`; reused by calendar reminders |
 | Wiki introspection | L4 | `SinkInService` | Weekly: surveys wiki → gaps → questions + connections; also powers `gctrl uber query` |
 | Calendar | L4 + L2 + L1 | `CalendarService` + `uber_calendar` index + `driver-markets`/`driver-sec`/`driver-gcal` producers | Vault-first events filterable by source/kind; today's events surface in brief; reminders fan-out via `DelivererService` — see [calendar.md](calendar.md) |
+| Timeboxes | L4 | `TimeboxService` + `uber_timeboxes` index + new `timebox_slug`/`step`/`step_total`/`step_units` columns on `uber_calendar` | Multi-event practice plans: parent goal under `calendar/timeboxes/<slug>.md` owns N child events. Deterministic and LLM-assisted planner; coaching nudges reuse `uber_calendar_reminders`; stalled-timebox alert via daily check — see [calendar-timeboxes.md](calendar-timeboxes.md) |
 | Eval (automated + human) | L4 + L2 | `EvaluatorService` + kernel `scores` table | Auto-runs after each brief |
 | Cost budget enforcement | L2 | `Guardrails` policies | Daily budget = profile value; violation pauses sessions |
 | Sync | L2 extension | `gctrl-sync` | `uber_*` SQLite → D1 (index); entire `$UBER_VAULT_DIR` → R2 (content, bidirectional) |

--- a/apps/uebermensch/vault/specs/briefing-pipeline.md
+++ b/apps/uebermensch/vault/specs/briefing-pipeline.md
@@ -94,6 +94,8 @@ Prompt templates under `apps/uebermensch/personas/<persona>.md`, overridable by 
 | `{{candidate_pages}}` | XML-tagged | see below |
 | `{{max_items}}` | number | derived from `brief_format` (long=12, short=6, digest=3) |
 | `{{today_local}}` | date | today in `profile.identity.tz` |
+| `{{calendar_today}}` | XML-tagged | today's events from [calendar.md § Briefing Integration](calendar.md#briefing-integration); includes timebox child events with `step/step_total` from [calendar-timeboxes.md § Briefing Integration](calendar-timeboxes.md#briefing-integration) |
+| `{{offtrack_timeboxes}}` | XML-tagged | active timeboxes that are stalled within `profile.timeboxes.stalled_threshold` of their deadline; omitted when empty (see [calendar-timeboxes.md § Off-track timeboxes block](calendar-timeboxes.md#off-track-timeboxes-block)) |
 
 **Candidate page wrapping** (prompt-injection defense):
 

--- a/apps/uebermensch/vault/specs/calendar-timeboxes.md
+++ b/apps/uebermensch/vault/specs/calendar-timeboxes.md
@@ -1,0 +1,506 @@
+# Uebermensch — Calendar Timeboxes
+
+> A Timebox is a parent vault file representing a practice plan: a goal that needs scheduled, repeated time-blocks toward a measurable outcome by a deadline. Children are ordinary calendar events carrying a `timebox:` frontmatter field; they live in the existing `calendar/` paths and reuse all calendar filtering, reminders, and ICS export for free.
+>
+> Related: [calendar.md](calendar.md) (sibling spec; event shape and storage this extends), [profile.md § working_windows](profile.md#profile-schema-additions) (working-window config the planner reads), [briefing-pipeline.md](briefing-pipeline.md) (how today's timebox events surface in the brief), [domain-model.md](domain-model.md) (Effect-TS port/service pattern), [architecture.md](architecture.md) (L4 layering rules — never open DuckDB, never call external APIs directly).
+
+## Why a Timebox Spec
+
+The brief tells the user what happened; the calendar tells the user what is about to happen. Neither is enough for goals that demand repeated, compounding effort — finishing a paper, training for a marathon, shipping a content series, building a language habit.
+
+Without first-class scheduling:
+
+1. Intent dissolves. A reader who marks "finish Constitutional AI" on a sticky note rarely finishes Constitutional AI. The plan needs to break into sessions and block the calendar accordingly.
+2. Reminders are not enough. A single alarm at the deadline tells the user they missed the target, not how to hit it. What is needed is a sequence of dated events, each a concrete unit of work.
+3. Ad-hoc events lose the through-line. If sessions are scattered across the calendar without a parent, there is no progress counter, no stall detection, no completion signal, and no audit trail.
+4. Disciplines look different but share one shape. Reading pages, running kilometres, recording podcast episodes, and drafting posts are all "divide a total by time remaining, spread into sessions, track done." The abstraction is the same; only the unit changes.
+
+A Timebox is the vault-first answer: one parent file captures the goal; the planner slices it into dated child events; progress rolls up automatically as children complete.
+
+## Principles
+
+1. **Markdown is the source of truth.** The parent file (`calendar/timeboxes/<slug>.md`) and all child events (`calendar/<date>--<slug>.md`) are the authoritative records. SQLite (`uber_timeboxes`, new columns on `uber_calendar`) is a rebuildable index. Deleting SQLite MUST be recoverable by re-running `gctrl uber timebox reindex`.
+2. **One shape across disciplines.** There is no `kind: study` vs. `kind: training` split. Every timebox is `kind: practice`, parameterised by `discipline:`. The planner only needs `unit` + `session_minutes`; `discipline` is for display and downstream filtering.
+3. **Children are first-class calendar events.** Timebox child events are ordinary entries in `uber_calendar`. They appear in calendar views, fire reminders, export to ICS, and mirror to Google Calendar exactly like any other event. No separate table; no special folder.
+4. **Planner is deterministic by default, LLM-assisted on demand.** `gctrl uber timebox plan` slices work with even arithmetic and produces a dry-run. `--llm` hands goal + profile working-windows to `driver-llm`; proposals are validated and presented before any write. Nothing is committed without `--apply`.
+5. **Re-plan preserves the audit trail.** Superseded child events are marked `status: superseded`, not deleted. The replaced plan remains browsable in Obsidian and searchable in SQLite.
+6. **Coaching nudges reuse the existing reminder pipeline.** Progress-threshold alerts and halfway messages insert rows into `uber_calendar_reminders` (channel = profile default channel). No new delivery infrastructure.
+7. **Wikilinks compound.** A timebox referencing `related_pages: [paper:constitutional-ai]` wires the practice plan into the vault graph, so the brief pipeline can surface it alongside related wiki pages on the same topic.
+
+## Vault Layout
+
+```
+$UBER_VAULT_DIR/
+├── calendar/
+│   │  ─── Authored (git-tracked) ───
+│   ├── timeboxes/                                   # NEW — parent files
+│   │   ├── sub-3-berlin.md                          # kind: practice, discipline: running
+│   │   └── constitutional-ai-reading.md             # kind: practice, discipline: reading
+│   │
+│   ├── 2026-06-02--sub-3-berlin.md                  # child event; timebox: sub-3-berlin
+│   ├── 2026-06-04--sub-3-berlin.md                  # child event; step 2/52
+│   ├── 2026-04-30--constitutional-ai-reading.md     # child event; timebox: constitutional-ai-reading
+│   └── ...
+│
+└── calendar/generated/                              # driver-pulled events (unchanged)
+```
+
+`calendar/timeboxes/` is a new authored-tier subdirectory — git-tracked, Obsidian-mountable. Child events live directly under `calendar/` with the existing `<date>--<slug>.md` naming, distinguished from one-off events only by the presence of `timebox:` in frontmatter. The `<slug>` portion of child filenames repeats the timebox slug for browsability; a numeric suffix disambiguates same-day sessions (`2026-06-02--sub-3-berlin-a.md`, `-b.md`).
+
+## Timebox Frontmatter
+
+### Running example
+
+```yaml
+---
+slug: sub-3-berlin
+kind: practice
+discipline: running
+title: "Sub-3 Berlin Marathon"
+goal: "Complete the Berlin Marathon in under 3 hours on 2026-09-27."
+deadline: 2026-09-27
+unit: km
+total: 600
+done: 142                         # rolled up from completed children; read-only from user's perspective
+session_minutes: 60
+sessions_per_week: 4
+status: active                    # active | paused | done | cancelled
+taper_days_before_deadline: 14    # optional; athletic disciplines only
+related_pages: [running-log]      # bare slugs; wikilinks into vault graph
+topics: [endurance-sports]
+tags: [marathon, berlin-2026]
+coaching:
+  nudges:
+    - { at: 0.25, template: "Quarter of the way there — {done}{unit} of {total}{unit} logged." }
+    - { at: 0.5,  template: "Halfway — {done}{unit} done. Pace: on track for deadline." }
+    - { at: 0.75, template: "Three-quarters in — final push. Taper starts in {taper_days} days." }
+created_at: 2026-04-29T08:00:00+08:00
+updated_at: 2026-04-29T08:00:00+08:00
+content_hash: sha256:…
+---
+
+## Goal
+
+Sub-3 hour marathon at Berlin on 2026-09-27.
+Base: 4 sessions/week, 600km total over 22 weeks (14-day taper).
+
+## Notes
+
+- Long run Sunday; intervals Tuesday; easy Wednesday + Friday.
+- See [[running-log]] for actual times accumulated by session.
+```
+
+### Reading example
+
+```yaml
+---
+slug: constitutional-ai-reading
+kind: practice
+discipline: reading
+title: "Constitutional AI — Anthropic paper"
+goal: "Read all 64 pages of the Constitutional AI paper with margin notes."
+deadline: 2026-05-20
+unit: pages
+total: 64
+done: 12
+session_minutes: 60
+sessions_per_week: 4
+status: active
+related_pages: [paper-constitutional-ai]
+topics: [ai-dev-workflows]
+tags: [alignment, reading]
+coaching:
+  nudges:
+    - { at: 0.5, template: "Page {done} of {total} — halfway through the paper." }
+created_at: 2026-04-25T07:30:00+08:00
+updated_at: 2026-04-29T09:00:00+08:00
+content_hash: sha256:…
+---
+```
+
+### Required vs. optional
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `slug` | yes | kebab-case; unique within `calendar/timeboxes/`; used as filename stem |
+| `kind` | yes | always `practice` |
+| `discipline` | yes | open string; see § Discipline Taxonomy |
+| `title` | yes | display string |
+| `goal` | yes | plain-language statement of the outcome |
+| `deadline` | yes | ISO 8601 date; must be in the future at create time |
+| `unit` | yes | open string (e.g., `km`, `pages`, `episodes`, `posts`) |
+| `total` | yes | numeric total units to complete |
+| `session_minutes` | yes | nominal duration of one session in minutes |
+| `sessions_per_week` | yes | default sessions per week for the planner |
+| `status` | yes | `active` is default |
+| `done` | no | rolled up by `complete`; do not set by hand |
+| `taper_days_before_deadline` | no | excludes the final N days from session scheduling |
+| `related_pages` | no | bare slugs; wikilinks to wiki/thesis/project pages |
+| `topics` | no | intersects with `profile.topics` for brief promotion |
+| `tags` | no | free-form taxonomy |
+| `coaching` | no | sub-block; see § Coaching Nudges |
+| `created_at` | yes | ISO 8601 with offset; set at creation |
+| `updated_at` | yes | ISO 8601 with offset; updated on every write |
+| `content_hash` | yes | sha256 of file bytes; set by writer |
+
+## Child Event Frontmatter Additions
+
+Child events are ordinary events conforming to [calendar.md § Event Frontmatter](calendar.md#event-frontmatter) with three additional fields and one extended enum value:
+
+```yaml
+---
+slug: 2026-06-02--sub-3-berlin
+title: "Sub-3 Berlin · 12km easy · session 3/52"
+kind: practice
+source: user
+starts_at: 2026-06-02T07:00:00+08:00
+ends_at: 2026-06-02T08:00:00+08:00
+tz: "Asia/Hong_Kong"
+status: confirmed                   # confirmed | tentative | cancelled | superseded (NEW)
+timebox: sub-3-berlin               # NEW — slug of the parent timebox
+step: 3                             # NEW — ordinal position within the plan (1-based)
+step_total: 52                      # NEW — total planned sessions at time of write
+step_units: "12km easy"             # NEW — human-readable description of this session's units
+---
+```
+
+New fields:
+
+| Field | Required on child | Notes |
+|-------|-------------------|-------|
+| `timebox` | yes (if child) | slug matching a `calendar/timeboxes/<slug>.md` file |
+| `step` | yes (if child) | integer ≥ 1; `step <= step_total` enforced by validation |
+| `step_total` | yes (if child) | total sessions in the current plan at write time |
+| `step_units` | yes (if child) | free-form string describing what this session covers (e.g., `"pages 30–40"`, `"12km easy"`, `"episode 3 outline"`) |
+
+`status: superseded` is a new value added to the `status` enum from [calendar.md](calendar.md). Superseded events are excluded from active calendar views by default but retained for audit. The `uber_calendar` index must handle `status = 'superseded'` without error.
+
+## Storage
+
+### `uber_timeboxes`
+
+New table; kernel daemon is the single writer.
+
+```sql
+CREATE TABLE uber_timeboxes (
+  id                  TEXT PRIMARY KEY,           -- "tb_" || ulid
+  slug                TEXT NOT NULL UNIQUE,
+  vault_path          TEXT NOT NULL UNIQUE,        -- e.g. "calendar/timeboxes/sub-3-berlin.md"
+  kind                TEXT NOT NULL DEFAULT 'practice',
+  discipline          TEXT NOT NULL,
+  title               TEXT NOT NULL,
+  goal                TEXT NOT NULL,
+  deadline            TEXT NOT NULL,               -- ISO 8601 date
+  unit                TEXT NOT NULL,
+  total               REAL NOT NULL,
+  done                REAL NOT NULL DEFAULT 0,
+  session_minutes     INTEGER NOT NULL,
+  sessions_per_week   REAL NOT NULL,
+  status              TEXT NOT NULL DEFAULT 'active',
+  content_hash        TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL
+);
+
+CREATE INDEX uber_timeboxes_status_idx ON uber_timeboxes(status, deadline);
+```
+
+### New columns on `uber_calendar`
+
+```sql
+ALTER TABLE uber_calendar ADD COLUMN timebox_slug  TEXT;
+ALTER TABLE uber_calendar ADD COLUMN step          INTEGER;
+ALTER TABLE uber_calendar ADD COLUMN step_total    INTEGER;
+ALTER TABLE uber_calendar ADD COLUMN step_units    TEXT;
+
+CREATE INDEX uber_calendar_timebox_idx
+  ON uber_calendar(timebox_slug, step);
+```
+
+These columns are `NULL` for all non-timebox events. The `uber_calendar_timebox_idx` covers the primary access pattern: "list all steps for timebox X in order."
+
+The single-writer rule from [calendar.md § Storage](calendar.md#storage) applies unchanged: the kernel daemon is the only process that inserts or updates these tables. Uebermensch app code reads via kernel HTTP routes.
+
+## Planner
+
+The planner is invoked by `gctrl uber timebox plan` and `gctrl uber timebox replan`. Both produce a dry-run by default; nothing is written until `--apply`.
+
+### Inputs
+
+- Timebox frontmatter (`total`, `done`, `deadline`, `session_minutes`, `sessions_per_week`, `taper_days_before_deadline`)
+- `profile.timeboxes.working_windows` — per-weekday time windows within which sessions may be scheduled
+- Existing `calendar/` events for the target user (read via `KbPort`) — used to avoid double-booking
+- For re-plan: which child events the user has manually edited (these are "pinned" — excluded from redistribution)
+
+### Default (deterministic) algorithm
+
+```
+remaining_units  = total - done
+weeks_remaining  = floor((deadline - today - taper_days) / 7)
+sessions_needed  = ceil(weeks_remaining * sessions_per_week)
+units_per_session = remaining_units / sessions_needed   (rounded to sensible precision)
+```
+
+The planner walks forward from `today + 1d`, for each day:
+
+1. Check if the day falls within a `working_windows` entry.
+2. Check if the time slot overlaps any existing confirmed/tentative calendar event (double-booking guard).
+3. If clear, allocate a session: `starts_at = window.start`, `ends_at = starts_at + session_minutes`.
+4. Repeat until `sessions_needed` events are placed or `deadline - taper_days` is reached (whichever comes first).
+
+If `taper_days_before_deadline > 0`, the final `taper_days` before the deadline are left clear (no new sessions placed). The taper window may receive manually added sessions via `gctrl uber timebox add-event`.
+
+### LLM-assisted (`--llm`)
+
+When `--llm` is passed, the planner instead:
+
+1. Composes a prompt containing: goal, total, done, deadline, unit, session_minutes, sessions_per_week, working_windows (serialised), and the list of already-blocked time slots.
+2. Sends to `driver-llm` via `POST /api/llm/generate` (kernel route — app code never calls the LLM directly).
+3. Expects a JSON response: `{ "sessions": [{ "date": "YYYY-MM-DD", "start": "HH:MM", "end": "HH:MM", "units": "string" }, ...] }`.
+4. Validates each proposal: date within range, no overlap with existing events, total proposed units approximately equals `remaining_units`, count matches `sessions_needed`.
+5. Presents the validated proposals as a dry-run diff. The user inspects and runs `--apply` to commit.
+
+The `--llm` path adds an `llm` span (cost tracked in the session) to the plan trace. The deterministic path emits no LLM call.
+
+### Re-plan
+
+`gctrl uber timebox replan <slug>` re-runs the algorithm against:
+
+- `remaining_units = total - done` (recalculated from completed children)
+- `remaining_time = deadline - today` (recalculated)
+- Pinned events: any child event the user has manually edited since creation (`updated_at > created_at + 60s`) is excluded from redistribution and kept in place
+
+Superseded events (old plan) are marked `status: superseded` in their frontmatter and in `uber_calendar`. New events are written at the new schedule. The audit trail is preserved.
+
+## CLI — `gctrl uber timebox`
+
+```sh
+# List all timeboxes (active by default; --all for all statuses)
+gctrl uber timebox list
+gctrl uber timebox list --status paused
+
+# Show a timebox (frontmatter + progress summary + child event list)
+gctrl uber timebox show <slug>
+
+# Plan a new timebox (dry-run by default; --apply to commit)
+gctrl uber timebox plan \
+  --discipline reading \
+  --title "Constitutional AI" \
+  --total 64 \
+  --unit pages \
+  --session-minutes 60 \
+  --sessions-per-week 4 \
+  --deadline 2026-05-20 \
+  --related-page paper-constitutional-ai
+
+gctrl uber timebox plan \
+  --discipline running \
+  --title "Sub-3 Berlin" \
+  --total 600 \
+  --unit km \
+  --sessions-per-week 4 \
+  --deadline 2026-09-27 \
+  --taper-days 14 \
+  --llm
+
+# --apply commits the dry-run plan (writes parent file + all child events)
+gctrl uber timebox plan --discipline reading ... --apply
+
+# Add a single child event manually (outside the planner's automatic slots)
+gctrl uber timebox add-event <slug> \
+  --start 2026-05-15T07:00 \
+  --units "12km easy"
+
+# Mark a step done; rolls up done on parent; checks nudge thresholds
+gctrl uber timebox complete <slug>:<step>
+
+# Mark a step skipped; updates plan offset for re-plan
+gctrl uber timebox skip <slug>:<step>
+
+# Re-plan remaining sessions (dry-run by default)
+gctrl uber timebox replan <slug>
+gctrl uber timebox replan <slug> --llm
+gctrl uber timebox replan <slug> --apply
+
+# Lifecycle transitions
+gctrl uber timebox pause <slug>
+gctrl uber timebox resume <slug>
+gctrl uber timebox cancel <slug>
+
+# Mark a timebox fully done (sets status: done, updates parent frontmatter)
+gctrl uber timebox complete <slug>
+
+# Rebuild uber_timeboxes and timebox columns in uber_calendar from vault
+gctrl uber timebox reindex
+```
+
+`plan` and `replan` default to dry-run — they print a table of proposed child events (date, start, end, units) without writing anything. Append `--apply` to commit. The `--llm` flag is available on both commands; without it the deterministic algorithm runs.
+
+## HTTP API
+
+Served on the Uebermensch app port (separate from kernel `:4318`). Mirrors CLI surface 1:1.
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/uber/calendar/timeboxes` | List timeboxes. Query params: `status`, `discipline`. |
+| POST | `/api/uber/calendar/timeboxes` | Create a new timebox (parent file only; no child events yet). |
+| GET | `/api/uber/calendar/timeboxes/{slug}` | Get one timebox (frontmatter + progress + child event list). |
+| PATCH | `/api/uber/calendar/timeboxes/{slug}` | Update frontmatter (title, goal, sessions_per_week, etc.). 422 on `done` or `content_hash` write attempts. |
+| DELETE | `/api/uber/calendar/timeboxes/{slug}` | Cancel and archive — sets `status: cancelled`; child events marked `status: superseded`. |
+| POST | `/api/uber/calendar/timeboxes/{slug}/plan` | Run the planner. Body: `{ apply: bool, llm: bool }`. Returns dry-run diff or applies and returns created event slugs. |
+| POST | `/api/uber/calendar/timeboxes/{slug}/replan` | Re-run planner against remaining work + time. Same body shape as plan. |
+| POST | `/api/uber/calendar/timeboxes/{slug}/complete/{step}` | Mark step N done. Updates `done` on parent; checks nudge thresholds; returns updated timebox. |
+| POST | `/api/uber/calendar/timeboxes/{slug}/skip/{step}` | Mark step N skipped. Does not increment `done`. |
+
+## Briefing Integration
+
+Today's timebox child events appear in the "On the calendar today" section of the morning brief. Each entry follows the line shape:
+
+```
+**Practice** — Sub-3 Berlin · 12km easy · 60min · session 18/52 · [[running-log]]
+**Practice** — Constitutional AI · pages 30–40 · 60min · session 4/7 · [[paper-constitutional-ai]]
+```
+
+Fields: `kind: practice` (the display label), timebox title, `step_units`, `session_minutes`, `step/step_total`, and the first `related_pages` bare wikilink if present.
+
+Practice events appear after `deadline` and before `personal` in the brief's kind ordering (see [calendar.md § Briefing Integration](calendar.md#briefing-integration) for the full ordering rule).
+
+### Off-track timeboxes block
+
+A new block fires in the brief when a timebox is stalled. Stall condition: no child event with `status: done` or `status: confirmed` has been seen within `2 × (7 / sessions_per_week)` days, AND the deadline is within `profile.timeboxes.stalled_threshold` (ISO 8601 duration, e.g. `P14D`).
+
+```markdown
+## Off track
+
+**Sub-3 Berlin** — last session 12 days ago · 142/600km done · deadline in 19 days
+**Constitutional AI** — last session 8 days ago · 12/64 pages done · deadline in 6 days
+```
+
+This block is included in the curator's prompt as `<offtrack_timeboxes>...</offtrack_timeboxes>` so the LLM may reference it in the brief summary (e.g., surfacing a deadline risk alongside related wiki updates). The block is omitted — not rendered as empty — when no timebox meets the stall condition.
+
+## Coaching Nudges
+
+The `coaching.nudges[]` sub-block in a timebox's frontmatter specifies progress-triggered messages. Each nudge has:
+
+- `at`: a progress fraction in `(0, 1]` (e.g., `0.5` = 50% of `total` done) or an absolute ISO 8601 date
+- `template`: a string with `{done}`, `{total}`, `{unit}`, `{taper_days}` interpolation placeholders
+
+On every `gctrl uber timebox complete <slug>:<step>` call, the writer checks which nudge thresholds have been crossed since the last complete. For each newly crossed threshold:
+
+1. Render the template with current progress values.
+2. Insert a row into `uber_calendar_reminders` with:
+   - `event_id` pointing at the parent timebox's synthetic event id (a stable id derived from the timebox slug)
+   - `fire_at = now + PT5M` (near-immediate; the scheduler picks it up on its next tick)
+   - `channel = profile.timeboxes.coaching.default_channel`
+   - `status = pending`
+3. Idempotency key: `(timebox_slug, nudge_index)` stored as `event_id || ':nudge:' || nudge_index`. A nudge fires at most once per timebox lifetime.
+
+The `Scheduler` → `DelivererService` path delivers the nudge message through the existing reminder pipeline. No new delivery infrastructure is introduced.
+
+## Discipline Taxonomy
+
+`discipline` is an open string enum — the planner does not validate it against a fixed list. Common values and their conventions:
+
+| Value | `unit` examples | `related_pages` convention |
+|-------|-----------------|---------------------------|
+| `reading` | `pages`, `chapters` | bare slug for the paper/book/course wiki page (e.g. `paper-constitutional-ai`, `book-thinking-fast-and-slow`) |
+| `writing` | `posts`, `words`, `chapters` | project or entity page |
+| `running` | `km`, `miles`, `sessions` | `running-log` or `training-log` |
+| `strength` | `sessions`, `sets` | `training-log` |
+| `recording` | `episodes`, `minutes` | podcast or project page |
+| `language` | `sessions`, `lessons` | `language-log` or course page |
+| `instrument` | `sessions`, `pieces` | practice log or repertoire page |
+| `meditation` | `sessions`, `minutes` | journal or habit log |
+| `other` | any | any |
+
+The planner only needs `unit` + `session_minutes`. `discipline` drives display labels, brief rendering, and downstream filtering. New discipline values are valid immediately — no schema migration required.
+
+## Wiki Linkage
+
+By convention:
+
+- `discipline: reading` timeboxes reference the source material via `related_pages` (e.g., `paper-constitutional-ai`, `book-thinking-fast-and-slow`, `course-fast-ai`). The linked page is the wiki entity for the material, where annotations, summaries, and deepdive results accumulate.
+- `discipline: writing` and `discipline: recording` timeboxes link to the project or entity page the output belongs to (e.g., a newsletter entity, a podcast project).
+- Athletic disciplines (`running`, `strength`, `instrument`, `meditation`) link to a log page (e.g., `running-log`, `strength-log`) where actual session data accumulates over time, separate from the timebox plan.
+
+All links use bare `[[slug]]` wikilinks — no typed prefixes (`[[paper:constitutional-ai]]` is forbidden; the vault's globally-unique slug rule makes prefixes unnecessary). See [calendar.md § Principles #5](calendar.md#principles) and [briefing-pipeline.md § Curator](briefing-pipeline.md#3-curator-llm) for the wikilink invariant.
+
+## Validation Rules
+
+`gctrl uber profile validate` extends with timebox checks — all must pass for the daemon to start:
+
+1. Every file under `calendar/timeboxes/` parses as `Timebox` schema (all required fields present; no unknown fields that would fail the decoder).
+2. Every child event with `timebox:` set has `step` and `step_total` set, and `step <= step_total`.
+3. Sum of completed children's numeric units for a given timebox does not exceed `total`. (Derived from `step_units` numeric prefix where parseable; skipped for free-form strings.)
+4. `discipline` is a non-empty string matching `[a-z][a-z0-9-]*`.
+5. `unit` is a non-empty string.
+6. `deadline` parses as ISO 8601 date; at create time, must be in the future (validator is lenient post-create — a past deadline is a warning, not an error, so completed timeboxes do not fail validation).
+7. For each nudge, `at` is either a fraction in `(0, 1]` or a valid ISO 8601 date.
+8. `slug` is unique across all files under `calendar/timeboxes/`.
+9. Every `timebox:` field on a child event resolves to an existing file under `calendar/timeboxes/<slug>.md`.
+10. `related_pages` slugs match `[a-z0-9-]+` (bare slug rule; no typed prefixes).
+
+## Eval & Observability
+
+- **Stalled timebox alert.** A daily check (registered alongside `uber.eval.daily`) queries `uber_timeboxes` for active timeboxes where `(today - last_completed_child_at) > 2 × (7 / sessions_per_week) days` AND `deadline - today < stalled_threshold`. For each match, inserts a row into `uber_alerts` with `kind = 'timebox_stalled'`, `subject = timebox.slug`, `urgency = high` if deadline is within 7 days, `medium` otherwise. The alert clears automatically on the next `complete` call.
+- **Plan and replan sessions.** Each `plan` or `replan` call creates a kernel `Session` with spans for: `loadProfile`, `loadExistingEvents`, `slice`, `validate`, `write`. When `--llm` is passed, an additional `llm` span is emitted (cost tracked in `sessions.total_cost_usd`). This makes plan regressions detectable — every generated schedule ties to a specific prompt hash and model.
+- **Progress rollup.** `uber_timeboxes.done` is updated on every `complete` call via `PATCH /api/uber/calendar/timeboxes/{slug}` (kernel route). The kernel's `updated_at` timestamp on the row enables the stall check without scanning all child events.
+
+## R2 Sync
+
+Both `calendar/timeboxes/**.md` (parent files) and child event files (`calendar/<date>--<slug>.md` with `timebox:` set) fall under the existing `**/*.md` include glob in the vault sync config (see [profile.md § Sync (R2)](profile.md#sync-r2)). No new sync mount or special handling is needed. The conflict policy (`local-wins-with-warning`) applies to timebox parent files the same as any authored-tier markdown.
+
+## Profile Schema Additions
+
+Add a `timeboxes:` section to `profile.md` frontmatter:
+
+```yaml
+timeboxes:
+  working_windows:
+    - { days: [mon, tue, wed, thu, fri], start: "07:00", end: "08:00" }
+    - { days: [sat, sun], start: "08:00", end: "10:00" }
+  default_session_minutes: 60
+  default_sessions_per_week: 3
+  stalled_threshold: P14D          # ISO 8601 duration; stall alert window before deadline
+  replan_policy: pin-edited        # pin-edited | redistribute-all
+  coaching:
+    default_channel: telegram_primary
+```
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `working_windows` | none | List of per-weekday time windows the planner may schedule into |
+| `default_session_minutes` | 60 | Used when `--session-minutes` is omitted from `plan` |
+| `default_sessions_per_week` | 3 | Used when `--sessions-per-week` is omitted |
+| `stalled_threshold` | `P14D` | ISO 8601 duration; stall alert fires when deadline is closer than this |
+| `replan_policy` | `pin-edited` | `pin-edited`: keep user-edited children fixed; `redistribute-all`: clear and re-plan all remaining steps |
+| `coaching.default_channel` | profile default channel | Which delivery channel coaching nudges use |
+
+Missing `timeboxes:` block falls back to in-app defaults (no working-window constraints; deterministic planner schedules any slot; stall alerts use `P14D`).
+
+## Roadmap Hooks
+
+Three implementation phases. See [ROADMAP.md](../ROADMAP.md) for the milestone breakdown.
+
+| Phase | Scope |
+|-------|-------|
+| **Timebox M0** | Parent vault files + `uber_timeboxes` table + `uber_calendar` new columns; manual `add-event` + `complete` + `skip` commands; briefing integration (today's practice events + off-track block); deterministic planner (`plan` without `--llm`); `reindex`. |
+| **Timebox M1** | LLM-assisted `plan` and `replan` (`--llm` flag); working-window scheduling (profile `timeboxes.working_windows` respected); coaching nudges (nudge threshold checks + `uber_calendar_reminders` inserts); stalled-timebox daily alert (`uber_alerts(kind='timebox_stalled')`); `replan` with pinned-event logic. |
+| **Timebox M2** | Web UI timebox view (gantt-lite showing sessions as bars, coloured by `status: done / confirmed / superseded`); `driver-gcal` write-back for timebox child events with title-prefix convention `[Sub-3 Berlin 18/52]` (opt-in; same write-back flag as calendar.md § Drivers). |
+
+## Non-Goals
+
+1. **Not a project management tool.** No Gantt dependencies, no resource allocation, no milestone relationships between timeboxes.
+2. **Not milestone tracking.** Use `kind: deadline` events for hard due dates — see [calendar.md § Event Kinds](calendar.md#event-kinds).
+3. **Not habit tracking.** `gctrl-context` covers daily journaling and recurring habits. Timeboxes have a definite end and a measurable total; they are not open-ended streaks.
+4. **Not a fitness app.** No biometric integration in M0. `done` is updated by the user via `complete`; the timebox does not read from Strava, Garmin, or any wearable automatically.
+5. **Not multi-user accountability.** The vault is a single-identity system per [profile.md § Location & Identity](profile.md#location--identity). Shared coaching or partner accountability is out of scope.
+
+## Open Questions
+
+1. **External tracker integration.** Auto-updating `done` from Strava km, Readwise pages-read, or GitHub commits would reduce manual `complete` calls. This is a natural extension but requires new kernel driver hooks and is deferred past M1.
+2. **Auto-extraction of reading structure.** For a given paper or book, `gctrl-net` + LLM could extract a page count or chapter list and pre-populate `total`. Useful; out of scope for M0.
+3. **Completed child event archival.** Should completed children remain in `calendar/` indefinitely, or be moved to an archive subfolder after the timebox closes? Current leaning: keep in place (audit trail in Obsidian); `gctrl uber calendar prune` handles bulk cleanup.
+4. **gcal write-back title-prefix format.** `[<title> <step>/<step_total>]` is readable but may pollute Google Calendar search results. An alternative is a structured description field. Needs user testing before M2.
+5. **Taper logic scope.** `taper_days_before_deadline` is currently a generic field. Should it be restricted to `discipline: running | strength` (hard-coded) or remain a generic declarative shape any discipline may use? Current leaning: generic — the planner does not need to know discipline to honour it.
+6. **Recurring timeboxes.** A user who sets a quarterly reading goal would want to create a new timebox each quarter. Recurrence support (e.g., `recurs: quarterly`) is out of scope; the user creates a new file per cycle and the vault graph links them via `related_pages`.

--- a/apps/uebermensch/vault/specs/calendar.md
+++ b/apps/uebermensch/vault/specs/calendar.md
@@ -2,7 +2,7 @@
 
 > Time-bound events live alongside the wiki. Personal commitments (meetings, deadlines, travel) and market-moving dates (earnings, FOMC, CPI prints, dividend ex-dates, lockup expiries, election days) share one storage shape and one query surface — filtered by source/kind for display.
 >
-> Related: [profile.md § Vault Layout](profile.md#vault-layout) (where calendar files live), [briefing-pipeline.md](briefing-pipeline.md) (how today's events surface in the morning brief), [knowledge-base.md § Wikilink Conventions](knowledge-base.md#wikilink-conventions) (link rules events follow), [delivery.md](delivery.md) (how reminders fan out).
+> Related: [profile.md § Vault Layout](profile.md#vault-layout) (where calendar files live), [briefing-pipeline.md](briefing-pipeline.md) (how today's events surface in the morning brief), [knowledge-base.md § Wikilink Conventions](knowledge-base.md#wikilink-conventions) (link rules events follow), [delivery.md](delivery.md) (how reminders fan out), [calendar-timeboxes.md](calendar-timeboxes.md) (multi-event practice plans built on top of this spec).
 
 ## Why a Calendar Spec
 
@@ -37,6 +37,9 @@ $UBER_VAULT_DIR/
 │   ├── 2026-05-15--family-trip-tokyo.md   # source: user (multi-day)
 │   ├── recurring/                         # optional — RFC 5545 RRULE files
 │   │   └── weekly-team-standup.md
+│   ├── timeboxes/                         # parent files for multi-event practice plans
+│   │   ├── sub-3-berlin.md                # see calendar-timeboxes.md
+│   │   └── constitutional-ai-reading.md
 │   │
 │   │  ─── Generated (gitignored; R2-synced) ───
 │   └── generated/
@@ -102,7 +105,9 @@ or holds the ingested description. For user-authored events this is your notes
 | `source` | yes | provenance (see § Sources) |
 | `starts_at` | yes | ISO 8601; for `all_day: true` use `YYYY-MM-DD` |
 | `tz` | yes | IANA timezone for display rendering |
-| `status` | yes | `confirmed` is default |
+| `status` | yes | `confirmed` is default; see [calendar-timeboxes.md](calendar-timeboxes.md) for the `superseded` value used by re-planned timebox children |
+| `timebox` | no | slug of a parent timebox (`calendar/timeboxes/<slug>.md`); see [calendar-timeboxes.md § Child Event Frontmatter Additions](calendar-timeboxes.md#child-event-frontmatter-additions) |
+| `step` / `step_total` / `step_units` | no | required if `timebox:` is set; ordering and unit description for one timebox session |
 | everything else | no | | 
 
 ### Event Kinds
@@ -119,6 +124,7 @@ or holds the ingested description. For user-authored events this is your notes
 | `political` | elections, vote dates, key floor votes | `-P1D` |
 | `prediction-market` | Kalshi/Polymarket resolution dates | `-PT1H` |
 | `industry` | conferences, summits, regulator hearings | `-P1D` |
+| `practice` | timebox child events (reading sessions, training blocks, recording slots) — see [calendar-timeboxes.md](calendar-timeboxes.md) | `-PT15M` to `app` |
 | `other` | catch-all | none |
 
 `kind` is intentionally coarse — fine taxonomy goes in `tags`. The curator and the visualizer key off `kind` for default colours, default reminder cadence, and the default visibility toggle.

--- a/apps/uebermensch/vault/specs/domain-model.md
+++ b/apps/uebermensch/vault/specs/domain-model.md
@@ -724,7 +724,25 @@ export class ProfilePort extends Context.Tag("uber/ProfilePort")<ProfilePort, {
   readonly current: Effect.Effect<Profile, ProfileInvalid>
   readonly changes: Stream.Stream<ProfileChange, ProfileInvalid>
 }>() {}
+
+// src/ports/timebox-port.ts  (see calendar-timeboxes.md)
+export class TimeboxPort extends Context.Tag("uber/TimeboxPort")<TimeboxPort, {
+  readonly list:       (filter?: { status?: TimeboxStatus; discipline?: string })
+    => Effect.Effect<ReadonlyArray<TimeboxRef>, TimeboxPortError>
+  readonly get:        (slug: string) => Effect.Effect<Timebox, TimeboxPortError>
+  readonly plan:       (req: TimeboxPlanRequest)
+    => Effect.Effect<TimeboxPlanProposal, TimeboxPortError>          // dry-run; --apply is a separate call
+  readonly apply:      (slug: string, proposal: TimeboxPlanProposal)
+    => Effect.Effect<ReadonlyArray<EventSlug>, TimeboxPortError>
+  readonly replan:     (slug: string, opts: { llm: boolean; apply: boolean })
+    => Effect.Effect<TimeboxPlanProposal | ReadonlyArray<EventSlug>, TimeboxPortError>
+  readonly complete:   (slug: string, step: number) => Effect.Effect<Timebox, TimeboxPortError>
+  readonly skip:       (slug: string, step: number) => Effect.Effect<Timebox, TimeboxPortError>
+  readonly setStatus:  (slug: string, status: TimeboxStatus) => Effect.Effect<Timebox, TimeboxPortError>
+}>() {}
 ```
+
+`Timebox` and `TimeboxPlanProposal` Schema definitions follow the field shape in [calendar-timeboxes.md § Timebox Frontmatter](calendar-timeboxes.md#timebox-frontmatter); `TimeboxStatus = "active" | "paused" | "done" | "cancelled"`.
 
 Adapters (Layers) — one per port, wired at the entrypoint:
 
@@ -735,6 +753,7 @@ Adapters (Layers) — one per port, wired at the entrypoint:
 | `KbPort` | `KbHttpLive` | `GET /api/kb/*`, `POST /api/kb/ingest` |
 | `SchedPort` | `SchedHttpLive` | `POST /api/scheduler/*` |
 | `ProfilePort` | `ProfileFsLive` | reads authored tier of `$UBER_VAULT_DIR` + `fs.watch` (VaultWatcher fiber) |
+| `TimeboxPort` | `TimeboxHttpLive` | `GET/POST/PATCH /api/uber/calendar/timeboxes/*` (see [calendar-timeboxes.md § HTTP API](calendar-timeboxes.md#http-api)) |
 
 ---
 

--- a/apps/uebermensch/vault/specs/eval.md
+++ b/apps/uebermensch/vault/specs/eval.md
@@ -197,6 +197,18 @@ gctrl uber scrape-health                     # table of domain -> success_rate, 
 gctrl uber scrape-health --domain foo.com    # focus; show last 20 requests
 ```
 
+## Timebox Health
+
+Daily check (registered alongside `uber.eval.daily`) detects practice plans that have stalled close to their deadline. For each active row in `uber_timeboxes`:
+
+1. Compute `last_completed_at` from the most recent child event with `status = done`.
+2. Compute `expected_session_interval_days = 7 / sessions_per_week`.
+3. Stall condition: `(today - last_completed_at) > 2 × expected_session_interval_days` AND `(deadline - today) < profile.timeboxes.stalled_threshold` (default `P14D`).
+4. On match, insert `uber_alerts(kind = 'timebox_stalled', subject = timebox.slug, urgency = 'high' if deadline within 7d else 'medium', payload = TimeboxStalledPayload)`.
+5. The alert clears automatically on the next `complete` call for that timebox.
+
+Stall metrics surface in the morning brief's "Off-track timeboxes" block (see [calendar-timeboxes.md § Off-track timeboxes block](calendar-timeboxes.md#off-track-timeboxes-block)). Plan and replan calls are full kernel `Session`s with cost-tracked `llm` spans when `--llm` is used, so plan regressions tie to a specific prompt hash and model.
+
 ## Budget Enforcement
 
 Tied to Guardrails. `DailyBudgetPolicy` (Uebermensch-contributed):

--- a/apps/uebermensch/vault/specs/profile.md
+++ b/apps/uebermensch/vault/specs/profile.md
@@ -294,9 +294,20 @@ delivery:
   retention:
     briefs_days: 180
     alerts_days: 90
+
+timeboxes:
+  working_windows:                            # planner schedules sessions only inside these windows
+    - { days: [mon, tue, wed, thu, fri], start: "07:00", end: "08:00" }
+    - { days: [sat, sun], start: "08:00", end: "10:00" }
+  default_session_minutes: 60
+  default_sessions_per_week: 3
+  stalled_threshold: P14D                     # ISO 8601 duration; stall alert window before deadline
+  replan_policy: pin-edited                   # pin-edited | redistribute-all
+  coaching:
+    default_channel: telegram_primary
 ```
 
-Maps to: `Profile.identity`, `Profile.budgets`, `Profile.delivery`.
+Maps to: `Profile.identity`, `Profile.budgets`, `Profile.delivery`, `Profile.timeboxes`. The `timeboxes:` block is optional; missing means no working-window constraint, defaults `60` minutes / `3` sessions per week, `P14D` stall window. Full semantics in [calendar-timeboxes.md § Profile Schema Additions](calendar-timeboxes.md#profile-schema-additions).
 
 ### topics.md
 


### PR DESCRIPTION
## Summary

Adds **Calendar Timeboxes** to Uebermensch — a parent vault file (`calendar/timeboxes/<slug>.md`) that owns N child calendar events for a goal that needs scheduled, repeated time-blocks toward a measurable outcome by a deadline.

One concept covers four use cases:

| Discipline | unit | total | session_minutes |
|---|---|---|---|
| reading a paper / book / course | pages or chapters | 64 | 60 |
| training for a marathon | km or sessions | 600 | 60 |
| podcast season / video series | episodes | 8 | 180 |
| weekly newsletter / blog | posts or words | 12 | 90 |

Children are ordinary calendar events with new `timebox` / `step` / `step_total` / `step_units` fields — they reuse all calendar filtering, ICS export, reminders, and gcal mirror for free. No separate event table, no special folder.

## What's in this PR

### Spec (commit 1)
- `apps/uebermensch/vault/specs/calendar-timeboxes.md` — new sibling spec to `calendar.md` (~500 lines).
- Cross-references in `calendar.md`, `profile.md`, `briefing-pipeline.md`, `architecture.md`, `domain-model.md`, `eval.md`.
- `ROADMAP.md` — new **M7** milestone with three sub-phases (M0 deterministic core, M1 LLM-assisted, M2 web UI + gcal mirror).

### Implementation — M0 (commit 2)
- `schemas.ts` — `TimeboxFrontmatter`, `Discipline`, `TimeboxStatus`, `TimeboxNudge`, `TimeboxWorkingWindow`, `TimeboxProfileConfig`. Extends `EventKind` with `practice`, `EventStatus` with `superseded`, `EventFrontmatter` with the four child fields.
- `services/TimeboxService.ts` — Effect-TS `Context.Tag` with `list` / `get` / `plan` / `apply` / `replan` / `applyReplan` / `addEvent` / `complete` / `skip` / `setStatus`.
- `adapters/FileSystemTimebox.ts` — vault-direct adapter mirroring `FileSystemCalendar`. Atomic writes, content-hash, dry-run plan separated from apply, replan supersedes prior pending children with audit trail.
- `lib/timebox-planner.ts` — pure deterministic algorithm. Even slicing of remaining work over remaining weeks × `sessions_per_week`, walks forward through profile working-windows, double-booking guard against existing events, honours `taper_days_before_deadline`.
- `commands/timebox.ts` + `bin/uber.ts` — CLI: `gctrl uber timebox {list, show, plan, replan, add-event, complete, skip, pause, resume, cancel}`. `plan` and `replan` are dry-run by default; `--apply` commits.
- `tests/timebox.test.ts` — 20 tests (schemas, planner, adapter): plan / apply / list / get, complete / skip / setStatus idempotency, replan with supersession audit, addEvent step-total bookkeeping.

### Deferred to follow-up PRs
- **M1**: LLM-assisted `plan --llm` and `replan --llm`; coaching nudges via `uber_calendar_reminders`; daily stalled-timebox alert.
- **M2**: web UI gantt-lite view; `driver-gcal` mirror with `[<title> <step>/<step_total>]` title prefix.

## Why ship spec + M0 in one PR

The spec is the contract; M0 is the smallest implementation that proves the contract works end-to-end (a user can plan a reading goal, see today's session in the calendar, `complete` to roll progress up). Splitting them risks the spec drifting from what's buildable. M1/M2 are larger, each has its own external dependency (LLM driver, gcal driver), and follow naturally as separate PRs.

## Verification

```sh
pnpm typecheck     # ✓ clean
pnpm test          # ✓ 161/161 (20 new timebox tests)
pnpm build         # ✓ dist/bin/uber.js — 224 KB
```

End-to-end smoke (against a tempdir vault):
```sh
$ UBER_VAULT_DIR=/tmp/v gctrl uber timebox plan \
    --title "Constitutional AI" --discipline reading \
    --total 64 --unit pages --session-minutes 60 --sessions-per-week 4 \
    --deadline 2026-05-29 --tz Asia/Hong_Kong --apply
proposed: 16/16 sessions  ~4 units each  remaining: 64
  2026-04-30  07:00-08:00  pages 1–4
  2026-05-01  07:00-08:00  pages 5–8
  ...
✓ wrote calendar/timeboxes/constitutional-ai.md
✓ wrote 16 child events
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (`apps/uebermensch`, 161/161)
- [x] `pnpm build` produces a working CLI bundle
- [x] `gctrl uber timebox plan ... --apply` writes parent + child files in expected paths
- [x] Child files re-decode cleanly through `EventFrontmatter` (covered by adapter tests)
- [x] `complete` rolls `done` up, parent status flips to `done` when total reached
- [x] `skip` marks child `cancelled` without crediting `done`
- [x] `replan` supersedes pending children + writes new schedule

Spec: `apps/uebermensch/vault/specs/calendar-timeboxes.md`.
Roadmap: `apps/uebermensch/ROADMAP.md` § M7.
