### PR TITLE
docs: desktop (Electron) + mobile app specs

### DIFF
--- a/vault/specs/architecture/README.md
+++ b/vault/specs/architecture/README.md
@@ -40,9 +40,11 @@ vault/specs/architecture/
 │
 ├── shell/             ← shell layer (CLI dispatcher, HTTP API, query engine)
 │
-└── apps/              ← native applications and utilities (Issues live here)
-    ├── gctrl-board.md      kanban — issues, board visualization, agent integration
-    └── tracker.md         Issue lifecycle, DAG, auto-transitions, TrackerPort
+└── apps/              ← native applications, utilities, and distribution targets (Issues live here)
+    ├── gctrl-board.md       kanban — issues, board visualization, agent integration
+    ├── tracker.md          Issue lifecycle, DAG, auto-transitions, TrackerPort
+    ├── gctrl-desktop.md    Electron macOS distribution — kernel sidecar, native packaging
+    └── gctrl-mobile.md     Mobile companion app — remote-only, no kernel, comms + prompting + analytics
 ```
 
 | Document | Scope |
@@ -58,6 +60,8 @@ vault/specs/architecture/
 | [kernel/browser.md](kernel/browser.md) | Browser control kernel extension — CDP daemon, ref system, tab management |
 | [apps/gctrl-board.md](apps/gctrl-board.md) | Kanban application — Issues, board visualization, agent integration |
 | [apps/tracker.md](apps/tracker.md) | Tracker application component — Issue lifecycle, DAG, auto-transitions, TrackerPort |
+| [apps/gctrl-desktop.md](apps/gctrl-desktop.md) | Electron macOS distribution — kernel sidecar, native packaging, tech stack rationale |
+| [apps/gctrl-mobile.md](apps/gctrl-mobile.md) | Mobile companion — remote-only, no kernel, scoped to comms + prompting + analytics |
 
 ---
 

--- a/vault/specs/architecture/apps/gctrl-desktop.md
+++ b/vault/specs/architecture/apps/gctrl-desktop.md
@@ -1,0 +1,160 @@
+# gctrl Desktop — Native macOS Distribution
+
+gctrl Desktop is a **packaging and distribution mode**, not a new application. It bundles the Rust kernel binary together with the React UI from `apps/gctrl-board/web/` (and future apps) into a single signed, notarized macOS `.app` that a user can drag into `/Applications`. macOS is the first target; Windows and Linux are out of scope for v1.
+
+The desktop app preserves every architectural invariant from [os.md](../os.md): the kernel runs as an independent binary, the UI consumes kernel HTTP on `:4318`, and dependency direction stays `App → Shell → Kernel`. From the kernel's perspective, the desktop app is identical to local-dev mode — a renderer process that talks HTTP. The Electron shell is a thin packaging layer, not a runtime the kernel knows about.
+
+## Architectural Position
+
+```mermaid
+flowchart TB
+  subgraph DesktopApp["gctrl.app (signed .app bundle)"]
+    subgraph Renderer["Electron Renderer (Chromium)"]
+      UI["React 19 SPA<br/>(reused from apps/gctrl-board/web/)"]
+    end
+
+    subgraph Main["Electron Main Process (Node.js)"]
+      Bootstrap["Bootstrap<br/>(spawn kernel, manage windows)"]
+      Updater["electron-updater<br/>(auto-update feed)"]
+    end
+
+    subgraph Sidecar["Kernel Sidecar (Rust binary)"]
+      Kernel["gctrl-kernel<br/>HTTP API on 127.0.0.1:4318"]
+      Storage["DuckDB<br/>~/Library/Application Support/gctrl/"]
+    end
+  end
+
+  UI -->|"fetch http://127.0.0.1:4318/api/*"| Kernel
+  UI -->|"EventSource /api/sessions/:id/stream"| Kernel
+  Bootstrap -->|"execFile + watchdog"| Kernel
+  Kernel --> Storage
+  Updater -.->|"https"| Feed["Update feed<br/>(R2 / GitHub Releases)"]
+```
+
+**Key invariants preserved:**
+
+1. **Local-first.** No network connectivity required for any feature. The kernel runs entirely on-device; no remote calls are added by the desktop shell.
+2. **Single-writer DuckDB.** The kernel sidecar is the sole writer (same as local-dev mode). The renderer never opens DuckDB directly.
+3. **Dependency direction unchanged.** The renderer is an HTTP client of the kernel — the same role the Cloudflare Worker SPA plays in cloud mode and the Vite dev server plays in local-dev mode.
+4. **No new application layer.** Desktop is a deployment target, not an app. There are no `desktop_*` tables, no `/api/desktop/*` routes. Bootstrap concerns (spawning the kernel, auto-update) live in the Electron main process and never touch the kernel.
+
+## Tech Stack Decision: Electron
+
+Electron was chosen over Tauri 2 and Flutter after evaluating tradeoffs against the Unix invariants in [principles.md](../../principles.md) and the kernel-as-HTTP architecture defined in [os.md](../os.md).
+
+### Decision matrix
+
+| Concern | Electron | Tauri 2 | Flutter |
+|---|---|---|---|
+| **React 19 + @dnd-kit reuse** | Near-100%, no rewrite | Near-100%, but WebView fragmentation | Full UI rewrite (~350–500 hrs) |
+| **Kernel sidecar pattern** | Standard (1Password 8, Pieces, Tabby) | First-class (`externalBin`) | Standard (Process API) |
+| **WebView consistency** | One Chromium across platforms | WKWebView/WebView2/WebKitGTK divergence | N/A (Skia/Impeller) |
+| **Native macOS feel** | Acceptable; not WKWebView-native | Better (WKWebView) | Worst (every pixel custom-painted) |
+| **Bundle / RAM** | ~80–120 MB / 150–300 MB | ~10 MB / 50–85 MB | ~30 MB / native-ish |
+| **Community / hireability** | Largest by far | Growing but smaller | Mid; Dart is niche |
+| **Linux story (future)** | Predictable | WebKitGTK rot — maintainers eyeing CEF | Acceptable |
+| **Mobile reuse** | None — separate project regardless | Tauri 2 mobile too young (GA Oct 2024) | Best — but irrelevant given separate-codebase decision |
+| **macOS App Store risk** | Well-trodden | Sandbox + localhost kernel = review risk | Well-trodden |
+
+### Why Electron wins for gctrl
+
+1. **The "Rust synergy" argument doesn't apply.** Tauri's value proposition leans on co-locating Rust with the WebView. The gctrl kernel is *already* a separate HTTP binary on `:4318` — Tauri vs Electron is purely a WebView-shell choice for us, not a Rust integration choice.
+2. **The existing React 19 + Tailwind + shadcn + @dnd-kit + custom-SVG visualization stack is the most-iterated layer.** Throwing it away (Flutter) is the largest cost; preserving it across all runtime modes (local dev, Cloudflare Worker, desktop) keeps one UI codebase.
+3. **WebView consistency matters for an agent-heavy UI.** Custom visualizations (`GanttBoard`, `SessionsTimeline`, `SessionsHeatmap`), live SSE streams, and dense kanban interactions benefit from one Chromium across platforms vs. three diverging WebViews.
+4. **Mobile is a separate codebase regardless** — see [gctrl-mobile.md](gctrl-mobile.md). Picking a desktop framework "for the mobile reuse" is moot.
+5. **Bloat is mitigated, not solved — but the kernel's heavy lifting is outside Electron.** All business logic, storage, and telemetry run in the Rust sidecar. Electron is just the shell around the renderer; the marginal cost of one more Chromium instance is acceptable for a tool the user opens deliberately, not a background daemon.
+
+### Tradeoffs accepted
+
+- **~150–300 MB RAM** for the renderer + main process (vs. ~50–85 MB on Tauri). Acceptable because the kernel is the heavy compute, not the UI.
+- **Hardened-runtime entitlements required** for V8 JIT (`com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`). Not required on Tauri.
+- **Auto-update via electron-updater** is the de-facto standard but adds a code path not present in cloud mode.
+
+## Runtime Modes
+
+The same React UI runs in three distinct runtime configurations. The desktop mode adds no new application logic — it is a third deployment target for code that already exists.
+
+| Mode | Frontend host | Kernel | Storage | Used for |
+|------|---------------|--------|---------|----------|
+| **Cloud (Cloudflare Worker)** | Worker serves SPA | None — Worker proxies select kernel routes via `KERNEL_URL`; some routes (board CRUD) are D1-backed at the edge | D1 (edge) | Hosted demo, mobile companion, public-facing analytics surfaces |
+| **Local dev (Vite + kernel daemon)** | Vite dev server proxies `/api` → `:4318` | Local Rust kernel daemon, manually started | DuckDB (`~/.local/share/gctrl/`) | Day-to-day development; full feature parity with desktop |
+| **Desktop (Electron + kernel sidecar)** | Electron renderer loads bundled SPA assets | Bundled Rust kernel spawned by Electron main on app launch | DuckDB (`~/Library/Application Support/gctrl/`) | End-user distribution; what we ship as `gctrl.app` |
+
+The frontend code in `apps/gctrl-board/web/` is identical in all three modes. Mode selection happens at *build time* (which bundle is being built) and *runtime* (which kernel URL the SPA points at). No conditional logic in the React tree itself.
+
+## Components and Responsibilities
+
+### Electron Main Process
+
+The main process is a **bootstrap and lifecycle manager**, not a business-logic surface. It MUST NOT replicate kernel functionality, hold secrets, or proxy non-kernel APIs.
+
+Responsibilities:
+1. Spawn the kernel sidecar binary on app launch (`execFile`, hardened-runtime safe).
+2. Watchdog the kernel — restart on crash with exponential backoff; surface fatal failures to the renderer via a banner.
+3. Kill the kernel cleanly on `before-quit`.
+4. Manage native windows, dock menu, application menu (`Edit`, `View`, `Window`, `Help`).
+5. Wire `electron-updater` to the auto-update feed.
+6. Forward deep links (`gctrl://open?session=...`) to the renderer.
+
+Explicit non-goals:
+- No IPC bridge for kernel data. The renderer talks to `http://127.0.0.1:4318` directly. This keeps Electron a true *shell* and keeps a single API path across runtime modes.
+- No Node integration in the renderer (`contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`).
+
+### Kernel Sidecar
+
+The same Rust kernel binary defined in `kernel/`, compiled as a universal2 macOS binary (arm64 + x86_64 via `cargo-zigbuild`) and bundled inside the `.app` under `Contents/Resources/kernel/`. Behavior is identical to local-dev mode; the only desktop-specific configuration is the storage path and the bind address (`127.0.0.1:4318`, never `0.0.0.0`).
+
+### Renderer (React 19 SPA)
+
+Loaded from a packaged `dist-web/` directory bundled into the `.app`. Routes use `HashRouter` (or `app://` protocol) instead of `BrowserRouter`. All `fetch('/api/...')` calls become `fetch('http://127.0.0.1:4318/api/...')` — a one-line base-URL change at the request wrapper.
+
+### Auto-Update
+
+`electron-updater` checks an update feed (S3/R2 hosted JSON manifest or GitHub Releases) on app launch and at a configurable interval. Updates are downloaded in the background and applied on next launch. Update payloads are signed with the same Developer ID Application certificate used for the app itself; signature verification is enforced by Squirrel.
+
+## Local-First Invariants
+
+The desktop mode MUST preserve the local-first guarantees from [principles.md](../../principles.md) § Design Principles:
+
+1. **Offline functional.** Disconnect the network; every feature continues to work, including session history, board state, analytics, and inbox. The kernel does not phone home.
+2. **No mandatory cloud account.** The desktop app launches and is fully usable without any login. Cloud sync (R2) and external drivers (GitHub, Linear) remain opt-in and configured per-user, exactly as in CLI/local-dev mode.
+3. **Data lives in `~/Library/Application Support/gctrl/`.** Uninstalling the app does NOT delete user data; deletion is a deliberate user action (`gctrl reset` or manual). The vault directory remains user-owned and Obsidian-mountable.
+4. **Updates do not require online presence.** The app launches and works without an update check succeeding; auto-update is a background concern.
+
+## Distribution
+
+### v1: Direct DMG
+
+- Download from project website / GitHub Releases.
+- Notarized + stapled DMG; Gatekeeper accepts on first launch without warning.
+- Auto-update via `electron-updater` against an R2-hosted JSON manifest.
+
+### v2 (optional): Homebrew Cask
+
+- Submit cask to `homebrew/homebrew-cask` once the DMG cadence is stable.
+- Cask references the GitHub Releases asset; `brew upgrade --cask gctrl` works.
+
+### Out of scope for v1
+
+- **Mac App Store (MAS).** The App Sandbox + localhost-binding kernel is a known review-risk combination. Auto-update inside MAS is also forbidden, which would force a divergent update path. Revisit only if a sandbox-friendly architecture is needed.
+- **Windows / Linux desktop.** Electron supports both, but they are not v1 targets. Linux distribution (`.deb`, `.rpm`, AppImage) and Windows installer (`.exe` via Squirrel) can be added later without changing the architecture — the kernel sidecar pattern is portable.
+
+## Mobile Relationship
+
+The mobile app is **a separate codebase with a different feature set**. It does NOT embed the kernel and is not a port of the desktop app. See [gctrl-mobile.md](gctrl-mobile.md) for the mobile architecture, scope, and rationale.
+
+The kernel-as-HTTP-server design means desktop and mobile are decoupled: they share kernel HTTP contracts (defined by the shell + apps), not UI code. This is intentional — mobile and desktop have different ergonomic targets, different feature subsets, and different platform constraints (iOS sandbox vs. macOS user filesystem).
+
+## Implementation Reference
+
+Concrete bundling, signing, notarization, and CI details live in the implementation spec:
+
+- [implementation/apps/desktop-electron.md](../../implementation/apps/desktop-electron.md) — `electron-builder` config, kernel sidecar bundling, code signing, hardened-runtime entitlements, universal binary build, auto-update wiring, CI workflow.
+
+## Related
+
+- [os.md](../os.md) — Unix layer model; dependency direction invariant
+- [principles.md](../../principles.md) — local-first, vendor independence, malleability
+- [gctrl-board.md](gctrl-board.md) — the React UI bundled by the desktop app
+- [implementation/apps/deployment.md](../../implementation/apps/deployment.md) — Cloudflare Worker deployment (the parallel runtime mode)
+- [gctrl-mobile.md](gctrl-mobile.md) — mobile app architecture (separate scope)

--- a/vault/specs/architecture/apps/gctrl-mobile.md
+++ b/vault/specs/architecture/apps/gctrl-mobile.md
@@ -1,0 +1,146 @@
+# gctrl Mobile — Remote-Only Companion App
+
+The gctrl mobile app is a **remote-only companion** for iOS and Android, scoped to a strict subset of the desktop feature set. It does NOT bundle the kernel; it does NOT store DuckDB locally; it is NOT a port of the desktop app. Mobile is closer in shape to the hosted Cloudflare Worker SPA than to the Electron desktop bundle — a thin client over HTTP, designed for the operations a user performs while away from their primary machine.
+
+This is a deliberate divergence from the desktop architecture. Mobile and desktop share kernel HTTP contracts, not UI code or runtime model.
+
+## Scope
+
+### In scope (v1)
+
+The mobile app supports three feature areas: **agent comms, prompting, and analytics**. These are read-mostly, low-state-mutation surfaces that work well over a network and do not require local DuckDB.
+
+| Feature area | Surface | Read or write | Backend route(s) |
+|---|---|---|---|
+| **Agent comms** | View running and recent sessions; tail span events live; receive push notification on session completion or guardrail intervention | Read + acknowledge | `/api/sessions/*`, `/api/sessions/:id/stream` (SSE), `/api/inbox/*` |
+| **Prompting** | View prompt history; trigger an agent dispatch (e.g. assign agent to an Issue, kick off a scheduled prompt); attach context from clipboard or share sheet | Write (dispatch) | `/api/team/recommend`, `/api/team/render`, `/api/board/issues/:id/move`, `/api/orchestrate/dispatch` |
+| **Analytics** | Cost summaries, latency p95s, token usage by day/model/persona; alerts list; daily aggregates | Read | `/api/analytics/*` |
+
+### Out of scope (v1)
+
+The mobile app explicitly omits surfaces that are unsuitable for remote-only operation, would be redundant on a small screen, or would require shipping the kernel:
+
+- **Local kernel.** No DuckDB on device; no sidecar binary; no local span ingestion.
+- **Vault editing.** The Obsidian-mountable vault is desktop-only; mobile does not mount or edit Markdown.
+- **Web crawling, browser control, network proxy.** Utilities under `gctrl net *` and `gctrl browser *` are kernel-side only.
+- **Eval engine, local model routing.** All LLM calls flow through the cloud kernel.
+- **Settings that touch local filesystem or system services.** Driver configuration, secrets, notarization-equivalent flows.
+
+If a feature requires the kernel, it is not in the mobile scope. If the feature can be expressed as "GET data, render it" or "POST a small command," it is a mobile candidate.
+
+## Architectural Position
+
+```mermaid
+flowchart TB
+  subgraph Device["Mobile Device (iOS / Android)"]
+    App["gctrl Mobile App<br/>(thin HTTP/SSE client + push)"]
+  end
+
+  subgraph Cloud["Hosted gctrl (Cloudflare)"]
+    Worker["gctrl-board Worker<br/>(unchanged from desktop cloud mode)"]
+    D1["D1 (board state at the edge)"]
+    KernelHosted["Hosted Kernel<br/>(future — for full feature parity)"]
+  end
+
+  subgraph User["User's Desktop (optional, intermittent)"]
+    Local["Local Kernel<br/>(127.0.0.1:4318)"]
+    Sync["Cloud Sync<br/>(R2 Parquet export)"]
+  end
+
+  App -->|"HTTPS /api/*"| Worker
+  App -->|"SSE for live spans"| Worker
+  Worker -->|"D1 binding"| D1
+  Worker -.->|"proxies select routes"| KernelHosted
+  Local -.->|"R2 sync (opt-in)"| Sync
+  Sync -.->|"feeds analytics"| Worker
+  Worker -.->|"APNs / FCM"| App
+```
+
+**Three separate runtime targets, one set of HTTP contracts:**
+
+1. **Desktop (Electron + local kernel)** — full feature set, source of truth for user data. See [gctrl-desktop.md](gctrl-desktop.md).
+2. **Cloud (Cloudflare Worker SPA)** — public hosted instance, also the backend the mobile app talks to. See [implementation/apps/deployment.md](../../implementation/apps/deployment.md).
+3. **Mobile (this spec)** — thin client over the same Worker. Native iOS/Android shell.
+
+The Worker plays two roles: it serves the public SPA (browsers) AND the mobile app (native HTTP/SSE clients). The kernel HTTP contracts shape both.
+
+## Why No Kernel on Mobile
+
+Shipping the kernel to mobile would be a significant architecture change for marginal user benefit. The constraints are concrete, not philosophical:
+
+1. **iOS sandbox.** No `fork`, restricted filesystem, no arbitrary `localhost` binding without entitlements unavailable to non-system apps. The kernel as it stands cannot run as a sidecar process on iOS. A Rust *library* (`cargo-lipo` + Swift bridge) would be possible but is a wholesale rewrite of how the kernel is exposed.
+2. **DuckDB on mobile is not a goal.** Vault, sessions, telemetry, and analytics live on the user's primary machine. Mobile is for monitoring and lightweight intervention, not parallel local-first operation.
+3. **Battery and storage.** A persistent OTel ingestion daemon on a phone is the wrong shape for a mobile lifecycle (background termination, cold starts, foreground-only network).
+4. **Sync complexity.** Two writable kernels (desktop + mobile) across devices needs CRDT-grade conflict resolution. R2 sync ([kernel/sync.md](../kernel/sync.md)) is designed for read replicas, not multi-master.
+
+The remote-only design accepts an explicit tradeoff: **mobile requires connectivity to be useful.** This is fine for the scoped feature set — checking on agents, kicking off prompts, viewing analytics — and is consistent with how users already think about phone-vs-laptop work boundaries.
+
+## How Mobile Talks to Cloud
+
+The mobile app talks to the same `gctrl-board` Cloudflare Worker that serves the public SPA. No new backend is introduced for mobile.
+
+| Concern | Mechanism |
+|---|---|
+| **Auth** | Session token issued by the Worker after sign-in (OAuth via GitHub for v1). Stored in iOS Keychain / Android EncryptedSharedPreferences. |
+| **Data fetch** | Standard HTTPS to `/api/*` routes. ETags / `If-None-Match` for caching. |
+| **Live updates** | EventSource (SSE) for session streams; falls back to polling when SSE is unavailable on mobile network paths. |
+| **Push notifications** | Worker emits to APNs (iOS) and FCM (Android) on session completion, guardrail signal, alert firing. |
+| **Offline** | Read-only cache of last-fetched analytics and inbox. Writes (dispatch) require connectivity; the UI surfaces this clearly. |
+
+## Tech Stack: Deferred Decision
+
+The mobile framework is **not chosen yet**. v1 is scoped intentionally so the choice can be made when mobile becomes a real product priority, not as a side-effect of the desktop decision.
+
+The three viable options, ranked by likely fit:
+
+| Option | When it wins | Cost |
+|---|---|---|
+| **React Native** | Maximum reuse of Effect-TS domain types from `packages/domain` and existing TS schemas; team already fluent in TS+React; some component patterns transfer | Native module surface still required for push, deep links, biometrics |
+| **Native (Swift + Kotlin/Compose)** | Best UX, smallest binaries, cleanest platform integration; what 1Password does | Two codebases, two languages, two CI pipelines; longer cycle |
+| **Flutter** | One mobile codebase across iOS/Android, single design language | Brand-new ecosystem for the team; no shared code with web/desktop |
+
+**Capacitor (wrap the React SPA) is explicitly rejected.** The desktop research surfaced that `@dnd-kit` and dense React 19 interactions fight WKWebView gesture handling on touch — the same UX failure mode that pushed many "wrap your web app" projects to native rewrites. The mobile feature set is small enough that a native or React Native app is feasible without the Capacitor compromise.
+
+A decision is expected when mobile moves from "future work" to "next quarter" — not before.
+
+## Relationship to the Cloud Worker SPA
+
+The hosted `gctrl-board` Cloudflare Worker SPA already solves most of mobile's data-access problem. Mobile v1 can be modeled as: "the Cloudflare SPA, but as a native app with push notifications and a touch-optimized layout."
+
+Concretely:
+- The mobile app uses the same `/api/*` contracts the Worker SPA already consumes.
+- Server-side rendering, D1 reads, and analytics aggregations are reused unchanged.
+- Mobile-specific additions on the Worker are limited to: APNs/FCM dispatch, session-token issuance, and any view models that don't make sense for the desktop SPA (e.g. condensed inbox digests).
+
+This means mobile development can begin without changes to the kernel and with minimal changes to the Worker — most of the "cloud backend for mobile" is already deployed.
+
+## Local-First Compatibility
+
+The desktop app remains the source of truth for user data. The mobile app is a *projection* of state that lives on the user's primary machine, accessed via cloud sync.
+
+The flow:
+
+1. User runs gctrl Desktop locally; kernel writes DuckDB.
+2. Cloud Sync ([kernel/sync.md](../kernel/sync.md)) periodically exports Parquet to the user's R2 bucket.
+3. The Cloudflare Worker reads from R2 to serve aggregations to the mobile app.
+4. The mobile app renders and notifies; writes (dispatch, acknowledgements) flow back to the Worker, which queues them for the desktop kernel to pick up on next sync OR routes them through the future hosted-kernel surface.
+
+For users who run *only* the cloud Worker (no desktop install), the mobile app works directly against the Worker's edge state — no R2 sync involved. For users who run only desktop (no R2 sync configured), mobile shows an empty state with a clear message: "Connect cloud sync to use the mobile app."
+
+This preserves [principles.md](../../principles.md) § Design Principles #3: **local-first, cloud-optional**. Mobile is itself opt-in; it does not change desktop behavior.
+
+## Out-of-Scope Discussions
+
+To prevent scope creep, the following are explicit non-goals for the mobile spec and should not be added without revisiting this document:
+
+- **Editing the vault from mobile.** Obsidian's mobile app exists; gctrl does not duplicate it.
+- **Running agents on the device.** Agents run where the kernel runs (desktop, or future hosted kernel). Mobile triggers them; it does not host them.
+- **Custom mobile-only data formats.** All mobile data flows through existing kernel HTTP contracts. New routes can be added on the Worker, but no parallel data model.
+- **Native widgets / Live Activities (iOS) / App Shortcuts (Android).** Out of v1; possible v2 once the core feature set is shipped.
+
+## Related
+
+- [gctrl-desktop.md](gctrl-desktop.md) — Electron desktop app architecture; deliberately separate codebase
+- [implementation/apps/deployment.md](../../implementation/apps/deployment.md) — Cloudflare Worker SPA the mobile app shares a backend with
+- [kernel/sync.md](../kernel/sync.md) — R2 cloud sync that feeds mobile
+- [principles.md](../../principles.md) — local-first invariant; remote-only mobile preserves it

--- a/vault/specs/implementation/apps/desktop-electron.md
+++ b/vault/specs/implementation/apps/desktop-electron.md
@@ -1,0 +1,464 @@
+# gctrl Desktop — Electron Implementation
+
+Implementation reference for the Electron-based macOS distribution. The architecture, layer boundaries, and stack-choice rationale live in [architecture/apps/gctrl-desktop.md](../../architecture/apps/gctrl-desktop.md). This document covers concrete tooling, project layout, build pipeline, signing/notarization, auto-update, and CI.
+
+## Project Layout
+
+The desktop app lives under `apps/gctrl-desktop/`. It does not introduce a new domain app — it is a packaging layer that consumes the existing React frontend from `apps/gctrl-board/web/` and the Rust kernel binary built by `kernel/`.
+
+```
+apps/gctrl-desktop/
+├── package.json                      ← electron-builder + electron-updater deps
+├── electron.vite.config.ts           ← electron-vite multi-target build
+├── tsconfig.json
+├── src/
+│   ├── main/                         ← Electron main process (Node)
+│   │   ├── index.ts                  ← app lifecycle, window mgmt
+│   │   ├── kernel-sidecar.ts         ← spawn / watchdog the Rust kernel
+│   │   ├── menu.ts                   ← native macOS menu bar
+│   │   └── updater.ts                ← electron-updater integration
+│   └── preload/
+│       └── index.ts                  ← contextBridge (intentionally minimal)
+├── build/
+│   ├── entitlements.mac.plist        ← hardened-runtime entitlements
+│   ├── icon.icns
+│   └── notarize.cjs                  ← @electron/notarize afterSign hook
+├── resources/
+│   └── kernel/                       ← populated at build time by CI
+│       └── gctrl-kernel              ← universal2 binary (built by cargo-zigbuild)
+└── README.md
+```
+
+The renderer is *not* in this package. The build pipeline copies the prebuilt SPA bundle from `apps/gctrl-board/dist-web/` into the Electron `dist/` output. This ensures one source of truth for the React UI across all runtime modes.
+
+## Tooling
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| **`electron-vite`** | Multi-target Vite build for main + preload + renderer | Picked over Electron Forge: forge's Vite plugin is still marked experimental |
+| **`electron-builder`** | Packaging into `.app` / `.dmg`, code signing, ASAR, autoupdate metadata | Industry standard; supports `extraResources` for sidecar binary |
+| **`@electron/notarize`** | Apple notarization via `notarytool` | Invoked from `electron-builder`'s `afterSign` hook |
+| **`electron-updater`** | Auto-update from a hosted feed | Used with `generic` provider (R2-hosted JSON manifest) or GitHub Releases |
+| **`@1password/electron-hardener`** | Optional: defense-in-depth wrapper from 1Password | Locks down powerful Electron APIs not used by the renderer |
+| **`cargo-zigbuild`** | Cross-compile Rust kernel as `universal2-apple-darwin` | Produces single binary for arm64 + x86_64; runs on any host |
+
+`pnpm` is the package manager — consistent with the rest of the workspace. The `apps/gctrl-desktop` package is registered in `pnpm-workspace.yaml`.
+
+## Build Pipeline
+
+End-to-end build for a release `.dmg`:
+
+```mermaid
+flowchart LR
+  Rust["cargo-zigbuild<br/>--target universal2-apple-darwin"] --> KernelBin["resources/kernel/gctrl-kernel<br/>(universal2)"]
+  Web["pnpm --filter gctrl-board build:web"] --> WebDist["apps/gctrl-board/dist-web/"]
+  Main["electron-vite build<br/>(main + preload + renderer)"] --> ElectronDist["apps/gctrl-desktop/dist/"]
+  WebDist --> ElectronDist
+  KernelBin --> Builder
+  ElectronDist --> Builder["electron-builder --mac"]
+  Builder --> Signed["gctrl-{version}-mac.dmg<br/>(signed + notarized + stapled)"]
+```
+
+### `electron-builder` Configuration
+
+`apps/gctrl-desktop/package.json` `build` section:
+
+```json
+{
+  "build": {
+    "appId": "dev.fractalbox.gctrl",
+    "productName": "gctrl",
+    "directories": {
+      "buildResources": "build",
+      "output": "release"
+    },
+    "files": [
+      "dist/**/*",
+      "package.json"
+    ],
+    "extraResources": [
+      {
+        "from": "resources/kernel/",
+        "to": "kernel/",
+        "filter": ["**/*"]
+      }
+    ],
+    "asar": true,
+    "asarUnpack": ["resources/kernel/**"],
+    "mac": {
+      "category": "public.app-category.developer-tools",
+      "target": [
+        { "target": "dmg", "arch": ["universal"] }
+      ],
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "notarize": false
+    },
+    "afterSign": "build/notarize.cjs",
+    "publish": {
+      "provider": "generic",
+      "url": "https://updates.gctrl.dev/mac"
+    }
+  }
+}
+```
+
+Key flags:
+
+- **`asarUnpack: ["resources/kernel/**"]`** — without this, the kernel binary is packed inside `app.asar` and cannot be `execFile`'d.
+- **`hardenedRuntime: true`** + entitlements file — required for notarization and for V8 JIT to function.
+- **`notarize: false`** at the builder level — we run notarization explicitly from `afterSign` for better error visibility and CI logging.
+- **`target: dmg, arch: universal`** — produces a single universal2 DMG. The `extraResources` kernel binary must also be universal2 (built by `cargo-zigbuild`).
+
+### Hardened-Runtime Entitlements
+
+`build/entitlements.mac.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+</dict>
+</plist>
+```
+
+Rationale per entitlement:
+
+- `allow-jit` — Electron's V8 JIT compiles JS to native code at runtime.
+- `allow-unsigned-executable-memory` — V8 writes generated code to RWX pages.
+- `disable-library-validation` — Electron loads its own native modules (e.g. ASAR helpers) that aren't signed by Apple.
+- `network.client` — the renderer makes outbound HTTP to the kernel sidecar on `127.0.0.1:4318` and to update feeds.
+- `network.server` — the kernel sidecar binds a listening socket on `127.0.0.1:4318`. *Note: Apple may flag inbound connections at MAS review; this is one of the reasons we skip MAS for v1.*
+
+### Universal Kernel Binary (`cargo-zigbuild`)
+
+```sh
+# One-time setup
+brew install zig
+cargo install --locked cargo-zigbuild
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+# Build (in CI or locally)
+cargo zigbuild \
+  --release \
+  --workspace \
+  --target universal2-apple-darwin \
+  --bin gctrl
+
+# Output
+ls target/universal2-apple-darwin/release/gctrl
+# → universal2 binary; verify with: file target/universal2-apple-darwin/release/gctrl
+
+# Copy into desktop bundle
+mkdir -p apps/gctrl-desktop/resources/kernel
+cp target/universal2-apple-darwin/release/gctrl \
+   apps/gctrl-desktop/resources/kernel/gctrl-kernel
+```
+
+`cargo-zigbuild` is preferred over manual `lipo` because it cross-compiles in one invocation and works on any CI host (no need for x86_64 macOS runners).
+
+## Kernel Sidecar Lifecycle
+
+`src/main/kernel-sidecar.ts` is the only place where the kernel binary is spawned, watched, and shut down. Cross-cutting concerns (logging, restart policy) live here, not in the renderer.
+
+```typescript
+import { app } from "electron"
+import { execFile, ChildProcess } from "node:child_process"
+import { join } from "node:path"
+
+const KERNEL_PORT = 4318
+const RESTART_BACKOFF_MS = [1000, 2000, 5000, 15000, 60000]
+
+let kernel: ChildProcess | null = null
+let restartCount = 0
+
+const kernelPath = () =>
+  app.isPackaged
+    ? join(process.resourcesPath, "kernel", "gctrl-kernel")
+    : join(__dirname, "../../resources/kernel/gctrl-kernel")
+
+export const startKernel = () => {
+  const dataDir = join(app.getPath("userData"), "kernel")
+  kernel = execFile(
+    kernelPath(),
+    ["serve", "--port", String(KERNEL_PORT), "--data-dir", dataDir, "--bind", "127.0.0.1"],
+    { env: { ...process.env, RUST_LOG: "info" } }
+  )
+  kernel.stdout?.on("data", (d) => console.log("[kernel]", d.toString()))
+  kernel.stderr?.on("data", (d) => console.error("[kernel]", d.toString()))
+  kernel.on("exit", (code, signal) => onKernelExit(code, signal))
+}
+
+const onKernelExit = (code: number | null, signal: NodeJS.Signals | null) => {
+  if (app.isQuitting) return
+  const delay = RESTART_BACKOFF_MS[Math.min(restartCount, RESTART_BACKOFF_MS.length - 1)]
+  console.warn(`[kernel] exited code=${code} signal=${signal}; restart in ${delay}ms`)
+  restartCount += 1
+  setTimeout(startKernel, delay)
+}
+
+export const stopKernel = () => {
+  if (!kernel) return
+  kernel.kill("SIGTERM")
+  kernel = null
+}
+
+app.on("before-quit", stopKernel)
+```
+
+**Invariants:**
+
+1. The kernel binds `127.0.0.1` exclusively. Never `0.0.0.0`. (This avoids inadvertently exposing the local kernel on a shared network and reduces App Store review risk.)
+2. The kernel's `--data-dir` is always `app.getPath("userData") + "/kernel"`, mapping to `~/Library/Application Support/gctrl/kernel/` on macOS. This directory survives app uninstall.
+3. The renderer never spawns the kernel and never knows where the binary is. All kernel access is HTTP.
+4. Watchdog uses bounded exponential backoff. After repeated failures, the renderer surfaces a banner with a "Restart kernel" button that resets the counter and calls `startKernel()`.
+
+## Renderer Wiring
+
+The React SPA from `apps/gctrl-board/web/` is reused unchanged except for two configuration points:
+
+1. **Router** — switch from `BrowserRouter` to `HashRouter` (or `app://` custom protocol) so file:// loads work.
+2. **API base URL** — the existing `request<T>(path)` wrapper in `web/src/api/` reads from a build-time environment variable. Desktop builds set it to `http://127.0.0.1:4318`; cloud builds leave it empty (relative paths resolve to the Worker origin).
+
+```typescript
+// web/src/api/base.ts
+export const API_BASE =
+  import.meta.env.VITE_API_BASE ?? ""  // "" in cloud mode → relative to current origin
+```
+
+```sh
+# Cloud build (existing)
+pnpm --filter gctrl-board build:web
+
+# Desktop build
+VITE_API_BASE=http://127.0.0.1:4318 pnpm --filter gctrl-board build:web
+```
+
+Everything else — components, drag-drop, EventSource for `/api/sessions/:id/stream`, analytics views — is identical between cloud and desktop.
+
+### Preload Script (Minimal)
+
+`src/preload/index.ts` exposes only what the renderer needs that *cannot* be accomplished with `fetch`. Per the architecture, this should be near-empty.
+
+```typescript
+import { contextBridge, ipcRenderer } from "electron"
+
+contextBridge.exposeInMainWorld("desktop", {
+  openExternal: (url: string) => ipcRenderer.invoke("open-external", url),
+  showInFinder: (path: string) => ipcRenderer.invoke("show-in-finder", path),
+  appVersion: () => ipcRenderer.invoke("app-version"),
+})
+```
+
+`nodeIntegration: false`, `contextIsolation: true`, `sandbox: true` are non-negotiable.
+
+## Code Signing and Notarization
+
+### One-Time Apple Setup
+
+1. Apple Developer Program membership ($99/yr).
+2. Generate `Developer ID Application` certificate via Apple Developer portal or Xcode → export as `.p12` with password.
+3. Generate App Store Connect API key (Users and Access → Keys → App Manager role) → download `.p8`, note Key ID and Issuer ID.
+4. Register the bundle ID `dev.fractalbox.gctrl` (placeholder — replace with chosen ID).
+
+### Required Environment Variables (CI)
+
+| Variable | Purpose |
+|---|---|
+| `CSC_LINK` | Base64-encoded `.p12` file contents (passed to `electron-builder`) |
+| `CSC_KEY_PASSWORD` | Password for the `.p12` |
+| `APPLE_API_KEY` | Path to the App Store Connect API key (`.p8`) |
+| `APPLE_API_KEY_ID` | Key ID from App Store Connect |
+| `APPLE_API_ISSUER` | Issuer ID from App Store Connect |
+| `APPLE_TEAM_ID` | 10-character Apple Team ID |
+
+`electron-builder` reads `CSC_LINK` / `CSC_KEY_PASSWORD` and signs every binary inside the `.app`. The `afterSign` hook then notarizes:
+
+```javascript
+// build/notarize.cjs
+const { notarize } = require("@electron/notarize")
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context
+  if (electronPlatformName !== "darwin") return
+  const appName = context.packager.appInfo.productFilename
+  return notarize({
+    tool: "notarytool",
+    appPath: `${appOutDir}/${appName}.app`,
+    appleApiKey: process.env.APPLE_API_KEY,
+    appleApiKeyId: process.env.APPLE_API_KEY_ID,
+    appleApiIssuer: process.env.APPLE_API_ISSUER,
+    teamId: process.env.APPLE_TEAM_ID,
+  })
+}
+```
+
+### Sidecar Signing
+
+The kernel binary inside `Contents/Resources/kernel/gctrl-kernel` MUST be signed individually with the same Developer ID Application identity. `electron-builder` signs `extraResources` automatically *if* they are flagged as binaries — this happens by default for files without a recognized text extension. Verify after every build:
+
+```sh
+codesign --verify --deep --strict --verbose=2 "release/mac/gctrl.app"
+spctl -a -t exec -vv "release/mac/gctrl.app"
+```
+
+If the sidecar is unsigned, Gatekeeper rejects the bundle on a fresh Mac (works locally, fails when downloaded). This is the most common first-ship failure — always test by downloading the DMG to a Mac that has never had your dev cert in its keychain.
+
+## Auto-Update
+
+`electron-updater` checks an update feed on app launch and at 4-hour intervals. v1 uses a `generic` provider hosted on Cloudflare R2:
+
+```
+https://updates.gctrl.dev/mac/
+├── latest-mac.yml          ← electron-updater manifest
+├── gctrl-1.2.3-mac.dmg
+├── gctrl-1.2.3-mac.zip     ← required by electron-updater for delta updates
+└── gctrl-1.2.3-mac.dmg.blockmap
+```
+
+The manifest is regenerated by `electron-builder` during `pnpm release` and uploaded to R2 by CI alongside the DMG. Updates are signed by the same Developer ID certificate; Squirrel verifies the signature before applying.
+
+```typescript
+// src/main/updater.ts
+import { autoUpdater } from "electron-updater"
+
+export const initAutoUpdater = () => {
+  autoUpdater.logger = console
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.checkForUpdatesAndNotify().catch(console.error)
+  setInterval(() => autoUpdater.checkForUpdatesAndNotify().catch(console.error), 4 * 60 * 60 * 1000)
+}
+```
+
+## CI Workflow Sketch
+
+`.github/workflows/release-mac.yml` (skeleton — to be implemented when desktop work begins):
+
+```yaml
+name: release-mac
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: macos-14   # arm64 runner; cargo-zigbuild produces universal2 from any host
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: dtolnay/rust-toolchain@stable
+        with: { targets: aarch64-apple-darwin,x86_64-apple-darwin }
+
+      - name: Install zig + cargo-zigbuild
+        run: |
+          brew install zig
+          cargo install --locked cargo-zigbuild
+
+      - name: Build kernel (universal2)
+        run: |
+          cargo zigbuild --release --workspace --target universal2-apple-darwin --bin gctrl
+          mkdir -p apps/gctrl-desktop/resources/kernel
+          cp target/universal2-apple-darwin/release/gctrl apps/gctrl-desktop/resources/kernel/gctrl-kernel
+
+      - name: Build web bundle
+        run: |
+          pnpm install --frozen-lockfile
+          VITE_API_BASE=http://127.0.0.1:4318 pnpm --filter gctrl-board build:web
+
+      - name: Build + sign + notarize
+        env:
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/apple_key.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 -d > "$APPLE_API_KEY"
+          pnpm --filter gctrl-desktop build
+          pnpm --filter gctrl-desktop release
+
+      - name: Upload to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          # rclone or aws s3 cp with --endpoint-url
+          aws s3 cp apps/gctrl-desktop/release/ s3://$R2_BUCKET/mac/ \
+            --endpoint-url https://<account>.r2.cloudflarestorage.com \
+            --recursive --exclude "*" \
+            --include "*.dmg" --include "*.zip" --include "*.yml" --include "*.blockmap"
+```
+
+## Local Development
+
+Two distinct local-dev modes for the desktop app:
+
+| Mode | Command | What runs |
+|---|---|---|
+| **Renderer dev (hot reload)** | `pnpm --filter gctrl-desktop dev` | electron-vite hot-reloads main + renderer; kernel must be started separately (`cargo run -- serve`) |
+| **Production-shaped local build** | `pnpm --filter gctrl-desktop build && open release/mac/gctrl.app` | Builds the bundle without signing; useful for catching bundling regressions |
+
+The renderer-dev mode is the day-to-day workflow. The bundled-kernel mode is for pre-release verification.
+
+## First-Ship Checklist
+
+1. ☐ Apple Developer Program membership active
+2. ☐ `Developer ID Application` cert in Keychain + `.p12` exported with password
+3. ☐ App Store Connect API key (`.p8`, key ID, issuer ID) generated
+4. ☐ Bundle ID registered (`dev.fractalbox.gctrl` or chosen)
+5. ☐ `cargo-zigbuild` produces a universal2 kernel binary that runs on both arm64 and x86_64 Macs
+6. ☐ `electron-builder` config with `extraResources` + `asarUnpack` + hardened-runtime entitlements
+7. ☐ `afterSign` notarize hook produces a stapled `.dmg`
+8. ☐ Verified: `codesign --verify --deep` and `spctl -a -t exec` both pass
+9. ☐ **Downloaded the DMG to a Mac that has never had your dev cert in its keychain**, opened it, app launches without Gatekeeper warning
+10. ☐ Auto-update feed (`latest-mac.yml`) hosted on R2; version bump triggers update on a stale install
+11. ☐ R2 / Cloudflare credentials stored in GitHub Actions secrets
+12. ☐ CI workflow produces a signed DMG end-to-end on tag push
+
+## Known Failure Modes
+
+| Symptom | Likely cause |
+|---|---|
+| App launches, Gatekeeper says "damaged" on a fresh Mac | Sidecar binary not signed; check `codesign --verify --deep` |
+| App quits immediately on launch with `EXC_BAD_ACCESS` in V8 | Missing `com.apple.security.cs.allow-jit` entitlement |
+| Auto-update never finds new version | `latest-mac.yml` not regenerated, or `publish.url` mismatch |
+| Kernel never starts; `kernel-sidecar.ts` logs ENOENT | `asarUnpack` missing for `resources/kernel/**` |
+| Notarization succeeds but Gatekeeper still complains | Missing `xcrun stapler staple` step (electron-builder runs this automatically; verify) |
+| First-launch hang, then works | macOS quarantine xattr; user must allow once via System Settings → Privacy & Security |
+
+## Out of Scope
+
+The implementation is intentionally narrow. The following are explicit non-goals for v1 and should not be added without revisiting [architecture/apps/gctrl-desktop.md](../../architecture/apps/gctrl-desktop.md):
+
+- Mac App Store target (separate provisioning profile, sandbox entitlements, and the localhost-kernel review risk)
+- Windows / Linux build targets
+- Custom IPC bridge for kernel data (`fetch` to localhost is sufficient and keeps cloud + desktop unified)
+- Multi-window / multi-tab UI (the React SPA is single-window today)
+- Native macOS menu bar / status bar (tray) UX (post-v1; possible to add via `Tray` API without architectural changes)
+
+## Related
+
+- [architecture/apps/gctrl-desktop.md](../../architecture/apps/gctrl-desktop.md) — desktop app architecture and stack rationale
+- [architecture/apps/gctrl-mobile.md](../../architecture/apps/gctrl-mobile.md) — mobile companion (separate codebase)
+- [implementation/apps/deployment.md](deployment.md) — Cloudflare Worker deployment (cloud runtime)
+- [architecture/os.md](../../architecture/os.md) — Unix layer model


### PR DESCRIPTION
## Summary

- Adds `architecture/apps/gctrl-desktop.md` — Electron-based macOS distribution with a Rust kernel sidecar bundled inside the .app. Preserves local-first invariants (renderer fetches `http://127.0.0.1:4318` directly; no IPC bridge for kernel data). Includes the Electron vs Tauri 2 vs Flutter decision matrix and the runtime-mode table (Cloud Worker / local dev / Electron desktop).
- Adds `architecture/apps/gctrl-mobile.md` — remote-only companion scoped to agent comms + prompting + analytics. Hits the same Cloudflare Worker as the public SPA plus APNs/FCM for push. Explicitly does NOT bundle the kernel (iOS sandbox + DuckDB on mobile out of scope). Framework choice deferred.
- Adds `implementation/apps/desktop-electron.md` — concrete `electron-builder` config, kernel sidecar lifecycle code, hardened-runtime entitlements plist, `cargo-zigbuild` universal2 binary, `@electron/notarize` afterSign hook, `electron-updater` wired against an R2-hosted feed, GitHub Actions `release-mac` workflow skeleton, and a first-ship checklist.
- Indexes both new architecture specs in `architecture/README.md` and reframes the apps section as "applications, utilities, and distribution targets".

The stray `gctl` → `gctrl` reference fixes that were originally bundled here are split out into #124.

## Test plan
- [x] Specs render in Obsidian with valid wikilinks
- [x] Decision matrix and runtime-mode tables read correctly
- [x] No code changes — docs-only PR
