### PR TITLE
refactor(uebermensch): replace --billing with --effort low|medium|high

### DIFF
--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -58,15 +58,44 @@ const ratesForModel = (model: string): CostRates => {
   return [3.0, 15.0];
 };
 
-// Billing mode override. When the operator is on a Claude Pro/Team/Max
-// subscription (or otherwise prepaid), per-token cost is irrelevant and
-// would just clutter the run output. UBER_LLM_BILLING=subscription forces
-// every cost calculation to $0; default is `metered` (per-token rates above).
-type BillingMode = "metered" | "subscription";
+// Effort tier — operator-facing knob for how much LLM work to spend on a
+// run. Maps to (max output tokens, thinking config). The lower-level
+// per-provider billing concern (subscription vs metered, AI Gateway vs
+// BYOK) lives in the kernel's driver-llm — uebermensch should not know
+// or care.
+type Effort = "low" | "medium" | "high";
 
-const billingMode = (): BillingMode => {
-  const raw = process.env.UBER_LLM_BILLING?.toLowerCase().trim();
-  return raw === "subscription" ? "subscription" : "metered";
+const effortFromEnv = (): Effort => {
+  const raw = process.env.UBER_LLM_EFFORT?.toLowerCase().trim();
+  if (raw === "low" || raw === "high") return raw;
+  return "medium";
+};
+
+// Anthropic `thinking` parameter shapes:
+// - "off"      → no thinking field (model answers directly)
+// - "adaptive" → `{ type: "adaptive" }` — model decides budget
+// - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
+type ThinkingMode = "off" | "adaptive" | "extended";
+
+type EffortConfig = {
+  readonly maxTokens: number;
+  readonly thinking: ThinkingMode;
+  readonly thinkingBudgetTokens: number;
+};
+
+const effortConfigFor = (effort: Effort): EffortConfig => {
+  switch (effort) {
+    case "low":
+      // Tight cap, no thinking. Single-pass, fast, cheap.
+      return { maxTokens: 4000, thinking: "off", thinkingBudgetTokens: 0 };
+    case "high":
+      // Generous output budget + explicit extended-thinking budget for
+      // deeper synthesis. Doubles default max for long deep-dives.
+      return { maxTokens: 32000, thinking: "extended", thinkingBudgetTokens: 16000 };
+    default:
+      // Adaptive thinking — model decides budget. Current default behavior.
+      return { maxTokens: DEFAULT_MAX_TOKENS, thinking: "adaptive", thinkingBudgetTokens: 0 };
+  }
 };
 
 // Per-article summarization shares the curator default by design — LM Studio
@@ -327,12 +356,24 @@ const fetchKernel = (
     return raw;
   });
 
+const thinkingBody = (
+  thinking: ThinkingMode,
+  budgetTokens: number,
+): Record<string, unknown> => {
+  if (thinking === "off") return {};
+  if (thinking === "extended") {
+    return { thinking: { type: "enabled", budget_tokens: budgetTokens } };
+  }
+  return { thinking: { type: "adaptive" } };
+};
+
 const postAnthropic = (
   model: string,
   system: string,
   userPrompt: string,
   maxTokens: number,
-  thinking: boolean,
+  thinking: ThinkingMode,
+  thinkingBudgetTokens: number,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   Effect.gen(function* () {
     const body: Record<string, unknown> = {
@@ -340,7 +381,7 @@ const postAnthropic = (
       max_tokens: maxTokens,
       system,
       messages: [{ role: "user", content: userPrompt }],
-      ...(thinking ? { thinking: { type: "adaptive" } } : {}),
+      ...thinkingBody(thinking, thinkingBudgetTokens),
     };
     const raw = yield* fetchKernel("/api/llm/messages", body);
     const parsed = yield* Effect.try({
@@ -428,12 +469,13 @@ const postLlm = (
   system: string,
   userPrompt: string,
   maxTokens: number,
-  thinking: boolean,
+  thinking: ThinkingMode,
+  thinkingBudgetTokens: number,
   jsonFormat: JsonResponseFormat | null,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   isWorkersAiModel(model)
     ? postWorkersAi(model, system, userPrompt, maxTokens, jsonFormat)
-    : postAnthropic(model, system, userPrompt, maxTokens, thinking);
+    : postAnthropic(model, system, userPrompt, maxTokens, thinking, thinkingBudgetTokens);
 
 // Effect schemas → JSON Schema, computed once. Used as the `response_format`
 // hint so local backends (LMStudio, llama.cpp grammar, vLLM) constrain the
@@ -488,7 +530,6 @@ const costForResponse = (
   inputRateOverride?: number,
   outputRateOverride?: number,
 ): number => {
-  if (billingMode() === "subscription") return 0;
   if (isWorkersAiModel(res.model)) return 0;
   if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
     return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride);
@@ -771,12 +812,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildUserPrompt(req);
       const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const eff = effortConfigFor(effortFromEnv());
       const res = yield* postLlm(
         model,
         SYSTEM_PROMPT,
         userPrompt,
-        DEFAULT_MAX_TOKENS,
-        true,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
         briefJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
@@ -804,12 +847,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildSubtopicUserPrompt(req);
       const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const eff = effortConfigFor(effortFromEnv());
       const res = yield* postLlm(
         model,
         SUBTOPIC_SYSTEM_PROMPT,
         userPrompt,
-        DEFAULT_MAX_TOKENS,
-        true,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
         subtopicJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
@@ -847,12 +892,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildInterestReportUserPrompt(req);
       const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const eff = effortConfigFor(effortFromEnv());
       const res = yield* postLlm(
         model,
         REPORT_SYSTEM_PROMPT,
         userPrompt,
-        DEFAULT_MAX_TOKENS,
-        true,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
         interestReportJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
@@ -886,12 +933,14 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildResearchQueryUserPrompt(req);
       const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      const eff = effortConfigFor(effortFromEnv());
       const res = yield* postLlm(
         model,
         RESEARCH_SYSTEM_PROMPT,
         userPrompt,
-        DEFAULT_MAX_TOKENS,
-        true,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
         null,
       );
       const answerMd = res.text.trim();
@@ -909,12 +958,16 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
           : req.text;
       const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
       const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
+      // Summary lane is always low-effort: short, cheap, no thinking. Not
+      // operator-tunable — bumping summarization to "high" would 10x the
+      // ingest spend with negligible quality lift.
       const res = yield* postLlm(
         summaryModelFor(),
         SUMMARY_SYSTEM_PROMPT,
         userPrompt,
         SUMMARY_MAX_TOKENS,
-        false,
+        "off",
+        0,
         null,
       );
       const insightsMd = normalizeInsights(res.text);
@@ -962,4 +1015,6 @@ export const _internal = {
   SERVICE_NAME,
   isAnthropicModel,
   isWorkersAiModel,
+  effortFromEnv,
+  effortConfigFor,
 };

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -104,9 +104,9 @@ const modelOpt = Options.text("model").pipe(
   Options.optional,
 )
 
-const billingOpt = Options.choice("billing", ["metered", "subscription"]).pipe(
+const effortOpt = Options.choice("effort", ["low", "medium", "high"]).pipe(
   Options.withDescription(
-    "Cost accounting mode. 'metered' (default) bills per-token at published rates; 'subscription' zeros all costs (use when on Claude Pro/Team/Max). Sets UBER_LLM_BILLING for the process.",
+    "How much LLM effort to spend per stage. 'low' caps output tokens and disables thinking; 'medium' (default) is adaptive thinking with the standard token budget; 'high' enables extended thinking with a budget bump and doubles the output cap. Sets UBER_LLM_EFFORT for the process. Per-token billing is a kernel/driver-llm concern, not exposed here.",
   ),
   Options.optional,
 )
@@ -186,7 +186,7 @@ export const report = Command.make(
     syncOpt,
     llmOpt,
     modelOpt,
-    billingOpt,
+    effortOpt,
   },
   ({
     sinceDaysOpt: sinceDays,
@@ -198,7 +198,7 @@ export const report = Command.make(
     syncOpt: doSyncOpt,
     llmOpt: llmKind,
     modelOpt: modelOverride,
-    billingOpt: billingOverride,
+    effortOpt: effortOverride,
   }) =>
     Effect.gen(function* () {
       const vaultDir = yield* resolveVaultDir()
@@ -211,27 +211,27 @@ export const report = Command.make(
           process.env.UBER_LLM_MODEL = m
         },
       })
-      Option.match(billingOverride, {
+      Option.match(effortOverride, {
         onNone: () => {},
-        onSome: (b) => {
-          process.env.UBER_LLM_BILLING = b
+        onSome: (e) => {
+          process.env.UBER_LLM_EFFORT = e
         },
       })
       const activeModel =
         Option.getOrUndefined(modelOverride) ??
         process.env.UBER_LLM_MODEL ??
         "(default)"
-      const activeBilling =
-        Option.getOrUndefined(billingOverride) ??
-        process.env.UBER_LLM_BILLING ??
-        "metered"
+      const activeEffort =
+        Option.getOrUndefined(effortOverride) ??
+        process.env.UBER_LLM_EFFORT ??
+        "medium"
       const anchor = Option.getOrElse(dateOptVal, today)
       const anchorDate = new Date(`${anchor}T00:00:00Z`)
       const { label: periodLabel } = isoWeekLabel(anchorDate)
       const periodEnd = anchor
       const periodStart = toYmd(addDays(anchorDate, -sinceDays))
       yield* Console.log(
-        `generating weekly reports ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind}, model=${activeModel}, billing=${activeBilling}, concurrency=${concurrency})`,
+        `generating weekly reports ${periodLabel} (${periodStart} → ${periodEnd}) from ${vaultDir} (llm=${llmKind}, model=${activeModel}, effort=${activeEffort}, concurrency=${concurrency})`,
       )
 
       const program = Effect.gen(function* () {

--- a/apps/uebermensch/src/commands/sinkin.ts
+++ b/apps/uebermensch/src/commands/sinkin.ts
@@ -127,7 +127,7 @@ export const sinkin = Command.make(
       const program = Effect.gen(function* () {
         const vaultSvc = yield* VaultService
         const slugs = yield* vaultSvc.listSlugs()
-        return slugs.length
+        return slugs.size
       })
       const pagesScanned = yield* program.pipe(
         Effect.provide(FileSystemVaultLive(vaultDir)),

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -5,7 +5,7 @@ import type { CandidateRef } from "../src/lib/candidates.js"
 import { LlmService } from "../src/services/LlmService.js"
 import type { WikiPage } from "../src/services/VaultService.js"
 
-const { extractJson, buildUserPrompt, kernelBase, normalizeInsights } = _internal
+const { extractJson, buildUserPrompt, kernelBase, normalizeInsights, effortFromEnv, effortConfigFor } = _internal
 
 // The Anthropic-routed tests in this file pin UBER_LLM_MODEL /
 // UBER_LLM_SUMMARY_MODEL to claude-* via beforeEach so they keep exercising
@@ -550,5 +550,41 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     )
 
     expect(result.selectedSlug).toBe("real-slug")
+  })
+
+  describe("effort tier mapping", () => {
+    const prevEffort = process.env.UBER_LLM_EFFORT
+
+    afterEach(() => {
+      if (prevEffort === undefined) delete process.env.UBER_LLM_EFFORT
+      else process.env.UBER_LLM_EFFORT = prevEffort
+    })
+
+    it("default effort is medium with adaptive thinking and 16k tokens", () => {
+      delete process.env.UBER_LLM_EFFORT
+      const cfg = effortConfigFor(effortFromEnv())
+      expect(cfg.maxTokens).toBe(16000)
+      expect(cfg.thinking).toBe("adaptive")
+    })
+
+    it("low effort caps tokens to 4k and disables thinking", () => {
+      process.env.UBER_LLM_EFFORT = "low"
+      const cfg = effortConfigFor(effortFromEnv())
+      expect(cfg.maxTokens).toBe(4000)
+      expect(cfg.thinking).toBe("off")
+    })
+
+    it("high effort doubles to 32k tokens with extended thinking budget", () => {
+      process.env.UBER_LLM_EFFORT = "high"
+      const cfg = effortConfigFor(effortFromEnv())
+      expect(cfg.maxTokens).toBe(32000)
+      expect(cfg.thinking).toBe("extended")
+      expect(cfg.thinkingBudgetTokens).toBeGreaterThan(0)
+    })
+
+    it("invalid UBER_LLM_EFFORT falls back to medium", () => {
+      process.env.UBER_LLM_EFFORT = "ludicrous"
+      expect(effortFromEnv()).toBe("medium")
+    })
   })
 })

--- a/apps/uebermensch/vault/specs/briefing-pipeline.md
+++ b/apps/uebermensch/vault/specs/briefing-pipeline.md
@@ -181,6 +181,20 @@ Routing follows the model id prefix:
 
 Switching model does not change the prompt — `prompt_hash` stays stable across model switches, which makes A/B comparison clean. Cost rates are looked up per-model on the kernel side.
 
+### Effort tiers
+
+Orthogonal to model selection. `--effort low|medium|high` (or `UBER_LLM_EFFORT`) controls how much LLM work each stage spends on a single call. The tier maps to (max output tokens, thinking config):
+
+| Effort | Max output tokens | Thinking | Notes |
+|---|---|---|---|
+| `low` | 4 000 | off | Single-pass, fast, cheap. Use for bulk runs or when iterating on prompts. |
+| `medium` (default) | 16 000 | adaptive | Model decides thinking budget. Current default behavior. |
+| `high` | 32 000 | extended (`budget_tokens: 16000`) | Explicit extended-thinking budget for deep synthesis. Roughly doubles output cap and adds a fixed thinking budget. |
+
+Effort applies uniformly across the brief / subtopic-propose / deep-dive / research-query stages. The summary lane (per-article ingest summarization) is hard-pinned to low effort and is not operator-tunable — high effort there would 10× ingest spend with negligible quality lift.
+
+Effort is an app-level knob (how hard to work). Per-token billing (subscription vs metered, BYOK vs gateway) lives in the kernel's driver-llm and is intentionally not exposed at the app layer.
+
 ### Prompt Versioning
 
 Every curator call:
@@ -316,7 +330,7 @@ Implemented in `apps/uebermensch/src/entrypoints/cli/`.
 | `gctrl uber run-daily` | Idempotent: generate today's brief if missing, then `send` against today. The kernel scheduler invokes this on cron — see [scheduling.md](scheduling.md). |
 | `gctrl uber schedule sync` | Reconcile `directives/schedules.md` → kernel `/api/schedules` (`name_prefix=uber.`). Vault is authoritative. |
 | `gctrl uber brief --model <id>` | Override model for this run (e.g. `claude-opus-4-7`); same flag on `report` and `deepdive` |
-| `gctrl uber report --billing <metered\|subscription>` | Cost accounting mode for the run. `metered` (default) bills per-token at published rates; `subscription` zeros all costs (use when on Claude Pro/Team/Max). Sets `UBER_LLM_BILLING` for the process. |
+| `gctrl uber report --effort <low\|medium\|high>` | How much LLM effort to spend per stage. `low` caps output tokens and disables thinking; `medium` (default) is adaptive thinking with the standard token budget; `high` enables extended thinking with a budget bump and doubles the output cap. Sets `UBER_LLM_EFFORT` for the process. Per-token billing is a kernel/driver-llm concern, not exposed at the app layer. |
 | `gctrl uber deepdive <slug>` | Run `BriefingService.generateDeepdive(slug)` |
 | `gctrl uber report` | Run weekly research reports across **all** `directives/research/*` interests (one report file per interest + one index) |
 | `gctrl uber report --model <id>` | Override model for the run; applies to subtopic-propose + deep-dive stages uniformly |


### PR DESCRIPTION
## Summary

Replaces `--billing` (introduced in #130) with `--effort low|medium|high` on `gctrl uber report`. Billing is a kernel concern — provider, gateway, subscription state all live there. The app-level knob is **how much LLM work to spend on a run**, which is effort.

Effort is orthogonal to `--model`: model says *which*, effort says *how hard to push it*.

## Effort tier mapping (`KernelLlm.ts:effortConfigFor`)

| Effort | Max output tokens | Thinking | Use case |
|---|---|---|---|
| `low` | 4 000 | off | Bulk runs, prompt iteration |
| `medium` (default) | 16 000 | adaptive | Current default — model decides budget |
| `high` | 32 000 | extended (`budget_tokens: 16000`) | Deep synthesis runs |

Effort applies uniformly across brief / subtopic-propose / deep-dive / research-query. The summary lane (per-article ingest) is hard-pinned to low and not operator-tunable — bumping it to high would 10× ingest spend with negligible quality lift.

## What changes

| Area | Change |
|---|---|
| `KernelLlm.ts` | `Effort` + `ThinkingMode` types; `effortConfigFor()`; `effortFromEnv()` reads `UBER_LLM_EFFORT`. `postAnthropic` takes a `ThinkingMode` instead of boolean; `thinkingBody()` helper renders the API shape (off / adaptive / extended). All four operator-facing call sites read effort uniformly. Drops the `UBER_LLM_BILLING` short-circuit in `costForResponse`. |
| `commands/report.ts` | `--effort` flag replaces `--billing`. Sets `UBER_LLM_EFFORT` for the process. Status line prints the active effort. |
| `commands/sinkin.ts` | Drive-by fix: `.length` on `ReadonlySet` (added by #132) → `.size`. Typecheck was broken on main. |
| `vault/specs/briefing-pipeline.md` | New "Effort tiers" section with mapping table. CLI Entrypoints row updated. Explicit note: billing is kernel-side, not exposed at app layer. |
| `tests/kernel-llm.test.ts` | 4 new effort-tier tests (defaults, low caps, high extended, invalid fallback). |

## Test plan

- [x] `pnpm vitest run` — 214/214 pass (4 new effort tests)
- [x] `pnpm typecheck` — clean (was broken on main due to sinkin `.length`/`.size` bug, now fixed)
- [x] `pnpm build` — clean
- [x] `gctrl uber report --help` shows `--effort` flag
- [ ] Manual: `gctrl uber report --model claude-opus-4-7 --effort high` against live kernel — expect deeper analysis with higher cost; `--effort low` for cheap iteration

## Why now

Per feedback during #130 review: billing is downstream of the kernel (it knows the provider, the gateway, the subscription state). At the app layer, the operator knob that actually changes outputs is effort.

## Migration

`--billing` flag is removed (was only released in #130, not in any external workflow). `UBER_LLM_BILLING` env var is no longer read.
