### PR TITLE
test(board): harden drag-and-drop acceptance test against preview Worker latency

### DIFF
--- a/apps/gctrl-board/tests/acceptance/kanban-board.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/kanban-board.spec.ts
@@ -122,13 +122,18 @@ test.describe("Kanban Board", () => {
 
     await dragIssueToColumn(page, issue.id, "todo")
 
-    // Card should now be in todo column
-    const todoCol = page.locator('[data-testid="column-todo"]')
-    await expect(todoCol.getByText(issue.title)).toBeVisible({ timeout: 5_000 })
+    // Kernel is the source of truth — wait for the move to land there first.
+    // Against the preview Worker on the local-Chromium fallback path the
+    // /move round-trip can occasionally exceed the 5s assertion window.
+    await expect
+      .poll(async () => (await kernel.getIssue(issue.id)).status, {
+        timeout: 10_000,
+      })
+      .toBe("todo")
 
-    // Kernel confirms the move
-    const updated = await kernel.getIssue(issue.id)
-    expect(updated.status).toBe("todo")
+    // Then the UI reflects it.
+    const todoCol = page.locator('[data-testid="column-todo"]')
+    await expect(todoCol.getByText(issue.title)).toBeVisible({ timeout: 15_000 })
   })
 
   test("drag across multiple columns auto-transits intermediate statuses", async ({


### PR DESCRIPTION
## Summary

Hardens `kanban-board.spec.ts › drag-and-drop moves issue to valid column` against a flake first observed on PR #89's preview run ([run 25070519078](https://github.com/OpenHackersClub/gctrl/actions/runs/25070519078) — passed cleanly on retry).

## How it works

When Cloudflare Browser Rendering rate-limits the CDP endpoint (HTTP 429 from CF's free-tier rolling window), the test fixture falls back to local Chromium and drives the *deployed* preview Worker over the public internet. `useBoard.moveIssue` awaits the `/api/board/issues/{id}/move` round-trip before updating React state, and the original 5s assertion window occasionally lost that race.

Fix: gate on the kernel (the source of truth) first via `expect.poll`, then wait on the UI text with a longer 15s timeout.

```ts
await dragIssueToColumn(page, issue.id, "todo")

await expect
  .poll(async () => (await kernel.getIssue(issue.id)).status, { timeout: 10_000 })
  .toBe("todo")

const todoCol = page.locator('[data-testid="column-todo"]')
await expect(todoCol.getByText(issue.title)).toBeVisible({ timeout: 15_000 })
```

Local runs against the in-memory kernel are unaffected — both polls resolve on first tick.

## Test plan

- [x] `pnpm exec playwright test --list tests/acceptance/kanban-board.spec.ts` parses the spec cleanly.
- [ ] CI green on this PR's preview run (acceptance suite against deployed Worker).
- [ ] No regression in the auto-transit drag test (skipped on `PREVIEW_URL`, so this fix doesn't affect that path).
