### PR TITLE
feat(kernel): SinkIn sessions index — uber_sinkin_sessions table + routes

### DIFF
--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -852,6 +852,41 @@ pub struct UberBrief {
     pub updated_at: DateTime<Utc>,
 }
 
+/// One row per SinkIn run. SinkIn introspects the wiki and files
+/// Question + Connection markdown pages; this row tracks the run itself
+/// (cost, scope, counts). Filed pages live in the vault.
+/// Spec: apps/uebermensch/vault/specs/sinkin.md
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UberSinkinSession {
+    pub id: String,
+    pub started_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    /// `running` | `completed` | `failed` | `aborted`
+    pub status: String,
+    /// `scheduled` | `interactive` | `manual`
+    pub mode: String,
+    /// e.g. `topic` or `thesis`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_kind: Option<String>,
+    /// The slug being scoped to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_value: Option<String>,
+    pub pages_scanned: i64,
+    pub gaps_found: i64,
+    pub gaps_answered: i64,
+    pub connections_found: i64,
+    pub cost_usd: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -281,6 +281,16 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(uber_briefs_list).post(uber_briefs_upsert),
         )
         .route("/api/uber/briefs/{date}", get(uber_briefs_get_by_date))
+        // Uebermensch SinkIn sessions — wiki-introspection runs.
+        // Spec: apps/uebermensch/vault/specs/sinkin.md
+        .route(
+            "/api/uber/sinkin/sessions",
+            get(uber_sinkin_sessions_list).post(uber_sinkin_sessions_upsert),
+        )
+        .route(
+            "/api/uber/sinkin/sessions/{id}",
+            get(uber_sinkin_sessions_get),
+        )
         // Search driver (Brave Search API)
         .route("/api/search/web", post(search_web))
         .route("/api/search/news", post(search_news))
@@ -4684,6 +4694,122 @@ async fn uber_briefs_get_by_date(
     match state.sqlite.get_uber_brief(&date, &kind) {
         Ok(Some(brief)) => Json(brief).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, format!("no brief for {date}/{kind}")).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// =============================================================================
+// Uebermensch SinkIn sessions — wiki-introspection runs.
+// `id` is supplied by the caller (the CLI/service generates it at run start)
+// so subsequent updates (counts, completion status) replace by id.
+// Spec: apps/uebermensch/vault/specs/sinkin.md
+// =============================================================================
+
+#[derive(Deserialize)]
+struct UberSinkinUpsertBody {
+    id: String,
+    /// `running` | `completed` | `failed` | `aborted`. Defaults to `running`.
+    #[serde(default)]
+    status: Option<String>,
+    /// `scheduled` | `interactive` | `manual`. Defaults to `manual`.
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    scope_kind: Option<String>,
+    #[serde(default)]
+    scope_value: Option<String>,
+    #[serde(default)]
+    pages_scanned: Option<i64>,
+    #[serde(default)]
+    gaps_found: Option<i64>,
+    #[serde(default)]
+    gaps_answered: Option<i64>,
+    #[serde(default)]
+    connections_found: Option<i64>,
+    #[serde(default)]
+    cost_usd: Option<f64>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    prompt_hash: Option<String>,
+    #[serde(default)]
+    failed_reason: Option<String>,
+    /// If supplied, marks the run as completed at this time.
+    #[serde(default)]
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Deserialize)]
+struct UberSinkinListQuery {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+async fn uber_sinkin_sessions_upsert(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<UberSinkinUpsertBody>,
+) -> impl IntoResponse {
+    let now = chrono::Utc::now();
+    // If the row already exists, preserve started_at; otherwise stamp now.
+    let started_at = state
+        .sqlite
+        .get_uber_sinkin_session(&body.id)
+        .ok()
+        .flatten()
+        .map(|prev| prev.started_at)
+        .unwrap_or(now);
+    let created_at = state
+        .sqlite
+        .get_uber_sinkin_session(&body.id)
+        .ok()
+        .flatten()
+        .map(|prev| prev.created_at)
+        .unwrap_or(now);
+    let sess = gctrl_core::UberSinkinSession {
+        id: body.id,
+        started_at,
+        completed_at: body.completed_at,
+        status: body.status.unwrap_or_else(|| "running".to_string()),
+        mode: body.mode.unwrap_or_else(|| "manual".to_string()),
+        scope_kind: body.scope_kind,
+        scope_value: body.scope_value,
+        pages_scanned: body.pages_scanned.unwrap_or(0),
+        gaps_found: body.gaps_found.unwrap_or(0),
+        gaps_answered: body.gaps_answered.unwrap_or(0),
+        connections_found: body.connections_found.unwrap_or(0),
+        cost_usd: body.cost_usd.unwrap_or(0.0),
+        model: body.model,
+        prompt_hash: body.prompt_hash,
+        failed_reason: body.failed_reason,
+        created_at,
+        updated_at: now,
+    };
+    match state.sqlite.upsert_uber_sinkin_session(&sess) {
+        Ok(()) => Json(sess).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn uber_sinkin_sessions_list(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<UberSinkinListQuery>,
+) -> impl IntoResponse {
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    match state.sqlite.list_uber_sinkin_sessions(q.status.as_deref(), limit) {
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn uber_sinkin_sessions_get(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.sqlite.get_uber_sinkin_session(&id) {
+        Ok(Some(sess)) => Json(sess).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, format!("no sinkin session {id}")).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/kernel/crates/gctrl-otel/tests/uber_sinkin.rs
+++ b/kernel/crates/gctrl-otel/tests/uber_sinkin.rs
@@ -1,0 +1,190 @@
+//! Integration tests for `/api/uber/sinkin/sessions` routes.
+//!
+//! SinkIn introspects the wiki and files Question + Connection markdown
+//! pages (those live in the vault). This index tracks the run itself —
+//! cost, scope, counts — so the dashboard can list recent runs without
+//! scanning the whole vault.
+
+use axum::body::Body;
+use gctrl_core::NetConfig;
+use gctrl_otel::create_router_full;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn router() -> axum::Router {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    create_router_full(store, sqlite, None, Arc::new(NetConfig::default()))
+}
+
+async fn post_json(app: &axum::Router, uri: &str, body: serde_json::Value) -> (u16, String) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+async fn get_url(app: &axum::Router, uri: &str) -> (u16, String) {
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[tokio::test]
+async fn upsert_open_then_close_round_trips() {
+    let app = router();
+
+    // Open a session in `running` state.
+    let (status, body) = post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({
+            "id": "sinkin-2026-05-01-001",
+            "status": "running",
+            "mode": "manual",
+            "scope_kind": "topic",
+            "scope_value": "ai-infrastructure",
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "open: {body}");
+
+    // Update with counts + complete it.
+    let (status, body) = post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({
+            "id": "sinkin-2026-05-01-001",
+            "status": "completed",
+            "mode": "manual",
+            "pages_scanned": 42,
+            "gaps_found": 5,
+            "gaps_answered": 3,
+            "connections_found": 2,
+            "cost_usd": 0.15,
+            "model": "google/gemma-4-31b",
+            "completed_at": "2026-05-01T12:34:56Z",
+        }),
+    )
+    .await;
+    assert_eq!(status, 200, "close: {body}");
+
+    let (status, body) = get_url(&app, "/api/uber/sinkin/sessions/sinkin-2026-05-01-001").await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["status"], "completed");
+    assert_eq!(v["pages_scanned"], 42);
+    assert_eq!(v["gaps_found"], 5);
+    assert_eq!(v["gaps_answered"], 3);
+    assert_eq!(v["connections_found"], 2);
+    assert!(v["completed_at"].is_string());
+}
+
+#[tokio::test]
+async fn upsert_preserves_started_at_across_updates() {
+    let app = router();
+    post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({
+            "id": "sinkin-1",
+            "status": "running",
+            "mode": "manual",
+        }),
+    )
+    .await;
+    let (_, body) = get_url(&app, "/api/uber/sinkin/sessions/sinkin-1").await;
+    let v1: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let started_first = v1["started_at"].as_str().unwrap().to_string();
+
+    // Sleep a tick, then update; started_at should remain.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({
+            "id": "sinkin-1",
+            "status": "completed",
+            "mode": "manual",
+            "pages_scanned": 7,
+        }),
+    )
+    .await;
+    let (_, body) = get_url(&app, "/api/uber/sinkin/sessions/sinkin-1").await;
+    let v2: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v2["started_at"].as_str().unwrap(), started_first);
+    assert_eq!(v2["pages_scanned"], 7);
+}
+
+#[tokio::test]
+async fn get_returns_404_when_missing() {
+    let app = router();
+    let (status, _) = get_url(&app, "/api/uber/sinkin/sessions/nonexistent").await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn list_returns_sessions_in_reverse_start_order() {
+    let app = router();
+    for (i, id) in ["sinkin-a", "sinkin-b", "sinkin-c"].iter().enumerate() {
+        post_json(
+            &app,
+            "/api/uber/sinkin/sessions",
+            serde_json::json!({"id": id, "status": "running", "mode": "manual"}),
+        )
+        .await;
+        // Force ordering — started_at is stamped at first upsert.
+        if i < 2 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+    let (status, body) = get_url(&app, "/api/uber/sinkin/sessions").await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert_eq!(arr[0]["id"], "sinkin-c");
+    assert_eq!(arr[2]["id"], "sinkin-a");
+}
+
+#[tokio::test]
+async fn list_filters_by_status() {
+    let app = router();
+    post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({"id": "open-1", "status": "running", "mode": "manual"}),
+    )
+    .await;
+    post_json(
+        &app,
+        "/api/uber/sinkin/sessions",
+        serde_json::json!({"id": "done-1", "status": "completed", "mode": "manual"}),
+    )
+    .await;
+
+    let (_, body) = get_url(&app, "/api/uber/sinkin/sessions?status=completed").await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 1);
+    assert_eq!(v[0]["id"], "done-1");
+
+    let (_, body) = get_url(&app, "/api/uber/sinkin/sessions?status=running").await;
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 1);
+    assert_eq!(v[0]["id"], "open-1");
+}

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -14,7 +14,7 @@ use gctrl_core::{
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
     PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRunUpdate,
-    OrchTask, UberBrief, VaultMount, VaultMountKind,
+    OrchTask, UberBrief, UberSinkinSession, VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 
@@ -311,6 +311,35 @@ CREATE TABLE IF NOT EXISTS uber_briefs (
 )
 "#;
 
+// App-namespaced (per the `<app>_*` invariant). One row per SinkIn run.
+// Per apps/uebermensch/vault/specs/sinkin.md, SinkIn introspects the wiki
+// and files Question + Connection markdown pages; this table tracks the
+// run itself (cost, scope, counts). The resulting Question/Connection
+// pages live in the vault and are indexed via the watcher in a follow-up.
+const CREATE_UBER_SINKIN_SESSIONS: &str = r#"
+CREATE TABLE IF NOT EXISTS uber_sinkin_sessions (
+    id                TEXT PRIMARY KEY,
+    started_at        TEXT NOT NULL,
+    completed_at      TEXT,
+    status            TEXT NOT NULL DEFAULT 'running',
+    -- 'scheduled' | 'interactive' | 'manual'
+    mode              TEXT NOT NULL,
+    -- Optional scope: a topic or thesis slug to constrain the pass.
+    scope_kind        TEXT,
+    scope_value       TEXT,
+    pages_scanned     INTEGER NOT NULL DEFAULT 0,
+    gaps_found        INTEGER NOT NULL DEFAULT 0,
+    gaps_answered     INTEGER NOT NULL DEFAULT 0,
+    connections_found INTEGER NOT NULL DEFAULT 0,
+    cost_usd          REAL NOT NULL DEFAULT 0.0,
+    model             TEXT,
+    prompt_hash       TEXT,
+    failed_reason     TEXT,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL
+)
+"#;
+
 const CREATE_SCHEDULES: &str = r#"
 CREATE TABLE IF NOT EXISTS schedules (
     id              TEXT PRIMARY KEY,
@@ -391,6 +420,10 @@ const CREATE_INDEXES: &[&str] = &[
     // Uebermensch briefs index — date lookup + reverse-chrono listing
     "CREATE INDEX IF NOT EXISTS idx_uber_briefs_date ON uber_briefs(date DESC)",
     "CREATE INDEX IF NOT EXISTS idx_uber_briefs_kind_date ON uber_briefs(kind, date DESC)",
+    // Uebermensch sinkin sessions index — list recent runs + scope filtering
+    "CREATE INDEX IF NOT EXISTS idx_uber_sinkin_started ON uber_sinkin_sessions(started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_uber_sinkin_status ON uber_sinkin_sessions(status, started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_uber_sinkin_scope ON uber_sinkin_sessions(scope_kind, scope_value)",
 ];
 
 // ═══════════════════════════════════════════════════════════════
@@ -453,6 +486,7 @@ impl SqliteStore {
             CREATE_MEMORY_ENTRIES,
             CREATE_VAULT_MOUNTS,
             CREATE_UBER_BRIEFS,
+            CREATE_UBER_SINKIN_SESSIONS,
             CREATE_SCHEDULES,
         ];
         for stmt in &tables {
@@ -2592,6 +2626,110 @@ impl SqliteStore {
         }
     }
 
+    // ───────────────────────── Uebermensch sinkin sessions ─────────────────────────
+
+    /// Idempotent upsert by `id`. The CLI generates the id at run start;
+    /// subsequent updates (counts, completion) replace by id.
+    pub fn upsert_uber_sinkin_session(&self, sess: &UberSinkinSession) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO uber_sinkin_sessions
+                (id, started_at, completed_at, status, mode, scope_kind, scope_value,
+                 pages_scanned, gaps_found, gaps_answered, connections_found, cost_usd,
+                 model, prompt_hash, failed_reason, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+             ON CONFLICT(id) DO UPDATE SET
+                completed_at = excluded.completed_at,
+                status = excluded.status,
+                pages_scanned = excluded.pages_scanned,
+                gaps_found = excluded.gaps_found,
+                gaps_answered = excluded.gaps_answered,
+                connections_found = excluded.connections_found,
+                cost_usd = excluded.cost_usd,
+                model = excluded.model,
+                prompt_hash = excluded.prompt_hash,
+                failed_reason = excluded.failed_reason,
+                updated_at = excluded.updated_at",
+            params![
+                sess.id,
+                sess.started_at.to_rfc3339(),
+                sess.completed_at.map(|dt| dt.to_rfc3339()),
+                sess.status,
+                sess.mode,
+                sess.scope_kind,
+                sess.scope_value,
+                sess.pages_scanned,
+                sess.gaps_found,
+                sess.gaps_answered,
+                sess.connections_found,
+                sess.cost_usd,
+                sess.model,
+                sess.prompt_hash,
+                sess.failed_reason,
+                sess.created_at.to_rfc3339(),
+                sess.updated_at.to_rfc3339(),
+            ],
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn get_uber_sinkin_session(&self, id: &str) -> Result<Option<UberSinkinSession>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT id, started_at, completed_at, status, mode, scope_kind, scope_value,
+                    pages_scanned, gaps_found, gaps_answered, connections_found, cost_usd,
+                    model, prompt_hash, failed_reason, created_at, updated_at
+             FROM uber_sinkin_sessions WHERE id = ?1",
+            [id],
+            row_to_uber_sinkin_session,
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(GctlError::Storage(other.to_string())),
+        })
+    }
+
+    /// Reverse-chrono list. Optional `status` filter (`running`, `completed`, …).
+    pub fn list_uber_sinkin_sessions(
+        &self,
+        status: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<UberSinkinSession>> {
+        let conn = self.conn.lock().unwrap();
+        match status {
+            Some(s) => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, started_at, completed_at, status, mode, scope_kind, scope_value,
+                                pages_scanned, gaps_found, gaps_answered, connections_found, cost_usd,
+                                model, prompt_hash, failed_reason, created_at, updated_at
+                         FROM uber_sinkin_sessions WHERE status = ?1 ORDER BY started_at DESC LIMIT ?2",
+                    )
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map(params![s, limit], row_to_uber_sinkin_session)
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                Ok(rows.filter_map(|r| r.ok()).collect())
+            }
+            None => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, started_at, completed_at, status, mode, scope_kind, scope_value,
+                                pages_scanned, gaps_found, gaps_answered, connections_found, cost_usd,
+                                model, prompt_hash, failed_reason, created_at, updated_at
+                         FROM uber_sinkin_sessions ORDER BY started_at DESC LIMIT ?1",
+                    )
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map(params![limit], row_to_uber_sinkin_session)
+                    .map_err(|e| GctlError::Storage(e.to_string()))?;
+                Ok(rows.filter_map(|r| r.ok()).collect())
+            }
+        }
+    }
+
     // ───────────────────────── Schedules ─────────────────────────
 
     pub fn create_schedule(&self, sched: &Schedule) -> Result<()> {
@@ -2859,6 +2997,37 @@ fn row_to_uber_brief(row: &rusqlite::Row<'_>) -> rusqlite::Result<UberBrief> {
         cited_claims: row.get(11)?,
         total_claims: row.get(12)?,
         failed_at: failed_at_str.as_deref().map(parse_dt),
+        failed_reason: row.get(14)?,
+        created_at: parse_dt(&created_at_str),
+        updated_at: parse_dt(&updated_at_str),
+    })
+}
+
+fn row_to_uber_sinkin_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<UberSinkinSession> {
+    let started_at_str: String = row.get(1)?;
+    let completed_at_str: Option<String> = row.get(2)?;
+    let created_at_str: String = row.get(15)?;
+    let updated_at_str: String = row.get(16)?;
+    let parse_dt = |s: &str| -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now())
+    };
+    Ok(UberSinkinSession {
+        id: row.get(0)?,
+        started_at: parse_dt(&started_at_str),
+        completed_at: completed_at_str.as_deref().map(parse_dt),
+        status: row.get(3)?,
+        mode: row.get(4)?,
+        scope_kind: row.get(5)?,
+        scope_value: row.get(6)?,
+        pages_scanned: row.get(7)?,
+        gaps_found: row.get(8)?,
+        gaps_answered: row.get(9)?,
+        connections_found: row.get(10)?,
+        cost_usd: row.get(11)?,
+        model: row.get(12)?,
+        prompt_hash: row.get(13)?,
         failed_reason: row.get(14)?,
         created_at: parse_dt(&created_at_str),
         updated_at: parse_dt(&updated_at_str),


### PR DESCRIPTION
## Summary

Kernel substrate for SinkIn — a persistence layer + HTTP API for tracking SinkIn run sessions, so the dashboard / shell can list recent runs without scanning the vault.

The companion uebermensch CLI scaffold + persona templates are in a separate PR (#TBD-cli) so this one stays purely kernel.

## What ships here

**`gctrl-storage` — `uber_sinkin_sessions` table**
- New SQLite table tracking status, mode, scope (topic/thesis), counts (`pages_scanned`, `gaps_found`, `gaps_answered`, `connections_found`), cost, model, prompt_hash, failed_reason. Three supporting indexes on `started_at`, `status`, `scope`.
- `UberSinkinSession` typed model in `gctrl-core`.
- 3 CRUD methods on `SqliteStore`: upsert / get / list (with optional status filter).
- Upsert preserves `started_at` and `created_at` across updates so the caller can reuse the same id to update counts without losing the original start time.

**`gctrl-otel` — HTTP routes**

| Route | Behavior |
|---|---|
| `GET    /api/uber/sinkin/sessions` | reverse-chrono list, `?status=` filter |
| `POST   /api/uber/sinkin/sessions` | idempotent upsert by id |
| `GET    /api/uber/sinkin/sessions/{id}` | fetch by id (404 if missing) |

## Test plan

- [x] 5 integration tests in `tests/uber_sinkin.rs`: open→close round trip, `started_at` preservation across updates, 404 on missing id, reverse-chrono list, status filter.
- [x] Existing kernel tests still pass.

Refs OpenHackersClub/uebermensch#5.
