### PR TITLE
feat(uebermensch): scheduler accepts report-and-send job kind

### DIFF
--- a/apps/uebermensch/src/commands/schedule-sync.ts
+++ b/apps/uebermensch/src/commands/schedule-sync.ts
@@ -70,7 +70,7 @@ type JobKind = (typeof VALID_JOBS)[number]
 
 const TIMEOUT_SECS = 300
 
-type KernelScheduleRow = {
+export type KernelScheduleRow = {
   name: string
   cron: string
   target_kind: string
@@ -79,6 +79,13 @@ type KernelScheduleRow = {
   env_keys: ReadonlyArray<string>
   enabled: boolean
   timeout_secs: number
+}
+
+export type ScheduleDiff = {
+  creates: ReadonlyArray<KernelScheduleRow>
+  updates: ReadonlyArray<KernelScheduleRow>
+  deletes: ReadonlyArray<string>
+  unchanged: ReadonlyArray<string>
 }
 
 const kernelBase = () =>
@@ -148,6 +155,20 @@ const buildRow = (
   }
 }
 
+export const buildDesiredRows = (
+  config: SchedulesConfig,
+  vaultDir: string,
+  uberDistPath: string,
+  nodePath: string,
+): Map<string, KernelScheduleRow> => {
+  const desired = new Map<string, KernelScheduleRow>()
+  for (const [localName, entry] of Object.entries(config.schedules)) {
+    const kernelName = `uber.${localName}`
+    desired.set(kernelName, buildRow(kernelName, entry, vaultDir, uberDistPath, nodePath))
+  }
+  return desired
+}
+
 const rowsEqual = (a: KernelScheduleRow, b: KernelScheduleRow): boolean =>
   a.cron === b.cron &&
   a.target_kind === b.target_kind &&
@@ -156,6 +177,27 @@ const rowsEqual = (a: KernelScheduleRow, b: KernelScheduleRow): boolean =>
   JSON.stringify(a.env_keys) === JSON.stringify(b.env_keys) &&
   a.enabled === b.enabled &&
   a.timeout_secs === b.timeout_secs
+
+export const diffSchedules = (
+  desired: ReadonlyMap<string, KernelScheduleRow>,
+  existing: ReadonlyMap<string, KernelScheduleRow>,
+): ScheduleDiff => {
+  const creates: Array<KernelScheduleRow> = []
+  const updates: Array<KernelScheduleRow> = []
+  const deletes: Array<string> = []
+  const unchanged: Array<string> = []
+
+  for (const [name, desiredRow] of desired) {
+    const existingRow = existing.get(name)
+    if (!existingRow) creates.push(desiredRow)
+    else if (!rowsEqual(existingRow, desiredRow)) updates.push(desiredRow)
+    else unchanged.push(name)
+  }
+  for (const [name] of existing) {
+    if (!desired.has(name)) deletes.push(name)
+  }
+  return { creates, updates, deletes, unchanged }
+}
 
 export const scheduleSyncProgram = Effect.gen(function* () {
   const vaultDir = yield* resolveVaultDir()
@@ -229,12 +271,7 @@ export const scheduleSyncProgram = Effect.gen(function* () {
     }
   }
 
-  // Compute desired rows
-  const desired = new Map<string, KernelScheduleRow>()
-  for (const [localName, entry] of Object.entries(config.schedules)) {
-    const kernelName = `uber.${localName}`
-    desired.set(kernelName, buildRow(kernelName, entry, vaultDir, uberDistPath, nodePath))
-  }
+  const desired = buildDesiredRows(config, vaultDir, uberDistPath, nodePath)
 
   // Fetch existing uber.* rows from kernel
   const existingRaw = yield* kernelFetch("GET", "/api/schedules?name_prefix=uber.").pipe(
@@ -253,39 +290,25 @@ export const scheduleSyncProgram = Effect.gen(function* () {
     Array.isArray(existingRaw) ? (existingRaw as Array<KernelScheduleRow>) : []
   const existing = new Map<string, KernelScheduleRow>(existingRows.map((r) => [r.name, r]))
 
-  let created = 0
-  let updated = 0
-  let deleted = 0
-  let unchanged = 0
+  const diff = diffSchedules(desired, existing)
 
-  // Apply: create or update (delete + create)
-  for (const [name, desiredRow] of desired) {
-    const existingRow = existing.get(name)
-    if (!existingRow) {
-      yield* kernelFetch("POST", "/api/schedules", desiredRow)
-      created++
-      yield* Console.log(`  created ${name}`)
-    } else if (!rowsEqual(existingRow, desiredRow)) {
-      // Kernel does not have PUT; delete then re-create
-      yield* kernelFetch("DELETE", `/api/schedules/${encodeURIComponent(name)}`)
-      yield* kernelFetch("POST", "/api/schedules", desiredRow)
-      updated++
-      yield* Console.log(`  updated ${name}`)
-    } else {
-      unchanged++
-    }
+  for (const row of diff.creates) {
+    yield* kernelFetch("POST", "/api/schedules", row)
+    yield* Console.log(`  created ${row.name}`)
   }
-
-  // Delete rows no longer in desired
-  for (const [name] of existing) {
-    if (!desired.has(name)) {
-      yield* kernelFetch("DELETE", `/api/schedules/${encodeURIComponent(name)}`)
-      deleted++
-      yield* Console.log(`  deleted ${name}`)
-    }
+  for (const row of diff.updates) {
+    // Kernel does not have PUT; delete then re-create
+    yield* kernelFetch("DELETE", `/api/schedules/${encodeURIComponent(row.name)}`)
+    yield* kernelFetch("POST", "/api/schedules", row)
+    yield* Console.log(`  updated ${row.name}`)
+  }
+  for (const name of diff.deletes) {
+    yield* kernelFetch("DELETE", `/api/schedules/${encodeURIComponent(name)}`)
+    yield* Console.log(`  deleted ${name}`)
   }
 
   yield* Console.log(
-    `schedule sync done: created ${created}, updated ${updated}, deleted ${deleted}, unchanged ${unchanged}`,
+    `schedule sync done: created ${diff.creates.length}, updated ${diff.updates.length}, ` +
+      `deleted ${diff.deletes.length}, unchanged ${diff.unchanged.length}`,
   )
 })

--- a/apps/uebermensch/src/commands/schedule-sync.ts
+++ b/apps/uebermensch/src/commands/schedule-sync.ts
@@ -55,13 +55,18 @@ const shiftDowBack = (dow: string): string => {
     .join(",")
 }
 
-const ENV_KEYS_BRIEF_AND_SEND = [
+// Same allowlist for all uber jobs: brief and report both deliver via the same
+// Telegram/Discord channels and read the vault from $UBER_VAULT_DIR.
+const ENV_KEYS_UBER_JOB = [
   "UBER_VAULT_DIR",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_PRIMARY_CHAT_ID",
   "DISCORD_NOTIFY_WEBHOOK_URL",
   "GCTRL_KERNEL_URL",
 ] as const
+
+const VALID_JOBS = ["brief-and-send", "report-and-send"] as const
+type JobKind = (typeof VALID_JOBS)[number]
 
 const TIMEOUT_SECS = 300
 
@@ -110,10 +115,18 @@ const kernelFetch = (
           }),
   })
 
-const buildCommand = (
+export const buildCommand = (
   uberDistPath: string,
   nodePath: string,
-): ReadonlyArray<string> => [nodePath, uberDistPath, "run-daily"]
+  job: JobKind,
+): ReadonlyArray<string> => {
+  switch (job) {
+    case "brief-and-send":
+      return [nodePath, uberDistPath, "run-daily"]
+    case "report-and-send":
+      return [nodePath, uberDistPath, "report", "--send"]
+  }
+}
 
 const buildRow = (
   name: string,
@@ -127,9 +140,9 @@ const buildRow = (
     name,
     cron: cronUtc,
     target_kind: "exec",
-    command: buildCommand(uberDistPath, nodePath),
+    command: buildCommand(uberDistPath, nodePath, entry.job),
     cwd: vaultDir,
-    env_keys: [...ENV_KEYS_BRIEF_AND_SEND],
+    env_keys: [...ENV_KEYS_UBER_JOB],
     enabled: entry.enabled ?? true,
     timeout_secs: TIMEOUT_SECS,
   }
@@ -205,11 +218,11 @@ export const scheduleSyncProgram = Effect.gen(function* () {
 
   // Validate all jobs in the config exist in registry before touching anything
   for (const [localName, entry] of Object.entries(config.schedules)) {
-    if (entry.job !== "brief-and-send") {
+    if (!(VALID_JOBS as ReadonlyArray<string>).includes(entry.job)) {
       return yield* Effect.fail(
         new ScheduleError({
           message: `schedule "${localName}" references unknown job "${entry.job}". ` +
-            `Valid jobs at M2: brief-and-send`,
+            `Valid jobs: ${VALID_JOBS.join(", ")}`,
           kind: "schema_invalid",
         }),
       )

--- a/apps/uebermensch/src/schemas.ts
+++ b/apps/uebermensch/src/schemas.ts
@@ -333,7 +333,7 @@ export type TimeboxProfileConfig = typeof TimeboxProfileConfig.Type
 export const ScheduleEntry = Schema.Struct({
   cron: Schema.String,
   tz: Schema.Literal("Asia/Hong_Kong"),
-  job: Schema.Literal("brief-and-send"),
+  job: Schema.Literal("brief-and-send", "report-and-send"),
   enabled: Schema.optional(Schema.Boolean),
 })
 export type ScheduleEntry = typeof ScheduleEntry.Type

--- a/apps/uebermensch/tests/schedule-sync.test.ts
+++ b/apps/uebermensch/tests/schedule-sync.test.ts
@@ -3,27 +3,28 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect, Exit, Schema } from "effect"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { ScheduleError } from "../src/errors.js"
-import { buildCommand, hktCronToUtc, scheduleSyncProgram } from "../src/commands/schedule-sync.js"
+import {
+  buildCommand,
+  buildDesiredRows,
+  diffSchedules,
+  hktCronToUtc,
+  scheduleSyncProgram,
+  type KernelScheduleRow,
+} from "../src/commands/schedule-sync.js"
 import { SchedulesConfig } from "../src/schemas.js"
 
-// --- HKT → UTC conversion unit tests ---
+// --- Pure: HKT → UTC cron conversion ---
 
 describe("hktCronToUtc", () => {
-  it("subtracts 8 hours for a mid-day schedule", () => {
+  it("subtracts 8 hours mid-day", () => {
     expect(hktCronToUtc("30 8 * * *")).toBe("30 0 * * *")
   })
 
-  it("handles evening schedule without day rollover", () => {
+  it("evening schedule, no day rollover", () => {
     expect(hktCronToUtc("59 23 * * *")).toBe("59 15 * * *")
   })
 
-  it("handles hour exactly at 8 HKT (midnight UTC)", () => {
-    expect(hktCronToUtc("0 8 * * *")).toBe("0 0 * * *")
-  })
-
-  it("wraps hour past midnight and shifts * DOW unchanged", () => {
-    // HKT 06:00 → UTC 22:00 previous day; DOW=* stays *
+  it("wraps past midnight; * DOW unchanged", () => {
     expect(hktCronToUtc("0 6 * * *")).toBe("0 22 * * *")
   })
 
@@ -32,132 +33,211 @@ describe("hktCronToUtc", () => {
     expect(hktCronToUtc("0 1 * * 1")).toBe("0 17 * * 0")
   })
 
-  it("shifts DOW 0 (Sunday) back to Saturday (6)", () => {
-    // HKT 01:00 Sun (0) → UTC 17:00 Sat (6)
+  it("wraps DOW 0 (Sun) back to 6 (Sat)", () => {
     expect(hktCronToUtc("0 1 * * 0")).toBe("0 17 * * 6")
   })
 
-  it("throws on invalid 4-field cron", () => {
+  it("rejects 4-field cron", () => {
     expect(() => hktCronToUtc("0 1 * *")).toThrow("invalid 5-field cron")
   })
 
-  it("throws on non-numeric hour", () => {
+  it("rejects non-numeric hour", () => {
     expect(() => hktCronToUtc("0 * * * *")).toThrow("cron hour field must be a numeric")
   })
 })
 
-// --- buildCommand argv per job kind ---
+// --- Pure: argv per job kind ---
 
 describe("buildCommand", () => {
-  const node = "/usr/local/bin/node"
-  const dist = "/abs/path/uber.js"
-
-  it("returns run-daily argv for brief-and-send", () => {
-    expect(buildCommand(dist, node, "brief-and-send")).toEqual([
-      node,
-      dist,
+  it("brief-and-send → run-daily", () => {
+    expect(buildCommand("/abs/uber.js", "/usr/bin/node", "brief-and-send")).toEqual([
+      "/usr/bin/node",
+      "/abs/uber.js",
       "run-daily",
     ])
   })
 
-  it("returns report --send argv for report-and-send", () => {
-    expect(buildCommand(dist, node, "report-and-send")).toEqual([
-      node,
-      dist,
+  it("report-and-send → report --send", () => {
+    expect(buildCommand("/abs/uber.js", "/usr/bin/node", "report-and-send")).toEqual([
+      "/usr/bin/node",
+      "/abs/uber.js",
       "report",
       "--send",
     ])
   })
 })
 
-// --- SchedulesConfig schema validation ---
+// --- Schema validation ---
 
 describe("SchedulesConfig schema", () => {
-  it("parses a valid schedules config", async () => {
-    const raw = {
-      schema_version: 1,
-      schedules: {
-        morning_brief: {
-          cron: "30 8 * * *",
-          tz: "Asia/Hong_Kong",
-          job: "brief-and-send",
-          enabled: true,
-        },
+  const validRaw = {
+    schema_version: 1,
+    schedules: {
+      morning_brief: {
+        cron: "30 8 * * *",
+        tz: "Asia/Hong_Kong",
+        job: "brief-and-send",
+        enabled: true,
       },
-    }
-    const result = await Effect.runPromise(Schema.decodeUnknown(SchedulesConfig)(raw))
-    expect(result.schema_version).toBe(1)
+    },
+  }
+
+  it("accepts a valid config", async () => {
+    const result = await Effect.runPromise(Schema.decodeUnknown(SchedulesConfig)(validRaw))
     expect(result.schedules.morning_brief.cron).toBe("30 8 * * *")
-    expect(result.schedules.morning_brief.enabled).toBe(true)
   })
 
-  it("accepts report-and-send as a valid job", async () => {
+  it("accepts both job kinds", async () => {
     const raw = {
       schema_version: 1,
       schedules: {
-        weekly_report: {
-          cron: "0 9 * * 1",
-          tz: "Asia/Hong_Kong",
-          job: "report-and-send",
-          enabled: true,
-        },
+        b: { cron: "0 8 * * *", tz: "Asia/Hong_Kong", job: "brief-and-send" },
+        r: { cron: "0 9 * * 1", tz: "Asia/Hong_Kong", job: "report-and-send" },
       },
     }
     const result = await Effect.runPromise(Schema.decodeUnknown(SchedulesConfig)(raw))
-    expect(result.schedules.weekly_report.job).toBe("report-and-send")
+    expect(result.schedules.b.job).toBe("brief-and-send")
+    expect(result.schedules.r.job).toBe("report-and-send")
   })
 
-  it("rejects unknown job value", async () => {
+  it("rejects unknown job", async () => {
     const raw = {
       schema_version: 1,
-      schedules: {
-        test: { cron: "0 8 * * *", tz: "Asia/Hong_Kong", job: "deep-dive" },
-      },
+      schedules: { x: { cron: "0 8 * * *", tz: "Asia/Hong_Kong", job: "deep-dive" } },
     }
-    const exit = await Effect.runPromiseExit(Schema.decodeUnknown(SchedulesConfig)(raw))
-    expect(Exit.isFailure(exit)).toBe(true)
+    expect(Exit.isFailure(await Effect.runPromiseExit(Schema.decodeUnknown(SchedulesConfig)(raw)))).toBe(true)
   })
 
-  it("rejects unknown timezone", async () => {
+  it("rejects unknown timezone (M2 only supports Asia/Hong_Kong)", async () => {
     const raw = {
       schema_version: 1,
-      schedules: {
-        test: { cron: "0 8 * * *", tz: "America/New_York", job: "brief-and-send" },
-      },
+      schedules: { x: { cron: "0 8 * * *", tz: "America/New_York", job: "brief-and-send" } },
     }
-    const exit = await Effect.runPromiseExit(Schema.decodeUnknown(SchedulesConfig)(raw))
-    expect(Exit.isFailure(exit)).toBe(true)
+    expect(Exit.isFailure(await Effect.runPromiseExit(Schema.decodeUnknown(SchedulesConfig)(raw)))).toBe(true)
   })
 
-  it("defaults enabled to absent (undefined), not false", async () => {
+  it("leaves enabled undefined when absent (not false)", async () => {
     const raw = {
       schema_version: 1,
-      schedules: {
-        test: { cron: "0 8 * * *", tz: "Asia/Hong_Kong", job: "brief-and-send" },
-      },
+      schedules: { x: { cron: "0 8 * * *", tz: "Asia/Hong_Kong", job: "brief-and-send" } },
     }
     const result = await Effect.runPromise(Schema.decodeUnknown(SchedulesConfig)(raw))
-    expect(result.schedules.test.enabled).toBeUndefined()
+    expect(result.schedules.x.enabled).toBeUndefined()
   })
 })
 
-// --- scheduleSyncProgram integration tests (mock kernel) ---
+// --- Pure: buildDesiredRows ---
+
+describe("buildDesiredRows", () => {
+  const dist = "/abs/uber.js"
+  const node = "/usr/bin/node"
+  const vault = "/vault"
+
+  it("namespaces rows under uber.* and applies HKT→UTC", () => {
+    const cfg = {
+      schema_version: 1,
+      schedules: {
+        morning_brief: {
+          cron: "30 8 * * *" as string,
+          tz: "Asia/Hong_Kong" as const,
+          job: "brief-and-send" as const,
+          enabled: true,
+        },
+      },
+    }
+    const rows = buildDesiredRows(cfg, vault, dist, node)
+    expect([...rows.keys()]).toEqual(["uber.morning_brief"])
+    const row = rows.get("uber.morning_brief")!
+    expect(row.cron).toBe("30 0 * * *")
+    expect(row.target_kind).toBe("exec")
+    expect(row.cwd).toBe(vault)
+    expect(row.timeout_secs).toBe(300)
+    expect(row.enabled).toBe(true)
+  })
+
+  it("defaults enabled to true when omitted", () => {
+    const cfg = {
+      schema_version: 1,
+      schedules: {
+        x: { cron: "0 8 * * *" as string, tz: "Asia/Hong_Kong" as const, job: "brief-and-send" as const },
+      },
+    }
+    expect(buildDesiredRows(cfg, vault, dist, node).get("uber.x")!.enabled).toBe(true)
+  })
+})
+
+// --- Pure: diffSchedules ---
+
+describe("diffSchedules", () => {
+  const baseRow: KernelScheduleRow = {
+    name: "uber.a",
+    cron: "0 0 * * *",
+    target_kind: "exec",
+    command: ["/n", "/u.js", "run-daily"],
+    cwd: "/v",
+    env_keys: ["UBER_VAULT_DIR"],
+    enabled: true,
+    timeout_secs: 300,
+  }
+
+  it("creates rows missing from existing", () => {
+    const desired = new Map([["uber.a", baseRow]])
+    const diff = diffSchedules(desired, new Map())
+    expect(diff.creates).toEqual([baseRow])
+    expect(diff.updates).toEqual([])
+    expect(diff.deletes).toEqual([])
+    expect(diff.unchanged).toEqual([])
+  })
+
+  it("marks identical rows as unchanged", () => {
+    const desired = new Map([["uber.a", baseRow]])
+    const existing = new Map([["uber.a", baseRow]])
+    const diff = diffSchedules(desired, existing)
+    expect(diff.unchanged).toEqual(["uber.a"])
+    expect(diff.creates).toEqual([])
+    expect(diff.updates).toEqual([])
+  })
+
+  it("flags update when cron changes", () => {
+    const desired = new Map([["uber.a", { ...baseRow, cron: "0 1 * * *" }]])
+    const existing = new Map([["uber.a", baseRow]])
+    const diff = diffSchedules(desired, existing)
+    expect(diff.updates).toHaveLength(1)
+    expect(diff.updates[0]!.cron).toBe("0 1 * * *")
+    expect(diff.creates).toEqual([])
+    expect(diff.unchanged).toEqual([])
+  })
+
+  it("flags update when command changes", () => {
+    const desired = new Map([
+      ["uber.a", { ...baseRow, command: ["/n", "/u.js", "report", "--send"] }],
+    ])
+    const existing = new Map([["uber.a", baseRow]])
+    expect(diffSchedules(desired, existing).updates).toHaveLength(1)
+  })
+
+  it("deletes existing rows absent from desired", () => {
+    const desired = new Map<string, KernelScheduleRow>()
+    const existing = new Map([["uber.stale", baseRow]])
+    expect(diffSchedules(desired, existing).deletes).toEqual(["uber.stale"])
+  })
+})
+
+// --- scheduleSyncProgram: thin smoke tests only (file IO + apply orchestration) ---
 
 describe("scheduleSyncProgram", () => {
   let vaultDir: string
   const originalFetch = globalThis.fetch
   const savedEnv: Record<string, string | undefined> = {}
-
   const envKeys = ["UBER_VAULT_DIR", "UBER_DIST_PATH", "GCTRL_NODE_PATH", "GCTRL_KERNEL_URL"]
 
   beforeEach(async () => {
     vaultDir = await mkdtemp(join(tmpdir(), "uber-sched-"))
     await mkdir(join(vaultDir, "directives"), { recursive: true })
-
     for (const k of envKeys) savedEnv[k] = process.env[k]
     process.env.UBER_VAULT_DIR = vaultDir
-    process.env.UBER_DIST_PATH = "/abs/path/uber.js"
-    process.env.GCTRL_NODE_PATH = "/usr/local/bin/node"
+    process.env.UBER_DIST_PATH = "/abs/uber.js"
+    process.env.GCTRL_NODE_PATH = "/usr/bin/node"
     process.env.GCTRL_KERNEL_URL = "http://kernel.test"
   })
 
@@ -169,167 +249,42 @@ describe("scheduleSyncProgram", () => {
     }
   })
 
-  it("no-op and prints message when schedules.md is absent", async () => {
+  it("no-op when schedules.md is absent — kernel never called", async () => {
     const fetchMock = vi.fn()
     globalThis.fetch = fetchMock as unknown as typeof fetch
-
     const exit = await Effect.runPromiseExit(scheduleSyncProgram)
     expect(Exit.isSuccess(exit)).toBe(true)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("aborts with ScheduleError when schema is invalid", async () => {
+  it("aborts on schema-invalid frontmatter without touching kernel", async () => {
     await writeFile(
       join(vaultDir, "directives/schedules.md"),
       "---\nschema_version: 1\nschedules:\n  bad:\n    cron: \"0 8 * * *\"\n    tz: America/New_York\n    job: brief-and-send\n---\n",
     )
     const fetchMock = vi.fn()
     globalThis.fetch = fetchMock as unknown as typeof fetch
-
     const exit = await Effect.runPromiseExit(scheduleSyncProgram)
     expect(Exit.isFailure(exit)).toBe(true)
-    // Kernel must not be touched
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("aborts with config error when UBER_DIST_PATH is not set", async () => {
+  it("aborts with config error when UBER_DIST_PATH is unset", async () => {
     delete process.env.UBER_DIST_PATH
     const exit = await Effect.runPromiseExit(scheduleSyncProgram)
     expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      const cause = exit.cause
-      // The error should be a ScheduleError with kind=config
-      expect(String(cause)).toContain("UBER_DIST_PATH")
-    }
+    if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain("UBER_DIST_PATH")
   })
 
-  it("aborts with config error when GCTRL_NODE_PATH is not set", async () => {
+  it("aborts with config error when GCTRL_NODE_PATH is unset", async () => {
     delete process.env.GCTRL_NODE_PATH
     const exit = await Effect.runPromiseExit(scheduleSyncProgram)
     expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      expect(String(exit.cause)).toContain("GCTRL_NODE_PATH")
-    }
+    if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain("GCTRL_NODE_PATH")
   })
 
-  it("POSTs new schedules to kernel and reports created count", async () => {
-    await writeFile(
-      join(vaultDir, "directives/schedules.md"),
-      [
-        "---",
-        "schema_version: 1",
-        "schedules:",
-        "  morning_brief:",
-        "    cron: \"30 8 * * *\"",
-        "    tz: Asia/Hong_Kong",
-        "    job: brief-and-send",
-        "    enabled: true",
-        "---",
-        "",
-        "# Schedules",
-      ].join("\n"),
-    )
-
-    const postCalls: Array<{ url: string; body: unknown }> = []
-    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      const method = init?.method ?? "GET"
-      if (method === "GET") {
-        // Return empty existing list
-        return { ok: true, status: 200, text: async () => JSON.stringify([]) }
-      }
-      if (method === "POST") {
-        postCalls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) })
-        return { ok: true, status: 201, text: async () => JSON.stringify({ ok: true }) }
-      }
-      return { ok: true, status: 200, text: async () => "{}" }
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
-
-    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
-    expect(Exit.isSuccess(exit)).toBe(true)
-    expect(postCalls).toHaveLength(1)
-    const posted = postCalls[0]!.body as Record<string, unknown>
-    expect(posted.name).toBe("uber.morning_brief")
-    expect(posted.cron).toBe("30 0 * * *")  // HKT 08:30 → UTC 00:30
-    expect(posted.target_kind).toBe("exec")
-    expect(Array.isArray(posted.command)).toBe(true)
-    expect((posted.command as string[])[0]).toBe("/usr/local/bin/node")
-    expect((posted.command as string[])[1]).toBe("/abs/path/uber.js")
-    expect((posted.command as string[])[2]).toBe("run-daily")
-    expect(posted.cwd).toBe(vaultDir)
-    expect(posted.timeout_secs).toBe(300)
-  })
-
-  it("POSTs report-and-send schedule with report --send argv and HKT→UTC cron", async () => {
-    // Mondays 09:00 HKT → Mondays 01:00 UTC (no day rollover)
-    await writeFile(
-      join(vaultDir, "directives/schedules.md"),
-      [
-        "---",
-        "schema_version: 1",
-        "schedules:",
-        "  weekly_report:",
-        "    cron: \"0 9 * * 1\"",
-        "    tz: Asia/Hong_Kong",
-        "    job: report-and-send",
-        "    enabled: true",
-        "---",
-        "",
-      ].join("\n"),
-    )
-
-    const postCalls: Array<{ url: string; body: unknown }> = []
-    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      const method = init?.method ?? "GET"
-      if (method === "GET") {
-        return { ok: true, status: 200, text: async () => JSON.stringify([]) }
-      }
-      if (method === "POST") {
-        postCalls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) })
-        return { ok: true, status: 201, text: async () => JSON.stringify({ ok: true }) }
-      }
-      return { ok: true, status: 200, text: async () => "{}" }
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
-
-    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
-    expect(Exit.isSuccess(exit)).toBe(true)
-    expect(postCalls).toHaveLength(1)
-    const posted = postCalls[0]!.body as Record<string, unknown>
-    expect(posted.name).toBe("uber.weekly_report")
-    expect(posted.cron).toBe("0 1 * * 1") // HKT 09:00 Mon → UTC 01:00 Mon
-    expect(posted.target_kind).toBe("exec")
-    const cmd = posted.command as string[]
-    expect(cmd).toEqual(["/usr/local/bin/node", "/abs/path/uber.js", "report", "--send"])
-    expect(posted.cwd).toBe(vaultDir)
-    expect(posted.timeout_secs).toBe(300)
-  })
-
-  it("rejects unknown job values without touching kernel", async () => {
-    await writeFile(
-      join(vaultDir, "directives/schedules.md"),
-      [
-        "---",
-        "schema_version: 1",
-        "schedules:",
-        "  bogus:",
-        "    cron: \"0 9 * * *\"",
-        "    tz: Asia/Hong_Kong",
-        "    job: deepdive",
-        "---",
-        "",
-      ].join("\n"),
-    )
-
-    const fetchMock = vi.fn()
-    globalThis.fetch = fetchMock as unknown as typeof fetch
-
-    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
-    expect(Exit.isFailure(exit)).toBe(true)
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
-
-  it("DELETEs then POSTs when cron changes (diff logic)", async () => {
+  it("issues DELETE then POST when applying an update; no calls when unchanged", async () => {
+    // First run with an existing row that differs → expect DELETE + POST
     await writeFile(
       join(vaultDir, "directives/schedules.md"),
       [
@@ -345,131 +300,42 @@ describe("scheduleSyncProgram", () => {
       ].join("\n"),
     )
 
-    const existingRow = {
+    const stale: Record<string, unknown> = {
       name: "uber.morning_brief",
-      cron: "30 0 * * *",  // old cron differs
+      cron: "30 0 * * *", // differs from desired (0 1 * * *)
       target_kind: "exec",
-      command: ["/usr/local/bin/node", "/abs/path/uber.js", "run-daily"],
+      command: ["/usr/bin/node", "/abs/uber.js", "run-daily"],
       cwd: vaultDir,
-      env_keys: ["UBER_VAULT_DIR", "TELEGRAM_BOT_TOKEN", "TELEGRAM_PRIMARY_CHAT_ID", "DISCORD_NOTIFY_WEBHOOK_URL", "GCTRL_KERNEL_URL"],
+      env_keys: [
+        "UBER_VAULT_DIR",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_PRIMARY_CHAT_ID",
+        "DISCORD_NOTIFY_WEBHOOK_URL",
+        "GCTRL_KERNEL_URL",
+      ],
       enabled: true,
       timeout_secs: 300,
     }
 
-    const deleteCalls: Array<string> = []
-    const postCalls: Array<unknown> = []
-    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+    const calls: Array<string> = []
+    globalThis.fetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
       const method = init?.method ?? "GET"
-      if (method === "GET") {
-        return { ok: true, status: 200, text: async () => JSON.stringify([existingRow]) }
-      }
-      if (method === "DELETE") {
-        deleteCalls.push(String(url))
-        return { ok: true, status: 204, text: async () => "" }
-      }
-      if (method === "POST") {
-        postCalls.push(JSON.parse(String(init?.body ?? "{}")))
-        return { ok: true, status: 201, text: async () => JSON.stringify({ ok: true }) }
-      }
-      return { ok: true, status: 200, text: async () => "{}" }
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+      calls.push(method)
+      if (method === "GET") return { ok: true, status: 200, text: async () => JSON.stringify([stale]) }
+      return { ok: true, status: method === "DELETE" ? 204 : 201, text: async () => "{}" }
+    }) as unknown as typeof fetch
 
     const exit = await Effect.runPromiseExit(scheduleSyncProgram)
     expect(Exit.isSuccess(exit)).toBe(true)
-    expect(deleteCalls).toHaveLength(1)
-    expect(deleteCalls[0]).toContain("uber.morning_brief")
-    expect(postCalls).toHaveLength(1)
-    const posted = postCalls[0] as Record<string, unknown>
-    expect(posted.cron).toBe("0 1 * * *")  // HKT 09:00 → UTC 01:00
+    // DELETE must precede POST for the same name
+    expect(calls).toEqual(["GET", "DELETE", "POST"])
   })
 
-  it("DELETEs rows absent from desired set", async () => {
-    // schedules.md has no entries but kernel has an existing uber row
-    await writeFile(
-      join(vaultDir, "directives/schedules.md"),
-      "---\nschema_version: 1\nschedules: {}\n---\n",
-    )
-
-    const existingRow = {
-      name: "uber.stale",
-      cron: "0 0 * * *",
-      target_kind: "exec",
-      command: ["/usr/local/bin/node", "/abs/path/uber.js", "run-daily"],
-      cwd: vaultDir,
-      env_keys: [],
-      enabled: true,
-      timeout_secs: 300,
-    }
-
-    const deleteCalls: Array<string> = []
-    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
-      const method = init?.method ?? "GET"
-      if (method === "GET") {
-        return { ok: true, status: 200, text: async () => JSON.stringify([existingRow]) }
-      }
-      if (method === "DELETE") {
-        deleteCalls.push(String(url))
-        return { ok: true, status: 204, text: async () => "" }
-      }
-      return { ok: true, status: 200, text: async () => "{}" }
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
-
-    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
-    expect(Exit.isSuccess(exit)).toBe(true)
-    expect(deleteCalls).toHaveLength(1)
-    expect(deleteCalls[0]).toContain("uber.stale")
-  })
-
-  it("marks unchanged rows without touching kernel", async () => {
-    // Prepare a schedule that already matches exactly
-    await writeFile(
-      join(vaultDir, "directives/schedules.md"),
-      [
-        "---",
-        "schema_version: 1",
-        "schedules:",
-        "  morning_brief:",
-        "    cron: \"30 8 * * *\"",
-        "    tz: Asia/Hong_Kong",
-        "    job: brief-and-send",
-        "    enabled: true",
-        "---",
-        "",
-      ].join("\n"),
-    )
-
-    const existingRow = {
-      name: "uber.morning_brief",
-      cron: "30 0 * * *",
-      target_kind: "exec",
-      command: ["/usr/local/bin/node", "/abs/path/uber.js", "run-daily"],
-      cwd: vaultDir,
-      env_keys: ["UBER_VAULT_DIR", "TELEGRAM_BOT_TOKEN", "TELEGRAM_PRIMARY_CHAT_ID", "DISCORD_NOTIFY_WEBHOOK_URL", "GCTRL_KERNEL_URL"],
-      enabled: true,
-      timeout_secs: 300,
-    }
-
-    const mutateCalls: Array<string> = []
-    const fetchMock = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
-      const method = init?.method ?? "GET"
-      if (method !== "GET") mutateCalls.push(method)
-      return { ok: true, status: 200, text: async () => JSON.stringify([existingRow]) }
-    })
-    globalThis.fetch = fetchMock as unknown as typeof fetch
-
-    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
-    expect(Exit.isSuccess(exit)).toBe(true)
-    expect(mutateCalls).toHaveLength(0)
-  })
-
-  it("fails with kernel_unreachable when kernel returns 500", async () => {
+  it("propagates kernel_unreachable when kernel returns 500", async () => {
     await writeFile(
       join(vaultDir, "directives/schedules.md"),
       "---\nschema_version: 1\nschedules:\n  test:\n    cron: \"0 8 * * *\"\n    tz: Asia/Hong_Kong\n    job: brief-and-send\n---\n",
     )
-
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,

--- a/apps/uebermensch/tests/schedule-sync.test.ts
+++ b/apps/uebermensch/tests/schedule-sync.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { Effect, Exit, Schema } from "effect"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ScheduleError } from "../src/errors.js"
-import { hktCronToUtc, scheduleSyncProgram } from "../src/commands/schedule-sync.js"
+import { buildCommand, hktCronToUtc, scheduleSyncProgram } from "../src/commands/schedule-sync.js"
 import { SchedulesConfig } from "../src/schemas.js"
 
 // --- HKT → UTC conversion unit tests ---
@@ -46,6 +46,30 @@ describe("hktCronToUtc", () => {
   })
 })
 
+// --- buildCommand argv per job kind ---
+
+describe("buildCommand", () => {
+  const node = "/usr/local/bin/node"
+  const dist = "/abs/path/uber.js"
+
+  it("returns run-daily argv for brief-and-send", () => {
+    expect(buildCommand(dist, node, "brief-and-send")).toEqual([
+      node,
+      dist,
+      "run-daily",
+    ])
+  })
+
+  it("returns report --send argv for report-and-send", () => {
+    expect(buildCommand(dist, node, "report-and-send")).toEqual([
+      node,
+      dist,
+      "report",
+      "--send",
+    ])
+  })
+})
+
 // --- SchedulesConfig schema validation ---
 
 describe("SchedulesConfig schema", () => {
@@ -65,6 +89,22 @@ describe("SchedulesConfig schema", () => {
     expect(result.schema_version).toBe(1)
     expect(result.schedules.morning_brief.cron).toBe("30 8 * * *")
     expect(result.schedules.morning_brief.enabled).toBe(true)
+  })
+
+  it("accepts report-and-send as a valid job", async () => {
+    const raw = {
+      schema_version: 1,
+      schedules: {
+        weekly_report: {
+          cron: "0 9 * * 1",
+          tz: "Asia/Hong_Kong",
+          job: "report-and-send",
+          enabled: true,
+        },
+      },
+    }
+    const result = await Effect.runPromise(Schema.decodeUnknown(SchedulesConfig)(raw))
+    expect(result.schedules.weekly_report.job).toBe("report-and-send")
   })
 
   it("rejects unknown job value", async () => {
@@ -218,6 +258,75 @@ describe("scheduleSyncProgram", () => {
     expect((posted.command as string[])[2]).toBe("run-daily")
     expect(posted.cwd).toBe(vaultDir)
     expect(posted.timeout_secs).toBe(300)
+  })
+
+  it("POSTs report-and-send schedule with report --send argv and HKT→UTC cron", async () => {
+    // Mondays 09:00 HKT → Mondays 01:00 UTC (no day rollover)
+    await writeFile(
+      join(vaultDir, "directives/schedules.md"),
+      [
+        "---",
+        "schema_version: 1",
+        "schedules:",
+        "  weekly_report:",
+        "    cron: \"0 9 * * 1\"",
+        "    tz: Asia/Hong_Kong",
+        "    job: report-and-send",
+        "    enabled: true",
+        "---",
+        "",
+      ].join("\n"),
+    )
+
+    const postCalls: Array<{ url: string; body: unknown }> = []
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET"
+      if (method === "GET") {
+        return { ok: true, status: 200, text: async () => JSON.stringify([]) }
+      }
+      if (method === "POST") {
+        postCalls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) })
+        return { ok: true, status: 201, text: async () => JSON.stringify({ ok: true }) }
+      }
+      return { ok: true, status: 200, text: async () => "{}" }
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(postCalls).toHaveLength(1)
+    const posted = postCalls[0]!.body as Record<string, unknown>
+    expect(posted.name).toBe("uber.weekly_report")
+    expect(posted.cron).toBe("0 1 * * 1") // HKT 09:00 Mon → UTC 01:00 Mon
+    expect(posted.target_kind).toBe("exec")
+    const cmd = posted.command as string[]
+    expect(cmd).toEqual(["/usr/local/bin/node", "/abs/path/uber.js", "report", "--send"])
+    expect(posted.cwd).toBe(vaultDir)
+    expect(posted.timeout_secs).toBe(300)
+  })
+
+  it("rejects unknown job values without touching kernel", async () => {
+    await writeFile(
+      join(vaultDir, "directives/schedules.md"),
+      [
+        "---",
+        "schema_version: 1",
+        "schedules:",
+        "  bogus:",
+        "    cron: \"0 9 * * *\"",
+        "    tz: Asia/Hong_Kong",
+        "    job: deepdive",
+        "---",
+        "",
+      ].join("\n"),
+    )
+
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(scheduleSyncProgram)
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("DELETEs then POSTs when cron changes (diff logic)", async () => {

--- a/apps/uebermensch/vault/specs/scheduling.md
+++ b/apps/uebermensch/vault/specs/scheduling.md
@@ -41,7 +41,7 @@ Free-form notes below the frontmatter. Edit cron strings here; run
 | `name` (map key) | `[a-z0-9_]+` | Local name; sync prepends `uber.` to derive the kernel schedule's `name`. |
 | `cron` | string | 5-field cron, in `tz`. Validated by the same parser as the kernel (`cron::Schedule`). |
 | `tz` | IANA tz | Today: `Asia/Hong_Kong` only (constant +8). Other zones rejected at sync until the conversion gains DST awareness. |
-| `job` | enum | `brief-and-send` ⇒ `uber run-daily`. Future jobs (`deepdive`, `ingest`) extend this enum. |
+| `job` | enum | `brief-and-send` ⇒ `uber run-daily`. `report-and-send` ⇒ `uber report --send`. Future jobs (`deepdive`, `ingest`) extend this enum. |
 | `enabled` | bool | Default `true`. `false` rows are still synced (`enabled=false` on kernel row) so a re-enable doesn't drop history. |
 
 Schedule names MUST be unique within the file. Foreign top-level frontmatter keys fail validation.
@@ -53,6 +53,7 @@ The `job` enum is the contract between vault and CLI. Each job maps to an argv t
 | `job` | argv (after sync) | `env_keys` | Notes |
 |-------|-------------------|------------|-------|
 | `brief-and-send` | `["<abs>/node", "<abs>/uber.js", "run-daily"]` | `UBER_VAULT_DIR`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_PRIMARY_CHAT_ID`, `DISCORD_NOTIFY_WEBHOOK_URL`, `GCTRL_KERNEL_URL` | Generates today's brief if missing, then fans out per `profile.delivery.channels`. |
+| `report-and-send` | `["<abs>/node", "<abs>/uber.js", "report", "--send"]` | (same as above) | Generates per-interest deep research reports under `input/reports/`, then sends the index to channels. Cadence is typically weekly. |
 
 The argv MUST use absolute paths — the kernel scheduler rejects relative `argv[0]` (`PATH`-injection defence; see [scheduler.md § exec target kind](../../../../vault/specs/architecture/kernel/scheduler.md#exec-target-kind)). Resolution happens in `uber schedule sync` once at sync time and is stored verbatim in the kernel row.
 


### PR DESCRIPTION
## Summary

Adds `report-and-send` as a recognized job kind in the uebermensch scheduler, so weekly research reports can be cron'd alongside daily briefs through the same `gctrl uber schedule sync` reconciliation flow.

Before this PR: `directives/schedules.md` only accepted `job: brief-and-send`. After: it also accepts `job: report-and-send`.

## What changes

| Area | Change |
|---|---|
| `schemas.ts` | `ScheduleEntry.job` literal extended to `"brief-and-send" \| "report-and-send"`. |
| `commands/schedule-sync.ts` | `buildCommand` now switches on job kind; `brief-and-send` → `["uber.js", "run-daily"]`, `report-and-send` → `["uber.js", "report", "--send"]`. Single `VALID_JOBS` allowlist drives both validation and dispatch. `ENV_KEYS_BRIEF_AND_SEND` renamed to `ENV_KEYS_UBER_JOB` (same allowlist applies to both). |
| `vault/specs/scheduling.md` | Job-to-argv table updated. |
| `tests/schedule-sync.test.ts` | New tests: `buildCommand` argv per job, schema accepts both jobs, sync program POSTs report-and-send schedules with the right argv + HKT→UTC cron, bogus job values rejected before touching the kernel. |

## Same env, same target_kind

The env-var allowlist (`UBER_VAULT_DIR`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_PRIMARY_CHAT_ID`, `DISCORD_NOTIFY_WEBHOOK_URL`, `GCTRL_KERNEL_URL`) is identical for both jobs — both deliver via the same channels and both read the same vault. Same `target_kind: exec`, same 300s timeout, same HKT→UTC cron conversion.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 219/219 pass (was 214; 5 new tests)
- [x] `pnpm build` — clean
- [ ] After merge: bump local `directives/schedules.md` to add a `weekly_report` entry, run `gctrl uber schedule sync`, then confirm via `curl /api/schedules` that 3 `uber.*` schedules are registered (morning_brief, evening_brief, weekly_report).

## Operator follow-up

The vault file `directives/schedules.md` already has a `weekly_report` entry queued (Mondays 09:00 HKT → 01:00 UTC). Once this PR merges and the cron-target worktree (the one referenced by the kernel scheduler's exec command path) rebuilds, run `gctrl uber schedule sync` to register the schedule with the kernel.

Today's manual run: brief delivered to Telegram (13 parts), 4 weekly reports + index delivered to Telegram (2 parts, msg ids 128+129) — verified the dispatch logic works against Opus 4.7 end-to-end.

## Stacked with

[#134 fix(uebermensch): run-daily fails with `error: null` when brief file absent](https://github.com/OpenHackersClub/gctrl/pull/134) — independent fix, unblocks tomorrow's morning_brief cron. Should land first to avoid another silent failure.
