### PR TITLE
fix(gctrl-desktop): drop cargo-zigbuild — use vanilla cargo + lipo

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -38,12 +38,7 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
-      - name: Install zig + cargo-zigbuild
-        run: |
-          brew install zig
-          cargo install --locked cargo-zigbuild
-
-      - name: Build kernel (universal2)
+      - name: Build kernel (universal2 via cargo + lipo)
         run: pnpm --filter gctrl-desktop build:kernel
 
       - name: Build Electron main + preload

--- a/apps/gctrl-desktop/README.md
+++ b/apps/gctrl-desktop/README.md
@@ -12,7 +12,7 @@ See the canonical specs:
 | Slice | Adds | PR |
 |---|---|---|
 | **#1+2** | Scaffold, kernel sidecar lifecycle, Electron main/preload/menu, dev-mode wiring | merged |
-| **#3+4** | `electron-builder` config, hardened-runtime entitlements, `@electron/notarize` afterSign, `cargo-zigbuild` universal2 binary, gctrl-board SPA bundled into the renderer slot, `electron-updater`, `release-mac.yml` CI workflow | this PR |
+| **#3+4** | `electron-builder` config, hardened-runtime entitlements, `@electron/notarize` afterSign, vanilla cargo + `lipo` universal2 binary, gctrl-board SPA bundled into the renderer slot, `electron-updater`, `release-mac.yml` CI workflow | this PR |
 
 ## Layout
 
@@ -23,7 +23,7 @@ apps/gctrl-desktop/
 │   ├── entitlements.mac.plist       # hardened-runtime entitlements
 │   └── notarize.cjs                 # electron-builder afterSign — @electron/notarize
 ├── scripts/
-│   └── build-kernel-universal.sh    # cargo-zigbuild → universal2 kernel binary
+│   └── build-kernel-universal.sh    # vanilla cargo + lipo → universal2 kernel binary
 ├── resources/
 │   └── kernel/                      # universal2 binary staged here for extraResources (gitignored)
 ├── src/
@@ -76,7 +76,7 @@ pnpm --filter gctrl-desktop release:mac
 
 Under the hood:
 
-1. `pnpm build:kernel` — `cargo-zigbuild` produces a `universal2-apple-darwin` kernel binary at `resources/kernel/gctrl-kernel`.
+1. `pnpm build:kernel` — vanilla cargo builds for `aarch64-apple-darwin` and `x86_64-apple-darwin` separately, then `lipo` fuses them into a universal2 binary at `resources/kernel/gctrl-kernel`.
 2. `pnpm build` — `electron-vite build` emits `out/main`, `out/preload`, `out/renderer` (placeholder).
 3. `pnpm build:renderer-spa` — builds `gctrl-board` and overwrites `out/renderer` with its production SPA bundle.
 4. `electron-builder --mac` — signs every binary in the `.app`, runs the `afterSign` hook to notarize via `notarytool`, staples the ticket, and emits a universal `.dmg` plus an `electron-updater` manifest under `release/`.

--- a/apps/gctrl-desktop/scripts/build-kernel-universal.sh
+++ b/apps/gctrl-desktop/scripts/build-kernel-universal.sh
@@ -3,10 +3,15 @@
 # and stage it under `apps/gctrl-desktop/resources/kernel/` for inclusion in
 # the Electron bundle as `extraResources`.
 #
-# Requires: rustup with both apple-darwin targets, zig, and cargo-zigbuild.
-#   brew install zig
-#   cargo install --locked cargo-zigbuild
+# Requires: macOS host, rustup with both apple-darwin targets.
 #   rustup target add aarch64-apple-darwin x86_64-apple-darwin
+#
+# Implementation note — why not cargo-zigbuild?
+# We tried zigbuild for single-command universal2 output, but zig's C
+# toolchain is incompatible with the `ring` crate's assembly: zig's `ar`
+# fails to link `libring_core_*.a`. Vanilla cargo + `lipo` works because
+# each per-arch build uses Apple's own toolchain (arm64 native, x86_64
+# cross-compiled via the Apple SDK that ships with Xcode/macOS).
 
 set -euo pipefail
 
@@ -17,7 +22,6 @@ PACKAGE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORKSPACE_ROOT="$(cd "${PACKAGE_ROOT}/../.." && pwd)"
 
 OUT_DIR="${PACKAGE_ROOT}/resources/kernel"
-TARGET="universal2-apple-darwin"
 # Source binary defined in `kernel/crates/gctrl-cli/Cargo.toml`. The kernel
 # daemon binary is `gctrld` (with the `d` suffix); we bundle it under a
 # friendlier `gctrl-kernel` name so the desktop's path resolver doesn't have
@@ -26,24 +30,33 @@ BIN_NAME="gctrld"
 DEST_NAME="gctrl-kernel"
 
 echo "[build-kernel] workspace: ${WORKSPACE_ROOT}"
-echo "[build-kernel] target: ${TARGET}"
 
 # Sanity-check toolchain so failures surface at the top of the log instead
 # of mid-cargo.
 command -v cargo >/dev/null || { echo "[build-kernel] cargo not found"; exit 1; }
-command -v zig >/dev/null || { echo "[build-kernel] zig not found — brew install zig"; exit 1; }
-command -v cargo-zigbuild >/dev/null || { echo "[build-kernel] cargo-zigbuild not found — cargo install --locked cargo-zigbuild"; exit 1; }
+command -v lipo >/dev/null || { echo "[build-kernel] lipo not found — macOS host required"; exit 1; }
 
 cd "${WORKSPACE_ROOT}"
 
-cargo zigbuild \
+echo "[build-kernel] building aarch64-apple-darwin (host arch on Apple Silicon)..."
+cargo build \
   --release \
+  --target aarch64-apple-darwin \
   --workspace \
-  --target "${TARGET}" \
   --bin "${BIN_NAME}"
 
+echo "[build-kernel] building x86_64-apple-darwin (cross-compile via Apple SDK)..."
+cargo build \
+  --release \
+  --target x86_64-apple-darwin \
+  --workspace \
+  --bin "${BIN_NAME}"
+
+echo "[build-kernel] fusing into universal2 with lipo..."
 mkdir -p "${OUT_DIR}"
-cp "target/${TARGET}/release/${BIN_NAME}" "${OUT_DIR}/${DEST_NAME}"
+lipo -create -output "${OUT_DIR}/${DEST_NAME}" \
+  "target/aarch64-apple-darwin/release/${BIN_NAME}" \
+  "target/x86_64-apple-darwin/release/${BIN_NAME}"
 
 echo "[build-kernel] staged ${OUT_DIR}/${DEST_NAME}"
 file "${OUT_DIR}/${DEST_NAME}"

--- a/vault/specs/implementation/apps/desktop-electron.md
+++ b/vault/specs/implementation/apps/desktop-electron.md
@@ -25,7 +25,7 @@ apps/gctrl-desktop/
 │   └── notarize.cjs                  ← @electron/notarize afterSign hook
 ├── resources/
 │   └── kernel/                       ← populated at build time by CI
-│       └── gctrl-kernel              ← universal2 binary (built by cargo-zigbuild)
+│       └── gctrl-kernel              ← universal2 binary (built by cargo + lipo)
 └── README.md
 ```
 
@@ -40,7 +40,7 @@ The renderer is *not* in this package. The build pipeline copies the prebuilt SP
 | **`@electron/notarize`** | Apple notarization via `notarytool` | Invoked from `electron-builder`'s `afterSign` hook |
 | **`electron-updater`** | Auto-update from a hosted feed | Used with `generic` provider (R2-hosted JSON manifest) or GitHub Releases |
 | **`@1password/electron-hardener`** | Optional: defense-in-depth wrapper from 1Password | Locks down powerful Electron APIs not used by the renderer |
-| **`cargo-zigbuild`** | Cross-compile Rust kernel as `universal2-apple-darwin` | Produces single binary for arm64 + x86_64; runs on any host |
+| **vanilla cargo + `lipo`** | Build Rust kernel for both `apple-darwin` arches and fuse into universal2 | macOS host required; Apple SDK handles the x86_64 cross-compile from Apple Silicon. (We tried `cargo-zigbuild` for one-command output, but zig's `ar` is incompatible with the `ring` crate's bundled assembly — see § Universal Kernel Binary.) |
 
 `pnpm` is the package manager — consistent with the rest of the workspace. The `apps/gctrl-desktop` package is registered in `pnpm-workspace.yaml`.
 
@@ -50,7 +50,7 @@ End-to-end build for a release `.dmg`:
 
 ```mermaid
 flowchart LR
-  Rust["cargo-zigbuild<br/>--target universal2-apple-darwin"] --> KernelBin["resources/kernel/gctrl-kernel<br/>(universal2)"]
+  Rust["cargo build --target {arm64,x86_64}-apple-darwin<br/>+ lipo -create"] --> KernelBin["resources/kernel/gctrl-kernel<br/>(universal2)"]
   Web["pnpm --filter gctrl-board build:web"] --> WebDist["apps/gctrl-board/dist-web/"]
   Main["electron-vite build<br/>(main + preload + renderer)"] --> ElectronDist["apps/gctrl-desktop/dist/"]
   WebDist --> ElectronDist
@@ -110,7 +110,7 @@ Key flags:
 - **`asarUnpack: ["resources/kernel/**"]`** — without this, the kernel binary is packed inside `app.asar` and cannot be `execFile`'d.
 - **`hardenedRuntime: true`** + entitlements file — required for notarization and for V8 JIT to function.
 - **`notarize: false`** at the builder level — we run notarization explicitly from `afterSign` for better error visibility and CI logging.
-- **`target: dmg, arch: universal`** — produces a single universal2 DMG. The `extraResources` kernel binary must also be universal2 (built by `cargo-zigbuild`).
+- **`target: dmg, arch: universal`** — produces a single universal2 DMG. The `extraResources` kernel binary must also be universal2 (built via vanilla cargo + `lipo`).
 
 ### Hardened-Runtime Entitlements
 
@@ -143,33 +143,33 @@ Rationale per entitlement:
 - `network.client` — the renderer makes outbound HTTP to the kernel sidecar on `127.0.0.1:4318` and to update feeds.
 - `network.server` — the kernel sidecar binds a listening socket on `127.0.0.1:4318`. *Note: Apple may flag inbound connections at MAS review; this is one of the reasons we skip MAS for v1.*
 
-### Universal Kernel Binary (`cargo-zigbuild`)
+### Universal Kernel Binary (vanilla cargo + `lipo`)
 
 ```sh
-# One-time setup
-brew install zig
-cargo install --locked cargo-zigbuild
+# One-time setup (no zig required)
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
-# Build (in CI or locally)
-cargo zigbuild \
-  --release \
-  --workspace \
-  --target universal2-apple-darwin \
-  --bin gctrld
+# Build each arch separately (Apple SDK handles the x86_64 cross-compile
+# from arm64), then fuse them into a universal2 binary with lipo.
+cargo build --release --target aarch64-apple-darwin --workspace --bin gctrld
+cargo build --release --target x86_64-apple-darwin  --workspace --bin gctrld
 
-# Output (the kernel daemon binary is `gctrld`, with the `d` suffix)
-ls target/universal2-apple-darwin/release/gctrld
-# → universal2 binary; verify with: file target/universal2-apple-darwin/release/gctrld
+# Verify both arches built
+file target/aarch64-apple-darwin/release/gctrld
+file target/x86_64-apple-darwin/release/gctrld
 
-# Copy into desktop bundle, renaming gctrld → gctrl-kernel so the consumer
-# (paths.ts) doesn't have to know about the daemon naming convention.
+# Fuse + stage under the consumer-facing name
 mkdir -p apps/gctrl-desktop/resources/kernel
-cp target/universal2-apple-darwin/release/gctrld \
-   apps/gctrl-desktop/resources/kernel/gctrl-kernel
+lipo -create \
+  -output apps/gctrl-desktop/resources/kernel/gctrl-kernel \
+  target/aarch64-apple-darwin/release/gctrld \
+  target/x86_64-apple-darwin/release/gctrld
+
+file apps/gctrl-desktop/resources/kernel/gctrl-kernel
+# → Mach-O universal binary with 2 architectures: [arm64], [x86_64]
 ```
 
-`cargo-zigbuild` is preferred over manual `lipo` because it cross-compiles in one invocation and works on any CI host (no need for x86_64 macOS runners).
+We initially tried `cargo-zigbuild` for single-command universal2 output, but zig's C toolchain is incompatible with the `ring` crate's bundled assembly (zig's `ar` fails to link `libring_core_*.a`). Vanilla cargo + `lipo` works because each per-arch build uses Apple's own toolchain. Trade-off: requires a macOS host (zigbuild would have worked on Linux runners). For gctrl this is fine — we already need macos-14 for `electron-builder` to sign and notarize.
 
 ## Kernel Sidecar Lifecycle
 
@@ -358,7 +358,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-14   # arm64 runner; cargo-zigbuild produces universal2 from any host
+    runs-on: macos-14   # arm64 runner with full Apple SDK for x86_64 cross-compile
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -368,16 +368,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: aarch64-apple-darwin,x86_64-apple-darwin }
 
-      - name: Install zig + cargo-zigbuild
+      - name: Build kernel (universal2 via cargo + lipo)
         run: |
-          brew install zig
-          cargo install --locked cargo-zigbuild
-
-      - name: Build kernel (universal2)
-        run: |
-          cargo zigbuild --release --workspace --target universal2-apple-darwin --bin gctrld
+          cargo build --release --target aarch64-apple-darwin --workspace --bin gctrld
+          cargo build --release --target x86_64-apple-darwin  --workspace --bin gctrld
           mkdir -p apps/gctrl-desktop/resources/kernel
-          cp target/universal2-apple-darwin/release/gctrld apps/gctrl-desktop/resources/kernel/gctrl-kernel
+          lipo -create \
+            -output apps/gctrl-desktop/resources/kernel/gctrl-kernel \
+            target/aarch64-apple-darwin/release/gctrld \
+            target/x86_64-apple-darwin/release/gctrld
 
       - name: Build web bundle
         run: |
@@ -427,7 +426,7 @@ The renderer-dev mode is the day-to-day workflow. The bundled-kernel mode is for
 2. ☐ `Developer ID Application` cert in Keychain + `.p12` exported with password
 3. ☐ App Store Connect API key (`.p8`, key ID, issuer ID) generated
 4. ☐ Bundle ID registered (`dev.fractalbox.gctrl` or chosen)
-5. ☐ `cargo-zigbuild` produces a universal2 kernel binary that runs on both arm64 and x86_64 Macs
+5. ☐ `cargo build` + `lipo` produce a universal2 kernel binary that runs on both arm64 and x86_64 Macs
 6. ☐ `electron-builder` config with `extraResources` + `asarUnpack` + hardened-runtime entitlements
 7. ☐ `afterSign` notarize hook produces a stapled `.dmg`
 8. ☐ Verified: `codesign --verify --deep` and `spctl -a -t exec` both pass


### PR DESCRIPTION
## Summary

Second iteration on the release-mac kernel build. The `v0.1.0-alpha.2` tag run ([failed run](https://github.com/OpenHackersClub/gctrl/actions/runs/25218224026)) made it past the `gctrld` bin-name fix from #136 but blew up at the `ring` crate:

```
error occurred in cc-rs: command did not execute successfully (status code exit status: 1):
ZERO_AR_DATE="1" "/Users/runner/Library/Caches/cargo-zigbuild/0.22.3/wrappers/.../ar" "cq"
"/Users/runner/work/gctrl/gctrl/target/release/build/ring-.../out/libring_core_0_17_14_.a" ...
ar: error: unable to open '...libring_core_0_17_14_.a': No such file or directory
```

Root cause: zig's bundled `ar` is incompatible with `ring`'s assembly objects. Known issue.

## Fix — drop `cargo-zigbuild` entirely

zigbuild was attractive because it produces universal2 in one command and works on Linux runners, but for gctrl neither benefit applies:

- We already need a **macOS host** for `electron-builder` to sign + notarize.
- One extra `cargo build` invocation is cheaper than fighting zig's toolchain.

The new pipeline uses **vanilla cargo + `lipo`**:

```sh
cargo build --release --target aarch64-apple-darwin --workspace --bin gctrld
cargo build --release --target x86_64-apple-darwin  --workspace --bin gctrld
lipo -create -output resources/kernel/gctrl-kernel \
  target/aarch64-apple-darwin/release/gctrld \
  target/x86_64-apple-darwin/release/gctrld
```

`ring` builds cleanly under Apple's toolchain. The arm64 build is host-native; the x86_64 build cross-compiles via the Apple SDK that ships with Xcode/macOS. Both work end-to-end.

## What's changed

- `scripts/build-kernel-universal.sh` — rewritten. No zig, no zigbuild. Two `cargo build`s + one `lipo -create`. Sanity-checks `cargo` and `lipo` at the top so missing tools surface early. Inline comment explains why zigbuild was abandoned.
- `.github/workflows/release-mac.yml` — drops `Install zig + cargo-zigbuild` step. Renames `Build kernel (universal2)` → `Build kernel (universal2 via cargo + lipo)` to make the change visible in run logs.
- `vault/specs/implementation/apps/desktop-electron.md` — per-arch cargo invocation + lipo, tooling table, mermaid diagram, inline CI snippet, and first-ship checklist all updated.
- `apps/gctrl-desktop/README.md` — matches.

## Net effect on the release workflow

- ⊖ Drops `brew install zig` (~10s) and `cargo install cargo-zigbuild` (~40s).
- ⊕ Adds a second `cargo build` invocation (incremental cache shares most of the workspace tree, so only a fraction is hot work the second time).
- ✓ `ring`, `rustls`, `reqwest` now compile cleanly.

## Test plan

- [x] `pnpm --filter gctrl-desktop test` — 25 tests pass
- [x] `shellcheck scripts/build-kernel-universal.sh` — clean
- [x] `actionlint .github/workflows/release-mac.yml` — clean
- [ ] CI green
- [ ] After merge: tag `v0.1.0-alpha.3` → release-mac progresses past the kernel build and produces an unsigned smoke `.dmg` (no Apple secrets configured yet)
