### PR TITLE
feat(uebermensch): kernel uber_briefs index + brief command registration

### DIFF
--- a/apps/uebermensch/src/commands/brief.ts
+++ b/apps/uebermensch/src/commands/brief.ts
@@ -130,6 +130,21 @@ export const brief = Command.make(
         yield* Console.log(
           `✓ wrote ${written.relPath} (${written.contentHash}) — ${rendered.citedClaims}/${rendered.totalClaims} claims cited`,
         )
+
+        yield* registerBriefInKernel({
+          date,
+          vaultPath: written.relPath,
+          contentHash: written.contentHash,
+          profileName: profile.profile.identity.name,
+          generator: llm.name(),
+          model: response.model,
+          promptHash: response.promptHash,
+          costUsd: response.costUsd,
+          itemCount: rendered.itemCount,
+          citedClaims: rendered.citedClaims,
+          totalClaims: rendered.totalClaims,
+        })
+
         yield* Console.log("")
         yield* Console.log(rendered.markdown)
       })
@@ -142,3 +157,52 @@ export const brief = Command.make(
       )
     }),
 ).pipe(Command.withDescription("Generate a daily brief from wiki pages + stub LLM"))
+
+// Best-effort POST to the kernel index. The brief is already written to the
+// vault (which is the source of truth); a kernel-down condition shouldn't
+// fail the command. We log a warning instead.
+type RegisterArgs = {
+  readonly date: string
+  readonly vaultPath: string
+  readonly contentHash: string
+  readonly profileName: string
+  readonly generator: string
+  readonly model: string
+  readonly promptHash: string
+  readonly costUsd: number
+  readonly itemCount: number
+  readonly citedClaims: number
+  readonly totalClaims: number
+}
+
+const registerBriefInKernel = (args: RegisterArgs) =>
+  Effect.gen(function* () {
+    const base = (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const resp = await fetch(`${base}/api/uber/briefs`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            date: args.date,
+            kind: "daily",
+            vault_path: args.vaultPath,
+            content_hash: args.contentHash,
+            profile_name: args.profileName,
+            generator: args.generator,
+            model: args.model,
+            prompt_hash: args.promptHash,
+            cost_usd: args.costUsd,
+            item_count: args.itemCount,
+            cited_claims: args.citedClaims,
+            total_claims: args.totalClaims,
+          }),
+        })
+        return resp.ok
+      },
+      catch: (e) => new Error(String(e)),
+    }).pipe(Effect.catchAll(() => Effect.succeed(false)))
+    if (!result) {
+      yield* Console.log("(kernel offline — brief written to vault but not indexed)")
+    }
+  })

--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -818,6 +818,40 @@ pub struct VaultMount {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Index row for an Uebermensch brief. Vault file is the source of truth;
+/// this row carries the metadata needed to list/filter without re-reading
+/// every markdown file. `(date, kind)` is the natural unique key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UberBrief {
+    pub id: String,
+    pub date: String,
+    pub kind: String,
+    pub vault_path: String,
+    pub content_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cited_claims: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_claims: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -255,6 +255,13 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/vault/mounts/{name}", delete(vault_mounts_delete))
         .route("/api/vault/page", get(vault_page_get).post(vault_page_put))
+        // Uebermensch briefs index — `(date, kind)` keyed; vault file is the
+        // source of truth, this is the queryable index for listing/filtering.
+        .route(
+            "/api/uber/briefs",
+            get(uber_briefs_list).post(uber_briefs_upsert),
+        )
+        .route("/api/uber/briefs/{date}", get(uber_briefs_get_by_date))
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -4556,6 +4563,110 @@ fn resolve_within(root: &str, rel: &str) -> Result<std::path::PathBuf, String> {
         }
     }
     Ok(PathBuf::from(root).join(rel_path))
+}
+
+// =============================================================================
+// Uebermensch briefs index — `(date, kind)` keyed app-namespaced table.
+// Vault markdown is the source of truth; this is the queryable metadata index.
+// =============================================================================
+
+#[derive(Deserialize)]
+struct UberBriefUpsertBody {
+    date: String,
+    #[serde(default)]
+    kind: Option<String>,
+    vault_path: String,
+    content_hash: String,
+    #[serde(default)]
+    profile_name: Option<String>,
+    #[serde(default)]
+    generator: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    prompt_hash: Option<String>,
+    #[serde(default)]
+    cost_usd: Option<f64>,
+    #[serde(default)]
+    item_count: Option<i64>,
+    #[serde(default)]
+    cited_claims: Option<i64>,
+    #[serde(default)]
+    total_claims: Option<i64>,
+    #[serde(default)]
+    failed_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct UberBriefListQuery {
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct UberBriefByDateQuery {
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+async fn uber_briefs_upsert(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<UberBriefUpsertBody>,
+) -> impl IntoResponse {
+    let now = chrono::Utc::now();
+    let kind = body.kind.unwrap_or_else(|| "daily".to_string());
+    // Stable id per (date, kind) so re-running doesn't churn ids.
+    let id = format!("brief-{}-{}", body.date, kind);
+    let failed_at = body.failed_reason.as_ref().map(|_| now);
+    let brief = gctrl_core::UberBrief {
+        id,
+        date: body.date,
+        kind,
+        vault_path: body.vault_path,
+        content_hash: body.content_hash,
+        profile_name: body.profile_name,
+        generator: body.generator,
+        model: body.model,
+        prompt_hash: body.prompt_hash,
+        cost_usd: body.cost_usd,
+        item_count: body.item_count,
+        cited_claims: body.cited_claims,
+        total_claims: body.total_claims,
+        failed_at,
+        failed_reason: body.failed_reason,
+        created_at: now,
+        updated_at: now,
+    };
+    match state.sqlite.upsert_uber_brief(&brief) {
+        Ok(()) => Json(brief).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn uber_briefs_list(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<UberBriefListQuery>,
+) -> impl IntoResponse {
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    match state.sqlite.list_uber_briefs(q.kind.as_deref(), limit) {
+        Ok(briefs) => Json(briefs).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn uber_briefs_get_by_date(
+    State(state): State<Arc<AppState>>,
+    Path(date): Path<String>,
+    Query(q): Query<UberBriefByDateQuery>,
+) -> impl IntoResponse {
+    let kind = q.kind.unwrap_or_else(|| "daily".to_string());
+    match state.sqlite.get_uber_brief(&date, &kind) {
+        Ok(Some(brief)) => Json(brief).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, format!("no brief for {date}/{kind}")).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
 }
 
 #[cfg(test)]

--- a/kernel/crates/gctrl-otel/tests/uber_briefs.rs
+++ b/kernel/crates/gctrl-otel/tests/uber_briefs.rs
@@ -1,0 +1,168 @@
+//! Integration tests for `/api/uber/briefs` index routes.
+//!
+//! Vault file is the source of truth — this index is `(date, kind)`-keyed
+//! metadata that lets the dashboard / shell list briefs without re-reading
+//! every markdown file in the vault.
+
+use axum::body::Body;
+use gctrl_core::NetConfig;
+use gctrl_otel::create_router_full;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn router() -> axum::Router {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    create_router_full(store, sqlite, None, Arc::new(NetConfig::default()))
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: serde_json::Value) -> (u16, String) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+async fn get_url(app: &axum::Router, uri: &str) -> (u16, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn brief_body(date: &str, vault_path: &str) -> serde_json::Value {
+    serde_json::json!({
+        "date": date,
+        "kind": "daily",
+        "vault_path": vault_path,
+        "content_hash": "0".repeat(64),
+        "profile_name": "test-investor",
+        "generator": "uebermensch",
+        "model": "google/gemma-4-31b",
+        "prompt_hash": "abcd".repeat(16),
+        "cost_usd": 0.0,
+        "item_count": 5,
+        "cited_claims": 4,
+        "total_claims": 7,
+    })
+}
+
+#[tokio::test]
+async fn upsert_then_get_round_trips() {
+    let app = router();
+    let (status, body) = post_json(
+        &app,
+        "/api/uber/briefs",
+        brief_body("2026-05-01", "input/briefs/2026-05-01.md"),
+    )
+    .await;
+    assert_eq!(status, 200, "upsert: {body}");
+
+    let (status, body) = get_url(&app, "/api/uber/briefs/2026-05-01").await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["date"], "2026-05-01");
+    assert_eq!(v["kind"], "daily");
+    assert_eq!(v["item_count"], 5);
+    assert_eq!(v["cited_claims"], 4);
+}
+
+#[tokio::test]
+async fn upsert_overwrites_existing_date_kind() {
+    let app = router();
+    post_json(
+        &app,
+        "/api/uber/briefs",
+        brief_body("2026-05-01", "input/briefs/2026-05-01.md"),
+    )
+    .await;
+
+    let mut second = brief_body("2026-05-01", "input/briefs/2026-05-01.md");
+    second["item_count"] = serde_json::json!(9);
+    second["cited_claims"] = serde_json::json!(8);
+    let (status, _) = post_json(&app, "/api/uber/briefs", second).await;
+    assert_eq!(status, 200);
+
+    let (_, body) = get_url(&app, "/api/uber/briefs/2026-05-01").await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["item_count"], 9);
+    assert_eq!(v["cited_claims"], 8);
+}
+
+#[tokio::test]
+async fn get_returns_404_when_missing() {
+    let app = router();
+    let (status, _) = get_url(&app, "/api/uber/briefs/2026-12-31").await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn list_returns_briefs_in_reverse_date_order() {
+    let app = router();
+    for date in ["2026-05-01", "2026-05-03", "2026-05-02"] {
+        post_json(
+            &app,
+            "/api/uber/briefs",
+            brief_body(date, &format!("input/briefs/{date}.md")),
+        )
+        .await;
+    }
+    let (status, body) = get_url(&app, "/api/uber/briefs").await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert_eq!(arr[0]["date"], "2026-05-03");
+    assert_eq!(arr[1]["date"], "2026-05-02");
+    assert_eq!(arr[2]["date"], "2026-05-01");
+}
+
+#[tokio::test]
+async fn list_filters_by_kind() {
+    let app = router();
+    let mut weekly = brief_body("2026-05-01", "input/briefs/2026-05-01-weekly.md");
+    weekly["kind"] = serde_json::json!("weekly");
+    post_json(&app, "/api/uber/briefs", weekly).await;
+    post_json(
+        &app,
+        "/api/uber/briefs",
+        brief_body("2026-05-02", "input/briefs/2026-05-02.md"),
+    )
+    .await;
+
+    let (_, body) = get_url(&app, "/api/uber/briefs?kind=weekly").await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 1);
+    assert_eq!(v[0]["date"], "2026-05-01");
+
+    let (_, body) = get_url(&app, "/api/uber/briefs?kind=daily").await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 1);
+    assert_eq!(v[0]["date"], "2026-05-02");
+}
+
+#[tokio::test]
+async fn upsert_with_failed_reason_records_failed_at() {
+    let app = router();
+    let mut body = brief_body("2026-05-01", "input/briefs/2026-05-01.md");
+    body["failed_reason"] = serde_json::json!("citation verifier rejected fabricated [[slug]]");
+    let (status, resp) = post_json(&app, "/api/uber/briefs", body).await;
+    assert_eq!(status, 200, "{resp}");
+    let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    assert!(v["failed_at"].is_string());
+    assert!(v["failed_reason"].as_str().unwrap().contains("fabricated"));
+}

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -14,7 +14,7 @@ use gctrl_core::{
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
     PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRunUpdate,
-    OrchTask, VaultMount, VaultMountKind,
+    OrchTask, UberBrief, VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 
@@ -285,6 +285,32 @@ CREATE TABLE IF NOT EXISTS gctrl_vault_mounts (
 )
 "#;
 
+// App-namespaced (per the `<app>_*` invariant). Vault file is the source of
+// truth; this table is an index keyed by `(date, kind)` with `vault_path`
+// + `content_hash` so the watcher's next scan is a no-op.
+const CREATE_UBER_BRIEFS: &str = r#"
+CREATE TABLE IF NOT EXISTS uber_briefs (
+    id              TEXT PRIMARY KEY,
+    date            TEXT NOT NULL,
+    kind            TEXT NOT NULL DEFAULT 'daily',
+    vault_path      TEXT NOT NULL,
+    content_hash    TEXT NOT NULL,
+    profile_name    TEXT,
+    generator       TEXT,
+    model           TEXT,
+    prompt_hash     TEXT,
+    cost_usd        REAL,
+    item_count      INTEGER,
+    cited_claims    INTEGER,
+    total_claims    INTEGER,
+    failed_at       TEXT,
+    failed_reason   TEXT,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    UNIQUE(date, kind)
+)
+"#;
+
 const CREATE_SCHEDULES: &str = r#"
 CREATE TABLE IF NOT EXISTS schedules (
     id              TEXT PRIMARY KEY,
@@ -358,6 +384,9 @@ const CREATE_INDEXES: &[&str] = &[
     // Schedule indexes — `due` is the hot path for the runner poll loop
     "CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(enabled, next_run_at)",
     "CREATE INDEX IF NOT EXISTS idx_schedules_name ON schedules(name)",
+    // Uebermensch briefs index — date lookup + reverse-chrono listing
+    "CREATE INDEX IF NOT EXISTS idx_uber_briefs_date ON uber_briefs(date DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_uber_briefs_kind_date ON uber_briefs(kind, date DESC)",
 ];
 
 // ═══════════════════════════════════════════════════════════════
@@ -419,6 +448,7 @@ impl SqliteStore {
             CREATE_CONTEXT_ENTRIES,
             CREATE_MEMORY_ENTRIES,
             CREATE_VAULT_MOUNTS,
+            CREATE_UBER_BRIEFS,
             CREATE_SCHEDULES,
         ];
         for stmt in &tables {
@@ -2448,6 +2478,110 @@ impl SqliteStore {
         Ok(())
     }
 
+    // ───────────────────────── Uebermensch briefs ─────────────────────────
+
+    /// Idempotent index write: replaces by `(date, kind)` so re-running a
+    /// brief on the same day overwrites cleanly. Kernel does not lint
+    /// content_hash — the writer (the brief command) computed it from the
+    /// markdown bytes already on disk, and the watcher will reconcile if
+    /// either side drifts.
+    pub fn upsert_uber_brief(&self, brief: &UberBrief) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO uber_briefs
+                (id, date, kind, vault_path, content_hash, profile_name, generator,
+                 model, prompt_hash, cost_usd, item_count, cited_claims, total_claims,
+                 failed_at, failed_reason, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+             ON CONFLICT(date, kind) DO UPDATE SET
+                vault_path = excluded.vault_path,
+                content_hash = excluded.content_hash,
+                profile_name = excluded.profile_name,
+                generator = excluded.generator,
+                model = excluded.model,
+                prompt_hash = excluded.prompt_hash,
+                cost_usd = excluded.cost_usd,
+                item_count = excluded.item_count,
+                cited_claims = excluded.cited_claims,
+                total_claims = excluded.total_claims,
+                failed_at = excluded.failed_at,
+                failed_reason = excluded.failed_reason,
+                updated_at = excluded.updated_at",
+            params![
+                brief.id,
+                brief.date,
+                brief.kind,
+                brief.vault_path,
+                brief.content_hash,
+                brief.profile_name,
+                brief.generator,
+                brief.model,
+                brief.prompt_hash,
+                brief.cost_usd,
+                brief.item_count,
+                brief.cited_claims,
+                brief.total_claims,
+                brief.failed_at.map(|dt| dt.to_rfc3339()),
+                brief.failed_reason,
+                brief.created_at.to_rfc3339(),
+                brief.updated_at.to_rfc3339(),
+            ],
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn get_uber_brief(&self, date: &str, kind: &str) -> Result<Option<UberBrief>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, date, kind, vault_path, content_hash, profile_name, generator,
+                    model, prompt_hash, cost_usd, item_count, cited_claims, total_claims,
+                    failed_at, failed_reason, created_at, updated_at
+             FROM uber_briefs WHERE date = ?1 AND kind = ?2",
+            [date, kind],
+            row_to_uber_brief,
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(GctlError::Storage(other.to_string())),
+        })
+    }
+
+    pub fn list_uber_briefs(&self, kind: Option<&str>, limit: i64) -> Result<Vec<UberBrief>> {
+        let conn = self.conn.lock().unwrap();
+        match kind {
+            Some(k) => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, date, kind, vault_path, content_hash, profile_name, generator,
+                                model, prompt_hash, cost_usd, item_count, cited_claims, total_claims,
+                                failed_at, failed_reason, created_at, updated_at
+                         FROM uber_briefs WHERE kind = ?1 ORDER BY date DESC LIMIT ?2",
+                    )
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map(params![k, limit], row_to_uber_brief)
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                Ok(rows.filter_map(|r| r.ok()).collect())
+            }
+            None => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, date, kind, vault_path, content_hash, profile_name, generator,
+                                model, prompt_hash, cost_usd, item_count, cited_claims, total_claims,
+                                failed_at, failed_reason, created_at, updated_at
+                         FROM uber_briefs ORDER BY date DESC LIMIT ?1",
+                    )
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map(params![limit], row_to_uber_brief)
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                Ok(rows.filter_map(|r| r.ok()).collect())
+            }
+        }
+    }
+
     // ───────────────────────── Schedules ─────────────────────────
 
     pub fn create_schedule(&self, sched: &Schedule) -> Result<()> {
@@ -2669,6 +2803,36 @@ fn row_to_vault_mount(row: &rusqlite::Row<'_>) -> rusqlite::Result<VaultMount> {
         updated_at: chrono::DateTime::parse_from_rfc3339(&updated_at_str)
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now()),
+    })
+}
+
+fn row_to_uber_brief(row: &rusqlite::Row<'_>) -> rusqlite::Result<UberBrief> {
+    let failed_at_str: Option<String> = row.get(13)?;
+    let created_at_str: String = row.get(15)?;
+    let updated_at_str: String = row.get(16)?;
+    let parse_dt = |s: &str| -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now())
+    };
+    Ok(UberBrief {
+        id: row.get(0)?,
+        date: row.get(1)?,
+        kind: row.get(2)?,
+        vault_path: row.get(3)?,
+        content_hash: row.get(4)?,
+        profile_name: row.get(5)?,
+        generator: row.get(6)?,
+        model: row.get(7)?,
+        prompt_hash: row.get(8)?,
+        cost_usd: row.get(9)?,
+        item_count: row.get(10)?,
+        cited_claims: row.get(11)?,
+        total_claims: row.get(12)?,
+        failed_at: failed_at_str.as_deref().map(parse_dt),
+        failed_reason: row.get(14)?,
+        created_at: parse_dt(&created_at_str),
+        updated_at: parse_dt(&updated_at_str),
     })
 }
 


### PR DESCRIPTION
## Summary

Closes the M1 brief→kernel handshake. The Curator pipeline (`selectCandidates`) + `StrictRenderer` + `FileSystemVault.writeBrief` + `KernelLlm` with session capture **already exist and pass 184 tests** — they were largely shipped before this issue was filed. What was missing was the kernel-side metadata index so the dashboard / shell can list briefs without re-reading every markdown file in the vault.

This PR adds that index (`uber_briefs` SQLite table + 3 routes) and wires `gctrl uber brief` to register the brief best-effort after writing the vault file.

## Kernel storage

- **`uber_briefs` SQLite table** — `(date, kind)` unique key; columns for `vault_path`, `content_hash`, `profile_name`, `generator`, `model`, `prompt_hash`, `cost_usd`, `item_count`, `cited_claims`, `total_claims`, `failed_at`, `failed_reason`. Indexed on `date DESC` and `(kind, date DESC)`.
- **`UberBrief` typed model** in `gctrl-core::types`.
- **CRUD methods** on `SqliteStore`: `upsert_uber_brief`, `get_uber_brief`, `list_uber_briefs(kind, limit)`.

## Kernel routes

| Route | Method | Behavior |
|---|---|---|
| `/api/uber/briefs` | `GET` | Reverse-chrono list; `?kind=` and `?limit=` filters |
| `/api/uber/briefs` | `POST` | Idempotent upsert (id derived from `date+kind`) |
| `/api/uber/briefs/{date}` | `GET` | Fetch by date; `?kind=` defaults to `daily`; 404 if missing |

## App wiring

`apps/uebermensch/src/commands/brief.ts` POSTs to `/api/uber/briefs` after the vault file is written. **Best-effort**: vault is the source of truth, so a kernel-down condition logs `(kernel offline — brief written to vault but not indexed)` and exits 0 instead of failing the brief.

## Tests

- **6 integration tests** in `tests/uber_briefs.rs` — upsert round-trip, upsert overwrites existing date+kind, 404 on missing, reverse-chrono list, kind filter, `failed_reason` → `failed_at`.
- **184 uebermensch tests** continue to pass (no regressions in brief/curator/renderer/citation suites).

## Test plan

- [x] `cargo test -p gctrl-otel --test uber_briefs` — 6/6 pass
- [x] `cargo test -p gctrl-otel` — 165/165 pass (was 159 after PR OpenHackersClub/gctrl#126)
- [x] `cargo test -p gctrl-storage` — 112/112 pass
- [x] `pnpm vitest run` in `apps/uebermensch` — 184/184 pass
- [ ] CI green
- [ ] Smoke test: live `gctrl uber brief` against running daemon, verify row in SQLite

## What this finishes from M1 acceptance criteria

- ✅ `uber_briefs` row inserted with `vault_path` + `content_hash`
- ✅ Existing (predates this PR): ≥3 items, citation verifier failing on unresolved/typed prefix, prompt versioning via kernel `/api/llm/*` capture, unit tests for citation verifier, integration test through `StubLlm`.

## Stacking

Stacked on top of `feat/vault-routes` (#126 — vault routes + shell command). Self-contained otherwise.

Refs OpenHackersClub/uebermensch#4.
