### PR TITLE
feat(uebermensch): events discovery — Luma → suggestions → calendar

### DIFF
--- a/apps/uebermensch-pages/src/layouts/Shell.astro
+++ b/apps/uebermensch-pages/src/layouts/Shell.astro
@@ -40,7 +40,7 @@ const { title } = Astro.props
 </head>
 <body>
 <main>
-<header><nav><a href="/">home</a><a href="/reports/">reports</a><a href="/briefs/">briefs</a></nav></header>
+<header><nav><a href="/">home</a><a href="/reports/">reports</a><a href="/briefs/">briefs</a><a href="/events/">events</a></nav></header>
 <slot />
 </main>
 </body>

--- a/apps/uebermensch-pages/src/lib/events.ts
+++ b/apps/uebermensch-pages/src/lib/events.ts
@@ -1,0 +1,192 @@
+// Read + mutate event suggestions in R2. Mirrors the local CLI's accept/dismiss
+// flow (apps/uebermensch/src/adapters/FileSystemCalendar.ts). The local daemon's
+// bidirectional R2 sync reflects these changes back into $UBER_VAULT_DIR within
+// one pull cycle.
+
+import matter from "gray-matter"
+import { listUnder, SAFE_KEY_RE } from "./vault.ts"
+
+const SUGGESTED_PREFIX = "calendar/suggested/"
+const CONFIRMED_PREFIX = "calendar/"
+
+export type Suggestion = Readonly<{
+  key: string
+  slug: string
+  title: string
+  startsAt: string
+  endsAt: string | null
+  tz: string
+  status: "tentative" | "confirmed" | "cancelled"
+  location: string | null
+  url: string | null
+  topics: ReadonlyArray<string>
+  tags: ReadonlyArray<string>
+  matchScore: number | null
+  matchedTerms: ReadonlyArray<string>
+}>
+
+const asString = (v: unknown): string | null =>
+  typeof v === "string" && v.trim().length > 0 ? v.trim() : null
+
+const asArray = (v: unknown): ReadonlyArray<string> => {
+  if (!Array.isArray(v)) return []
+  return v.filter((x): x is string => typeof x === "string")
+}
+
+const decodeSuggestion = (key: string, raw: string): Suggestion | null => {
+  const parsed = matter(raw)
+  const fm = (parsed.data ?? {}) as Record<string, unknown>
+  const slug = asString(fm.slug)
+  const title = asString(fm.title)
+  const startsAt = asString(fm.starts_at)
+  const tz = asString(fm.tz)
+  const status = asString(fm.status)
+  if (!slug || !title || !startsAt || !tz) return null
+  if (status !== "tentative" && status !== "confirmed" && status !== "cancelled") return null
+  const links = Array.isArray(fm.links)
+    ? (fm.links as ReadonlyArray<Record<string, unknown>>)
+    : []
+  const firstLink = links[0]
+  const url = firstLink ? asString(firstLink.url) : null
+  const score = typeof fm.match_score === "number" ? fm.match_score : null
+  return {
+    key,
+    slug,
+    title,
+    startsAt,
+    endsAt: asString(fm.ends_at),
+    tz,
+    status,
+    location: asString(fm.location),
+    url,
+    topics: asArray(fm.topics),
+    tags: asArray(fm.tags),
+    matchScore: score,
+    matchedTerms: asArray(fm.matched_terms),
+  }
+}
+
+export const listSuggestions = async (
+  bucket: R2Bucket,
+): Promise<ReadonlyArray<Suggestion>> => {
+  const objects = await listUnder(bucket, SUGGESTED_PREFIX)
+  const out: Array<Suggestion> = []
+  // Bounded fetch — don't fan out to thousands. R2 list is already sorted desc.
+  for (const obj of objects.slice(0, 200)) {
+    const got = await bucket.get(obj.key)
+    if (!got) continue
+    const raw = await got.text()
+    const s = decodeSuggestion(obj.key, raw)
+    if (s) out.push(s)
+  }
+  out.sort((a, b) => a.startsAt.localeCompare(b.startsAt))
+  return out
+}
+
+const findSuggestionByslug = async (
+  bucket: R2Bucket,
+  slug: string,
+): Promise<Suggestion | null> => {
+  if (!SAFE_KEY_RE.test(slug)) return null
+  const objects = await listUnder(bucket, SUGGESTED_PREFIX)
+  for (const obj of objects) {
+    if (!obj.key.endsWith(`--${slug}.md`)) continue
+    const got = await bucket.get(obj.key)
+    if (!got) return null
+    const raw = await got.text()
+    return decodeSuggestion(obj.key, raw)
+  }
+  return null
+}
+
+const findEverywhere = async (
+  bucket: R2Bucket,
+  slug: string,
+): Promise<Suggestion | null> => {
+  if (!SAFE_KEY_RE.test(slug)) return null
+  const inSuggested = await findSuggestionByslug(bucket, slug)
+  if (inSuggested) return inSuggested
+  // Already-promoted? Look directly under calendar/.
+  const objects = await listUnder(bucket, CONFIRMED_PREFIX)
+  for (const obj of objects) {
+    if (obj.key.startsWith(SUGGESTED_PREFIX)) continue
+    if (!obj.key.endsWith(`--${slug}.md`)) continue
+    const got = await bucket.get(obj.key)
+    if (!got) return null
+    const raw = await got.text()
+    return decodeSuggestion(obj.key, raw)
+  }
+  return null
+}
+
+const datePart = (startsAt: string): string => {
+  const m = startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
+  if (m && m[1]) return m[1]
+  return startsAt.slice(0, 10)
+}
+
+const restamp = (
+  raw: string,
+  status: "confirmed" | "cancelled",
+): string => {
+  const parsed = matter(raw)
+  const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
+  data.status = status
+  data.updated_at = new Date().toISOString()
+  // Drop content_hash — local daemon will recompute on next index walk. The R2
+  // key is still source of truth for sync purposes.
+  delete data.content_hash
+  return matter.stringify(parsed.content, data)
+}
+
+export type DecisionResult = Readonly<{
+  ok: boolean
+  message: string
+  newKey?: string
+}>
+
+export const acceptSuggestion = async (
+  bucket: R2Bucket,
+  slug: string,
+): Promise<DecisionResult> => {
+  const found = await findEverywhere(bucket, slug)
+  if (!found) return { ok: false, message: `not found: ${slug}` }
+  if (found.status === "cancelled") {
+    return { ok: false, message: "already dismissed; cannot promote" }
+  }
+  const inSuggested = found.key.startsWith(SUGGESTED_PREFIX)
+  if (found.status === "confirmed" && !inSuggested) {
+    return { ok: true, message: "already confirmed", newKey: found.key }
+  }
+  const got = await bucket.get(found.key)
+  if (!got) return { ok: false, message: `read failed: ${found.key}` }
+  const raw = await got.text()
+  const newRaw = restamp(raw, "confirmed")
+  const newKey = `${CONFIRMED_PREFIX}${datePart(found.startsAt)}--${found.slug}.md`
+  await bucket.put(newKey, newRaw, {
+    httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+  })
+  if (newKey !== found.key) {
+    await bucket.delete(found.key)
+  }
+  return { ok: true, message: "accepted", newKey }
+}
+
+export const dismissSuggestion = async (
+  bucket: R2Bucket,
+  slug: string,
+): Promise<DecisionResult> => {
+  const found = await findEverywhere(bucket, slug)
+  if (!found) return { ok: false, message: `not found: ${slug}` }
+  if (found.status === "cancelled") {
+    return { ok: true, message: "already dismissed", newKey: found.key }
+  }
+  const got = await bucket.get(found.key)
+  if (!got) return { ok: false, message: `read failed: ${found.key}` }
+  const raw = await got.text()
+  const newRaw = restamp(raw, "cancelled")
+  await bucket.put(found.key, newRaw, {
+    httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+  })
+  return { ok: true, message: "dismissed", newKey: found.key }
+}

--- a/apps/uebermensch-pages/src/pages/api/events/[slug]/accept.ts
+++ b/apps/uebermensch-pages/src/pages/api/events/[slug]/accept.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro"
+import { acceptSuggestion } from "../../../../lib/events.ts"
+
+export const prerender = false
+
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+  const slug = String(params.slug ?? "")
+  const env = (locals as { runtime: { env: { VAULT: R2Bucket } } }).runtime.env
+  const result = await acceptSuggestion(env.VAULT, slug)
+  const msg = `${result.ok ? "✓" : "✗"} ${slug}: ${result.message}`
+  return redirect(`/events/?msg=${encodeURIComponent(msg)}`, 303)
+}

--- a/apps/uebermensch-pages/src/pages/api/events/[slug]/dismiss.ts
+++ b/apps/uebermensch-pages/src/pages/api/events/[slug]/dismiss.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro"
+import { dismissSuggestion } from "../../../../lib/events.ts"
+
+export const prerender = false
+
+export const POST: APIRoute = async ({ params, locals, redirect }) => {
+  const slug = String(params.slug ?? "")
+  const env = (locals as { runtime: { env: { VAULT: R2Bucket } } }).runtime.env
+  const result = await dismissSuggestion(env.VAULT, slug)
+  const msg = `${result.ok ? "✓" : "✗"} ${slug}: ${result.message}`
+  return redirect(`/events/?msg=${encodeURIComponent(msg)}`, 303)
+}

--- a/apps/uebermensch-pages/src/pages/events/index.astro
+++ b/apps/uebermensch-pages/src/pages/events/index.astro
@@ -1,0 +1,97 @@
+---
+import Shell from "../../layouts/Shell.astro"
+import { listSuggestions } from "../../lib/events.ts"
+import { escapeHtml } from "../../lib/markdown.ts"
+
+const suggestions = await listSuggestions(Astro.locals.runtime.env.VAULT)
+const tentative = suggestions.filter((s) => s.status === "tentative")
+const flash = Astro.url.searchParams.get("msg") ?? null
+Astro.response.headers.set("Cache-Control", "no-store")
+
+const formatTime = (s: { startsAt: string; endsAt: string | null; tz: string }) => {
+  const d = new Date(s.startsAt)
+  if (Number.isNaN(d.getTime())) return s.startsAt
+  try {
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      weekday: "short",
+      day: "2-digit",
+      month: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: s.tz,
+    })
+    return `${fmt.format(d)} ${s.tz}`
+  } catch {
+    return s.startsAt
+  }
+}
+---
+
+<Shell title="Event suggestions">
+  <h1>Event suggestions</h1>
+  <p class="muted">
+    Topic-matched events from configured discovery sources. Accept to add to your
+    calendar; dismiss to never see this event again.
+  </p>
+  {flash ? <p class="flash">{flash}</p> : null}
+  {tentative.length === 0 ? (
+    <p>No tentative suggestions. Run <code>uber events pull</code> on your local daemon.</p>
+  ) : (
+    <ul class="events">
+      {tentative.map((s) => (
+        <li class="event">
+          <div class="event-head">
+            <span class="when">{formatTime(s)}</span>
+            {s.matchScore !== null ? (
+              <span class="score" title={s.matchedTerms.join(", ")}>
+                {s.matchScore.toFixed(2)}
+              </span>
+            ) : null}
+          </div>
+          <h2 class="title">
+            {s.url ? (
+              <a href={s.url} target="_blank" rel="noopener noreferrer">{s.title}</a>
+            ) : (
+              s.title
+            )}
+          </h2>
+          {s.location ? <div class="loc">{s.location}</div> : null}
+          {s.matchedTerms.length > 0 ? (
+            <div class="terms">
+              {s.matchedTerms.map((t) => <span class="chip">{t}</span>)}
+            </div>
+          ) : null}
+          <div class="actions">
+            <form method="POST" action={`/api/events/${encodeURIComponent(s.slug)}/accept`}>
+              <button type="submit" class="primary">Accept</button>
+            </form>
+            <form method="POST" action={`/api/events/${encodeURIComponent(s.slug)}/dismiss`}>
+              <button type="submit">Dismiss</button>
+            </form>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )}
+  <style>
+    .flash { background: var(--code-bg); padding: .6rem .9rem; border-radius: 4px; margin: 1rem 0; }
+    ul.events { list-style: none; padding: 0; margin: 1.5rem 0 0; display: grid; gap: 1.2rem; }
+    .event { border: 1px solid var(--rule); border-radius: 6px; padding: 1rem 1.2rem; background: var(--bg); }
+    .event-head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; }
+    .when { font-size: .9rem; color: var(--muted); font-variant-numeric: tabular-nums; }
+    .score { font-size: .85rem; color: var(--accent); font-variant-numeric: tabular-nums; }
+    .title { font-size: 1.1rem; margin: .2rem 0 .4rem; line-height: 1.3; }
+    .title a { color: var(--fg); text-decoration: none; }
+    .title a:hover { color: var(--accent); }
+    .loc { font-size: .85rem; color: var(--muted); margin-bottom: .5rem; }
+    .terms { display: flex; gap: .35rem; flex-wrap: wrap; margin: .4rem 0 .8rem; }
+    .chip { background: var(--code-bg); color: var(--muted); font-size: .78rem; padding: .1rem .55rem; border-radius: 99px; }
+    .actions { display: flex; gap: .5rem; margin-top: .6rem; }
+    .actions form { margin: 0; }
+    .actions button { font: inherit; padding: .35rem .9rem; border: 1px solid var(--rule); border-radius: 4px; background: var(--bg); color: var(--fg); cursor: pointer; }
+    .actions button.primary { background: var(--accent); color: white; border-color: var(--accent); }
+    .actions button:hover { filter: brightness(1.05); }
+  </style>
+</Shell>
+<Fragment set:html={`<!-- ${escapeHtml(`${suggestions.length} suggestions; ${tentative.length} tentative`)} -->`} />

--- a/apps/uebermensch/src/adapters/FileSystemCalendar.ts
+++ b/apps/uebermensch/src/adapters/FileSystemCalendar.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises"
 import { extname, join, relative } from "node:path"
 import { Effect, Either, Layer, Schema } from "effect"
 import matter from "gray-matter"
@@ -12,15 +12,20 @@ import {
   type CalendarEvent,
   type EventAddInput,
   type EventStamp,
+  type SuggestionDecision,
+  type SuggestionInput,
 } from "../services/CalendarService.js"
 
 // All calendar events live under a single root: action/events/. Authored
 // events sit at the top level; driver-pulled events live under
-// action/events/generated/. Both feed the same uber_calendar index. Recurring
-// rules live under action/events/recurring/ and are skipped by the loader.
-// Timebox parent files live under action/events/timeboxes/ and are also
-// skipped — they have a different schema (TimeboxFrontmatter, no starts_at)
-// and are owned by FileSystemTimebox, not the calendar service.
+// action/events/generated/. Driver-events suggestions land under
+// action/events/suggested/ until accepted (moved out, status:confirmed) or
+// dismissed (status:cancelled, kept for dedupe). Recurring rules live under
+// action/events/recurring/ and are skipped by the loader. Timebox parent
+// files live under action/events/timeboxes/ and are also skipped — they
+// have a different schema (TimeboxFrontmatter, no starts_at) and are owned
+// by FileSystemTimebox.
+const SUGGESTED_SUBDIR = "suggested"
 const RECURRING_SUBDIR = "recurring" // deferred — see calendar.md open question #2
 const TIMEBOXES_SUBDIR = "timeboxes" // owned by FileSystemTimebox
 const GENERATOR = "gctrl-uber-cli"
@@ -35,6 +40,25 @@ const slugify = (s: string): string =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 60)
+
+const round = (n: number, places: number): number => {
+  const f = 10 ** places
+  return Math.round(n * f) / f
+}
+
+const deriveSuggestionSlug = (
+  title: string,
+  datePrefix: string,
+  taken: ReadonlyArray<{ readonly slug: string }>,
+): string => {
+  const base = slugify(title)
+  const candidate = base.length > 0 ? base : `event-${datePrefix}`
+  const used = new Set(taken.map((e) => e.slug))
+  if (!used.has(candidate)) return candidate
+  let n = 2
+  while (used.has(`${candidate}-${n}`)) n += 1
+  return `${candidate}-${n}`
+}
 
 const datePart = (startsAt: string): Either.Either<string, string> => {
   const bare = startsAt.match(/^(\d{4}-\d{2}-\d{2})/)
@@ -147,6 +171,8 @@ const decodeEvent = (
       contentHash: decoded.content_hash ?? null,
       createdAt: decoded.created_at ?? null,
       updatedAt: decoded.updated_at ?? null,
+      matchScore: decoded.match_score ?? null,
+      matchedTerms: decoded.matched_terms ?? [],
       body: parsed.content,
       relPath: entry.rel,
       absPath: entry.abs,
@@ -310,6 +336,187 @@ export const FileSystemCalendarLive = (vaultDir: string) =>
           message: "stamp event failed",
           path: target.absPath,
         })
+      }),
+
+    addSuggestion: (input: SuggestionInput) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const calRoot = join(vaultDir, ACTION_EVENTS_DIR, SUGGESTED_SUBDIR)
+        const datePrefix = yield* Either.match(datePart(input.startsAt), {
+          onLeft: (msg) => failVault(msg, calRoot, "parse_failure"),
+          onRight: (v) => Effect.succeed(v),
+        })
+        // Upsert by (source=driver-events, external_id). On collision we
+        // overwrite the existing suggestion in place, preserving its slug so
+        // backlinks survive re-pulls.
+        const existing = all.find(
+          (e) => e.source === "driver-events" && e.externalId === input.externalId,
+        )
+        // Do not resurrect dismissed events.
+        if (existing && existing.status === "cancelled") {
+          return {
+            slug: existing.slug,
+            absPath: existing.absPath,
+            relPath: existing.relPath,
+            contentHash: existing.contentHash ?? "",
+          }
+        }
+        const slug = existing?.slug ?? deriveSuggestionSlug(input.title, datePrefix, all)
+        const relPath =
+          existing?.relPath ?? `${ACTION_EVENTS_DIR}/${SUGGESTED_SUBDIR}/${datePrefix}--${slug}.md`
+        const absPath = join(vaultDir, relPath)
+        const now = new Date().toISOString()
+        const body = (input.description ?? "").trim()
+        const links = input.url
+          ? [{ title: "Event page", url: input.url }]
+          : undefined
+
+        const fmInput = omitEmpty({
+          slug,
+          title: input.title,
+          kind: "industry",
+          source: "driver-events",
+          starts_at: input.startsAt,
+          ends_at: input.endsAt,
+          tz: input.tz,
+          status: "tentative",
+          location: input.location,
+          topics: input.topics,
+          tags: input.tags,
+          links,
+          external_id: input.externalId,
+          external_etag: input.externalEtag,
+          generator: input.generator,
+          match_score: round(input.matchScore, 3),
+          matched_terms: input.matchedTerms,
+          created_at: existing?.createdAt ?? now,
+          updated_at: now,
+        })
+
+        yield* decodeFrontmatter(fmInput, absPath, "suggestion")
+        const draft = renderFrontmatter(fmInput, body)
+        const contentHash = hashContent(draft)
+        const final = renderFrontmatter({ ...fmInput, content_hash: contentHash }, body)
+        yield* vaultIo(() => atomicWrite(absPath, final), {
+          message: "write suggestion failed",
+          path: absPath,
+        })
+        return { slug, absPath, relPath, contentHash }
+      }),
+
+    accept: (slug) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const target = all.find((e) => e.slug === slug)
+        if (!target) {
+          return yield* failVault(
+            `event not found: ${slug}`,
+            join(vaultDir, ACTION_EVENTS_DIR, SUGGESTED_SUBDIR),
+            "not_found",
+          )
+        }
+        if (target.source !== "driver-events") {
+          return yield* failVault(
+            `accept only applies to source=driver-events events (got ${target.source})`,
+            target.absPath,
+            "parse_failure",
+          )
+        }
+        // Already promoted? No-op.
+        const isInSuggested = target.relPath.startsWith(`${ACTION_EVENTS_DIR}/${SUGGESTED_SUBDIR}/`)
+        if (target.status === "confirmed" && !isInSuggested) {
+          return {
+            slug: target.slug,
+            status: target.status,
+            relPath: target.relPath,
+            noop: true,
+          } satisfies SuggestionDecision
+        }
+        const datePrefix = yield* Either.match(datePart(target.startsAt), {
+          onLeft: (msg) => failVault(msg, target.absPath, "parse_failure"),
+          onRight: (v) => Effect.succeed(v),
+        })
+        const newRelPath = `${ACTION_EVENTS_DIR}/${datePrefix}--${target.slug}.md`
+        const newAbsPath = join(vaultDir, newRelPath)
+        // Re-render frontmatter with status:confirmed + bumped updated_at + recomputed hash.
+        const raw = yield* vaultIo(() => readFile(target.absPath, "utf8"), {
+          message: "read suggestion failed",
+          path: target.absPath,
+        })
+        const parsed = matter(raw)
+        const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
+        data.status = "confirmed"
+        data.updated_at = new Date().toISOString()
+        delete (data as Record<string, unknown>).content_hash
+        const draft = renderFrontmatter(data, parsed.content)
+        data.content_hash = hashContent(draft)
+        const final = renderFrontmatter(data, parsed.content)
+        yield* vaultIo(() => atomicWrite(newAbsPath, final), {
+          message: "write accepted event failed",
+          path: newAbsPath,
+        })
+        if (target.absPath !== newAbsPath) {
+          yield* vaultIo(() => unlink(target.absPath), {
+            message: "remove old suggestion failed",
+            path: target.absPath,
+          })
+        }
+        return {
+          slug: target.slug,
+          status: "confirmed",
+          relPath: newRelPath,
+          noop: false,
+        } satisfies SuggestionDecision
+      }),
+
+    dismiss: (slug) =>
+      Effect.gen(function* () {
+        const all = yield* loadAll(vaultDir)
+        const target = all.find((e) => e.slug === slug)
+        if (!target) {
+          return yield* failVault(
+            `event not found: ${slug}`,
+            join(vaultDir, ACTION_EVENTS_DIR, SUGGESTED_SUBDIR),
+            "not_found",
+          )
+        }
+        if (target.source !== "driver-events") {
+          return yield* failVault(
+            `dismiss only applies to source=driver-events events (got ${target.source})`,
+            target.absPath,
+            "parse_failure",
+          )
+        }
+        if (target.status === "cancelled") {
+          return {
+            slug: target.slug,
+            status: target.status,
+            relPath: target.relPath,
+            noop: true,
+          } satisfies SuggestionDecision
+        }
+        const raw = yield* vaultIo(() => readFile(target.absPath, "utf8"), {
+          message: "read suggestion failed",
+          path: target.absPath,
+        })
+        const parsed = matter(raw)
+        const data = { ...((parsed.data ?? {}) as Record<string, unknown>) }
+        data.status = "cancelled"
+        data.updated_at = new Date().toISOString()
+        delete (data as Record<string, unknown>).content_hash
+        const draft = renderFrontmatter(data, parsed.content)
+        data.content_hash = hashContent(draft)
+        const final = renderFrontmatter(data, parsed.content)
+        yield* vaultIo(() => atomicWrite(target.absPath, final), {
+          message: "write dismissed event failed",
+          path: target.absPath,
+        })
+        return {
+          slug: target.slug,
+          status: "cancelled",
+          relPath: target.relPath,
+          noop: false,
+        } satisfies SuggestionDecision
       }),
   })
 

--- a/apps/uebermensch/src/adapters/FileSystemTimebox.ts
+++ b/apps/uebermensch/src/adapters/FileSystemTimebox.ts
@@ -217,6 +217,8 @@ const decodeEvent = (
       contentHash: decoded.content_hash ?? null,
       createdAt: decoded.created_at ?? null,
       updatedAt: decoded.updated_at ?? null,
+      matchScore: decoded.match_score ?? null,
+      matchedTerms: decoded.matched_terms ?? [],
       body: parsed.content,
       relPath: entry.rel,
       absPath: entry.abs,

--- a/apps/uebermensch/src/adapters/LumaSuggester.ts
+++ b/apps/uebermensch/src/adapters/LumaSuggester.ts
@@ -1,0 +1,168 @@
+import { Effect, Layer } from "effect"
+import { ProfileError } from "../errors.js"
+import {
+  buildKeywords,
+  eventTokens,
+  scoreMatch,
+} from "../lib/event-match.js"
+import { fetchLumaEvents, LumaError, lumaCityUrl, type FetchFn } from "../lib/luma.js"
+import { CalendarService, type SuggestionInput } from "../services/CalendarService.js"
+import {
+  EventSuggesterService,
+  type SuggestPullInput,
+  type SuggestionWritten,
+} from "../services/EventSuggesterService.js"
+import { ProfileService } from "../services/ProfileService.js"
+
+const DEFAULT_MIN_MATCH = 0.2
+const DEFAULT_LIMIT = 100
+const GENERATOR = "driver-events.luma"
+
+export type LumaSuggesterDeps = {
+  readonly fetch?: FetchFn
+}
+
+const resolveCity = (
+  flagCity: string | undefined,
+  profileCity: string | undefined,
+): Effect.Effect<string, ProfileError> => {
+  const c = (flagCity ?? profileCity ?? "").trim()
+  if (c.length === 0) {
+    return Effect.fail(
+      new ProfileError({
+        message:
+          "no city configured: pass --city or set identity.city in profile.md",
+      }),
+    )
+  }
+  return Effect.succeed(c)
+}
+
+export const LumaSuggesterLive = (deps: LumaSuggesterDeps = {}) =>
+  Layer.effect(
+    EventSuggesterService,
+    Effect.gen(function* () {
+      const cal = yield* CalendarService
+      const profileSvc = yield* ProfileService
+      return {
+        pull: (input: SuggestPullInput) =>
+          Effect.gen(function* () {
+            const loaded = yield* profileSvc.load()
+            const city = yield* resolveCity(input.city, loaded.profile.identity.city)
+            const minMatch =
+              input.minMatchScore ??
+              loaded.profile.events?.min_match_score ??
+              DEFAULT_MIN_MATCH
+            const limit = input.limit ?? DEFAULT_LIMIT
+
+            // Build keyword set from topics + profile.events.interests + CLI flag.
+            const topicTitles = loaded.topics.topics.map((t) => t.title)
+            const topicAliases = loaded.topics.topics.flatMap((t) => t.aliases ?? [])
+            const profileInterests = loaded.profile.events?.interests ?? []
+            const cliInterests = input.interests ?? []
+            const keywords = buildKeywords({
+              topicTitles,
+              topicAliases,
+              interests: [...profileInterests, ...cliInterests],
+            })
+            // Topic-slug list (only those whose tokens hit, surfaced on the
+            // suggestion's `topics:` frontmatter for downstream filtering).
+            const topicSlugByToken = new Map<string, string>()
+            for (const t of loaded.topics.topics) {
+              const seed = [t.title, ...(t.aliases ?? [])]
+              for (const s of seed) {
+                for (const tok of s
+                  .toLowerCase()
+                  .split(/[^a-z0-9]+/)
+                  .filter((x) => x.length > 1)) {
+                  if (!topicSlugByToken.has(tok)) topicSlugByToken.set(tok, t.slug)
+                }
+              }
+            }
+
+            const cityUrl = yield* lumaCityUrl(city).pipe(
+              Effect.mapError(
+                (e: LumaError) =>
+                  new ProfileError({ message: `invalid city: ${e.message}` }),
+              ),
+            )
+            const fetched = yield* fetchLumaEvents(cityUrl, { fetch: deps.fetch }).pipe(
+              Effect.mapError(
+                (e: LumaError) =>
+                  new ProfileError({
+                    message: `luma fetch failed for ${cityUrl}: ${e.message}`,
+                  }),
+              ),
+            )
+
+            const written: Array<SuggestionWritten> = []
+            let matchedCount = 0
+            let skippedDismissed = 0
+
+            for (const ev of fetched.slice(0, limit)) {
+              const tokens = eventTokens({
+                title: ev.title,
+                description: ev.description,
+                tags: ev.tags,
+              })
+              const m = scoreMatch(keywords, tokens)
+              if (m.score < minMatch) continue
+              matchedCount += 1
+
+              const matchedTopicSlugs = new Set<string>()
+              for (const term of m.matched) {
+                const slug = topicSlugByToken.get(term)
+                if (slug) matchedTopicSlugs.add(slug)
+              }
+
+              const fallbackTz = loaded.profile.identity.tz
+              const tags = ["meetup", "event-suggestion", "source:luma", ...ev.tags]
+              const inputForCal: SuggestionInput = {
+                title: ev.title,
+                startsAt: ev.startsAt,
+                endsAt: ev.endsAt ?? undefined,
+                tz: ev.tz ?? fallbackTz,
+                location: ev.location ?? undefined,
+                url: ev.url || undefined,
+                description: ev.description ?? undefined,
+                externalId: ev.externalId,
+                externalEtag: ev.externalId,
+                topics: [...matchedTopicSlugs],
+                tags,
+                matchScore: m.score,
+                matchedTerms: m.matched,
+                generator: GENERATOR,
+              }
+              const before = (yield* cal.list({
+                source: ["driver-events"],
+                status: ["tentative", "confirmed", "cancelled"],
+              })).find(
+                (e) => e.externalId === ev.externalId,
+              )
+              const wasDismissed = before?.status === "cancelled"
+              if (wasDismissed) {
+                skippedDismissed += 1
+                continue
+              }
+              const w = yield* cal.addSuggestion(inputForCal)
+              written.push({
+                slug: w.slug,
+                relPath: w.relPath,
+                title: ev.title,
+                startsAt: ev.startsAt,
+                score: m.score,
+                matched: m.matched,
+                upserted: before !== undefined,
+              })
+            }
+
+            return {
+              fetched: fetched.length,
+              matched: matchedCount,
+              written,
+              skippedDismissed,
+            }
+          }),
+      }
+    }),
+  )

--- a/apps/uebermensch/src/bin/uber.ts
+++ b/apps/uebermensch/src/bin/uber.ts
@@ -3,6 +3,7 @@ import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 import { brief } from "../commands/brief.js"
 import { calendar } from "../commands/calendar.js"
+import { events } from "../commands/events.js"
 import { ingest } from "../commands/ingest.js"
 import { profile } from "../commands/profile-validate.js"
 import { prompts } from "../commands/prompts.js"
@@ -13,7 +14,7 @@ import { timebox } from "../commands/timebox.js"
 import { vault } from "../commands/vault.js"
 
 const root = Command.make("uber").pipe(
-  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, calendar, timebox, sync]),
+  Command.withSubcommands([vault, profile, brief, ingest, send, report, prompts, calendar, events, timebox, sync]),
   Command.withDescription("uebermensch Chief-of-Staff CLI"),
 )
 

--- a/apps/uebermensch/src/commands/events.ts
+++ b/apps/uebermensch/src/commands/events.ts
@@ -1,0 +1,175 @@
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Option } from "effect"
+import { FileSystemCalendarLive } from "../adapters/FileSystemCalendar.js"
+import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
+import { LumaSuggesterLive } from "../adapters/LumaSuggester.js"
+import { resolveVaultDir } from "../lib/env.js"
+import { CalendarService, type CalendarEvent } from "../services/CalendarService.js"
+import { EventSuggesterService } from "../services/EventSuggesterService.js"
+
+const splitCsv = (s: string): ReadonlyArray<string> =>
+  s.split(",").map((x) => x.trim()).filter((x) => x.length > 0)
+
+// --- pull ---
+
+const cityOpt = Options.text("city").pipe(
+  Options.withDescription("city slug (defaults to profile.identity.city)"),
+  Options.optional,
+)
+const interestsOpt = Options.text("interests").pipe(
+  Options.withDescription("comma-separated extra interests, e.g. 'ai,prediction-markets'"),
+  Options.optional,
+)
+const limitOpt = Options.integer("limit").pipe(
+  Options.withDescription("max candidates to score per source (default 100)"),
+  Options.optional,
+)
+const minScoreOpt = Options.float("min-score").pipe(
+  Options.withDescription("minimum match score 0..1 (overrides profile)"),
+  Options.optional,
+)
+
+const pull = Command.make(
+  "pull",
+  { cityOpt, interestsOpt, limitOpt, minScoreOpt },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const sug = yield* EventSuggesterService
+        const result = yield* sug.pull({
+          city: Option.getOrUndefined(opts.cityOpt),
+          interests: Option.getOrUndefined(Option.map(opts.interestsOpt, splitCsv)),
+          limit: Option.getOrUndefined(opts.limitOpt),
+          minMatchScore: Option.getOrUndefined(opts.minScoreOpt),
+        })
+        yield* Console.log(
+          `fetched ${result.fetched}, matched ${result.matched}, wrote ${result.written.length} (skipped ${result.skippedDismissed} previously-dismissed)`,
+        )
+        for (const w of result.written) {
+          const tag = w.upserted ? "upd" : "new"
+          yield* Console.log(
+            `  ${tag} ${w.startsAt.slice(0, 10)} ${w.score.toFixed(2)} ${w.title}  #${w.slug}`,
+          )
+        }
+      })
+      yield* program.pipe(
+        Effect.provide(LumaSuggesterLive()),
+        Effect.provide(FileSystemCalendarLive(vaultDir)),
+        Effect.provide(FileSystemProfileLive(vaultDir)),
+      )
+    }),
+).pipe(Command.withDescription("Pull events from configured sources and write topic-matched suggestions"))
+
+// --- list ---
+
+const formatSuggestionLine = (e: CalendarEvent): string => {
+  const date = e.startsAt.slice(0, 10)
+  const score = e.matchScore !== null ? e.matchScore.toFixed(2) : "----"
+  const loc = e.location ? ` @ ${e.location.slice(0, 32)}` : ""
+  return `${e.status.padEnd(9)} ${date} ${score} ${e.title}${loc}  #${e.slug}`
+}
+
+const statusFilterOpt = Options.text("status").pipe(
+  Options.withDescription("comma-separated statuses (default: tentative). Pass 'all' to widen."),
+  Options.optional,
+)
+
+const list = Command.make(
+  "list",
+  { statusFilterOpt },
+  (opts) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const raw = Option.getOrUndefined(opts.statusFilterOpt)
+      const statuses =
+        !raw || raw === "tentative"
+          ? (["tentative"] as const)
+          : raw === "all"
+            ? (["tentative", "confirmed", "cancelled"] as const)
+            : (splitCsv(raw) as ReadonlyArray<"tentative" | "confirmed" | "cancelled">)
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const events = yield* cal.list({
+          source: ["driver-events"],
+          status: statuses,
+        })
+        if (events.length === 0) {
+          yield* Console.log("(no event suggestions)")
+          return
+        }
+        for (const e of events) yield* Console.log(formatSuggestionLine(e))
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("List event suggestions (default: tentative)"))
+
+// --- show ---
+
+const show = Command.make(
+  "show",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const e = yield* cal.get(slug)
+        const score = e.matchScore !== null ? e.matchScore.toFixed(2) : "n/a"
+        yield* Console.log(`# ${e.title}`)
+        yield* Console.log(
+          `slug: ${e.slug}  status: ${e.status}  score: ${score}  source: ${e.source}`,
+        )
+        yield* Console.log(
+          `starts_at: ${e.startsAt}${e.endsAt ? `  ends_at: ${e.endsAt}` : ""}  tz: ${e.tz}`,
+        )
+        if (e.location) yield* Console.log(`location: ${e.location}`)
+        if (e.topics.length > 0) yield* Console.log(`topics: ${e.topics.join(", ")}`)
+        if (e.tags.length > 0) yield* Console.log(`tags: ${e.tags.join(", ")}`)
+        if (e.links.length > 0) {
+          yield* Console.log("links:")
+          for (const l of e.links) yield* Console.log(`  - ${l.title}: ${l.url}`)
+        }
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Show one event suggestion"))
+
+// --- accept / dismiss ---
+
+const accept = Command.make(
+  "accept",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const r = yield* cal.accept(slug)
+        const tag = r.noop ? "(already confirmed)" : "✓ accepted"
+        yield* Console.log(`${tag} → ${r.relPath}`)
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Promote a suggestion to a confirmed calendar event"))
+
+const dismiss = Command.make(
+  "dismiss",
+  { slug: Args.text({ name: "slug" }) },
+  ({ slug }) =>
+    Effect.gen(function* () {
+      const vaultDir = yield* resolveVaultDir()
+      const program = Effect.gen(function* () {
+        const cal = yield* CalendarService
+        const r = yield* cal.dismiss(slug)
+        const tag = r.noop ? "(already dismissed)" : "✓ dismissed"
+        yield* Console.log(`${tag} → ${r.relPath}`)
+      })
+      yield* program.pipe(Effect.provide(FileSystemCalendarLive(vaultDir)))
+    }),
+).pipe(Command.withDescription("Mark a suggestion cancelled (won't resurface on re-pulls)"))
+
+export const events = Command.make("events").pipe(
+  Command.withSubcommands([pull, list, show, accept, dismiss]),
+  Command.withDescription("Discover and triage event suggestions (specs/events.md)"),
+)

--- a/apps/uebermensch/src/lib/event-match.ts
+++ b/apps/uebermensch/src/lib/event-match.ts
@@ -1,0 +1,62 @@
+// Pure topic-matching for event suggestions (specs/events.md § Matching algorithm).
+// Score = |keywords ∩ tokens| / max(1, |keywords|), thresholded by min_match_score.
+
+const STOPWORDS = new Set([
+  "the", "and", "or", "for", "of", "in", "on", "at", "to", "a", "an",
+  "is", "are", "be", "by", "with", "from", "this", "that", "as",
+  "it", "its", "into", "your", "our", "we", "you", "i",
+])
+
+const tokenise = (s: string): ReadonlyArray<string> =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, " ")
+    .split(/[\s-]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 1 && !STOPWORDS.has(t))
+
+// Build the keyword set from topics + free-form interests.
+// Each topic.title and topic.aliases entry is split into tokens; events.interests
+// strings are tokenised the same way. Returns a Set for fast intersection.
+export const buildKeywords = (input: {
+  topicTitles: ReadonlyArray<string>
+  topicAliases: ReadonlyArray<string>
+  interests: ReadonlyArray<string>
+}): ReadonlySet<string> => {
+  const out = new Set<string>()
+  for (const s of input.topicTitles) for (const t of tokenise(s)) out.add(t)
+  for (const s of input.topicAliases) for (const t of tokenise(s)) out.add(t)
+  for (const s of input.interests) for (const t of tokenise(s)) out.add(t)
+  return out
+}
+
+// Tokenise the free-form text of an event.
+export const eventTokens = (input: {
+  title: string
+  description?: string | null
+  tags?: ReadonlyArray<string>
+}): ReadonlySet<string> => {
+  const out = new Set<string>()
+  for (const t of tokenise(input.title)) out.add(t)
+  if (input.description) for (const t of tokenise(input.description)) out.add(t)
+  if (input.tags) {
+    for (const tag of input.tags) for (const t of tokenise(tag)) out.add(t)
+  }
+  return out
+}
+
+export type MatchResult = {
+  readonly score: number
+  readonly matched: ReadonlyArray<string>
+}
+
+export const scoreMatch = (
+  keywords: ReadonlySet<string>,
+  tokens: ReadonlySet<string>,
+): MatchResult => {
+  if (keywords.size === 0) return { score: 0, matched: [] }
+  const matched: Array<string> = []
+  for (const kw of keywords) if (tokens.has(kw)) matched.push(kw)
+  matched.sort()
+  return { score: matched.length / keywords.size, matched }
+}

--- a/apps/uebermensch/src/lib/luma.ts
+++ b/apps/uebermensch/src/lib/luma.ts
@@ -1,0 +1,253 @@
+// Luma events fetcher (specs/events.md).
+//
+// Strategy: extract schema.org `Event` entries from JSON-LD <script> blocks.
+// Luma's city pages embed both a per-event JSON-LD block and a richer Next.js
+// hydration payload; JSON-LD is the documented public format and is what we
+// rely on. The hydration payload is best-effort fallback.
+//
+// All HTTP I/O is funneled through a single `fetch` parameter so tests can
+// supply HTML directly without going to the network.
+
+import { Effect, Schema } from "effect"
+
+const DEFAULT_USER_AGENT = "uebermensch/0.1 (+https://github.com/anthropics/claude-code)"
+
+export class LumaError extends Schema.TaggedError<LumaError>()("LumaError", {
+  message: Schema.String,
+  url: Schema.optional(Schema.String),
+  status: Schema.optional(Schema.Number),
+  kind: Schema.Literal("invalid_input", "fetch_failed", "http_error"),
+}) {}
+
+export type RawEvent = {
+  readonly externalId: string
+  readonly title: string
+  readonly description: string | null
+  readonly url: string
+  readonly startsAt: string
+  readonly endsAt: string | null
+  readonly tz: string | null
+  readonly location: string | null
+  readonly tags: ReadonlyArray<string>
+}
+
+export const lumaCityUrl = (city: string): Effect.Effect<string, LumaError> => {
+  const slug = city.trim().toLowerCase()
+  if (slug.length === 0) {
+    return Effect.fail(
+      new LumaError({ message: "city is empty", kind: "invalid_input" }),
+    )
+  }
+  return Effect.succeed(`https://lu.ma/${encodeURIComponent(slug)}`)
+}
+
+const JSON_LD_RE = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+
+const tryParse = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+const flatten = (input: unknown): ReadonlyArray<Record<string, unknown>> => {
+  if (input === null || input === undefined) return []
+  if (Array.isArray(input)) return input.flatMap(flatten)
+  if (typeof input !== "object") return []
+  const obj = input as Record<string, unknown>
+  // Unwrap @graph / itemListElement shapes that wrap multiple Events.
+  if (Array.isArray(obj["@graph"])) return flatten(obj["@graph"])
+  if (Array.isArray(obj.itemListElement)) {
+    // ItemList entries can be `{ item: { ... Event ... } }` or the Event directly.
+    const items = (obj.itemListElement as ReadonlyArray<unknown>).map((entry) => {
+      if (entry && typeof entry === "object") {
+        const e = entry as Record<string, unknown>
+        if (e.item && typeof e.item === "object") return e.item as Record<string, unknown>
+      }
+      return entry
+    })
+    return flatten(items)
+  }
+  return [obj]
+}
+
+const isEventShape = (obj: Record<string, unknown>): boolean => {
+  const t = obj["@type"]
+  if (typeof t === "string") return t === "Event" || t.endsWith("Event")
+  if (Array.isArray(t)) return t.some((x) => typeof x === "string" && x.endsWith("Event"))
+  return false
+}
+
+const stringField = (obj: Record<string, unknown>, key: string): string | null => {
+  const v = obj[key]
+  if (typeof v === "string" && v.trim().length > 0) return v.trim()
+  return null
+}
+
+// schema.org `location` can be a string, a Place, an array of Places.
+const extractLocation = (obj: Record<string, unknown>): string | null => {
+  const v = obj.location
+  if (!v) return null
+  if (typeof v === "string") return v.trim()
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      const s = extractLocation({ location: item } as Record<string, unknown>)
+      if (s) return s
+    }
+    return null
+  }
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>
+    const name = stringField(o, "name")
+    const addressRaw = o.address
+    let address: string | null = null
+    if (typeof addressRaw === "string") {
+      address = addressRaw.trim()
+    } else if (addressRaw && typeof addressRaw === "object") {
+      const a = addressRaw as Record<string, unknown>
+      const parts = [
+        stringField(a, "streetAddress"),
+        stringField(a, "addressLocality"),
+        stringField(a, "addressRegion"),
+        stringField(a, "addressCountry"),
+      ].filter((p): p is string => p !== null)
+      address = parts.length > 0 ? parts.join(", ") : null
+    }
+    return [name, address].filter((s): s is string => s !== null).join(" — ") || null
+  }
+  return null
+}
+
+const extractTzOffset = (iso: string): string | null => {
+  const m = iso.match(/([+-]\d{2}):?(\d{2})$/)
+  if (!m) return null
+  return `UTC${m[1]}:${m[2]}`
+}
+
+// Stable external_id: prefer the URL (canonical Luma event page),
+// fall back to a hash-y derivation from name + start.
+const externalIdOf = (url: string | null, title: string, startsAt: string): string => {
+  if (url) {
+    const m = url.match(/lu\.ma\/([A-Za-z0-9_-]+)/)
+    if (m) return `luma:${m[1]}`
+  }
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+  return `luma:${slug}-${startsAt.slice(0, 10)}`
+}
+
+const decodeEvent = (obj: Record<string, unknown>): RawEvent | null => {
+  const title = stringField(obj, "name")
+  const startsAt = stringField(obj, "startDate")
+  if (!title || !startsAt) return null
+  const url = stringField(obj, "url")
+  const description = stringField(obj, "description")
+  const endsAt = stringField(obj, "endDate")
+  const location = extractLocation(obj)
+  const tz = extractTzOffset(startsAt)
+  const keywordsRaw = obj.keywords
+  let tags: ReadonlyArray<string> = []
+  if (typeof keywordsRaw === "string") {
+    tags = keywordsRaw.split(",").map((s) => s.trim()).filter((s) => s.length > 0)
+  } else if (Array.isArray(keywordsRaw)) {
+    tags = keywordsRaw.filter((x): x is string => typeof x === "string")
+  }
+  return {
+    externalId: externalIdOf(url, title, startsAt),
+    title,
+    description,
+    url: url ?? "",
+    startsAt,
+    endsAt,
+    tz,
+    location,
+    tags,
+  }
+}
+
+// Pure: given a Luma HTML page, return all distinct Event entries it embeds.
+export const parseLumaPage = (html: string): ReadonlyArray<RawEvent> => {
+  const seen = new Map<string, RawEvent>()
+  const re = new RegExp(JSON_LD_RE.source, JSON_LD_RE.flags)
+  for (;;) {
+    const m = re.exec(html)
+    if (m === null) break
+    const captured = m[1]
+    if (captured === undefined) continue
+    const parsed = tryParse(captured.trim())
+    if (!parsed) continue
+    for (const candidate of flatten(parsed)) {
+      if (!isEventShape(candidate)) continue
+      const ev = decodeEvent(candidate)
+      if (!ev) continue
+      if (!seen.has(ev.externalId)) seen.set(ev.externalId, ev)
+    }
+  }
+  return [...seen.values()]
+}
+
+export type FetchFn = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>
+
+export type FetchLumaOpts = {
+  readonly fetch?: FetchFn
+  readonly userAgent?: string
+}
+
+export const fetchLumaEvents = (
+  cityUrl: string,
+  opts: FetchLumaOpts = {},
+): Effect.Effect<ReadonlyArray<RawEvent>, LumaError> =>
+  Effect.gen(function* () {
+    const f = opts.fetch ?? (globalThis.fetch as unknown as FetchFn | undefined)
+    if (!f) {
+      return yield* Effect.fail(
+        new LumaError({
+          message: "no fetch implementation available",
+          url: cityUrl,
+          kind: "fetch_failed",
+        }),
+      )
+    }
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        f(cityUrl, {
+          headers: {
+            "user-agent": opts.userAgent ?? DEFAULT_USER_AGENT,
+            accept: "text/html",
+          },
+        }),
+      catch: (e) =>
+        new LumaError({
+          message: `luma fetch failed: ${String(e)}`,
+          url: cityUrl,
+          kind: "fetch_failed",
+        }),
+    })
+    if (!res.ok) {
+      return yield* Effect.fail(
+        new LumaError({
+          message: `luma fetch ${cityUrl} → ${res.status}`,
+          url: cityUrl,
+          status: res.status,
+          kind: "http_error",
+        }),
+      )
+    }
+    const html = yield* Effect.tryPromise({
+      try: () => res.text(),
+      catch: (e) =>
+        new LumaError({
+          message: `luma read body failed: ${String(e)}`,
+          url: cityUrl,
+          kind: "fetch_failed",
+        }),
+    })
+    return parseLumaPage(html)
+  })

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -17,6 +17,8 @@ export const Identity = Schema.Struct({
   slug: Slug,
   tz: Schema.String,
   lang: Schema.String,
+  city: Schema.optional(Slug),
+  country: Schema.optional(Schema.String.pipe(Schema.pattern(/^[A-Z]{2}$/))),
 })
 
 export const Budgets = Schema.Struct({
@@ -48,11 +50,28 @@ export const Delivery = Schema.Struct({
   ),
 })
 
+// Events discovery (specs/events.md). Optional — vaults without an `events:`
+// block fall back to driver-disabled defaults.
+export const EventsSourceConfig = Schema.Struct({
+  driver: Schema.Literal("luma"),
+  city: Schema.optional(Slug),
+})
+
+export const EventsConfig = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+  min_match_score: Schema.optional(
+    Schema.Number.pipe(Schema.between(0, 1)),
+  ),
+  interests: Schema.optional(Schema.Array(Schema.String)),
+  sources: Schema.optional(Schema.Array(EventsSourceConfig)),
+})
+
 export const ProfileConfig = Schema.Struct({
   schema_version: Schema.Number,
   identity: Identity,
   budgets: Budgets,
   delivery: Delivery,
+  events: Schema.optional(EventsConfig),
 })
 
 // Person topics open up name/alias matching and feed discovery.
@@ -163,6 +182,7 @@ export const EventSource = Schema.Literal(
   "driver-markets",
   "driver-sec",
   "driver-gcal",
+  "driver-events",
   "import",
 )
 export type EventSource = typeof EventSource.Type
@@ -227,6 +247,10 @@ export const EventFrontmatter = Schema.Struct({
   step: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(1))),
   step_total: Schema.optional(Schema.Int.pipe(Schema.greaterThanOrEqualTo(1))),
   step_units: Schema.optional(Schema.String),
+  // Events-discovery extension (specs/events.md). Optional, set by
+  // driver-events; ignored by other sources.
+  match_score: Schema.optional(Schema.Number.pipe(Schema.between(0, 1))),
+  matched_terms: Schema.optional(Schema.Array(Schema.String)),
 })
 export type EventFrontmatter = typeof EventFrontmatter.Type
 

--- a/apps/uebermensch/src/services/CalendarService.ts
+++ b/apps/uebermensch/src/services/CalendarService.ts
@@ -33,6 +33,9 @@ export type CalendarEvent = {
   readonly contentHash: string | null
   readonly createdAt: string | null
   readonly updatedAt: string | null
+  // Events-discovery extension (specs/events.md) — set by driver-events.
+  readonly matchScore: number | null
+  readonly matchedTerms: ReadonlyArray<string>
   readonly body: string
   readonly relPath: string
   readonly absPath: string
@@ -75,6 +78,25 @@ export type EventAddInput = {
   readonly slug?: string
 }
 
+// Inputs to addSuggestion() — driver-events-flavoured event written under
+// calendar/suggested/. status starts as "tentative"; promote with accept().
+export type SuggestionInput = {
+  readonly title: string
+  readonly startsAt: string
+  readonly endsAt?: string
+  readonly tz: string
+  readonly location?: string
+  readonly url?: string
+  readonly description?: string
+  readonly externalId: string
+  readonly externalEtag?: string
+  readonly topics?: ReadonlyArray<string>
+  readonly tags?: ReadonlyArray<string>
+  readonly matchScore: number
+  readonly matchedTerms: ReadonlyArray<string>
+  readonly generator: string
+}
+
 export type WrittenEvent = {
   readonly slug: string
   readonly absPath: string
@@ -90,11 +112,27 @@ export type EventStamp = {
   readonly contentHash?: string
 }
 
+// Outcome of accept/dismiss — `noop: true` means the event was already in the
+// requested terminal state. Idempotency by design.
+export type SuggestionDecision = {
+  readonly slug: string
+  readonly status: EventStatus
+  readonly relPath: string
+  readonly noop: boolean
+}
+
 export interface CalendarServiceShape {
   readonly list: (filter?: EventFilter) => Effect.Effect<ReadonlyArray<CalendarEvent>, VaultError>
   readonly get: (slug: string) => Effect.Effect<CalendarEvent, VaultError>
   readonly add: (input: EventAddInput) => Effect.Effect<WrittenEvent, VaultError>
   readonly stamp: (slug: string, stamp: EventStamp) => Effect.Effect<void, VaultError>
+  // Driver-events writes a `status: tentative, source: driver-events` file under
+  // calendar/suggested/. Re-calls with the same externalId are upserts.
+  readonly addSuggestion: (input: SuggestionInput) => Effect.Effect<WrittenEvent, VaultError>
+  // Promote a suggestion to a confirmed event (move out of suggested/).
+  readonly accept: (slug: string) => Effect.Effect<SuggestionDecision, VaultError>
+  // Mark a suggestion cancelled (kept in place for audit + dedupe).
+  readonly dismiss: (slug: string) => Effect.Effect<SuggestionDecision, VaultError>
 }
 
 export class CalendarService extends Context.Tag("uebermensch/CalendarService")<

--- a/apps/uebermensch/src/services/EventSuggesterService.ts
+++ b/apps/uebermensch/src/services/EventSuggesterService.ts
@@ -1,0 +1,41 @@
+import { Context, type Effect } from "effect"
+import type { ProfileError, VaultError } from "../errors.js"
+
+export type SuggestPullInput = {
+  // City slug used to pick the source URL. CLI flag wins; falls back to
+  // profile.identity.city; fails if neither is set.
+  readonly city?: string
+  // Free-form interest strings; merged with profile.topics + events.interests.
+  readonly interests?: ReadonlyArray<string>
+  // Override profile.events.min_match_score for this run (0..1).
+  readonly minMatchScore?: number
+  // Cap candidates fetched from each source.
+  readonly limit?: number
+}
+
+export type SuggestionWritten = {
+  readonly slug: string
+  readonly relPath: string
+  readonly title: string
+  readonly startsAt: string
+  readonly score: number
+  readonly matched: ReadonlyArray<string>
+  readonly upserted: boolean
+}
+
+export type SuggestPullResult = {
+  readonly fetched: number
+  readonly matched: number
+  readonly written: ReadonlyArray<SuggestionWritten>
+  readonly skippedDismissed: number
+}
+
+export interface EventSuggesterServiceShape {
+  readonly pull: (
+    input: SuggestPullInput,
+  ) => Effect.Effect<SuggestPullResult, VaultError | ProfileError>
+}
+
+export class EventSuggesterService extends Context.Tag(
+  "uebermensch/EventSuggesterService",
+)<EventSuggesterService, EventSuggesterServiceShape>() {}

--- a/apps/uebermensch/tests/calendar.test.ts
+++ b/apps/uebermensch/tests/calendar.test.ts
@@ -107,6 +107,8 @@ describe("calendar — pure helpers (parseDateShortcut, matchesFilter, sortBySta
       contentHash: null,
       createdAt: null,
       updatedAt: null,
+      matchScore: null,
+      matchedTerms: [],
       body: "Quarterly call",
       relPath: "action/events/2026-05-21--nvda.md",
       absPath: "/x",

--- a/apps/uebermensch/tests/event-match.test.ts
+++ b/apps/uebermensch/tests/event-match.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { buildKeywords, eventTokens, scoreMatch } from "../src/lib/event-match.js"
+
+describe("event-match — buildKeywords", () => {
+  it("merges topic titles, aliases, and interests, dropping stopwords", () => {
+    const kw = buildKeywords({
+      topicTitles: ["Artificial Intelligence", "Prediction Markets"],
+      topicAliases: ["AI", "ML"],
+      interests: ["the futures of llms"],
+    })
+    expect(kw.has("artificial")).toBe(true)
+    expect(kw.has("intelligence")).toBe(true)
+    expect(kw.has("prediction")).toBe(true)
+    expect(kw.has("markets")).toBe(true)
+    expect(kw.has("ai")).toBe(true)
+    expect(kw.has("ml")).toBe(true)
+    expect(kw.has("llms")).toBe(true)
+    expect(kw.has("the")).toBe(false)
+    expect(kw.has("of")).toBe(false)
+  })
+})
+
+describe("event-match — scoreMatch", () => {
+  const keywords = buildKeywords({
+    topicTitles: ["AI Infrastructure"],
+    topicAliases: [],
+    interests: ["llms"],
+  })
+  // keywords now: { ai, infrastructure, llms }
+
+  it("returns 0 with no overlap", () => {
+    const tokens = eventTokens({ title: "Pottery class for beginners" })
+    const r = scoreMatch(keywords, tokens)
+    expect(r.score).toBe(0)
+    expect(r.matched).toEqual([])
+  })
+
+  it("returns 1.0 when every keyword is matched", () => {
+    const tokens = eventTokens({
+      title: "AI Infrastructure meetup",
+      description: "Talk on LLMs",
+    })
+    const r = scoreMatch(keywords, tokens)
+    expect(r.score).toBeCloseTo(1, 5)
+    expect([...r.matched].sort()).toEqual(["ai", "infrastructure", "llms"])
+  })
+
+  it("partial match returns proportion", () => {
+    const tokens = eventTokens({ title: "AI startup demo" })
+    const r = scoreMatch(keywords, tokens)
+    expect(r.score).toBeCloseTo(1 / 3, 5)
+    expect(r.matched).toEqual(["ai"])
+  })
+
+  it("matched terms are deduped against tags", () => {
+    const tokens = eventTokens({
+      title: "AI talk",
+      tags: ["ai", "infrastructure"],
+    })
+    const r = scoreMatch(keywords, tokens)
+    expect([...r.matched].sort()).toEqual(["ai", "infrastructure"])
+  })
+
+  it("empty keyword set returns 0 (avoids div-by-zero)", () => {
+    const empty = buildKeywords({ topicTitles: [], topicAliases: [], interests: [] })
+    const tokens = eventTokens({ title: "anything" })
+    expect(scoreMatch(empty, tokens).score).toBe(0)
+  })
+})

--- a/apps/uebermensch/tests/events.test.ts
+++ b/apps/uebermensch/tests/events.test.ts
@@ -1,0 +1,343 @@
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Either, Layer } from "effect"
+import matter from "gray-matter"
+import { beforeEach, describe, expect, it } from "vitest"
+import { FileSystemCalendarLive } from "../src/adapters/FileSystemCalendar.js"
+import { LumaSuggesterLive } from "../src/adapters/LumaSuggester.js"
+import { CalendarService } from "../src/services/CalendarService.js"
+import { EventSuggesterService } from "../src/services/EventSuggesterService.js"
+import { ProfileService } from "../src/services/ProfileService.js"
+
+// --- helpers ---
+
+const seedFile = async (root: string, rel: string, body: string) => {
+  const full = join(root, rel)
+  await mkdir(join(full, ".."), { recursive: true })
+  await writeFile(full, body, "utf8")
+}
+
+const buildVault = async (city: string | null): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), "uber-vault-events-"))
+  const cityLine = city ? `\n  city: ${city}` : ""
+  await seedFile(
+    dir,
+    "directives/profile.md",
+    `---
+schema_version: 1
+
+identity:
+  name: "Test"
+  slug: "test"
+  tz: "Asia/Hong_Kong"
+  lang: "en"${cityLine}
+
+budgets:
+  daily_usd: 1.00
+  per_brief_usd: 0.25
+
+delivery:
+  brief:
+    cron: "0 30 7 * * *"
+    format: "long"
+  channels:
+    app:
+      enabled: true
+      driver: "app"
+      target_ref: "default"
+
+events:
+  enabled: true
+  min_match_score: 0.3
+  interests:
+    - artificial intelligence
+    - llms
+---
+# Profile
+`,
+  )
+  await seedFile(
+    dir,
+    "directives/topics.md",
+    `---
+topics:
+  - slug: "ai-infra-capex"
+    title: "AI infrastructure capex"
+    horizon: both
+    weight: 1.0
+---
+`,
+  )
+  await seedFile(
+    dir,
+    "directives/sources.md",
+    `---
+sources:
+  - slug: "manual"
+    driver: "manual"
+    cadence: "manual"
+    topics: ["ai-infra-capex"]
+---
+`,
+  )
+  return dir
+}
+
+const makeLumaHtml = (events: ReadonlyArray<Record<string, unknown>>): string => {
+  const list = events.map((e) => ({ "@context": "https://schema.org", "@type": "Event", ...e }))
+  return `<html><head>
+    <script type="application/ld+json">${JSON.stringify({ "@graph": list })}</script>
+    </head></html>`
+}
+
+const stubFetch =
+  (html: string) =>
+  async (_url: string) => ({ ok: true, status: 200, text: async () => html })
+
+// --- tests ---
+
+describe("events — pull (LumaSuggester) writes topic-matched suggestions", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await buildVault("hong-kong")
+  })
+
+  it("writes suggestions only for events that meet min_match_score", async () => {
+    const html = makeLumaHtml([
+      {
+        name: "AI Infrastructure & LLMs Meetup",
+        startDate: "2026-05-12T19:00:00+08:00",
+        url: "https://lu.ma/abc",
+        description: "Talk on inference",
+      },
+      {
+        name: "Sourdough bread workshop",
+        startDate: "2026-05-13T10:00:00+08:00",
+        url: "https://lu.ma/bread",
+      },
+    ])
+    const fakeFetch = stubFetch(html)
+
+    const program = Effect.gen(function* () {
+      const sug = yield* EventSuggesterService
+      return yield* sug.pull({})
+    })
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(LumaSuggesterLive({ fetch: fakeFetch })),
+        Effect.provide(
+          Layer.merge(
+            FileSystemCalendarLive(vaultDir),
+            (await import("../src/adapters/FileSystemProfile.js")).FileSystemProfileLive(
+              vaultDir,
+            ),
+          ),
+        ),
+      ),
+    )
+    expect(result.fetched).toBe(2)
+    expect(result.matched).toBe(1)
+    expect(result.written).toHaveLength(1)
+    expect(result.written[0]?.title).toBe("AI Infrastructure & LLMs Meetup")
+    expect(result.written[0]?.matched).toEqual(
+      expect.arrayContaining(["ai", "infrastructure", "llms"]),
+    )
+
+    const files = await readdir(join(vaultDir, "action/events/suggested"))
+    expect(files).toHaveLength(1)
+    const text = await readFile(
+      join(vaultDir, "action/events/suggested", files[0]!),
+      "utf8",
+    )
+    const fm = matter(text).data as Record<string, unknown>
+    expect(fm.source).toBe("driver-events")
+    expect(fm.status).toBe("tentative")
+    expect(fm.kind).toBe("industry")
+    expect(fm.external_id).toBe("luma:abc")
+    expect(fm.match_score).toBeGreaterThan(0)
+  })
+
+  it("uses --city flag over profile.identity.city", async () => {
+    const noCityVault = await buildVault(null)
+    const fakeFetch = stubFetch(makeLumaHtml([]))
+    const program = Effect.gen(function* () {
+      const sug = yield* EventSuggesterService
+      return yield* sug.pull({ city: "tokyo" })
+    })
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(LumaSuggesterLive({ fetch: fakeFetch })),
+        Effect.provide(
+          Layer.merge(
+            FileSystemCalendarLive(noCityVault),
+            (await import("../src/adapters/FileSystemProfile.js")).FileSystemProfileLive(
+              noCityVault,
+            ),
+          ),
+        ),
+      ),
+    )
+    expect(result.fetched).toBe(0)
+  })
+
+  it("fails clearly when neither flag nor profile city is set", async () => {
+    const noCityVault = await buildVault(null)
+    const fakeFetch = stubFetch(makeLumaHtml([]))
+    const program = Effect.gen(function* () {
+      const sug = yield* EventSuggesterService
+      return yield* sug.pull({})
+    })
+    const result = await Effect.runPromise(
+      Effect.either(
+        program.pipe(
+          Effect.provide(LumaSuggesterLive({ fetch: fakeFetch })),
+          Effect.provide(
+            Layer.merge(
+              FileSystemCalendarLive(noCityVault),
+              (await import("../src/adapters/FileSystemProfile.js")).FileSystemProfileLive(
+                noCityVault,
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    expect(Either.isLeft(result)).toBe(true)
+  })
+
+  it("re-pulling does not resurrect a dismissed suggestion", async () => {
+    const html = makeLumaHtml([
+      {
+        name: "AI Infra LLMs",
+        startDate: "2026-05-20T19:00:00+08:00",
+        url: "https://lu.ma/xyz",
+      },
+    ])
+    const fakeFetch = stubFetch(html)
+    const profileLayer = (
+      await import("../src/adapters/FileSystemProfile.js")
+    ).FileSystemProfileLive(vaultDir)
+
+    // First pull creates the suggestion
+    const created = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sug = yield* EventSuggesterService
+        return yield* sug.pull({})
+      }).pipe(
+        Effect.provide(LumaSuggesterLive({ fetch: fakeFetch })),
+        Effect.provide(Layer.merge(FileSystemCalendarLive(vaultDir), profileLayer)),
+      ),
+    )
+    expect(created.written).toHaveLength(1)
+    const slug = created.written[0]!.slug
+
+    // User dismisses it
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.dismiss(slug)
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+
+    // Second pull skips it (does not flip back to tentative)
+    const second = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sug = yield* EventSuggesterService
+        return yield* sug.pull({})
+      }).pipe(
+        Effect.provide(LumaSuggesterLive({ fetch: fakeFetch })),
+        Effect.provide(Layer.merge(FileSystemCalendarLive(vaultDir), profileLayer)),
+      ),
+    )
+    expect(second.skippedDismissed).toBe(1)
+    expect(second.written).toHaveLength(0)
+  })
+})
+
+describe("events — accept / dismiss", () => {
+  let vaultDir: string
+
+  beforeEach(async () => {
+    vaultDir = await buildVault("hong-kong")
+    const html = makeLumaHtml([
+      {
+        name: "AI Infra LLMs",
+        startDate: "2026-05-20T19:00:00+08:00",
+        url: "https://lu.ma/xyz",
+      },
+    ])
+    const profileLayer = (
+      await import("../src/adapters/FileSystemProfile.js")
+    ).FileSystemProfileLive(vaultDir)
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sug = yield* EventSuggesterService
+        return yield* sug.pull({})
+      }).pipe(
+        Effect.provide(LumaSuggesterLive({ fetch: stubFetch(html) })),
+        Effect.provide(Layer.merge(FileSystemCalendarLive(vaultDir), profileLayer)),
+      ),
+    )
+  })
+
+  it("accept flips status to confirmed and moves out of suggested/", async () => {
+    const before = await readdir(join(vaultDir, "action/events/suggested"))
+    const slug = before[0]!.match(/--([a-z0-9-]+)\.md$/)![1]!
+
+    const r = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.accept(slug)
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(r.status).toBe("confirmed")
+    expect(r.relPath.startsWith("action/events/")).toBe(true)
+    expect(r.relPath.includes("/suggested/")).toBe(false)
+
+    const suggestedNow = await readdir(join(vaultDir, "action/events/suggested"))
+    expect(suggestedNow).toHaveLength(0)
+
+    const promotedText = await readFile(join(vaultDir, r.relPath), "utf8")
+    const fm = matter(promotedText).data as Record<string, unknown>
+    expect(fm.status).toBe("confirmed")
+    expect(fm.source).toBe("driver-events")
+  })
+
+  it("dismiss flips status to cancelled and keeps file in place", async () => {
+    const before = await readdir(join(vaultDir, "action/events/suggested"))
+    const slug = before[0]!.match(/--([a-z0-9-]+)\.md$/)![1]!
+
+    const r = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.dismiss(slug)
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(r.status).toBe("cancelled")
+    expect(r.relPath.startsWith("action/events/suggested/")).toBe(true)
+
+    const text = await readFile(join(vaultDir, r.relPath), "utf8")
+    expect((matter(text).data as Record<string, unknown>).status).toBe("cancelled")
+  })
+
+  it("accept twice is a no-op the second time", async () => {
+    const before = await readdir(join(vaultDir, "action/events/suggested"))
+    const slug = before[0]!.match(/--([a-z0-9-]+)\.md$/)![1]!
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.accept(slug)
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    const second = await Effect.runPromise(
+      Effect.gen(function* () {
+        const cal = yield* CalendarService
+        return yield* cal.accept(slug)
+      }).pipe(Effect.provide(FileSystemCalendarLive(vaultDir))),
+    )
+    expect(second.noop).toBe(true)
+  })
+})

--- a/apps/uebermensch/tests/luma.test.ts
+++ b/apps/uebermensch/tests/luma.test.ts
@@ -1,0 +1,149 @@
+import { Effect, Either, Exit } from "effect"
+import { describe, expect, it } from "vitest"
+import { fetchLumaEvents, lumaCityUrl, parseLumaPage } from "../src/lib/luma.js"
+
+const lumaCityHtml = (events: ReadonlyArray<Record<string, unknown>>): string => {
+  const itemList = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    itemListElement: events.map((e, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: { "@context": "https://schema.org", "@type": "Event", ...e },
+    })),
+  }
+  return `<!doctype html><html><head><title>lu.ma/hong-kong</title>
+  <script type="application/ld+json">${JSON.stringify(itemList)}</script>
+  </head><body>luma</body></html>`
+}
+
+describe("luma — parseLumaPage", () => {
+  it("extracts JSON-LD Event entries with name, startDate, url", () => {
+    const html = lumaCityHtml([
+      {
+        name: "AI Infrastructure Meetup",
+        startDate: "2026-05-12T19:00:00+08:00",
+        endDate: "2026-05-12T21:30:00+08:00",
+        url: "https://lu.ma/abc123",
+        description: "Discussion on inference + capex",
+        location: { "@type": "Place", name: "WeWork Causeway Bay" },
+      },
+      {
+        name: "Pottery basics",
+        startDate: "2026-05-15T18:00:00+08:00",
+        url: "https://lu.ma/def456",
+      },
+    ])
+    const events = parseLumaPage(html)
+    expect(events).toHaveLength(2)
+    expect(events[0]?.title).toBe("AI Infrastructure Meetup")
+    expect(events[0]?.startsAt).toBe("2026-05-12T19:00:00+08:00")
+    expect(events[0]?.endsAt).toBe("2026-05-12T21:30:00+08:00")
+    expect(events[0]?.url).toBe("https://lu.ma/abc123")
+    expect(events[0]?.location).toContain("WeWork")
+    expect(events[0]?.externalId).toBe("luma:abc123")
+    expect(events[0]?.tz).toBe("UTC+08:00")
+  })
+
+  it("dedupes by externalId across overlapping JSON-LD blocks", () => {
+    const ev = {
+      name: "Same event",
+      startDate: "2026-05-20T19:00:00Z",
+      url: "https://lu.ma/dup",
+    }
+    const html = `<html><head>
+      <script type="application/ld+json">${JSON.stringify({ "@type": "Event", ...ev })}</script>
+      <script type="application/ld+json">${JSON.stringify({
+        "@graph": [{ "@type": "Event", ...ev }],
+      })}</script>
+      </head></html>`
+    const events = parseLumaPage(html)
+    expect(events).toHaveLength(1)
+  })
+
+  it("ignores non-Event JSON-LD blocks", () => {
+    const html = `<html><head>
+      <script type="application/ld+json">${JSON.stringify({
+        "@type": "WebSite",
+        url: "https://lu.ma",
+      })}</script>
+      </head></html>`
+    expect(parseLumaPage(html)).toHaveLength(0)
+  })
+
+  it("handles malformed JSON without throwing", () => {
+    const html = `<html><head>
+      <script type="application/ld+json">{ this is not json }</script>
+      </head></html>`
+    expect(parseLumaPage(html)).toEqual([])
+  })
+
+  it("extracts Place address as location", () => {
+    const html = `<html><head>
+      <script type="application/ld+json">${JSON.stringify({
+        "@type": "Event",
+        name: "x",
+        startDate: "2026-05-01T10:00:00Z",
+        location: {
+          "@type": "Place",
+          name: "Some venue",
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: "1 Main St",
+            addressLocality: "Hong Kong",
+          },
+        },
+      })}</script>
+      </head></html>`
+    const e = parseLumaPage(html)[0]
+    expect(e?.location).toBe("Some venue — 1 Main St, Hong Kong")
+  })
+})
+
+describe("luma — lumaCityUrl + fetch wrapper", () => {
+  it("builds URL from city slug", async () => {
+    expect(await Effect.runPromise(lumaCityUrl("hong-kong"))).toBe(
+      "https://lu.ma/hong-kong",
+    )
+    expect(await Effect.runPromise(lumaCityUrl("Tokyo  "))).toBe("https://lu.ma/tokyo")
+  })
+
+  it("rejects empty city with a tagged LumaError", async () => {
+    const result = await Effect.runPromise(Effect.either(lumaCityUrl("")))
+    Either.match(result, {
+      onLeft: (e) => expect(e.kind).toBe("invalid_input"),
+      onRight: () => expect.fail("expected Left"),
+    })
+  })
+
+  it("uses the injected fetch impl (no network)", async () => {
+    const html = lumaCityHtml([
+      { name: "Test", startDate: "2026-05-01T10:00:00Z", url: "https://lu.ma/zzz" },
+    ])
+    let called = ""
+    const fakeFetch = async (url: string) => {
+      called = url
+      return { ok: true, status: 200, text: async () => html }
+    }
+    const events = await Effect.runPromise(
+      fetchLumaEvents("https://lu.ma/test", { fetch: fakeFetch }),
+    )
+    expect(called).toBe("https://lu.ma/test")
+    expect(events[0]?.title).toBe("Test")
+  })
+
+  it("fails with http_error on non-OK response", async () => {
+    const fakeFetch = async () => ({ ok: false, status: 404, text: async () => "" })
+    const exit = await Effect.runPromiseExit(
+      fetchLumaEvents("https://lu.ma/missing", { fetch: fakeFetch }),
+    )
+    Exit.match(exit, {
+      onSuccess: () => expect.fail("expected failure"),
+      onFailure: (cause) => {
+        const msg = JSON.stringify(cause)
+        expect(msg).toMatch(/404/)
+        expect(msg).toMatch(/http_error/)
+      },
+    })
+  })
+})

--- a/apps/uebermensch/tests/timebox.test.ts
+++ b/apps/uebermensch/tests/timebox.test.ts
@@ -45,6 +45,8 @@ const stubEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
   contentHash: null,
   createdAt: null,
   updatedAt: null,
+  matchScore: null,
+  matchedTerms: [],
   body: "",
   relPath: "",
   absPath: "",

--- a/apps/uebermensch/vault/specs/events.md
+++ b/apps/uebermensch/vault/specs/events.md
@@ -1,0 +1,135 @@
+# Uebermensch — Events Discovery
+
+> Crawl public event sources for the user's city, score against profile interests, and write candidate **suggestions** to the vault. The user reviews, accepts, or dismisses; accepted suggestions become normal calendar events.
+>
+> Related: [calendar.md](calendar.md) (event storage shape — events use `kind: industry`), [profile.md](profile.md) (city + interests), [knowledge-base.md](knowledge-base.md) (suggestions may link wiki entities).
+
+## Why
+
+The morning brief tells the user what *happened*; the calendar tells them what *will* happen on dates already known. **Events discovery** answers the third question: "what's worth showing up to that I don't yet know about?" Conferences, meetups, hackathons, and talks are high-signal once filtered by topic — and ungoogleable in batch. A daily crawl + topic match makes them tractable.
+
+## Principles
+
+1. **Suggestions are tentative until confirmed.** Driver-pulled candidates land under `calendar/suggested/` with `status: tentative`. They appear in `events list` but **not** in the default calendar view (which filters `status=confirmed`). The morning brief's "On the calendar today" section MUST NOT include suggestions.
+2. **Accept = promote.** Accepting a suggestion flips `status: confirmed` and moves the file from `calendar/suggested/<date>--<slug>.md` to `calendar/<date>--<slug>.md`. The slug is preserved; backlinks stay valid.
+3. **Dismiss is sticky.** Dismiss flips `status: cancelled` and leaves the file in place. Re-pulls MUST NOT resurrect dismissed events — `(source, external_id)` is the dedupe key.
+4. **City + interests come from the profile.** Defaults read from `profile.identity.city` and `profile.topics[]`; CLI flags (`--city`, `--interests`) override per-call. No secret config.
+5. **Match is transparent.** Each suggestion records `match_score` (0..1) and `matched_terms` in frontmatter so the user can see *why* it was suggested.
+6. **Local-first.** The CLI is the canonical writer. The web UI's accept/dismiss writes through R2 sync (same vault as the local daemon).
+
+## Sources (M0: Luma only)
+
+| Driver | URL pattern | Notes |
+|--------|-------------|-------|
+| `driver-events.luma` | `https://lu.ma/<city-slug>` | Public Luma city page. We extract JSON-LD `Event` entries and embedded hydration data. Respects User-Agent + robots.txt. |
+
+Future sources (Meetup, Eventbrite, IRL conference calendars) use the same `EventCandidate` shape — only the fetcher changes.
+
+## Suggestion frontmatter (extends `EventFrontmatter`)
+
+```yaml
+---
+slug: 2026-05-12--ai-infra-meetup-hk
+title: "AI Infrastructure Meetup — Hong Kong"
+kind: industry
+source: driver-events
+starts_at: 2026-05-12T19:00:00+08:00
+ends_at:   2026-05-12T21:30:00+08:00
+tz: "Asia/Hong_Kong"
+status: tentative
+location: "WeWork Tower 535, Causeway Bay"
+topics: [ai-infra-capex]
+tags: [meetup, event-suggestion, source:luma]
+links:
+  - { title: "Event page", url: "https://lu.ma/abc123" }
+external_id: "luma:abc123"
+external_etag: "luma:abc123:2026-04-28"
+generator: "driver-events.luma"
+match_score: 0.62
+matched_terms: ["ai", "infrastructure"]
+---
+```
+
+`match_score` and `matched_terms` are events-only extensions. The `EventFrontmatter` schema accepts them via the existing forward-compat policy (unknown fields preserved on round-trip).
+
+## Profile additions
+
+```yaml
+# profile.md frontmatter
+identity:
+  city: hong-kong            # optional; lowercase kebab-case city slug
+  country: HK                # optional; ISO 3166-1 alpha-2
+
+events:
+  enabled: true              # default true once any source is configured
+  min_match_score: 0.2       # below this, candidates are not written to disk
+  interests:                 # optional; augments topics[].title + aliases
+    - artificial intelligence
+    - prediction markets
+  sources:
+    - driver: luma
+      city: hong-kong        # falls back to identity.city if omitted
+```
+
+`events.interests[]` is **additive** to `topics[].title` and `topics[].aliases`. The matcher's keyword set is the union.
+
+## CLI
+
+```sh
+gctrl uber events pull                     # uses profile.identity.city + profile.topics
+gctrl uber events pull --city tokyo
+gctrl uber events pull --interests "ai,llm,prediction-markets" --limit 50
+
+gctrl uber events list                     # tentative suggestions (default)
+gctrl uber events list --status all
+gctrl uber events show <slug>
+
+gctrl uber events accept <slug>            # status: confirmed; move out of suggested/
+gctrl uber events dismiss <slug>           # status: cancelled; remains in suggested/
+```
+
+`accept` and `dismiss` are no-ops if the slug already has the target status (idempotent). Both fail if the event's `source` is not `driver-events` — the existing `calendar add/edit/remove` commands handle user-authored events.
+
+## Web UI
+
+`/events` lists tentative suggestions from R2 (read path mirrors `/briefs`). Each card has **Accept** and **Dismiss** buttons that POST to Astro server endpoints (`/api/events/<slug>/accept`, `.../dismiss`). The endpoint:
+
+1. Reads the suggestion's markdown from R2 (`vault/<identity.slug>/calendar/suggested/<date>--<slug>.md`).
+2. Decodes frontmatter, applies the status flip.
+3. On `accept`: writes the new key (`calendar/<date>--<slug>.md`), then deletes the old one.
+4. On `dismiss`: writes back in place with `status: cancelled`.
+
+The local daemon's bidirectional R2 sync (per [profile.md § Sync](profile.md#sync-r2)) reflects the change locally on the next pull cycle (≤5 min).
+
+## Matching algorithm (M0 — keyword)
+
+1. Build the **keyword set** from `topics[].title`, `topics[].aliases`, and `events.interests[]`. Lowercase, strip punctuation, drop stopwords (`the`, `and`, `for`, …).
+2. Build the **event tokens** from `title + description + tags` of each fetched event. Same normalisation.
+3. `match_score = |keywords ∩ tokens| / max(1, |keywords|)`. `matched_terms = keywords ∩ tokens` sorted alphabetically.
+4. Drop candidates with `match_score < min_match_score` (default 0.2).
+5. Tie-break by `starts_at` ascending.
+
+Embedding-based matching is a follow-up (M1).
+
+## Storage
+
+No new SQLite tables. Suggestions are normal `uber_calendar` rows with `source='driver-events'` and `status='tentative'`. The existing `(source, external_id)` unique index is the dedupe key.
+
+## Eval & observability
+
+- Each `events pull` is a kernel `Session` with spans for fetch + parse + score + write.
+- Per-source success rate (events fetched vs. matched vs. accepted) feeds into the existing scrape-health dashboard.
+- Acceptance rate is the north star: fewer than 5% of suggestions accepted over 30 days → tighten `min_match_score` or revisit interest keywords.
+
+## Non-goals
+
+1. **Not a discovery feed.** Suggestions are scoped to the user's interests; we do not surface "popular events in your city" without a topic match.
+2. **Not RSVP.** Accepting a suggestion adds it to the calendar; the user RSVPs on the event's own page (link preserved in frontmatter).
+3. **Not multi-city.** One identity = one default city. CLI flag is per-call.
+4. **Not paid-event filtering.** Cost is preserved as a tag (`tags: [paid]` if detected) but not used for ranking. Open question — see below.
+
+## Open questions
+
+1. **Luma JSON-LD vs. hydration scrape.** Luma emits JSON-LD for individual event pages but the city page uses Next.js hydration. **Leaning:** parse the city page's `__NEXT_DATA__` for the event list, then optionally fetch each event page for richer JSON-LD. Document the fragility. Needed by M0.
+2. **Cost as a ranking signal.** Should free events outrank paid ones at the same match score? **Leaning:** no — leave to the user; show price in the card.
+3. **De-dupe across sources.** Once Meetup is added, the same conference may appear twice. **Leaning:** dedupe key is `(starts_at, normalised_title)`; second occurrence merges its `links[]` into the first.


### PR DESCRIPTION
## Summary

Adds a third surface alongside briefs and the calendar: discover meetups and conferences in the user's city, score them against profile topics + interests, and let the user accept (→ confirmed calendar event) or dismiss.

- **spec**: `vault/specs/events.md` (Luma source, suggestion → confirmed flow)
- **schema**: optional `identity.city` + `events.{enabled,min_match_score,interests,sources}`; new `driver-events` `EventSource` and `match_score` / `matched_terms` on `EventFrontmatter`. `CalendarEvent` exposes these as first-class fields — no more type casts at the call site.
- **lib**: `luma.ts` JSON-LD `Event` extractor (returns `Effect` with a tagged `LumaError`); `event-match.ts` keyword scorer
- **services**: `EventSuggesterService.pull()`; `CalendarService` gains `addSuggestion` / `accept` / `dismiss` (suggestions land under `action/events/suggested/`, accept moves out and flips `status:confirmed`, dismiss is sticky for dedupe)
- **CLI**: `gctrl uber events {pull,list,show,accept,dismiss}` with `--city` flag defaulting to `profile.identity.city`
- **web**: `/events` Astro page lists tentative suggestions from R2 with Accept/Dismiss POST forms; `api/events/<slug>/{accept,dismiss}.ts` mutates R2 in place — local daemon's bidirectional sync reflects the change
- **tests**: 22 new — keyword scoring, JSON-LD parse + dedupe, city flag fallback, dismissed re-pull skip, accept moves out, dismiss is sticky, idempotency

### Effect-TS pass

- `lumaCityUrl` and `fetchLumaEvents` return `Effect` with a tagged `LumaError` instead of throwing; `LumaError.kind` enumerates failure modes (`invalid_input | fetch_failed | http_error`).
- `datePart` in `FileSystemCalendar` is unified to `Either` across user adds and driver suggestions.
- Tests use `Either.match` / `Exit.match` instead of bare `._tag` access.
- Command layer uses `Option.map` + `Option.getOrUndefined` instead of `Option.getOrThrow`.
- `match_score` / `matched_terms` are first-class fields on `CalendarEvent` (decoded by the schema), removing `as unknown as { matchScore?: number }` casts in the events command.

## Test plan

- [x] `pnpm typecheck` (uebermensch)
- [x] `pnpm test` (uebermensch) — 184/184 passing
- [ ] Manual: `gctrl uber events pull --city hong-kong` then `list`, `accept`, `dismiss`
- [ ] Manual: `/events` page on uebermensch-pages renders suggestions and Accept/Dismiss POST forms work
