### PR TITLE
fix(uebermensch): run-daily fails with error: null when brief file absent

### DIFF
--- a/apps/uebermensch/src/commands/run-daily.ts
+++ b/apps/uebermensch/src/commands/run-daily.ts
@@ -38,10 +38,13 @@ const runBriefGeneration = (
 ): Effect.Effect<string, unknown, ProfileService | VaultService | LlmService | RendererService> =>
   Effect.gen(function* () {
     const briefAbs = join(vaultDir, `${INPUT_BRIEFS_DIR}/${date}.md`)
-    const existing = yield* Effect.tryPromise({
-      try: () => readFile(briefAbs, "utf8"),
-      catch: () => null as null,
-    })
+    // ENOENT means "no brief yet, generate one" — must be a successful null,
+    // NOT a failure. Effect.tryPromise's `catch` produces a failure value, so
+    // an absent file was killing the pipeline with `error: null` (the morning
+    // cron run-daily was hitting this every day the brief didn't pre-exist).
+    const existing = yield* Effect.tryPromise(() => readFile(briefAbs, "utf8")).pipe(
+      Effect.orElseSucceed(() => null as string | null),
+    )
     if (existing !== null) {
       yield* Console.log(`brief already exists for ${date}, reusing`)
       return existing


### PR DESCRIPTION
## Summary

One-line fix: `gctrl uber run-daily` (the cron-invoked daily brief job) crashes with `brief generation failed: null` whenever today's brief file doesn't already exist — i.e. exactly when the cron actually needs to do work.

## Root cause

```ts
const existing = yield* Effect.tryPromise({
  try: () => readFile(briefAbs, "utf8"),
  catch: () => null as null,   // ← makes the Effect FAIL with null on ENOENT
})
```

`Effect.tryPromise({ try, catch })` makes the Effect **fail** with the catch-return value, not succeed. The intent was clearly "absent → null → fall through to generate", but the actual behavior was "absent → fail with `null` → kill pipeline".

## Evidence from production

Kernel scheduler logs from `2026-05-01 00:33 UTC`:

```
WARN scheduler::runner: scheduler: exec failed
  schedule=uber.morning_brief exit_code=Some(1) elapsed_ms=2619
  stderr=brief generation failed: null
```

2.6s elapsed → no LLM call, hit before generation.

The afternoon manual run-daily succeeded because the brief file did pre-exist (reused path bypasses the broken check).

## Fix

```ts
const existing = yield* Effect.tryPromise(() => readFile(briefAbs, "utf8")).pipe(
  Effect.orElseSucceed(() => null as string | null),
)
```

ENOENT now becomes a successful `null`, generator path runs.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run tests/run-daily.test.ts` — 5/5 pass
- [x] `pnpm build` — clean
- [x] Manual: `uber run-daily` against a vault without today's brief generated and delivered to all 3 channels (Telegram 13 parts, Discord 13 parts, app)

## Why no new test

The existing 5 run-daily tests bypass the `runBriefGeneration` helper and exercise the underlying services directly. The bug was in the helper's file-check logic, not in any service the existing tests cover. Adding a test for it requires exporting the helper (or running the full `Command`); kept out of scope to keep this PR minimal — verified live in production instead.

Follow-up worth considering: export `runBriefGeneration` and add an ENOENT-path unit test, or exercise the full Command in an integration test.
