### PR TITLE
chore(deps): centralize sha2, url, dirs, tempfile in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,18 @@ parquet = "54"
 # MITM Proxy
 hudsucker = "0.24"
 
+# Hashing
+sha2 = "0.10"
+
+# URL parsing
+url = "2"
+
+# Filesystem paths
+dirs = "6"
+
 # Testing
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace"] }
 http = "1"
 http-body-util = "0.1"
+tempfile = "3"

--- a/kernel/crates/gctrl-context/Cargo.toml
+++ b/kernel/crates/gctrl-context/Cargo.toml
@@ -12,8 +12,8 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-sha2 = "0.10"
-dirs = "6"
+sha2 = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-net/Cargo.toml
+++ b/kernel/crates/gctrl-net/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true }
 htmd = "0.5"
 readability = "0.3"
 scraper = "0.22"
-url = "2"
+url = { workspace = true }
 
 # Render / search backends
 base64 = "0.22"
@@ -28,7 +28,7 @@ async-trait = "0.1"
 futures = "0.3"
 
 # File system
-dirs = "6"
+dirs = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-storage/Cargo.toml
+++ b/kernel/crates/gctrl-storage/Cargo.toml
@@ -14,9 +14,9 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-sha2 = "0.10"
+sha2 = { workspace = true }
 rusqlite = { version = "0.31", features = ["bundled"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-sync/Cargo.toml
+++ b/kernel/crates/gctrl-sync/Cargo.toml
@@ -20,4 +20,4 @@ reqwest = { workspace = true }
 duckdb = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }


### PR DESCRIPTION
## Summary
- Move `sha2`, `url`, `dirs`, and `tempfile` to `[workspace.dependencies]` so member crates inherit a single version pin.
- Switch `gctrl-storage`, `gctrl-context`, `gctrl-net`, and `gctrl-sync` to `{ workspace = true }` for those deps.
- Eliminates version-drift risk and trims per-crate `Cargo.toml` noise.

## Test plan
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace --no-run` — all test binaries built
