### PR TITLE
fix(gctrl-desktop): kernel daemon binary is gctrld, not gctrl

### DIFF
--- a/apps/gctrl-desktop/scripts/build-kernel-universal.sh
+++ b/apps/gctrl-desktop/scripts/build-kernel-universal.sh
@@ -18,7 +18,11 @@ WORKSPACE_ROOT="$(cd "${PACKAGE_ROOT}/../.." && pwd)"
 
 OUT_DIR="${PACKAGE_ROOT}/resources/kernel"
 TARGET="universal2-apple-darwin"
-BIN_NAME="gctrl"
+# Source binary defined in `kernel/crates/gctrl-cli/Cargo.toml`. The kernel
+# daemon binary is `gctrld` (with the `d` suffix); we bundle it under a
+# friendlier `gctrl-kernel` name so the desktop's path resolver doesn't have
+# to know about the daemon convention.
+BIN_NAME="gctrld"
 DEST_NAME="gctrl-kernel"
 
 echo "[build-kernel] workspace: ${WORKSPACE_ROOT}"

--- a/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
@@ -24,9 +24,9 @@ describe("resolveKernelBinPath", () => {
     )
   })
 
-  it("dev: defaults to the workspace's cargo release binary at ../../target/release/gctrl", () => {
+  it("dev: defaults to the workspace's cargo release binary at ../../target/release/gctrld", () => {
     expect(resolveKernelBinPath(devCtx)).toBe(
-      path.join("/Users/alice/repo/apps/gctrl-desktop", "..", "..", "target", "release", "gctrl"),
+      path.join("/Users/alice/repo/apps/gctrl-desktop", "..", "..", "target", "release", "gctrld"),
     )
   })
 

--- a/apps/gctrl-desktop/src/main/paths.ts
+++ b/apps/gctrl-desktop/src/main/paths.ts
@@ -36,10 +36,12 @@ export type PathContext = {
 /**
  * Resolve the absolute path to the bundled kernel binary.
  *
- * Packaged: `<resourcesPath>/kernel/gctrl-kernel`.
+ * Packaged: `<resourcesPath>/kernel/gctrl-kernel` — renamed from `gctrld`
+ * by the `build-kernel-universal.sh` script so the consumer doesn't have
+ * to know about the daemon `d`-suffix convention.
  * Dev (override): the `devKernelPath` value verbatim.
- * Dev (default): `<appRoot>/../../target/release/gctrl` — the workspace's
- * cargo release binary.
+ * Dev (default): `<appRoot>/../../target/release/gctrld` — the workspace's
+ * cargo release binary as produced by `cargo build --bin gctrld`.
  */
 export const resolveKernelBinPath = (ctx: PathContext): string => {
   if (ctx.isPackaged) {
@@ -48,7 +50,7 @@ export const resolveKernelBinPath = (ctx: PathContext): string => {
   if (ctx.devKernelPath) {
     return ctx.devKernelPath
   }
-  return path.join(ctx.appRoot, "..", "..", "target", "release", "gctrl")
+  return path.join(ctx.appRoot, "..", "..", "target", "release", "gctrld")
 }
 
 /**

--- a/vault/specs/implementation/apps/desktop-electron.md
+++ b/vault/specs/implementation/apps/desktop-electron.md
@@ -156,15 +156,16 @@ cargo zigbuild \
   --release \
   --workspace \
   --target universal2-apple-darwin \
-  --bin gctrl
+  --bin gctrld
 
-# Output
-ls target/universal2-apple-darwin/release/gctrl
-# → universal2 binary; verify with: file target/universal2-apple-darwin/release/gctrl
+# Output (the kernel daemon binary is `gctrld`, with the `d` suffix)
+ls target/universal2-apple-darwin/release/gctrld
+# → universal2 binary; verify with: file target/universal2-apple-darwin/release/gctrld
 
-# Copy into desktop bundle
+# Copy into desktop bundle, renaming gctrld → gctrl-kernel so the consumer
+# (paths.ts) doesn't have to know about the daemon naming convention.
 mkdir -p apps/gctrl-desktop/resources/kernel
-cp target/universal2-apple-darwin/release/gctrl \
+cp target/universal2-apple-darwin/release/gctrld \
    apps/gctrl-desktop/resources/kernel/gctrl-kernel
 ```
 
@@ -374,9 +375,9 @@ jobs:
 
       - name: Build kernel (universal2)
         run: |
-          cargo zigbuild --release --workspace --target universal2-apple-darwin --bin gctrl
+          cargo zigbuild --release --workspace --target universal2-apple-darwin --bin gctrld
           mkdir -p apps/gctrl-desktop/resources/kernel
-          cp target/universal2-apple-darwin/release/gctrl apps/gctrl-desktop/resources/kernel/gctrl-kernel
+          cp target/universal2-apple-darwin/release/gctrld apps/gctrl-desktop/resources/kernel/gctrl-kernel
 
       - name: Build web bundle
         run: |


### PR DESCRIPTION
## Summary

The `release-mac` workflow on tag `v0.1.0-alpha.1` failed at the kernel build step ([failed run](https://github.com/OpenHackersClub/gctrl/actions/runs/25180766551)):

```
error: no bin target named `gctrl` in default-run packages
help: a target with a similar name exists: `gctrld`
```

The kernel crate `gctrl-cli` defines its `[[bin]]` as `gctrld` (with the `d` suffix — the standard daemon convention). Both `scripts/build-kernel-universal.sh` and the implementation spec were calling `cargo --bin gctrl`, which doesn't exist.

## Fix

- `scripts/build-kernel-universal.sh` — pass `--bin gctrld` to cargo, copy to the staging dir as `gctrl-kernel` (consumer-facing name).
- `src/main/paths.ts` — dev-mode default now resolves `target/release/gctrld` (was `gctrl`).
- `__tests__/paths.test.ts` — asserts the corrected dev-mode path.
- `vault/specs/implementation/apps/desktop-electron.md` — spec aligned with the working pipeline (cargo command, copy step, CI workflow snippet).

## Why this slipped through

PR #128's CI surface only exercised `pnpm test` / `type-check` / `build` on the Electron side. The universal2 kernel build is gated by tag pushes (`release-mac.yml`), so the wrong bin name only surfaced when the release workflow first ran. The fix is small enough to ship as its own PR rather than fold back into the merged stack.

## Test plan

- [x] `pnpm --filter gctrl-desktop test` — 25 tests pass (paths test now asserts the corrected `gctrld` dev-mode path)
- [x] `shellcheck apps/gctrl-desktop/scripts/build-kernel-universal.sh` — clean
- [ ] CI green
- [ ] After merge: tag `v0.1.0-alpha.2` → `release-mac` workflow gets past the kernel build step
