### PR TITLE
fix(gctrl-desktop): x64ArchFiles for universal2 kernel sidecar

### DIFF
--- a/apps/gctrl-desktop/package.json
+++ b/apps/gctrl-desktop/package.json
@@ -63,7 +63,8 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "notarize": false
+      "notarize": false,
+      "x64ArchFiles": "Contents/Resources/kernel/*"
     },
     "afterSign": "build/notarize.cjs",
     "publish": {


### PR DESCRIPTION
## Summary

Third iteration. Tag `v0.1.0-alpha.3` got past the kernel build + Electron + SPA build, then electron-builder's universal-merge rejected our pre-built universal2 kernel ([failed run](https://github.com/OpenHackersClub/gctrl/actions/runs/25218786788)):

```
Detected file "Contents/Resources/kernel/gctrl-kernel" that's the same
in both x64 and arm64 builds and not covered by the x64ArchFiles rule:
"undefined"
```

## Fix

`@electron/universal` builds the .app twice (per arch) and merges. It expects per-arch differences; identical files raise this error unless declared as arch-agnostic via `mac.x64ArchFiles`.

Our kernel binary is **pre-built universal2** by `cargo + lipo` — byte-identical across the two arch builds by design. One-liner fix:

```diff
   "mac": {
     ...
     "entitlementsInherit": "build/entitlements.mac.plist",
-    "notarize": false
+    "notarize": false,
+    "x64ArchFiles": "Contents/Resources/kernel/*"
   },
```

## Test plan

- [x] `pnpm --filter gctrl-desktop test` — 25 tests pass
- [x] `node -e 'JSON.parse(...)'` — package.json still valid
- [ ] CI green
- [ ] After merge: tag `v0.1.0-alpha.4` → release-mac succeeds end-to-end (electron-builder produces a `.dmg`; unsigned smoke since no Apple secrets)
