### PR TITLE
fix(release-mac): unsigned smoke build when no CSC_LINK

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -71,7 +71,16 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: pnpm --filter gctrl-desktop exec electron-builder --mac
+        run: |
+          # Without a signing cert, electron-builder defaults to keychain
+          # auto-discovery and dies on a CI runner with no keychain. Force
+          # an unsigned smoke build in that case so the rest of the
+          # pipeline still produces a verifiable artifact.
+          if [ -z "${CSC_LINK}" ]; then
+            echo "[release-mac] no CSC_LINK — disabling identity auto-discovery (unsigned smoke build)"
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+          fi
+          pnpm --filter gctrl-desktop exec electron-builder --mac
 
       # Verify Gatekeeper acceptance before publishing the artifact. Self-
       # skips when no signing cert is configured (unsigned smoke build).


### PR DESCRIPTION
## Summary

Iteration 4. Tag `v0.1.0-alpha.4`'s release-mac ([failed run](https://github.com/OpenHackersClub/gctrl/actions/runs/25220004840)) got past the universal-merge fix from #138 and successfully packaged the universal `.app`, then died at signing:

```
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/gctrl/gctrl/apps/gctrl-desktop not a file
```

## Fix

When `CSC_LINK` and `CSC_KEY_PASSWORD` are both unset, electron-builder defaults to keychain auto-discovery via `CSC_IDENTITY_AUTO_DISCOVERY`. On a CI runner with no keychain, that discovery throws a confusing "<dir> not a file" error from internal identity-resolution code.

The fix: when the workflow detects no signing cert, set `CSC_IDENTITY_AUTO_DISCOVERY=false` for the electron-builder call. This produces an explicitly unsigned `.app` — the documented behavior for smoke builds without secrets — instead of trying to find a non-existent keychain identity.

```diff
       - name: Package, sign, and notarize
         env:
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           ...
-        run: pnpm --filter gctrl-desktop exec electron-builder --mac
+        run: |
+          if [ -z "${CSC_LINK}" ]; then
+            echo "[release-mac] no CSC_LINK — disabling identity auto-discovery"
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+          fi
+          pnpm --filter gctrl-desktop exec electron-builder --mac
```

`notarize.cjs` already self-skips when the Apple API key env vars are absent, so this completes the no-secrets path.

## Test plan

- [x] `actionlint .github/workflows/release-mac.yml` — clean
- [ ] CI green
- [ ] After merge: tag `v0.1.0-alpha.5` → release-mac succeeds end-to-end and attaches an unsigned `.dmg` to the GitHub Release
