### PR TITLE
docs: fix lingering gctl references in two spec files

### DIFF
--- a/apps/gctrl-board/vault/specs/gantt.md
+++ b/apps/gctrl-board/vault/specs/gantt.md
@@ -285,7 +285,7 @@ The Gantt renders **Issues only**. Tasks (Scheduler primitives) do not appear â€
 2. **Task timing is Scheduler-owned and ephemeral.** A Task's `start` / `end` is determined by agent runtime and can change within seconds.
 3. **Invariant preservation.** `architecture.md` defines Tasks as read-only in Kanban; the simplest way to respect that here is to not render them at all.
 
-If an agent-execution timeline is ever needed, it belongs in a separate view (e.g., per-session trace visualization implied by `gctl sessions tree`), not bolted onto the Issue Gantt.
+If an agent-execution timeline is ever needed, it belongs in a separate view (e.g., per-session trace visualization implied by `gctrl sessions tree`), not bolted onto the Issue Gantt.
 
 ## Testing
 

--- a/vault/specs/implementation/kernel/session-trigger.md
+++ b/vault/specs/implementation/kernel/session-trigger.md
@@ -142,7 +142,7 @@ Soak tests wait until real compute is wired — no value running the stub under 
 - [ ] `cargo test -p gctrl-orch` green.
 - [ ] `pnpm --filter gctrl-board test` green.
 - [ ] `pnpm --filter gctrl-board exec playwright test session-trigger` green locally.
-- [ ] Manual: `gctrl serve` + open local board, drag an Issue to `in_progress`, see a session row in `gctl sessions list`.
+- [ ] Manual: `gctrl serve` + open local board, drag an Issue to `in_progress`, see a session row in `gctrl sessions list`.
 
 ---
 


### PR DESCRIPTION
## Summary

Two stray `gctl` references in spec content. Brand is `gctrl` (renamed in #22) and the typo'd filenames were fixed in #119; these inline command references were missed.

- `apps/gctrl-board/vault/specs/gantt.md` — `gctl sessions tree` → `gctrl sessions tree`
- `vault/specs/implementation/kernel/session-trigger.md` — `gctl sessions list` → `gctrl sessions list`

Split out from #120 so the typo cleanup can land independently.

## Test plan
- [x] `git grep '\bgctl\b' -- vault/specs apps/gctrl-board/vault` — no remaining hits in spec content (only a `bun.lock` package-name reference outside scope)
