### PR TITLE
feat(kernel): /api/vault/* routes + gctrl vault shell command

### DIFF
--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -9,7 +9,7 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
     },
-    routing::{get, patch, post},
+    routing::{delete, get, patch, post},
     Json, Router,
 };
 use async_stream::stream;
@@ -246,6 +246,15 @@ fn build_router(state: Arc<AppState>) -> Router {
         // RSS driver (LKM — fetch + parse RSS/Atom/JSON Feed, write entries
         // to a vault dir under `<vault>/input/raw/`)
         .route("/api/rss/poll", post(rss_poll))
+        // Vault mounts (kernel KB primitive — registry of named vault roots
+        // that any app can read/write through the kernel, replacing per-app
+        // FS shims). Atomic page write reuses gctrl-storage::vault_io.
+        .route(
+            "/api/vault/mounts",
+            get(vault_mounts_list).post(vault_mounts_create),
+        )
+        .route("/api/vault/mounts/{name}", delete(vault_mounts_delete))
+        .route("/api/vault/page", get(vault_page_get).post(vault_page_put))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -4381,6 +4390,172 @@ async fn rss_poll(
         "failed": failed,
     }))
     .into_response()
+}
+
+// =============================================================================
+// Vault mounts — kernel KB primitive.
+// Apps register a named mount once, then read/write atomic markdown pages
+// through `/api/vault/page` instead of carrying their own filesystem shims.
+// `vault_io::write_atomic` already gives us torn-write-free updates.
+// =============================================================================
+
+#[derive(Deserialize)]
+struct VaultMountCreateBody {
+    name: String,
+    root_path: String,
+    /// `workspace` | `app` | `external`. Defaults to `workspace`.
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    git_url: Option<String>,
+    #[serde(default)]
+    app_id: Option<String>,
+}
+
+async fn vault_mounts_list(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.sqlite.list_vault_mounts() {
+        Ok(mounts) => Json(mounts).into_response(),
+        Err(e) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+    }
+}
+
+async fn vault_mounts_create(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<VaultMountCreateBody>,
+) -> impl IntoResponse {
+    let kind = body
+        .kind
+        .as_deref()
+        .and_then(gctrl_core::VaultMountKind::from_str)
+        .unwrap_or(gctrl_core::VaultMountKind::Workspace);
+    let now = chrono::Utc::now();
+    let mount = gctrl_core::VaultMount {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: body.name.clone(),
+        root_path: body.root_path,
+        kind,
+        git_url: body.git_url,
+        app_id: body.app_id,
+        last_commit_sha: None,
+        last_synced_at: None,
+        created_at: now,
+        updated_at: now,
+    };
+    match state.sqlite.create_vault_mount(&mount) {
+        Ok(()) => (StatusCode::CREATED, Json(mount)).into_response(),
+        Err(e) => {
+            // UNIQUE constraint → 409.
+            let msg = e.to_string();
+            let status = if msg.contains("UNIQUE") || msg.contains("constraint") {
+                StatusCode::CONFLICT
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, msg).into_response()
+        }
+    }
+}
+
+async fn vault_mounts_delete(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.delete_vault_mount(&name) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct VaultPageQuery {
+    /// Mount name (looked up via `gctrl_vault_mounts.name`).
+    mount: String,
+    /// Path relative to the mount's `root_path`. Must not escape the root.
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct VaultPagePutBody {
+    mount: String,
+    path: String,
+    content: String,
+}
+
+async fn vault_page_get(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<VaultPageQuery>,
+) -> impl IntoResponse {
+    let mount = match state.sqlite.get_vault_mount(&q.mount) {
+        Ok(Some(m)) => m,
+        Ok(None) => return (StatusCode::NOT_FOUND, format!("mount {} not found", q.mount)).into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let abs = match resolve_within(&mount.root_path, &q.path) {
+        Ok(p) => p,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+    match std::fs::read_to_string(&abs) {
+        Ok(content) => Json(serde_json::json!({
+            "mount": q.mount,
+            "path": q.path,
+            "abs_path": abs.to_string_lossy(),
+            "content_hash": gctrl_storage::sha256_hex(&content),
+            "content": content,
+        }))
+        .into_response(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            (StatusCode::NOT_FOUND, e.to_string()).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn vault_page_put(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<VaultPagePutBody>,
+) -> impl IntoResponse {
+    let mount = match state.sqlite.get_vault_mount(&body.mount) {
+        Ok(Some(m)) => m,
+        Ok(None) => return (StatusCode::NOT_FOUND, format!("mount {} not found", body.mount)).into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let abs = match resolve_within(&mount.root_path, &body.path) {
+        Ok(p) => p,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+    match gctrl_storage::write_atomic(&abs, &body.content) {
+        Ok(hash) => Json(serde_json::json!({
+            "mount": body.mount,
+            "path": body.path,
+            "abs_path": abs.to_string_lossy(),
+            "content_hash": hash,
+        }))
+        .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// Refuse paths that escape `root` via `..` or absolute components. The
+/// kernel exposes vault writes to apps; without this, an app could write
+/// anywhere on disk via `path: "../../../etc/passwd"`.
+fn resolve_within(root: &str, rel: &str) -> Result<std::path::PathBuf, String> {
+    use std::path::{Component, PathBuf};
+    let rel_path = PathBuf::from(rel);
+    if rel_path.is_absolute() {
+        return Err("path must be relative to mount root".into());
+    }
+    for c in rel_path.components() {
+        match c {
+            Component::ParentDir => return Err("path must not contain ..".into()),
+            Component::RootDir | Component::Prefix(_) => {
+                return Err("path must be relative to mount root".into())
+            }
+            _ => {}
+        }
+    }
+    Ok(PathBuf::from(root).join(rel_path))
 }
 
 #[cfg(test)]

--- a/kernel/crates/gctrl-otel/tests/vault_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/vault_routes.rs
@@ -1,0 +1,193 @@
+//! Integration tests for `/api/vault/*` routes.
+//!
+//! Covers: register a mount → list it → write a page → read it back →
+//! reject path-traversal → delete the mount.
+
+use axum::body::Body;
+use gctrl_core::NetConfig;
+use gctrl_otel::create_router_full;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn router() -> axum::Router {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    create_router_full(store, sqlite, None, Arc::new(NetConfig::default()))
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: serde_json::Value) -> (u16, String) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+async fn get_url(app: &axum::Router, uri: &str) -> (u16, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+async fn delete_url(app: &axum::Router, uri: &str) -> u16 {
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    app.clone().oneshot(req).await.unwrap().status().as_u16()
+}
+
+#[tokio::test]
+async fn mount_lifecycle_create_list_delete() {
+    let app = router();
+    let dir = TempDir::new().unwrap();
+
+    let (status, body) = post_json(
+        &app,
+        "/api/vault/mounts",
+        serde_json::json!({
+            "name": "personal",
+            "root_path": dir.path().to_string_lossy(),
+            "kind": "workspace",
+        }),
+    )
+    .await;
+    assert_eq!(status, 201, "create returned: {body}");
+
+    let (status, body) = get_url(&app, "/api/vault/mounts").await;
+    assert_eq!(status, 200);
+    let mounts: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let arr = mounts.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "personal");
+    assert_eq!(arr[0]["kind"], "workspace");
+
+    assert_eq!(delete_url(&app, "/api/vault/mounts/personal").await, 204);
+
+    let (_, body) = get_url(&app, "/api/vault/mounts").await;
+    let mounts: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(mounts.as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn create_mount_with_duplicate_name_conflicts() {
+    let app = router();
+    let dir = TempDir::new().unwrap();
+    let body = serde_json::json!({
+        "name": "kb",
+        "root_path": dir.path().to_string_lossy(),
+    });
+    let (s1, _) = post_json(&app, "/api/vault/mounts", body.clone()).await;
+    let (s2, _) = post_json(&app, "/api/vault/mounts", body).await;
+    assert_eq!(s1, 201);
+    assert_eq!(s2, 409);
+}
+
+#[tokio::test]
+async fn vault_page_put_then_get_round_trips_content() {
+    let app = router();
+    let dir = TempDir::new().unwrap();
+
+    let (status, _) = post_json(
+        &app,
+        "/api/vault/mounts",
+        serde_json::json!({"name": "kb", "root_path": dir.path().to_string_lossy()}),
+    )
+    .await;
+    assert_eq!(status, 201);
+
+    let (status, body) = post_json(
+        &app,
+        "/api/vault/page",
+        serde_json::json!({
+            "mount": "kb",
+            "path": "notes/hello.md",
+            "content": "# hello\nworld\n",
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "put returned: {body}");
+    let written: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let put_hash = written["content_hash"].as_str().unwrap().to_string();
+    assert_eq!(put_hash.len(), 64);
+
+    let (status, body) = get_url(&app, "/api/vault/page?mount=kb&path=notes/hello.md").await;
+    assert_eq!(status, 200);
+    let read: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(read["content"], "# hello\nworld\n");
+    assert_eq!(read["content_hash"].as_str().unwrap(), put_hash);
+}
+
+#[tokio::test]
+async fn vault_page_get_returns_404_for_unknown_mount() {
+    let app = router();
+    let (status, _) = get_url(&app, "/api/vault/page?mount=nope&path=x.md").await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn vault_page_get_returns_404_when_file_missing() {
+    let app = router();
+    let dir = TempDir::new().unwrap();
+    post_json(
+        &app,
+        "/api/vault/mounts",
+        serde_json::json!({"name": "kb", "root_path": dir.path().to_string_lossy()}),
+    )
+    .await;
+    let (status, _) = get_url(&app, "/api/vault/page?mount=kb&path=missing.md").await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn vault_page_rejects_path_traversal() {
+    let app = router();
+    let dir = TempDir::new().unwrap();
+    post_json(
+        &app,
+        "/api/vault/mounts",
+        serde_json::json!({"name": "kb", "root_path": dir.path().to_string_lossy()}),
+    )
+    .await;
+
+    let (status, body) = post_json(
+        &app,
+        "/api/vault/page",
+        serde_json::json!({
+            "mount": "kb",
+            "path": "../escape.md",
+            "content": "x",
+        }),
+    )
+    .await;
+    assert_eq!(status, 400, "got: {body}");
+    assert!(body.contains(".."));
+
+    let (status, body) = post_json(
+        &app,
+        "/api/vault/page",
+        serde_json::json!({
+            "mount": "kb",
+            "path": "/etc/passwd",
+            "content": "x",
+        }),
+    )
+    .await;
+    assert_eq!(status, 400, "got: {body}");
+}

--- a/shell/gctrl-shell/src/commands/vault.ts
+++ b/shell/gctrl-shell/src/commands/vault.ts
@@ -1,0 +1,187 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Option, Schema } from "effect"
+import { KernelClient } from "../services/KernelClient"
+
+// --- schemas ---
+
+const VaultMount = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  root_path: Schema.String,
+  kind: Schema.String,
+  git_url: Schema.optional(Schema.NullOr(Schema.String)),
+  app_id: Schema.optional(Schema.NullOr(Schema.String)),
+  last_commit_sha: Schema.optional(Schema.NullOr(Schema.String)),
+  last_synced_at: Schema.optional(Schema.NullOr(Schema.String)),
+  created_at: Schema.String,
+  updated_at: Schema.String,
+})
+const VaultMountList = Schema.Array(VaultMount)
+
+const VaultPagePut = Schema.Struct({
+  mount: Schema.String,
+  path: Schema.String,
+  abs_path: Schema.String,
+  content_hash: Schema.String,
+})
+
+const VaultPageGet = Schema.Struct({
+  mount: Schema.String,
+  path: Schema.String,
+  abs_path: Schema.String,
+  content_hash: Schema.String,
+  content: Schema.String,
+})
+
+// --- list ---
+
+const formatOption = Options.choice("format", ["table", "json"]).pipe(
+  Options.withDefault("table"),
+)
+
+const listCommand = Command.make("list", { format: formatOption }, ({ format }) =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const mounts = yield* kernel.get("/api/vault/mounts", VaultMountList)
+
+    if (mounts.length === 0) {
+      yield* Console.log("No vault mounts. Register one with `gctrl vault mount`.")
+      return
+    }
+
+    if (format === "json") {
+      yield* Console.log(JSON.stringify(mounts, null, 2))
+      return
+    }
+
+    yield* Console.log(`${"NAME".padEnd(20)} ${"KIND".padEnd(11)} ROOT`)
+    yield* Console.log("-".repeat(80))
+    for (const m of mounts) {
+      yield* Console.log(
+        `${m.name.padEnd(20)} ${m.kind.padEnd(11)} ${m.root_path}`,
+      )
+    }
+  }),
+)
+
+// --- mount (create) ---
+
+const nameOption = Options.text("name").pipe(
+  Options.withDescription("Mount name (unique)"),
+)
+const rootOption = Options.text("root").pipe(
+  Options.withDescription("Absolute path to vault root"),
+)
+const kindOption = Options.choice("kind", ["workspace", "app", "external"]).pipe(
+  Options.withDefault("workspace"),
+)
+const gitUrlOption = Options.text("git-url").pipe(Options.optional)
+const appIdOption = Options.text("app-id").pipe(Options.optional)
+
+const mountCommand = Command.make(
+  "mount",
+  { name: nameOption, root: rootOption, kind: kindOption, gitUrl: gitUrlOption, appId: appIdOption },
+  ({ name, root, kind, gitUrl, appId }) =>
+    Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      const created = yield* kernel.post(
+        "/api/vault/mounts",
+        {
+          name,
+          root_path: root,
+          kind,
+          git_url: Option.getOrUndefined(gitUrl),
+          app_id: Option.getOrUndefined(appId),
+        },
+        VaultMount,
+      )
+      yield* Console.log(`Mounted: ${created.name} → ${created.root_path}`)
+    }),
+)
+
+// --- unmount (delete) ---
+
+const unmountName = Args.text({ name: "name" })
+
+const unmountCommand = Command.make("unmount", { name: unmountName }, ({ name }) =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    yield* kernel.delete(`/api/vault/mounts/${encodeURIComponent(name)}`)
+    yield* Console.log(`Unmounted: ${name}`)
+  }),
+)
+
+// --- get (read a page) ---
+
+const getMount = Args.text({ name: "mount" })
+const getPath = Args.text({ name: "path" })
+const outOption = Options.text("out").pipe(
+  Options.withDescription("Write content to this file instead of stdout"),
+  Options.optional,
+)
+
+const getCommand = Command.make(
+  "get",
+  { mount: getMount, path: getPath, out: outOption },
+  ({ mount, path, out }) =>
+    Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      const page = yield* kernel.get(
+        `/api/vault/page?mount=${encodeURIComponent(mount)}&path=${encodeURIComponent(path)}`,
+        VaultPageGet,
+      )
+      const dest = Option.getOrUndefined(out)
+      if (dest) {
+        writeFileSync(dest, page.content)
+        yield* Console.log(`Wrote ${page.content.length} bytes to ${dest}`)
+      } else {
+        yield* Console.log(page.content)
+      }
+    }),
+)
+
+// --- put (write a page) ---
+
+const putMount = Args.text({ name: "mount" })
+const putPath = Args.text({ name: "path" })
+const contentOption = Options.text("content").pipe(
+  Options.withDescription("Content (mutually exclusive with --file)"),
+  Options.optional,
+)
+const fileOption = Options.text("file").pipe(
+  Options.withDescription("Read content from this file (mutually exclusive with --content)"),
+  Options.optional,
+)
+
+const putCommand = Command.make(
+  "put",
+  { mount: putMount, path: putPath, content: contentOption, file: fileOption },
+  ({ mount, path, content, file }) =>
+    Effect.gen(function* () {
+      const inline = Option.getOrUndefined(content)
+      const fromFile = Option.getOrUndefined(file)
+      if (!inline && !fromFile) {
+        return yield* Effect.fail({
+          _tag: "MissingContent" as const,
+          message: "Provide --content or --file",
+        })
+      }
+      const body = fromFile ? readFileSync(fromFile, "utf-8") : (inline ?? "")
+      const kernel = yield* KernelClient
+      const written = yield* kernel.post(
+        "/api/vault/page",
+        { mount, path, content: body },
+        VaultPagePut,
+      )
+      yield* Console.log(
+        `Wrote ${written.path} (${body.length} bytes, hash ${written.content_hash.slice(0, 12)}…)`,
+      )
+    }),
+)
+
+// --- compose ---
+
+export const vaultCommand = Command.make("vault").pipe(
+  Command.withSubcommands([listCommand, mountCommand, unmountCommand, getCommand, putCommand]),
+)

--- a/shell/gctrl-shell/src/main.ts
+++ b/shell/gctrl-shell/src/main.ts
@@ -21,6 +21,7 @@ import { searchCommand } from "./commands/search"
 import { personaCommand } from "./commands/persona"
 import { teamCommand } from "./commands/team"
 import { inboxCommand } from "./commands/inbox"
+import { vaultCommand } from "./commands/vault"
 import { wranglerCommand } from "./commands/wrangler"
 import { HttpKernelClientLive } from "./adapters/HttpKernelClient"
 
@@ -38,6 +39,7 @@ const command = Command.make("gctrl").pipe(
     personaCommand,
     teamCommand,
     inboxCommand,
+    vaultCommand,
     wranglerCommand,
   ])
 )

--- a/shell/gctrl-shell/test/vault.test.ts
+++ b/shell/gctrl-shell/test/vault.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest"
+import { Effect, Schema } from "effect"
+import { KernelClient } from "../src/services/KernelClient"
+import { createMockKernelClient } from "./helpers/mock-kernel"
+
+const mountPersonal = {
+  id: "mnt-1",
+  name: "personal",
+  root_path: "/Users/me/notes",
+  kind: "workspace",
+  git_url: null,
+  app_id: null,
+  last_commit_sha: null,
+  last_synced_at: null,
+  created_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+}
+
+const mountKb = {
+  ...mountPersonal,
+  id: "mnt-2",
+  name: "kb",
+  root_path: "/Users/me/kb",
+}
+
+const VaultMount = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  root_path: Schema.String,
+  kind: Schema.String,
+})
+const VaultMountList = Schema.Array(VaultMount)
+
+const VaultPagePut = Schema.Struct({
+  mount: Schema.String,
+  path: Schema.String,
+  abs_path: Schema.String,
+  content_hash: Schema.String,
+})
+
+const VaultPageGet = Schema.Struct({
+  mount: Schema.String,
+  path: Schema.String,
+  content: Schema.String,
+  content_hash: Schema.String,
+})
+
+const MockLayer = createMockKernelClient(
+  {
+    "/api/vault/mounts": [mountPersonal, mountKb],
+    "/api/vault/page": {
+      mount: "kb",
+      path: "notes/hello.md",
+      abs_path: "/Users/me/kb/notes/hello.md",
+      content: "# hello\nworld\n",
+      content_hash: "0".repeat(64),
+    },
+  },
+  {
+    "/api/vault/mounts": {
+      ...mountPersonal,
+      name: "newmount",
+      root_path: "/tmp/new",
+    },
+    "/api/vault/page": {
+      mount: "kb",
+      path: "notes/hello.md",
+      abs_path: "/Users/me/kb/notes/hello.md",
+      content_hash: "abcd".repeat(16),
+    },
+  },
+)
+
+describe("Vault commands (via KernelClient)", () => {
+  it("list mounts decodes and returns all", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/vault/mounts", VaultMountList)
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe("personal")
+    expect(result[1].name).toBe("kb")
+  })
+
+  it("create mount returns the created record", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/vault/mounts",
+        { name: "newmount", root_path: "/tmp/new", kind: "workspace" },
+        VaultMount,
+      )
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.name).toBe("newmount")
+    expect(result.root_path).toBe("/tmp/new")
+  })
+
+  it("delete mount calls the delete route", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      yield* kernel.delete("/api/vault/mounts/personal")
+    })
+    await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+  })
+
+  it("get page returns content + hash", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get(
+        "/api/vault/page?mount=kb&path=notes/hello.md",
+        VaultPageGet,
+      )
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.content).toBe("# hello\nworld\n")
+    expect(result.content_hash.length).toBe(64)
+  })
+
+  it("put page returns the new content_hash", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/vault/page",
+        { mount: "kb", path: "notes/hello.md", content: "x" },
+        VaultPagePut,
+      )
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.path).toBe("notes/hello.md")
+    expect(result.content_hash).toMatch(/^abcd/)
+  })
+})


### PR DESCRIPTION
## Summary

Promotes the existing `gctrl_vault_mounts` table + `vault_io::write_atomic` plumbing into a first-class kernel KB primitive that any app can use, per the wip notes ("build the knowledge-base ability into the kernel and shell").

The CRUD methods on `SqliteStore` (`create_vault_mount`, `list_vault_mounts`, `get_vault_mount`, `delete_vault_mount`) and the atomic-write helper already existed but had no HTTP surface and no shell command. This PR wires them up end-to-end.

## Kernel routes

| Route | Method | Behavior |
|---|---|---|
| `/api/vault/mounts` | `GET` | List registered mounts |
| `/api/vault/mounts` | `POST` | Register a mount (409 on duplicate name) |
| `/api/vault/mounts/{name}` | `DELETE` | Unregister |
| `/api/vault/page?mount=&path=` | `GET` | Read a page; returns content + sha256 |
| `/api/vault/page` | `POST` | Atomic write via `vault_io::write_atomic` |

`resolve_within` rejects `..` and absolute paths so apps can't escape the mount root via `path: "../../etc/passwd"`.

## Shell command

```sh
gctrl vault list [--format table|json]
gctrl vault mount --name personal --root /Users/me/notes --kind workspace
gctrl vault unmount personal
gctrl vault get kb notes/hello.md [--out file.md]
gctrl vault put kb notes/hello.md --content "# hi"
gctrl vault put kb notes/hello.md --file ./local.md
```

## Tests

- **6 integration tests** in `tests/vault_routes.rs`: CRUD lifecycle, duplicate-name conflict, page round-trip, missing-mount + missing-file 404s, path-traversal rejection.
- **5 shell unit tests** in `test/vault.test.ts` (mock kernel layer).

## Test plan

- [x] `cargo test -p gctrl-otel --test vault_routes` — 6/6 pass
- [x] `cargo test -p gctrl-otel` — 159/159 pass (up from 153, +6 vault routes)
- [x] `pnpm vitest run` in `shell/gctrl-shell` — 140/140 pass (up from 135, +5 vault)
- [ ] CI green

## What's deferred

- **Generalising `watch_board_dir` into a per-mount vault watcher** — needed before Uebermensch can move its `FileSystemVault` adapter onto these routes (the index → fs feedback loop has to flow through the kernel for parity).
- **Migrating Uebermensch's `FileSystemVault` adapter** — depends on the watcher generalisation above.

Refs OpenHackersClub/uebermensch#3.
