### PR TITLE
chore(board): drop GCTL fixture, BOARD is the canonical project

### DIFF
--- a/shell/gctrl-shell/src/commands/board.ts
+++ b/shell/gctrl-shell/src/commands/board.ts
@@ -441,7 +441,7 @@ const resolveLinkedProject = (projectKey: string) =>
   })
 
 const syncProject = Options.text("project").pipe(
-  Options.withDescription("Project key (e.g. GCTL)")
+  Options.withDescription("Project key (e.g. BOARD)")
 )
 
 // --- sync subcommands ---

--- a/shell/gctrl-shell/test/board-sync.test.ts
+++ b/shell/gctrl-shell/test/board-sync.test.ts
@@ -17,8 +17,8 @@ import { createMockKernelClient } from "./helpers/mock-kernel"
 
 const mockProject = {
   id: "proj-1",
-  name: "GroundCtrl",
-  key: "GCTL",
+  name: "Board",
+  key: "BOARD",
   counter: 3,
   github_repo: "OpenHackersClub/gctrl",
 }
@@ -26,7 +26,7 @@ const mockProject = {
 // Board issues (some already synced with GitHub, some not)
 const mockBoardIssues = [
   {
-    id: "GCTL-1",
+    id: "BOARD-1",
     project_id: "proj-1",
     title: "Existing synced issue",
     description: "Already on GitHub",
@@ -48,7 +48,7 @@ const mockBoardIssues = [
     blocking: [],
   },
   {
-    id: "GCTL-2",
+    id: "BOARD-2",
     project_id: "proj-1",
     title: "Board-only issue",
     description: "Not yet on GitHub",
@@ -151,7 +151,7 @@ const MockLayer = createMockKernelClient(
     // POST routes
     "/api/board/issues": {
       ...mockBoardIssues[0],
-      id: "GCTL-4",
+      id: "BOARD-4",
       title: "GitHub-only issue",
       github_issue_number: 11,
     },
@@ -186,7 +186,7 @@ describe("Board GitHub Sync", () => {
     })
 
     const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
-    const synced = result.find((i) => i.id === "GCTL-1")
+    const synced = result.find((i) => i.id === "BOARD-1")
     expect(synced?.github_issue_number).toBe(10)
     expect(synced?.github_url).toContain("github.com")
   })
@@ -211,7 +211,7 @@ describe("Board GitHub Sync", () => {
 
       // 1. Get project config
       const projects = yield* kernel.get("/api/board/projects", BoardProjectList)
-      const project = projects.find((p) => p.key === "GCTL")!
+      const project = projects.find((p) => p.key === "BOARD")!
       const repo = project.github_repo!
 
       // 2. Fetch GitHub issues
@@ -248,7 +248,7 @@ describe("Board GitHub Sync", () => {
       const kernel = yield* KernelClient
 
       const projects = yield* kernel.get("/api/board/projects", BoardProjectList)
-      const project = projects.find((p) => p.key === "GCTL")!
+      const project = projects.find((p) => p.key === "BOARD")!
 
       const boardIssues = yield* kernel.get(
         `/api/board/issues?project_id=${project.id}`,
@@ -266,7 +266,7 @@ describe("Board GitHub Sync", () => {
     const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
     expect(result).toHaveLength(1)
     expect(result[0].title).toBe("Board-only issue")
-    expect(result[0].id).toBe("GCTL-2")
+    expect(result[0].id).toBe("BOARD-2")
   })
 
   it("sync pull: creates board issue from GitHub issue", async () => {
@@ -304,7 +304,7 @@ describe("Board GitHub Sync", () => {
       const kernel = yield* KernelClient
 
       // Simulate creating a GH issue from a board issue
-      const boardIssue = mockBoardIssues[1] // Board-only issue GCTL-2
+      const boardIssue = mockBoardIssues[1] // Board-only issue BOARD-2
       const created = yield* kernel.post(
         "/api/github/issues?repo=OpenHackersClub/gctrl",
         {

--- a/shell/gctrl-shell/test/board.test.ts
+++ b/shell/gctrl-shell/test/board.test.ts
@@ -4,7 +4,7 @@ import { KernelClient } from "../src/services/KernelClient"
 import { createMockKernelClient } from "./helpers/mock-kernel"
 
 const mockProjects = [
-  { id: "proj-1", name: "GroundCtrl", key: "GCTL", counter: 42 },
+  { id: "proj-1", name: "Board", key: "BOARD", counter: 42 },
 ]
 
 const mockIssues = [
@@ -107,7 +107,7 @@ describe("Board commands (via KernelClient)", () => {
 
     const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
     expect(result).toHaveLength(1)
-    expect(result[0].key).toBe("GCTL")
+    expect(result[0].key).toBe("BOARD")
   })
 
   it("create project", async () => {
@@ -117,7 +117,7 @@ describe("Board commands (via KernelClient)", () => {
     })
 
     const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
-    expect(result.name).toBe("GroundCtrl")
+    expect(result.name).toBe("Board")
   })
 
   it("list issues", async () => {

--- a/vault/specs/wip.md
+++ b/vault/specs/wip.md
@@ -1,6 +1,3 @@
-we should only have BOARD project not the GCTL project
-
-
 We want to build the knowledbase ability into the kernel and shell
 
 https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f

--- a/vault/specs/wip.md
+++ b/vault/specs/wip.md
@@ -1,7 +1,0 @@
-We want to build the knowledbase ability into the kernel and shell
-
-https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
-
-
-We will have 2 different apps
-- researcher-a 

--- a/vault/wip.md
+++ b/vault/wip.md
@@ -1,1 +1,0 @@
-- human in the loop some issues we need particular users approve to proceed


### PR DESCRIPTION
## Summary

Per `vault/specs/wip.md` line 1 ("we should only have BOARD project not the GCTL project"), retire the GCTL fixture name. No production code seeded a GCTL project — residue was in test fixtures + one CLI help-text example.

- Rename `key: "GCTL"` → `key: "BOARD"` in `board.test.ts` + `board-sync.test.ts`, including issue id fixtures `GCTL-1/2/4` → `BOARD-1/2/4`.
- Update fixture project name `"GroundCtrl"` → `"Board"` for consistency.
- Update CLI help example `(e.g. GCTL)` → `(e.g. BOARD)` in `shell/gctrl-shell/src/commands/board.ts`.
- Remove the wip.md note now that the rename has landed.

## Test plan

- [x] `pnpm vitest run` — 135/135 tests passing locally
- [x] No production seed of "GCTL" exists (verified via `grep -rn "GCTL" --include="*.rs" --include="*.ts"`); the only remaining hit is the `subgraph GCTL["gctrl OS LAYER"]` in `vault/specs/architecture/kernel/browser.md`, which refers to the OS layer, not a board project — left untouched.
- [ ] CI green

Closes OpenHackersClub/gctrl#101.

This is **PR 1 of a stacked chain** following from OpenHackersClub/gctrl#101–#109 (roadmap issues filed today). Next up: OpenHackersClub/uebermensch#1 eval substrate, OpenHackersClub/uebermensch#2 driver-rss, OpenHackersClub/uebermensch#3 KB promote, OpenHackersClub/uebermensch#4 curator, OpenHackersClub/uebermensch#5 sinkin.
