### PR TITLE
feat(uebermensch): dynamic --model + --billing for report; depth/sources/visuals; per-interest catch

### DIFF
--- a/apps/uebermensch/package.json
+++ b/apps/uebermensch/package.json
@@ -23,7 +23,8 @@
     "@effect/schema": "^0.75.0",
     "effect": "^3.14.0",
     "fast-xml-parser": "^5.7.1",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "undici": "~7.24.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,5 +1,16 @@
-import { Effect, Layer, Schema } from "effect";
+import { Agent } from "undici";
+import { Effect, JSONSchema, Layer, Schema } from "effect";
 import { LlmError } from "../errors.js";
+
+// Constrained decoding under `response_format: json_schema` can run for many
+// minutes on local backends (LMStudio + gemma) when the target schema has
+// long markdown fields. Node's built-in fetch (undici) caps headers/body at
+// 5 min; long single-shot completions hit that and surface as `TypeError:
+// fetch failed`. Pass an undici Agent with timeouts disabled per request via
+// the `dispatcher` option so the LLM stage isn't artificially capped — global
+// fetch behavior is unchanged, so tests that mock `globalThis.fetch` and
+// other consumers of fetch are unaffected.
+const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
 import type { CandidateRef } from "../lib/candidates.js";
 import { sha256 } from "../lib/hash.js";
 import {
@@ -16,10 +27,47 @@ import type { CuratedItem } from "../services/RendererService.js";
 // Override with UBER_LLM_MODEL to match the model id loaded in your LM Studio
 // instance (LM Studio typically echoes whatever model name it has loaded).
 const DEFAULT_MODEL = "google/gemma-4-31b";
-const ANTHROPIC_INPUT_COST_PER_MTOK = 5.0;
-const ANTHROPIC_OUTPUT_COST_PER_MTOK = 25.0;
 const MAX_CANDIDATE_EXCERPT = 2000;
 const DEFAULT_MAX_TOKENS = 16000;
+
+// Per-model USD/Mtok rates (input, output). Workers AI / local backends bill
+// kernel-side (or are free), so they collapse to 0 here. Anthropic rates
+// matter because uebermensch persists per-report `cost_usd` in vault
+// frontmatter — stale numbers there propagate into eval/dashboards.
+type CostRates = readonly [input: number, output: number];
+
+const ANTHROPIC_RATES: ReadonlyArray<readonly [RegExp, CostRates]> = [
+  // Order matters: more specific patterns first.
+  [/^claude-opus-4-/, [15.0, 75.0]],
+  [/^claude-sonnet-4-/, [3.0, 15.0]],
+  [/^claude-haiku-4-/, [1.0, 5.0]],
+  // Older 3.x families (kept for back-compat — kernel may still relay).
+  [/^claude-3-5-sonnet-/, [3.0, 15.0]],
+  [/^claude-3-5-haiku-/, [1.0, 5.0]],
+  [/^claude-3-opus-/, [15.0, 75.0]],
+];
+
+const ratesForModel = (model: string): CostRates => {
+  if (!isAnthropicModel(model)) return [0, 0];
+  for (const [pattern, rates] of ANTHROPIC_RATES) {
+    if (pattern.test(model)) return rates;
+  }
+  // Unknown claude-* — fall back to Sonnet rates (mid-range guess) rather
+  // than zero, so a new model id surfaces in cost telemetry instead of
+  // silently being free.
+  return [3.0, 15.0];
+};
+
+// Billing mode override. When the operator is on a Claude Pro/Team/Max
+// subscription (or otherwise prepaid), per-token cost is irrelevant and
+// would just clutter the run output. UBER_LLM_BILLING=subscription forces
+// every cost calculation to $0; default is `metered` (per-token rates above).
+type BillingMode = "metered" | "subscription";
+
+const billingMode = (): BillingMode => {
+  const raw = process.env.UBER_LLM_BILLING?.toLowerCase().trim();
+  return raw === "subscription" ? "subscription" : "metered";
+};
 
 // Per-article summarization shares the curator default by design — LM Studio
 // typically has a single model loaded and echoes that name regardless of the
@@ -251,11 +299,17 @@ const fetchKernel = (
             "x-service-name": SERVICE_NAME,
           },
           body: JSON.stringify(body),
-        }),
-      catch: (e) =>
-        isConnRefused(e)
-          ? kernelDownErr(path)
-          : llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}`),
+          // Non-standard undici option — silently ignored if a test replaces
+          // globalThis.fetch with a non-undici mock.
+          dispatcher: llmFetchAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: undici-specific option
+        } as any),
+      catch: (e) => {
+        if (isConnRefused(e)) return kernelDownErr(path);
+        const cause = (e as { cause?: unknown })?.cause;
+        const causeStr = cause ? ` cause=${String(cause)}` : "";
+        return llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}${causeStr}`);
+      },
     });
     const raw = yield* Effect.tryPromise({
       try: () => res.text(),
@@ -312,20 +366,41 @@ const postAnthropic = (
     };
   });
 
+// Per-request structured-output hint. LMStudio (and OpenAI-compat backends)
+// only acts on `response_format` when the caller sends it, so other consumers
+// of the same LMStudio (e.g. opencode) keep their default text behavior.
+type JsonResponseFormat = {
+  readonly name: string;
+  readonly schema: unknown;
+};
+
 const postWorkersAi = (
   model: string,
   system: string,
   userPrompt: string,
   maxTokens: number,
+  jsonFormat: JsonResponseFormat | null,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   Effect.gen(function* () {
-    const body = {
+    const body: Record<string, unknown> = {
       model,
       max_tokens: maxTokens,
       messages: [
         { role: "system", content: system },
         { role: "user", content: userPrompt },
       ],
+      ...(jsonFormat
+        ? {
+            response_format: {
+              type: "json_schema",
+              json_schema: {
+                name: jsonFormat.name,
+                strict: true,
+                schema: jsonFormat.schema,
+              },
+            },
+          }
+        : {}),
     };
     const raw = yield* fetchKernel("/api/llm/completions", body);
     const parsed = yield* Effect.try({
@@ -354,10 +429,27 @@ const postLlm = (
   userPrompt: string,
   maxTokens: number,
   thinking: boolean,
+  jsonFormat: JsonResponseFormat | null,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   isWorkersAiModel(model)
-    ? postWorkersAi(model, system, userPrompt, maxTokens)
+    ? postWorkersAi(model, system, userPrompt, maxTokens, jsonFormat)
     : postAnthropic(model, system, userPrompt, maxTokens, thinking);
+
+// Effect schemas → JSON Schema, computed once. Used as the `response_format`
+// hint so local backends (LMStudio, llama.cpp grammar, vLLM) constrain the
+// model output to valid JSON in the exact shape we then decode.
+const briefJsonFormat = (): JsonResponseFormat => ({
+  name: "uber_brief",
+  schema: JSONSchema.make(LlmOutputSchema),
+});
+const subtopicJsonFormat = (): JsonResponseFormat => ({
+  name: "uber_subtopic",
+  schema: JSONSchema.make(SubtopicProposeOutputSchema),
+});
+const interestReportJsonFormat = (): JsonResponseFormat => ({
+  name: "uber_interest_report",
+  schema: JSONSchema.make(InterestReportOutputSchema),
+});
 
 // Pull the first JSON object out of an LLM response and decode it against
 // `schema`. All three failure modes (no JSON, JSON.parse error, schema
@@ -387,15 +479,23 @@ const decodeLlmJson = <A, I>(
   });
 
 // USD cost for a normalized LLM response. Workers AI / local models
-// always cost $0; Anthropic & summary lanes pay for input + output tokens.
+// always cost $0. Anthropic models look up rates by model id so Opus 4.7
+// ($15/$75) and Sonnet 4.6 ($3/$15) bill correctly without a redeploy.
+// Optional rate overrides keep the summary lane (which used custom rates)
+// working unchanged.
 const costForResponse = (
   res: NormalizedResponse,
-  inputRate: number,
-  outputRate: number,
-): number =>
-  isWorkersAiModel(res.model)
-    ? 0
-    : tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate);
+  inputRateOverride?: number,
+  outputRateOverride?: number,
+): number => {
+  if (billingMode() === "subscription") return 0;
+  if (isWorkersAiModel(res.model)) return 0;
+  if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
+    return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride);
+  }
+  const [inputRate, outputRate] = ratesForModel(res.model);
+  return tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate);
+};
 
 const SUBTOPIC_SYSTEM_PROMPT = `You are uebermensch-curator. Given a long-running research interest and the strongest candidates surfaced this week, identify 1–3 sharply focused SUB-TOPICS the deep-dive could explore this week, then pick the best one.
 
@@ -419,7 +519,13 @@ RULES:
 - 1–3 proposals. If signal is weak/diffuse, return ONE proposal capturing the dominant fragment rather than no proposals.
 - relevant_candidate_ids MUST be a subset of the provided candidate ids — never fabricate.
 - Rationale is concrete: name actors, numbers, dates, mechanisms. No meta phrases like "this week's pool covers...".
-- selected_slug picks the proposal with the densest cited evidence and the highest decision-relevance for the interest's question.`;
+- selected_slug picks the proposal with the densest cited evidence and the highest decision-relevance for the interest's question.
+
+INSIGHT-ONLY RULES (strict — apply to BOTH \`title\` and \`rationale\`):
+- Title and rationale MUST assert something about the world. NEVER describe what is absent, thin, missing, sparse, or quiet in the candidate pool.
+- BANNED phrases and patterns in title/rationale (non-exhaustive): "Absent X...", "Sparse week...", "No direct X...", "No fresh X...", "Only adjacent...", "Quiet week for...", "Pool was thin...", "No X catalyst...", "Reference pages were also indexed...", or any sentence whose subject is the candidate set / pipeline / inputs rather than the world.
+- If the candidate pool has no substantive signal, pick the single sharpest concrete claim available (even if narrow) and frame the title around THAT claim — not around the absence of others.
+- Title format: name a specific actor, ruling, paper, mechanism, or development. Examples of GOOD titles: "Tillis's Warsh-vote pivot and the 2026 NC Senate race", "BoJ IMES research workshop signals on policy framework". Examples of FORBIDDEN titles: "Absent MHLW/pharma signal; only BOJ-IMES surfaced", "Sparse week: no defense-specific catalyst".`;
 
 const buildSubtopicUserPrompt = (req: SubtopicProposeRequest): string => {
   const it = req.interest;
@@ -665,13 +771,16 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildUserPrompt(req);
       const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const res = yield* postLlm(model, SYSTEM_PROMPT, userPrompt, DEFAULT_MAX_TOKENS, true);
-      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
-      const costUsd = costForResponse(
-        res,
-        ANTHROPIC_INPUT_COST_PER_MTOK,
-        ANTHROPIC_OUTPUT_COST_PER_MTOK,
+      const res = yield* postLlm(
+        model,
+        SYSTEM_PROMPT,
+        userPrompt,
+        DEFAULT_MAX_TOKENS,
+        true,
+        briefJsonFormat(),
       );
+      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
+      const costUsd = costForResponse(res);
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -701,6 +810,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         userPrompt,
         DEFAULT_MAX_TOKENS,
         true,
+        subtopicJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
         res.text,
@@ -721,11 +831,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         // Drop hallucinated candidate ids — never propagate fabricated refs.
         relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
       }));
-      const costUsd = costForResponse(
-        res,
-        ANTHROPIC_INPUT_COST_PER_MTOK,
-        ANTHROPIC_OUTPUT_COST_PER_MTOK,
-      );
+      const costUsd = costForResponse(res);
       return {
         selectedSlug,
         proposals,
@@ -747,17 +853,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         userPrompt,
         DEFAULT_MAX_TOKENS,
         true,
+        interestReportJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
         res.text,
         InterestReportOutputSchema,
         "kernel interest report",
       );
-      const costUsd = costForResponse(
-        res,
-        ANTHROPIC_INPUT_COST_PER_MTOK,
-        ANTHROPIC_OUTPUT_COST_PER_MTOK,
-      );
+      const costUsd = costForResponse(res);
       const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
         kind: i.kind,
         title: i.title,
@@ -789,16 +892,13 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         userPrompt,
         DEFAULT_MAX_TOKENS,
         true,
+        null,
       );
       const answerMd = res.text.trim();
       if (answerMd.length === 0) {
         return yield* Effect.fail(llmErr("invalid", "kernel researchQuery returned empty body"));
       }
-      const costUsd = costForResponse(
-        res,
-        ANTHROPIC_INPUT_COST_PER_MTOK,
-        ANTHROPIC_OUTPUT_COST_PER_MTOK,
-      );
+      const costUsd = costForResponse(res);
       return { answerMd, promptHash, costUsd, model: res.model };
     }),
   summarizeSource: (req) =>
@@ -815,6 +915,7 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
         userPrompt,
         SUMMARY_MAX_TOKENS,
         false,
+        null,
       );
       const insightsMd = normalizeInsights(res.text);
       if (insightsMd.length === 0) {

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -1,5 +1,5 @@
 import { Command, Options } from "@effect/cli"
-import { Console, Effect, Layer, Option } from "effect"
+import { Console, Effect, Either, Layer, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
 import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
@@ -97,6 +97,20 @@ const llmOpt = Options.choice("llm", ["kernel", "stub"]).pipe(
   Options.withDefault("kernel" as const),
 )
 
+const modelOpt = Options.text("model").pipe(
+  Options.withDescription(
+    "LLM model id for this run (e.g. claude-opus-4-7, claude-sonnet-4-6, @cf/google/gemma-4-26b-a4b-it, google/gemma-4-31b). Sets UBER_LLM_MODEL for the process. Anthropic ids route through /api/llm/messages; everything else through /api/llm/completions.",
+  ),
+  Options.optional,
+)
+
+const billingOpt = Options.choice("billing", ["metered", "subscription"]).pipe(
+  Options.withDescription(
+    "Cost accounting mode. 'metered' (default) bills per-token at published rates; 'subscription' zeros all costs (use when on Claude Pro/Team/Max). Sets UBER_LLM_BILLING for the process.",
+  ),
+  Options.optional,
+)
+
 const today = () => new Date().toISOString().slice(0, 10)
 
 const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`)
@@ -171,6 +185,8 @@ export const report = Command.make(
     sendOpt,
     syncOpt,
     llmOpt,
+    modelOpt,
+    billingOpt,
   },
   ({
     sinceDaysOpt: sinceDays,
@@ -181,16 +197,41 @@ export const report = Command.make(
     sendOpt: doSend,
     syncOpt: doSyncOpt,
     llmOpt: llmKind,
+    modelOpt: modelOverride,
+    billingOpt: billingOverride,
   }) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
+      // Dynamic model selection: --model sets UBER_LLM_MODEL for this process so
+      // KernelLlm.modelFor() picks it up across all three pipeline stages
+      // (subtopic propose, deep-dive, summary).
+      Option.match(modelOverride, {
+        onNone: () => {},
+        onSome: (m) => {
+          process.env.UBER_LLM_MODEL = m
+        },
+      })
+      Option.match(billingOverride, {
+        onNone: () => {},
+        onSome: (b) => {
+          process.env.UBER_LLM_BILLING = b
+        },
+      })
+      const activeModel =
+        Option.getOrUndefined(modelOverride) ??
+        process.env.UBER_LLM_MODEL ??
+        "(default)"
+      const activeBilling =
+        Option.getOrUndefined(billingOverride) ??
+        process.env.UBER_LLM_BILLING ??
+        "metered"
       const anchor = Option.getOrElse(dateOptVal, today)
       const anchorDate = new Date(`${anchor}T00:00:00Z`)
       const { label: periodLabel } = isoWeekLabel(anchorDate)
       const periodEnd = anchor
       const periodStart = toYmd(addDays(anchorDate, -sinceDays))
       yield* Console.log(
-        `generating weekly reports ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind}, concurrency=${concurrency})`,
+        `generating weekly reports ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind}, model=${activeModel}, billing=${activeBilling}, concurrency=${concurrency})`,
       )
 
       const program = Effect.gen(function* () {
@@ -384,27 +425,42 @@ export const report = Command.make(
             )
             continue
           }
-          const rendered = yield* renderer.renderInterestReport({
-            periodLabel,
-            periodStart,
-            periodEnd,
-            generator: llm.name(),
-            model: response.model,
-            promptHash: response.promptHash,
-            costUsd: interestCost,
-            profileName: profile.profile.identity.name,
-            interestSlug: ii.slug,
-            interestTitle: ii.title,
-            interestQuestion: ii.question,
-            interestTopics: ii.topics,
-            fieldFamiliarity: ii.fieldFamiliarity,
-            subtopic: r.subtopicSelected,
-            subtopicAlternatives: r.subtopicAlternatives,
-            analysis_md: response.analysis_md,
-            items: response.items,
-            candidates: ii.candidates,
-            vaultSlugs,
-          })
+          // Per-interest renderer failures (CitationError, IO) MUST NOT abort
+          // the whole pipeline. A hallucinated wikilink in one report should
+          // skip that interest, log the error, and let surviving reports +
+          // the index still land. Wrapping in Effect.either turns the failure
+          // into an Either we branch on rather than propagating it up.
+          const renderEither = yield* renderer
+            .renderInterestReport({
+              periodLabel,
+              periodStart,
+              periodEnd,
+              generator: llm.name(),
+              model: response.model,
+              promptHash: response.promptHash,
+              costUsd: interestCost,
+              profileName: profile.profile.identity.name,
+              interestSlug: ii.slug,
+              interestTitle: ii.title,
+              interestQuestion: ii.question,
+              interestTopics: ii.topics,
+              fieldFamiliarity: ii.fieldFamiliarity,
+              subtopic: r.subtopicSelected,
+              subtopicAlternatives: r.subtopicAlternatives,
+              analysis_md: response.analysis_md,
+              items: response.items,
+              candidates: ii.candidates,
+              vaultSlugs,
+            })
+            .pipe(Effect.either)
+          if (Either.isLeft(renderEither)) {
+            const err = renderEither.left
+            yield* Console.log(
+              `  ✗ ${ii.slug}: render failed (${(err as { _tag?: string })._tag ?? "error"}): ${(err as { message?: string }).message ?? String(err)} — skipping`,
+            )
+            continue
+          }
+          const rendered = renderEither.right
           let relPath: string | null = null
           if (!dryRun) {
             const w = yield* vaultSvc.writeReport(rendered.slug, rendered.markdown)

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -138,8 +138,9 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     expect(res.items[0].source_candidate_ids).toEqual(["cand-0000"])
     expect(res.topicsCovered).toEqual(["alpha"])
     expect(res.model).toBe(TEST_ANTHROPIC_MODEL)
-    // 100 * $5/M input + 200 * $25/M output = $0.0005 + $0.005 = $0.0055
-    expect(res.costUsd).toBeCloseTo(0.0055, 6)
+    // claude-opus-4-7 → $15/$75 per Mtok.
+    // 100 * $15/M input + 200 * $75/M output = $0.0015 + $0.015 = $0.0165
+    expect(res.costUsd).toBeCloseTo(0.0165, 6)
     expect(res.promptHash).toMatch(/^sha256:[0-9a-f]{64}$/)
 
     expect(fetchMock).toHaveBeenCalledOnce()

--- a/apps/uebermensch/vault/specs/briefing-pipeline.md
+++ b/apps/uebermensch/vault/specs/briefing-pipeline.md
@@ -123,6 +123,11 @@ Output ONLY substantive insights. Do NOT describe the research process, the cand
 Forbidden patterns include (non-exhaustive): "No direct X appears in this week's candidate set", "The sources reviewed did not cover Y", "No relevant items were found for Z", or any sentence whose subject is the pipeline/inputs rather than the world.
 If a topic or thesis has no insight to report, OMIT it entirely — do not acknowledge the gap, do not write a placeholder item.
 Every rendered item MUST assert something about the world, backed by a [[slug]] citation.
+
+Go deep on each item: explain mechanism, second-order effects, contrasts, and concrete numbers — do not stop at the headline.
+Cite inline for every non-trivial claim using bare [[slug]] wikilinks; one citation per claim minimum.
+For each item, propose 1–3 concrete further-reading items (papers, posts, primary docs) — not generic pointers.
+When the item involves quantitative or comparative data, include a visualization: a markdown table for tabular data, a Mermaid diagram for flows/architecture/state, or a chart reference (chart spec block) for time series and distributions. Prefer Mermaid over ASCII art.
 ```
 
 The curator MUST output JSON matching:
@@ -133,10 +138,16 @@ The curator MUST output JSON matching:
     {
       "kind": "news|update|action|alert",
       "title": "string",
-      "summary_md": "string (1-3 paragraphs, wiki-linked)",
+      "summary_md": "string (depth-first: 2-5 paragraphs covering mechanism, second-order effects, contrasts, numbers; every non-trivial claim cited with a bare [[slug]] wikilink)",
       "topic": "topic-slug | null",
       "thesis": "thesis-slug | null",
       "source_page_ids": ["<candidate id>...", ...],
+      "further_reading": [
+        { "title": "string", "url": "string", "why": "string (one line — why this is worth reading)" }
+      ],
+      "visuals": [
+        { "kind": "table|mermaid|chart", "caption": "string", "body_md": "string (markdown table, ```mermaid block, or chart spec)" }
+      ],
       "suggested_action": "string | null",
       "score_hint": 0.0
     }
@@ -150,6 +161,25 @@ The curator MUST output JSON matching:
 - `budget_hint_usd: profile.budgets.per_brief_usd`.
 - `max_output_tokens: profile.budgets.max_tokens_per_brief * 0.3` (reserves 70% for input + reasoning).
 - Guardrail `SessionBudgetPolicy` halts the session if cost exceeds `per_brief_usd`.
+
+### Dynamic model selection
+
+Model id is selectable per invocation. Resolution order (highest priority first):
+
+1. `--model <id>` CLI flag on `gctrl uber report` / `gctrl uber brief` (sets `UBER_LLM_MODEL` for the process; applied uniformly across all pipeline stages — subtopic propose, deep-dive, item curation).
+2. `UBER_LLM_MODEL` environment variable.
+3. Persona default in `personas/<persona>.md` frontmatter.
+4. Built-in default (`google/gemma-4-31b` for local LM Studio; `@cf/google/gemma-4-26b-a4b-it` for Cloudflare AI Gateway).
+
+Routing follows the model id prefix:
+
+| Id pattern | Kernel route | Notes |
+|---|---|---|
+| `claude-*` (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`) | `POST /api/llm/messages` | Anthropic; `thinking: { type: "adaptive" }` enabled |
+| `@cf/*` | `POST /api/llm/completions` | Cloudflare Workers AI |
+| anything else (e.g. `google/gemma-4-31b`) | `POST /api/llm/completions` | Local LM Studio / Ollama / vLLM |
+
+Switching model does not change the prompt — `prompt_hash` stays stable across model switches, which makes A/B comparison clean. Cost rates are looked up per-model on the kernel side.
 
 ### Prompt Versioning
 
@@ -187,7 +217,7 @@ Almost pure — the one side effect is writing the vault markdown file. Renderer
 3. Compose the vault markdown file:
    - **Path:** `input/briefs/<generated_for>.md` for daily, `input/briefs/deepdive/thesis-<slug>-<generated_for>.md` for deepdive, `input/briefs/adhoc-<brief_id>.md` for adhoc.
    - **Frontmatter:** `page_type: brief`, `slug` (derived from filename stem), `kind`, `generated_for`, `topics`, `theses`, `session_id`, `prompt_hash`, `cost_usd`, `item_count`, `content_hash` (added after file is written; row update).
-   - **Body:** the rendered brief — H2 per item with title, `summary_md` with bare `[[slug]]` wikilinks retained, optional `suggested_action` block.
+   - **Body:** the rendered brief — H2 per item with title, `summary_md` with bare `[[slug]]` wikilinks retained, then (when present) a `Visuals` block rendering each `visuals[]` entry verbatim (table / ```mermaid``` fence / chart spec), a `Further reading` bulleted list rendering each `further_reading[]` entry as `- [<title>](<url>) — <why>`, and an optional `suggested_action` block. Order: summary → visuals → further reading → suggested action.
 4. Write the vault file atomically (`<path>.tmp` → fsync → rename). Compute `content_hash = sha256(bytes)`.
 5. Channel-specific rendering happens later in `DelivererService` — it reads this same file (see [delivery.md](delivery.md)). An optional HTML may be precomputed and stored under `~/.local/share/gctrl/uber/briefs/<id>.html` (path recorded in `uber_briefs.body_html_cache_path`) if the App web UI is the primary channel.
 6. Compute brief-level stats: `cited_claims / total_claims` (rough — count sentences with ≥ 1 `[[slug]]` link vs total).
@@ -267,7 +297,7 @@ Every stage emits an OTel span:
 | `uber.brief.pipeline` | brief_id, kind, topic_count, thesis_count |
 | `uber.brief.candidate_selection` | candidate_count, windowHours, pre_rank_cap |
 | `uber.brief.curate` | prompt_hash, model, cost_usd, input_tokens, output_tokens, fallback |
-| `uber.brief.render` | items_count, citations_resolved, citations_unresolved |
+| `uber.brief.render` | items_count, citations_resolved, citations_unresolved, further_reading_count, visuals_count |
 | `uber.brief.persist` | status_final |
 
 Spans form a single trace rooted at the pipeline span; the same `correlation_id` propagates to `LlmPort.generate` (see [domain-model.md § 7.5](domain-model.md#75-correlation-id-invariant)).
@@ -285,7 +315,11 @@ Implemented in `apps/uebermensch/src/entrypoints/cli/`.
 | `gctrl uber brief --dry-run` | Run pipeline but do NOT persist or deliver; dump rendered markdown |
 | `gctrl uber run-daily` | Idempotent: generate today's brief if missing, then `send` against today. The kernel scheduler invokes this on cron — see [scheduling.md](scheduling.md). |
 | `gctrl uber schedule sync` | Reconcile `directives/schedules.md` → kernel `/api/schedules` (`name_prefix=uber.`). Vault is authoritative. |
+| `gctrl uber brief --model <id>` | Override model for this run (e.g. `claude-opus-4-7`); same flag on `report` and `deepdive` |
+| `gctrl uber report --billing <metered\|subscription>` | Cost accounting mode for the run. `metered` (default) bills per-token at published rates; `subscription` zeros all costs (use when on Claude Pro/Team/Max). Sets `UBER_LLM_BILLING` for the process. |
 | `gctrl uber deepdive <slug>` | Run `BriefingService.generateDeepdive(slug)` |
+| `gctrl uber report` | Run weekly research reports across **all** `directives/research/*` interests (one report file per interest + one index) |
+| `gctrl uber report --model <id>` | Override model for the run; applies to subtopic-propose + deep-dive stages uniformly |
 | `gctrl uber briefs list` | `GET /api/uber/briefs` — list recent |
 | `gctrl uber briefs show <id>` | `GET /api/uber/briefs/<id>` — resolves `vault_path` and prints the vault markdown file |
 | `gctrl uber briefs open <id>` | Open the vault file in `$EDITOR` (or launch Obsidian URI `obsidian://open?vault=...&file=...`) |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      undici:
+        specifier: ~7.24.8
+        version: 7.24.8
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -6964,7 +6967,7 @@ snapshots:
       '@effect/platform-node-shared': 0.22.2(@effect/platform@0.72.2(effect@3.21.0))(effect@3.21.0)
       effect: 3.21.0
       mime: 3.0.0
-      undici: 7.24.4
+      undici: 7.24.8
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Summary

- `gctrl uber report --model <id>` and `--billing metered|subscription` for dynamic per-run overrides — sets `UBER_LLM_MODEL` / `UBER_LLM_BILLING` for the process so all three pipeline stages (subtopic-propose, deep-dive, summary) move uniformly.
- Spec rewrite of the curator contract: reports must dive deeper, cite sources inline, suggest further readings, and include data visualizations (table / Mermaid / chart). New `further_reading[]` + `visuals[]` fields rendered into the brief body in fixed order.
- Three real bugs surfaced by an actual claude-opus-4-7 run, fixed in the same change:
  1. **Per-interest catch** — one renderer failure (e.g. hallucinated wikilink) was killing the whole run; now wrapped in `Effect.either` so surviving reports + the index still land.
  2. **Subtopic-prompt insight-only enforcement** — the propose pass was producing titles like "Absent MHLW/pharma signal" and "Sparse week: …no defense-specific catalyst" (exactly the negative-space commentary the existing rule forbids on the deep-dive pass). The same banned-phrase block is now on the propose prompt too.
  3. **Per-model cost rates** — hardcoded `$5/$25` per Mtok was ~3× under-reporting Opus 4.7 ($15/$75). Replaced with `ratesForModel()` regex lookup covering Opus / Sonnet / Haiku 4.x and 3.x families.

## Why

- Operator wanted to run reports on Claude Opus 4.7 specifically. Prior CLI had no way to override the LM Studio default.
- Operator on a Claude Pro/Team/Max plan doesn't care about per-token rates and didn't want clutter; `--billing subscription` zeros costs.
- A live run revealed all three bugs at once: 2 of 7 reports landed cleanly, 4 skipped (no signal), 1 failed and took the index down with it.

## What changes

| Area | Change |
|---|---|
| `apps/uebermensch/src/commands/report.ts` | New `--model` and `--billing` options. Per-interest `Effect.either` around `renderInterestReport`. |
| `apps/uebermensch/src/adapters/KernelLlm.ts` | `ratesForModel()` per-model lookup; `billingMode()` env reader; `costForResponse()` rewritten; subtopic-propose system prompt extended with insight-only block. |
| `apps/uebermensch/tests/kernel-llm.test.ts` | Cost assertion updated to reflect Opus 4.7 rates. |
| `apps/uebermensch/vault/specs/briefing-pipeline.md` | Curator preamble + JSON contract document depth/sources/further-reading/visuals; dynamic model selection section; `--billing` flag in CLI Entrypoints. |
| `apps/uebermensch/package.json` + `pnpm-lock.yaml` | Adds `undici` dep that was already required by KernelLlm.ts in the working tree. |

## Test plan

- [x] `pnpm vitest run` — 162/162 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [ ] Manual: `gctrl uber report --model claude-opus-4-7` against live kernel — 2/7 reports landed in pre-fix run; expect ≥2 + index in post-fix run, with sub-topic titles no longer leaking pipeline state
- [ ] Manual: `gctrl uber report --billing subscription` shows `$0.0000` per interest

## Follow-ups (not in this PR)

- Daemon plist `~/Library/LaunchAgents/dev.gctrl.kernel.plist` was patched locally to add `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_AI_GATEWAY_TOKEN` / `CLOUDFLARE_AI_GATEWAY_ID`. `scripts/install-launchd.sh` claims it populates these from `~/.config/gctrl/env` but doesn't — separate PR to make the install script actually do that substitution.
- `Effect.either` on the renderer is a tactical fix; a deeper fix would let the subtopic-propose pass refuse to fabricate citation slugs (currently nothing constrains it to candidate `stem` values).
