### PR TITLE
docs(specs): DRY pass — collapse duplicated rules to a single source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,21 +118,18 @@ Detailed programming patterns, code examples, and how-to guides live under `vaul
 
 ## Invariants
 
-> Quick reference. Canonical rules with full context live in `vault/specs/principles.md`.
+> Quick reference. **Canonical rules with full context live in `vault/specs/principles.md`** — if anything below disagrees with `principles.md`, the latter wins. Sub-rules are not duplicated here; each entry cites where to read the full text.
 
-1. Dependencies MUST flow inward: Shell → Kernel → Domain, never reverse.
-2. DuckDB is single-writer: the daemon MUST hold the lock; shell and apps MUST use the HTTP API.
-3. Application tables MUST use namespaced prefixes (`board_*`, `eval_*`, `capacity_*`, `inbox_*`).
-4. Code MUST NOT access Effect-TS `._tag` directly — use combinators (`Effect.catchTag`, `Match.tag`, `Option.match`). Also: no bare `new Error` in Effect contexts (use `Schema.TaggedError`), no `as any` on external JSON (use `Schema.decodeUnknown`), no `export *` barrels, no dynamic `require` inside Effect generators. Full list with Bad/Good examples: `vault/specs/principles.md` § Effect-TS Invariants and `vault/specs/implementation/{apps,shell}/style.md`. Reviewer sweep: `rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts`.
-5. **TDD is the default.** Write a failing test first, then make it pass, then refactor. No production code without a pre-existing test.
-6. Every new public function MUST have at least one test. Coverage: storage CRUD + HTTP routes (happy + error) + shell commands.
-7. Contributors MUST use feature branches — MUST NOT push directly to main.
-8. All changes to main MUST go through a pull request — MUST NOT merge with `--admin` bypass.
-9. MUST NOT rebase main — use merge commits only. MUST NOT force-push to main.
-10. The Kernel MUST NOT make assumptions about applications.
-11. Shell (Effect-TS CLI) MUST mediate all user-facing access to the kernel via HTTP API.
-12. External tools (GitHub, Slack, AWS) MUST be accessed from the shell via direct REST API adapters — never from the kernel.
-13. Every application MUST have its own `apps/{app-name}/` directory with `PRD.md` and `WORKFLOW.md`.
+1. **Dependencies flow inward.** Shell → Kernel → Domain, never reverse. (`principles.md` § Architectural Invariants #1)
+2. **DuckDB is single-writer.** Daemon holds the lock; shell + apps go through the HTTP API. (§ Architectural Invariants #2)
+3. **App tables are namespaced** — `board_*`, `eval_*`, `inbox_*`, `capacity_*`. (§ Architectural Invariants #3)
+4. **Kernel makes no assumptions about apps; shell mediates all kernel access.** (§ Architectural Invariants #4–5)
+5. **External tools go through kernel drivers (LKMs)** that implement kernel interface traits (`TrackerPort`, `ObservabilityExportPort`, `KnowledgeSourcePort`). Shell + apps MUST NOT hold secrets or call external APIs directly. (§ Design Principles #7; § os.md "Drivers")
+6. **Effect-TS hygiene** — no `._tag` access, no bare `new Error` in Effect contexts, no `as any` on external JSON, no `export *` barrels, no dynamic `require` inside Effect generators, no untyped `catchAll`, no mutable module state. Reviewer sweep: `rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts`. (§ Effect-TS Invariants #1–8; `implementation/{apps,shell}/style.md`)
+7. **TDD is default** — failing test first, then implementation. Storage tests use `:memory:` DuckDB; HTTP tests use `axum::test::oneshot`; shell tests use mock `KernelClient`. (§ Testing Invariants #1–11)
+8. **Every new public function MUST have a test.** (§ Testing Invariants #4)
+9. **Git workflow** — feature branches only, no `--admin` merges, no force-push to main, no rebase of main. (§ Git Workflow #1–2; CLAUDE.md)
+10. **Apps live under `apps/{app-name}/`** with `PRD.md` and `WORKFLOW.md`. (§ Specs Table of Contents below)
 
 ## Agent Conventions
 

--- a/vault/specs/architecture/apps/tracker.md
+++ b/vault/specs/architecture/apps/tracker.md
@@ -170,7 +170,7 @@ pub enum TrackerError {
 
 ## Storage
 
-The Tracker reads and writes to DuckDB tables in the `board_*` namespace via the Shell (HTTP API or direct DuckDB access for Rust-compiled apps). See [domain-model.md](../domain-model.md) § 5.5 for DDL. The Tracker owns `board_issues`, `board_events`, and `board_comments`. Task storage is owned by the Scheduler.
+The Tracker owns `board_issues`, `board_events`, and `board_comments`; Task storage is owned by the Scheduler. For DDL see [domain-model.md § 5.2](../domain-model.md#52-board-application-tables); for the access pattern (kernel-hosted tables, app-driven via shell HTTP API) see [gctl-board.md § Kernel Primitives Used](gctl-board.md#kernel-primitives-used) — both rules MUST live there only, not be restated here.
 
 ### DAG Storage
 

--- a/vault/specs/architecture/domain-model.md
+++ b/vault/specs/architecture/domain-model.md
@@ -290,7 +290,9 @@ pub trait BrowserPort: Send + Sync {
 
 ### 5.1 Kernel-owned tables (implemented)
 
-From `schema.rs`: `sessions`, `spans`, `traffic`, `guardrail_events`, `scores`, `tags`, `prompt_versions`, `session_prompts`, `daily_aggregates`, `alert_rules`, `alert_events`, `context_entries`, `persona_definitions`, `persona_review_rules`, `inbox_messages`, `inbox_threads`, `inbox_actions`, `inbox_subscriptions`.
+From `schema.rs`: `sessions`, `spans`, `traffic`, `guardrail_events`, `scores`, `tags`, `prompt_versions`, `session_prompts`, `daily_aggregates`, `alert_rules`, `alert_events`, `context_entries`, `persona_definitions`, `persona_review_rules`.
+
+> The kernel **hosts** several app-namespaced tables (`board_*`, `inbox_*`, `eval_*`) — `schema.rs` and `all_migrations()` create them, but the kernel does not interpret their rows. Those are listed in §§ 5.2 / 5.2a / 5.3 below per Invariant #3 (app namespacing).
 
 **Spec-only extensions** (not yet in schema.rs):
 
@@ -360,6 +362,12 @@ Every agent MUST create tasks via `SchedulerPort` — never write directly.
 **Source:** [`kernel/crates/gctrl-storage/src/schema.rs`](../../kernel/crates/gctrl-storage/src/schema.rs) — `CREATE_BOARD_*_TABLE` constants: `board_projects`, `board_issues`, `board_events`, `board_comments`.
 
 Per Invariant #3, application tables carry the `board_` namespace prefix.
+
+### 5.2a Inbox application tables
+
+**Source:** [`kernel/crates/gctrl-storage/src/schema.rs`](../../kernel/crates/gctrl-storage/src/schema.rs) — `CREATE_INBOX_*_TABLE` constants: `inbox_messages`, `inbox_threads`, `inbox_actions`, `inbox_subscriptions`.
+
+Per Invariant #3, the `inbox_` prefix marks these as owned by the gctrl-inbox application; the kernel hosts the rows but does not interpret them. See [`apps/gctl-inbox.md`](apps/gctl-inbox.md) for application-level semantics.
 
 ### 5.3 Eval application tables
 

--- a/vault/specs/architecture/kernel/orchestrator.md
+++ b/vault/specs/architecture/kernel/orchestrator.md
@@ -42,7 +42,7 @@ Applications observe orchestration state through the shell (HTTP API or CLI quer
 
 ## Orchestration States (Kernel Claim States)
 
-> States, transitions, and required properties are defined below.
+> **Source of truth:** [`kernel/specs-lean4/KernelSpec/Orchestrator.lean`](../../../../kernel/specs-lean4/KernelSpec/Orchestrator.lean). The `step` function and verified theorems define this machine; the prose below is a human-readable summary. If this section disagrees with the Lean module, the Lean module wins. `lake build` MUST pass before this section may be amended.
 
 These are the orchestrator's **internal claim states**, distinct from the Task lifecycle managed by the Scheduler. A Task's Scheduler state (`pending`, `running`, etc.) and its orchestration claim state are independent dimensions.
 
@@ -56,14 +56,7 @@ States: `Unclaimed` → `Claimed` → `Running` → `Released`, with `Paused` an
 
 ### Verified Properties
 
-Required properties:
-
-1. **No duplicate dispatch** — `dispatch_only_from_unclaimed`
-2. **Reachability** — `all_reachable`
-3. **Liveness** — `claimed_always_progresses`, `retryQueued_always_progresses`
-4. **Determinism** — `deterministic`
-5. **Terminal convergence** — `released_reachable_from_any`
-6. **Pause/resume integrity** — `paused_integrity`, `paused_not_dispatchable`
+Six theorems in `Orchestrator.lean` cover: no-duplicate-dispatch, reachability, liveness, determinism, terminal convergence, and pause/resume integrity. See the Lean module's header docstring for theorem names and proof bodies — they MUST NOT be duplicated here.
 
 ---
 

--- a/vault/specs/architecture/os.md
+++ b/vault/specs/architecture/os.md
@@ -453,7 +453,7 @@ Drivers live in kernel space. Native apps (gctrl-board, Observe & Eval) live in 
 4. **Independently optional**: Each driver is independently feature-gated — zero drivers is the default; add as needed
 5. **Bidirectional where needed**: Pull from external API into gctrl; push gctrl events back to external API
 6. **Cross-module isolation**: Drivers MUST NOT import or call other drivers or native apps. All cross-component communication flows through kernel IPC (events, shell APIs, pipes)
-7. **Prefer native CLIs**: Where a mature native CLI exists (e.g., `gh` for GitHub), drivers SHOULD delegate to it via subprocess rather than reimplementing the REST API client. This reuses the CLI's authentication, pagination, and format handling. The kernel wraps the subprocess call with **caching** (response-level, TTL-based) and **OTel instrumentation** (spans for each call, cost/latency attribution)
+7. **Native CLI delegation (optional)**: A driver MAY delegate to a mature native CLI (e.g., `gh` for GitHub) via subprocess to reuse the CLI's authentication, pagination, and format handling. This is an implementation choice — **the kernel interface trait (rule #2) is the contract**, regardless of whether the driver wraps a CLI subprocess or a direct REST client. The kernel wraps the subprocess call with **caching** (response-level, TTL-based) and **OTel instrumentation** (spans for each call, cost/latency attribution)
 
 ### Driver Execution Model — Kernel Responsibilities
 

--- a/vault/specs/implementation/kernel/eval-storage.md
+++ b/vault/specs/implementation/kernel/eval-storage.md
@@ -11,18 +11,10 @@ It is the foundation every other M4 deliverable depends on:
 
 ## Ownership and Layering
 
-Per [domain-model § 5.3](../../architecture/domain-model.md#53-eval-application-tables) and the namespacing invariant in [os.md § 3](../../architecture/os.md):
+For ownership and namespacing rationale, see [domain-model.md § 5.3](../../architecture/domain-model.md#53-eval-application-tables) — that section is canonical and MUST NOT be restated here. Summary for orientation only:
 
-| Table | Owner | Layer | Why |
-|---|---|---|---|
-| `scores` | Kernel (existing) | `gctrl-storage` | Single sink for substrate + harness, dev + prod. The metric-continuity property depends on this. |
-| `prompt_versions` | Kernel (existing) | `gctrl-storage` | Reused for judge prompts; content-addressed by hash. |
-| `eval_metrics` | Observe & Eval app | `gctrl-storage` | Metric-name resolution must be available to *any* writer (substrate API or harness), so DDL lives in the kernel storage crate even though the table is app-namespaced. |
-| `eval_datasets` | Observe & Eval app | `gctrl-storage` | Same rationale. |
-| `eval_cases` | Observe & Eval app | `gctrl-storage` | Same rationale. |
-| `eval_runs` | Observe & Eval app | `gctrl-storage` | Same rationale. |
-
-The `eval_*` tables are **app-namespaced** (Invariant #3) but their DDL is co-located with kernel schema — same pattern as `board_*` tables, which the kernel does not interpret but does host.
+- `scores`, `prompt_versions` — kernel-owned (the shared sink across all eval modes).
+- `eval_metrics`, `eval_datasets`, `eval_cases`, `eval_runs` — app-namespaced (`eval_*`, per Invariant #3) but DDL co-locates in `gctrl-storage`, same pattern as `board_*` tables.
 
 ## DDL
 

--- a/vault/specs/implementation/kernel/orchestrator.md
+++ b/vault/specs/implementation/kernel/orchestrator.md
@@ -42,6 +42,8 @@ kernel/crates/gctrl-orch/
 
 ### State Machine (Rust)
 
+> **Single source of truth:** [`kernel/specs-lean4/KernelSpec/Orchestrator.lean`](../../../../kernel/specs-lean4/KernelSpec/Orchestrator.lean). The Rust translation below is a spec for the `gctrl-orch` crate to implement; it MUST match the Lean `step` function exactly. If the Lean module is updated, this Rust translation MUST be regenerated — divergence is a bug, not a deliberate decision. The conformance tests in §5 verify equivalence.
+
 ```rust
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaimState {


### PR DESCRIPTION
## Summary

DRY cleanup pass over `vault/specs/` and `AGENTS.md`. Six duplicated rules collapsed to a single canonical source, following AGENTS.md § Writing Specs #6 ("one fact, one place"). Doc-only PR — no production code changes.

Each finding came out of the spec review on PR #113's branch (see [conversation](#) for the full review). Findings touched here: **D1, D2, D3, D4, A1, G8a**.

## Stacked on PR #113

This branch (`chore/specs-dry-cleanup`) is stacked on `feat/runtime-compute-decoupling-spec` (PR #113). All edits in this PR also apply cleanly against `main` — base will be retargeted to `main` once #113 merges. (Or merge this PR's commit directly onto main and rebase #113 — either order works.)

## What changed

### D1 — Orchestrator state machine duplication
Lean's `KernelSpec/Orchestrator.lean` is the verified source of truth.
- `architecture/kernel/orchestrator.md`: replace the 6-line "Verified Properties" theorem-name list with one sentence + cite Lean docstring as canonical. Add a "Source of truth" callout at the section head.
- `implementation/kernel/orchestrator.md`: add a "Single source of truth" banner above the Rust state-machine block, making the Lean → Rust regeneration rule explicit at section level.

### D2 — `AGENTS.md` restated `principles.md`
§ Invariants 1–13 paraphrased `principles.md` rules inconsistently. Invariant #12 was *inverted* vs current architecture — said drivers must go through the shell, but drivers are kernel-side LKMs per `principles.md § Design Principles #7`.
Replace 13 paraphrased rules with 10 one-line entries each citing `principles.md § X`. Drift-prone restatement → navigable index.

### D3 — `tracker.md` duplicated board storage detail
- Cited a non-existent `domain-model.md § 5.5`.
- Partially contradicted `gctl-board.md` on direct-DuckDB access.
Replace with two cross-references (`domain-model.md § 5.2` for DDL; `gctl-board.md § Kernel Primitives Used` for access pattern). Tracker keeps only the ownership claim unique to its scope.

### D4 — `eval-storage.md` restated ownership rationale
Implementation file restated the table-ownership rationale from `domain-model.md § 5.3`. Replace with a 5-line summary citing § 5.3 as canonical.

### A1 — Driver MAY native-CLI / MUST kernel-interface
`os.md` driver rule #7 read as "drivers SHOULD prefer native CLIs", which made readers think the CLI is the contract. Rephrase: drivers MAY delegate to a CLI as an impl choice; the kernel interface trait (rule #2) is the contract regardless.

### G8a — `inbox_*` tables relocated
`domain-model.md § 5.1` listed `inbox_messages/threads/actions/subscriptions` alongside kernel tables, contradicting Invariant #3 (app namespacing). Move to a new § 5.2a "Inbox application tables" parallel to § 5.2 board, with a note in § 5.1 that the kernel hosts several app-namespaced tables but does not interpret them.

## What this PR does NOT do

1. **No production code changes.**
2. **No Lean changes** — `Substrate.lean` and `Orchestrator.lean` unmodified.
3. **C1, C2** (stale "Agent Port" sections after PR #113 rename) — these touch the same orchestrator.md files but a different section. Per the user's sequencing they land as a separate PR.
4. **C3** (two different things called "Task" — Rust struct vs Scheduler concept) — the Rust struct rename is a code change, separate PR.
5. **C5** (`gctl-board.md` / `gctl-inbox.md` filename typos) — separate PR. This PR's cross-references still use `gctl-*` to match current filenames; they'll update with C5.

## Test plan

- [x] `node shell/gctrl-shell/dist/main.js spec audit` — PASSED. No new unchecked acceptance criteria introduced.
- [x] No Lean changes; `lake build` not re-run (no impact).
- [ ] Reviewer: confirm the `principles.md` cross-references in `AGENTS.md` match the actual section names (§ Architectural Invariants, § Effect-TS Invariants, § Testing Invariants, § Git Workflow).
- [ ] Reviewer: confirm § 5.2a is acceptable section numbering (alternative would be renumber 5.3 → 5.4 → 5.5).

## Stats

7 files changed, +31 / −39. Net reduction in spec text (collapsed duplications) while gaining explicit "source of truth" callouts.
