### PR TITLE
feat(driver-rss): RSS/Atom/JSON Feed → vault input/raw/ pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "feed-rs"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c0591d23efd0d595099af69a31863ac1823046b1b021e3b06ba3aae7e00991"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.2",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1725,7 @@ dependencies = [
  "axum",
  "chrono",
  "duckdb",
+ "feed-rs",
  "futures-core",
  "gctrl-context",
  "gctrl-core",
@@ -1721,10 +1739,13 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -2815,6 +2836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3477,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -4906,6 +4946,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ sha2 = "0.10"
 # URL parsing
 url = "2"
 
+# Feed parsing (RSS 2.0 + Atom + JSON Feed) — used by driver-rss
+feed-rs = "2"
+
 # Filesystem paths
 dirs = "6"
 

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -27,8 +27,13 @@ tracing = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 http = { workspace = true }
+# driver-rss
+feed-rs = { workspace = true }
+sha2 = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }
 http-body-util = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod contributions;
 pub mod event_bus;
 pub mod receiver;
+pub mod rss;
 pub mod span_processor;
 
 pub use event_bus::{EventBus, ReplayResult, SessionEvent};

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -243,6 +243,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         // /completions → Workers AI OpenAI-compat upstream (e.g. @cf/google/gemma-*)
         .route("/api/llm/messages", post(llm_messages))
         .route("/api/llm/completions", post(llm_completions))
+        // RSS driver (LKM — fetch + parse RSS/Atom/JSON Feed, write entries
+        // to a vault dir under `<vault>/input/raw/`)
+        .route("/api/rss/poll", post(rss_poll))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -4304,6 +4307,80 @@ fn llm_capture_header(headers: &HeaderMap, name: &str) -> Option<String> {
         .get(name)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
+}
+
+// =============================================================================
+// driver-rss — fetch + parse RSS/Atom/JSON Feed → vault markdown.
+// Scheduler wiring (cron-driven polling) lands in a follow-up after the
+// kb→kernel promotion (#104) defines the canonical vault mount port.
+// =============================================================================
+
+#[derive(Deserialize)]
+struct RssPollBody {
+    feed_url: String,
+    /// Absolute path to a vault root. Entries land under
+    /// `<vault_dir>/input/raw/<YYYY-MM-DD>--<slug>--<guid_hash8>.md`.
+    vault_dir: String,
+}
+
+async fn rss_poll(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<RssPollBody>,
+) -> impl IntoResponse {
+    let bytes = match state.http_client.get(&body.feed_url).send().await {
+        Ok(r) => match r.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!("read feed body: {e}"),
+                )
+                    .into_response()
+            }
+        },
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("fetch feed: {e}"),
+            )
+                .into_response()
+        }
+    };
+
+    let entries = match crate::rss::parse_feed(&bytes) {
+        Ok(es) => es,
+        Err(e) => {
+            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response()
+        }
+    };
+
+    let vault = std::path::PathBuf::from(&body.vault_dir);
+    let mut written: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    let mut failed: Vec<serde_json::Value> = Vec::new();
+    for entry in &entries {
+        match crate::rss::write_entry(&vault, entry, &body.feed_url) {
+            Ok(crate::rss::WriteOutcome::Written(p)) => {
+                written.push(p.to_string_lossy().into_owned())
+            }
+            Ok(crate::rss::WriteOutcome::SkippedExisting(p)) => {
+                skipped.push(p.to_string_lossy().into_owned())
+            }
+            Err(e) => failed.push(serde_json::json!({
+                "guid": entry.guid,
+                "error": e.to_string(),
+            })),
+        }
+    }
+
+    Json(serde_json::json!({
+        "ok": true,
+        "fetched": entries.len(),
+        "written": written,
+        "skipped": skipped,
+        "failed": failed,
+    }))
+    .into_response()
 }
 
 #[cfg(test)]

--- a/kernel/crates/gctrl-otel/src/rss.rs
+++ b/kernel/crates/gctrl-otel/src/rss.rs
@@ -1,0 +1,354 @@
+//! driver-rss — fetch RSS/Atom/JSON Feed sources, parse via `feed-rs`, and
+//! materialise each new entry as a markdown file under
+//! `<vault_dir>/input/raw/<YYYY-MM-DD>--<slug>.md` with YAML frontmatter.
+//!
+//! Scope of this PR: parsing + slugification + atomic vault write +
+//! filesystem-level dedupe (skip if target file already exists). Scheduler
+//! wiring, profile-driven feed lists, and SQLite index rows land in follow-up
+//! PRs once the kb→kernel promotion (#104) defines the canonical vault
+//! mount port.
+//!
+//! Spec: vault/specs/architecture/apps/uebermensch.md (M1 driver-rss row).
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use feed_rs::parser;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RssError {
+    #[error("feed parse: {0}")]
+    Parse(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid vault dir: {0}")]
+    InvalidVault(String),
+}
+
+/// One parsed feed entry, normalised for downstream consumers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RssEntry {
+    pub guid: String,
+    pub title: String,
+    pub url: Option<String>,
+    pub published_at: Option<DateTime<Utc>>,
+    pub summary: Option<String>,
+    pub content: Option<String>,
+}
+
+/// Result of writing one entry to the vault.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WriteOutcome {
+    Written(PathBuf),
+    SkippedExisting(PathBuf),
+}
+
+pub fn parse_feed(bytes: &[u8]) -> Result<Vec<RssEntry>, RssError> {
+    let feed = parser::parse(bytes).map_err(|e| RssError::Parse(e.to_string()))?;
+    Ok(feed
+        .entries
+        .into_iter()
+        .map(|e| {
+            let title = e.title.map(|t| t.content).unwrap_or_else(|| e.id.clone());
+            let url = e.links.first().map(|l| l.href.clone());
+            let summary = e.summary.map(|s| s.content);
+            let content = e.content.and_then(|c| c.body);
+            RssEntry {
+                guid: e.id,
+                title,
+                url,
+                published_at: e.published.or(e.updated),
+                summary,
+                content,
+            }
+        })
+        .collect())
+}
+
+/// Convert an arbitrary string to a kebab-case slug safe for filenames.
+/// Lowercases, keeps `[a-z0-9]`, collapses everything else to single hyphens,
+/// trims leading/trailing hyphens, and caps at 80 chars to keep paths sane.
+pub fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_hyphen = true; // skip leading hyphens
+    for ch in s.chars() {
+        let c = ch.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+            prev_hyphen = false;
+        } else if !prev_hyphen {
+            out.push('-');
+            prev_hyphen = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        out.push_str("untitled");
+    }
+    if out.len() > 80 {
+        out.truncate(80);
+        while out.ends_with('-') {
+            out.pop();
+        }
+    }
+    out
+}
+
+/// Stable file path: `<vault>/input/raw/<YYYY-MM-DD>--<slug>--<guid_hash8>.md`.
+/// Including a short hash of the GUID prevents collisions when two entries
+/// share a date + title (e.g. multi-feed re-syndication).
+pub fn entry_path(vault_dir: &Path, entry: &RssEntry) -> PathBuf {
+    let date = entry
+        .published_at
+        .unwrap_or_else(Utc::now)
+        .format("%Y-%m-%d");
+    let slug = slugify(&entry.title);
+    let mut hasher = Sha256::new();
+    hasher.update(entry.guid.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    let short = &hash[..8];
+    vault_dir
+        .join("input")
+        .join("raw")
+        .join(format!("{date}--{slug}--{short}.md"))
+}
+
+/// Render frontmatter + body. Single source of truth for what a vault
+/// source page looks like; downstream curators rely on this shape.
+pub fn render_markdown(entry: &RssEntry, feed_url: &str) -> String {
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str("source: driver-rss\n");
+    out.push_str(&format!("feed_url: {feed_url}\n"));
+    if let Some(u) = &entry.url {
+        out.push_str(&format!("entry_url: {u}\n"));
+    }
+    out.push_str(&format!("guid: {}\n", entry.guid));
+    if let Some(t) = entry.published_at {
+        out.push_str(&format!("published_at: {}\n", t.to_rfc3339()));
+    }
+    out.push_str(&format!(
+        "title: {}\n",
+        // YAML scalars containing colons / quotes get fenced; the raw title
+        // is preserved in the H1 below for human reading.
+        yaml_safe(&entry.title)
+    ));
+    out.push_str("---\n\n");
+    out.push_str(&format!("# {}\n\n", entry.title));
+    if let Some(s) = &entry.summary {
+        out.push_str(s);
+        out.push_str("\n\n");
+    }
+    if let Some(c) = &entry.content {
+        out.push_str(c);
+        out.push('\n');
+    }
+    out
+}
+
+fn yaml_safe(s: &str) -> String {
+    // Quote and escape doublequotes — sufficient for titles. Real YAML
+    // multiline strings are out of scope here.
+    let escaped = s.replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Write an entry to the vault, atomically and skip-if-existing.
+/// Returns `SkippedExisting` if the target path is already present —
+/// the dedupe contract for the M1 polling loop.
+pub fn write_entry(
+    vault_dir: &Path,
+    entry: &RssEntry,
+    feed_url: &str,
+) -> Result<WriteOutcome, RssError> {
+    if !vault_dir.exists() {
+        return Err(RssError::InvalidVault(format!(
+            "{} does not exist",
+            vault_dir.display()
+        )));
+    }
+    let path = entry_path(vault_dir, entry);
+    if path.exists() {
+        return Ok(WriteOutcome::SkippedExisting(path));
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = render_markdown(entry, feed_url);
+    // Atomic-ish: write to sibling tmp then rename.
+    let tmp = path.with_extension("md.tmp");
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(WriteOutcome::Written(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const RSS_2_FIXTURE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <link>https://example.com</link>
+    <description>Test</description>
+    <item>
+      <title>Hello, RSS</title>
+      <link>https://example.com/posts/hello</link>
+      <guid isPermaLink="false">post-1</guid>
+      <pubDate>Wed, 01 May 2026 09:00:00 GMT</pubDate>
+      <description>The first post.</description>
+    </item>
+    <item>
+      <title>Second: with colons &amp; ampersands</title>
+      <link>https://example.com/posts/second</link>
+      <guid isPermaLink="false">post-2</guid>
+      <pubDate>Wed, 01 May 2026 10:00:00 GMT</pubDate>
+      <description>Second body.</description>
+    </item>
+  </channel>
+</rss>"#;
+
+    const ATOM_FIXTURE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Example</title>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <updated>2026-05-01T12:00:00Z</updated>
+  <entry>
+    <title>Atom entry one</title>
+    <id>urn:uuid:atom-1</id>
+    <link href="https://atom.example.com/1"/>
+    <updated>2026-05-01T12:00:00Z</updated>
+    <summary>Summary one</summary>
+  </entry>
+</feed>"#;
+
+    #[test]
+    fn parses_rss_2_fixture() {
+        let entries = parse_feed(RSS_2_FIXTURE.as_bytes()).expect("parse");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].title, "Hello, RSS");
+        assert_eq!(entries[0].guid, "post-1");
+        assert_eq!(
+            entries[0].url.as_deref(),
+            Some("https://example.com/posts/hello")
+        );
+        assert!(entries[0].published_at.is_some());
+        assert!(entries[0].summary.is_some());
+    }
+
+    #[test]
+    fn parses_atom_fixture() {
+        let entries = parse_feed(ATOM_FIXTURE.as_bytes()).expect("parse");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "Atom entry one");
+        assert_eq!(entries[0].guid, "urn:uuid:atom-1");
+    }
+
+    #[test]
+    fn rejects_malformed_feed() {
+        let result = parse_feed(b"<not-a-feed>").err();
+        assert!(matches!(result, Some(RssError::Parse(_))));
+    }
+
+    #[test]
+    fn slugify_handles_edge_cases() {
+        assert_eq!(slugify("Hello, World!"), "hello-world");
+        assert_eq!(slugify("  --leading--trailing--  "), "leading-trailing");
+        assert_eq!(slugify("中文 mixed 標題 123"), "mixed-123");
+        assert_eq!(slugify(""), "untitled");
+        assert_eq!(slugify("---"), "untitled");
+        let long = "a".repeat(200);
+        assert!(slugify(&long).len() <= 80);
+    }
+
+    #[test]
+    fn entry_path_includes_date_slug_and_guid_hash() {
+        let entry = RssEntry {
+            guid: "some-guid-1".into(),
+            title: "Hello, World!".into(),
+            url: None,
+            published_at: Some(
+                DateTime::parse_from_rfc3339("2026-05-01T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+            summary: None,
+            content: None,
+        };
+        let p = entry_path(Path::new("/v"), &entry);
+        let s = p.to_string_lossy();
+        assert!(s.contains("input/raw/2026-05-01--hello-world--"));
+        assert!(s.ends_with(".md"));
+    }
+
+    #[test]
+    fn entry_paths_disambiguate_same_date_same_title() {
+        let mk = |guid: &str| RssEntry {
+            guid: guid.into(),
+            title: "Same Title".into(),
+            url: None,
+            published_at: Some(
+                DateTime::parse_from_rfc3339("2026-05-01T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+            summary: None,
+            content: None,
+        };
+        let p1 = entry_path(Path::new("/v"), &mk("a"));
+        let p2 = entry_path(Path::new("/v"), &mk("b"));
+        assert_ne!(p1, p2);
+    }
+
+    #[test]
+    fn write_entry_writes_then_dedupes_on_second_write() {
+        let dir = tempdir().unwrap();
+        let entries = parse_feed(RSS_2_FIXTURE.as_bytes()).unwrap();
+
+        let r1 = write_entry(dir.path(), &entries[0], "https://example.com/feed").unwrap();
+        let path = match r1 {
+            WriteOutcome::Written(p) => p,
+            WriteOutcome::SkippedExisting(_) => panic!("first write should not skip"),
+        };
+        assert!(path.exists());
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.starts_with("---\nsource: driver-rss\n"));
+        assert!(body.contains("guid: post-1"));
+        assert!(body.contains("# Hello, RSS"));
+
+        let r2 = write_entry(dir.path(), &entries[0], "https://example.com/feed").unwrap();
+        assert!(matches!(r2, WriteOutcome::SkippedExisting(_)));
+
+        // No tmp file left behind.
+        let tmp = path.with_extension("md.tmp");
+        assert!(!tmp.exists());
+    }
+
+    #[test]
+    fn write_entry_errors_when_vault_dir_missing() {
+        let entries = parse_feed(RSS_2_FIXTURE.as_bytes()).unwrap();
+        let err = write_entry(
+            Path::new("/nonexistent/vault"),
+            &entries[0],
+            "https://example.com/feed",
+        )
+        .err();
+        assert!(matches!(err, Some(RssError::InvalidVault(_))));
+    }
+
+    #[test]
+    fn render_markdown_includes_frontmatter_and_title() {
+        let entries = parse_feed(RSS_2_FIXTURE.as_bytes()).unwrap();
+        let md = render_markdown(&entries[1], "https://example.com/feed");
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("title: \"Second: with colons & ampersands\""));
+        assert!(md.contains("# Second: with colons & ampersands"));
+    }
+}


### PR DESCRIPTION
## Summary

Lands the kernel-side parsing + write pipeline for `driver-rss` per the M1 row in [`apps/uebermensch/ROADMAP.md`](apps/uebermensch/ROADMAP.md). Implementation lives inside `gctrl-otel` (same as `driver-llm` / `driver-github` / `driver-net`) rather than as a separate crate — matches the existing LKM pattern.

## What ships

- **`gctrl-otel::rss` module** — `parse_feed` (RSS 2.0 + Atom + JSON Feed via `feed-rs`), `slugify` (Unicode-safe, capped at 80 chars), `entry_path`, `render_markdown` (YAML frontmatter + H1 + body), `write_entry` (atomic-ish: sibling `.md.tmp` → rename, skip-if-existing dedupe).
- **`POST /api/rss/poll { feed_url, vault_dir }`** — fetches via the kernel's shared `reqwest::Client`, parses, writes each entry to `<vault>/input/raw/<YYYY-MM-DD>--<slug>--<guid_hash8>.md`, returns `{ fetched, written[], skipped[], failed[] }`.
- **9 unit tests** in `rss::tests` covering: RSS 2.0 + Atom parsing, malformed-feed rejection, slug edge cases (Unicode, all-symbols, >80 chars), path disambiguation by GUID hash, write/dedupe round trip, frontmatter shape, missing-vault error.

## What's deferred

- **Scheduler-driven polling** (cron from profile) — needs the kb→kernel promotion (#104) to define the canonical vault mount port first.
- **SQLite index rows** for ingested sources — depends on the vault watcher generalisation (`project_vault_is_source_of_truth`).
- **`gctrl uber ingest --rss`** shell command — thin client of this route.

## Test plan

- [x] `cargo test -p gctrl-otel rss::` — 9/9 RSS tests pass
- [x] Full otel suite — 153 tests pass, no regressions
- [ ] CI green
- [ ] Smoke test against a real feed once route lands on a deployed daemon

Refs OpenHackersClub/uebermensch#2.
