### PR TITLE
feat(kernel): gcal driver (LKM) — read-by-default Google Calendar routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gctrl-gcal"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "gctrl-guardrails"
 version = "0.1.0"
 dependencies = [
@@ -1730,6 +1744,7 @@ dependencies = [
  "futures-core",
  "gctrl-context",
  "gctrl-core",
+ "gctrl-gcal",
  "gctrl-net",
  "gctrl-proxy",
  "gctrl-scheduler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "kernel/crates/gctrl-context",
     "kernel/crates/gctrl-orch",
     "kernel/crates/gctrl-scheduler",
+    "kernel/crates/gctrl-gcal",
 ]
 
 [workspace.package]

--- a/kernel/crates/gctrl-gcal/Cargo.toml
+++ b/kernel/crates/gctrl-gcal/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gctrl-gcal"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/kernel/crates/gctrl-gcal/src/client.rs
+++ b/kernel/crates/gctrl-gcal/src/client.rs
@@ -1,0 +1,267 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::error::GcalError;
+use crate::model::{Calendar, CalendarEvent, CalendarList, EventInput, EventList};
+
+const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const API_BASE: &str = "https://www.googleapis.com/calendar/v3";
+
+/// OAuth credentials. The refresh token is long-lived; access tokens are
+/// minted on demand and held in memory only.
+#[derive(Debug, Clone)]
+pub struct GcalCredentials {
+    pub client_id: String,
+    pub client_secret: String,
+    pub refresh_token: String,
+    /// Optional override for the token endpoint — useful for tests against a
+    /// mock OAuth server.
+    pub token_url: Option<String>,
+    /// Optional override for the API base URL — useful for tests.
+    pub api_base: Option<String>,
+}
+
+impl GcalCredentials {
+    /// Read credentials from `GCAL_CLIENT_ID`, `GCAL_CLIENT_SECRET`,
+    /// `GCAL_REFRESH_TOKEN`. Returns `Ok(None)` if any is missing — the
+    /// driver is meant to advertise itself as offline rather than crashing
+    /// the daemon.
+    pub fn from_env() -> Result<Option<Self>, GcalError> {
+        let client_id = std::env::var("GCAL_CLIENT_ID").ok();
+        let client_secret = std::env::var("GCAL_CLIENT_SECRET").ok();
+        let refresh_token = std::env::var("GCAL_REFRESH_TOKEN").ok();
+        match (client_id, client_secret, refresh_token) {
+            (Some(id), Some(secret), Some(token))
+                if !id.is_empty() && !secret.is_empty() && !token.is_empty() =>
+            {
+                Ok(Some(Self {
+                    client_id: id,
+                    client_secret: secret,
+                    refresh_token: token,
+                    token_url: None,
+                    api_base: None,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedToken {
+    access_token: String,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default = "default_expires")]
+    expires_in: u64,
+}
+
+fn default_expires() -> u64 {
+    3600
+}
+
+#[derive(Clone)]
+pub struct GcalClient {
+    http: reqwest::Client,
+    creds: GcalCredentials,
+    token: Arc<Mutex<Option<CachedToken>>>,
+}
+
+impl GcalClient {
+    pub fn new(http: reqwest::Client, creds: GcalCredentials) -> Self {
+        Self {
+            http,
+            creds,
+            token: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn api_base(&self) -> &str {
+        self.creds.api_base.as_deref().unwrap_or(API_BASE)
+    }
+
+    fn token_url(&self) -> &str {
+        self.creds.token_url.as_deref().unwrap_or(TOKEN_URL)
+    }
+
+    /// Returns a valid access token, refreshing if the cached value is missing
+    /// or within 60s of expiry.
+    async fn access_token(&self) -> Result<String, GcalError> {
+        let mut guard = self.token.lock().await;
+        if let Some(cached) = guard.as_ref() {
+            if cached.expires_at.saturating_duration_since(Instant::now()) > Duration::from_secs(60)
+            {
+                return Ok(cached.access_token.clone());
+            }
+        }
+
+        let params = [
+            ("client_id", self.creds.client_id.as_str()),
+            ("client_secret", self.creds.client_secret.as_str()),
+            ("refresh_token", self.creds.refresh_token.as_str()),
+            ("grant_type", "refresh_token"),
+        ];
+        let resp = self
+            .http
+            .post(self.token_url())
+            .form(&params)
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            return Err(GcalError::OauthRefresh(format!(
+                "{} {}",
+                status.as_u16(),
+                body
+            )));
+        }
+        let parsed: TokenResponse = serde_json::from_str(&body)
+            .map_err(|e| GcalError::Parse(format!("token response: {e}")))?;
+        let cached = CachedToken {
+            access_token: parsed.access_token.clone(),
+            expires_at: Instant::now() + Duration::from_secs(parsed.expires_in),
+        };
+        *guard = Some(cached);
+        Ok(parsed.access_token)
+    }
+
+    async fn authed(&self, builder: reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder, GcalError> {
+        let token = self.access_token().await?;
+        Ok(builder.bearer_auth(token))
+    }
+
+    async fn send_json<T: serde::de::DeserializeOwned>(
+        &self,
+        builder: reqwest::RequestBuilder,
+    ) -> Result<T, GcalError> {
+        let resp = self.authed(builder).await?.send().await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            return Err(GcalError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        serde_json::from_str::<T>(&body).map_err(|e| GcalError::Parse(e.to_string()))
+    }
+
+    pub async fn list_calendars(&self) -> Result<Vec<Calendar>, GcalError> {
+        let url = format!("{}/users/me/calendarList", self.api_base());
+        let parsed: CalendarList = self.send_json(self.http.get(&url)).await?;
+        Ok(parsed.items)
+    }
+
+    pub async fn list_events(
+        &self,
+        calendar_id: &str,
+        time_min: Option<&str>,
+        time_max: Option<&str>,
+        max_results: Option<u32>,
+    ) -> Result<Vec<CalendarEvent>, GcalError> {
+        let url = format!(
+            "{}/calendars/{}/events",
+            self.api_base(),
+            urlencoding(calendar_id)
+        );
+        let mut req = self.http.get(&url).query(&[
+            ("singleEvents", "true"),
+            ("orderBy", "startTime"),
+        ]);
+        if let Some(t) = time_min {
+            req = req.query(&[("timeMin", t)]);
+        }
+        if let Some(t) = time_max {
+            req = req.query(&[("timeMax", t)]);
+        }
+        if let Some(n) = max_results {
+            req = req.query(&[("maxResults", n.to_string())]);
+        }
+        let parsed: EventList = self.send_json(req).await?;
+        Ok(parsed.items)
+    }
+
+    pub async fn get_event(
+        &self,
+        calendar_id: &str,
+        event_id: &str,
+    ) -> Result<CalendarEvent, GcalError> {
+        let url = format!(
+            "{}/calendars/{}/events/{}",
+            self.api_base(),
+            urlencoding(calendar_id),
+            urlencoding(event_id)
+        );
+        self.send_json(self.http.get(&url)).await
+    }
+
+    pub async fn create_event(
+        &self,
+        calendar_id: &str,
+        input: &EventInput,
+    ) -> Result<CalendarEvent, GcalError> {
+        let url = format!(
+            "{}/calendars/{}/events",
+            self.api_base(),
+            urlencoding(calendar_id)
+        );
+        self.send_json(self.http.post(&url).json(input)).await
+    }
+
+    pub async fn patch_event(
+        &self,
+        calendar_id: &str,
+        event_id: &str,
+        input: &EventInput,
+    ) -> Result<CalendarEvent, GcalError> {
+        let url = format!(
+            "{}/calendars/{}/events/{}",
+            self.api_base(),
+            urlencoding(calendar_id),
+            urlencoding(event_id)
+        );
+        self.send_json(self.http.patch(&url).json(input)).await
+    }
+}
+
+/// Minimal percent-encoding for path segments (calendar id can contain `@`).
+fn urlencoding(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_env_returns_none_when_missing() {
+        // Snapshot + clear potentially-set vars; restore at end.
+        let prev_id = std::env::var("GCAL_CLIENT_ID").ok();
+        let prev_secret = std::env::var("GCAL_CLIENT_SECRET").ok();
+        let prev_token = std::env::var("GCAL_REFRESH_TOKEN").ok();
+        std::env::remove_var("GCAL_CLIENT_ID");
+        std::env::remove_var("GCAL_CLIENT_SECRET");
+        std::env::remove_var("GCAL_REFRESH_TOKEN");
+
+        let result = GcalCredentials::from_env().unwrap();
+        assert!(result.is_none());
+
+        if let Some(v) = prev_id {
+            std::env::set_var("GCAL_CLIENT_ID", v);
+        }
+        if let Some(v) = prev_secret {
+            std::env::set_var("GCAL_CLIENT_SECRET", v);
+        }
+        if let Some(v) = prev_token {
+            std::env::set_var("GCAL_REFRESH_TOKEN", v);
+        }
+    }
+}

--- a/kernel/crates/gctrl-gcal/src/error.rs
+++ b/kernel/crates/gctrl-gcal/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GcalError {
+    #[error("missing credential: {0}")]
+    MissingCredential(&'static str),
+
+    #[error("oauth refresh failed: {0}")]
+    OauthRefresh(String),
+
+    #[error("calendar api error ({status}): {body}")]
+    Api { status: u16, body: String },
+
+    #[error("http transport error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("response parse error: {0}")]
+    Parse(String),
+}

--- a/kernel/crates/gctrl-gcal/src/lib.rs
+++ b/kernel/crates/gctrl-gcal/src/lib.rs
@@ -1,0 +1,23 @@
+//! gctrl-gcal — Kernel driver for Google Calendar API v3.
+//!
+//! Holds OAuth refresh-token credentials and exposes a thin client for the
+//! handful of Calendar API operations the rest of gctrl needs (list calendars,
+//! list/get/create/update events). Deletion is intentionally absent.
+//!
+//! Auth model (v1): the refresh token is provisioned out-of-band (env vars
+//! `GCAL_CLIENT_ID`, `GCAL_CLIENT_SECRET`, `GCAL_REFRESH_TOKEN`). The client
+//! caches the resulting access token in-memory until ~60s before its `expires_in`
+//! and refreshes lazily on the next call. A future PR will add an interactive
+//! `gctrl uber gcal auth` flow.
+//!
+//! Permissions are enforced by the HTTP layer (`gctrl-otel/receiver.rs`) via
+//! `GCAL_ALLOWED_SCOPES`; this crate is intentionally permission-agnostic so
+//! tests can exercise the API surface directly.
+
+pub mod client;
+pub mod error;
+pub mod model;
+
+pub use client::{GcalClient, GcalCredentials};
+pub use error::GcalError;
+pub use model::{Calendar, CalendarEvent, EventDateTime, EventInput};

--- a/kernel/crates/gctrl-gcal/src/model.rs
+++ b/kernel/crates/gctrl-gcal/src/model.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+
+/// Subset of `calendars#resource` we surface upstream.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Calendar {
+    pub id: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default, rename = "timeZone")]
+    pub time_zone: Option<String>,
+    #[serde(default, rename = "accessRole")]
+    pub access_role: Option<String>,
+    #[serde(default)]
+    pub primary: Option<bool>,
+}
+
+/// Google represents `start`/`end` as either `dateTime` (RFC 3339, with `timeZone`)
+/// or `date` (YYYY-MM-DD, all-day). We preserve both forms verbatim.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EventDateTime {
+    #[serde(default, rename = "dateTime", skip_serializing_if = "Option::is_none")]
+    pub date_time: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    #[serde(default, rename = "timeZone", skip_serializing_if = "Option::is_none")]
+    pub time_zone: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    #[serde(default)]
+    pub etag: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub location: Option<String>,
+    #[serde(default)]
+    pub start: Option<EventDateTime>,
+    #[serde(default)]
+    pub end: Option<EventDateTime>,
+    #[serde(default, rename = "htmlLink")]
+    pub html_link: Option<String>,
+    #[serde(default, rename = "iCalUID")]
+    pub ical_uid: Option<String>,
+    #[serde(default)]
+    pub recurrence: Option<Vec<String>>,
+    #[serde(default)]
+    pub created: Option<String>,
+    #[serde(default)]
+    pub updated: Option<String>,
+}
+
+/// Body for create + patch. Only fields the user can actually change in v1.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EventInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<EventDateTime>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<EventDateTime>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct EventList {
+    #[serde(default)]
+    pub items: Vec<CalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CalendarList {
+    #[serde(default)]
+    pub items: Vec<Calendar>,
+}

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -14,6 +14,7 @@ gctrl-scheduler = { path = "../gctrl-scheduler" }
 # (e.g. driver-llm clients like uebermensch) write the same prompt_bodies
 # rows + OTLP spans the relay does.
 gctrl-proxy = { path = "../gctrl-proxy" }
+gctrl-gcal = { path = "../gctrl-gcal" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/gcal_routes.rs
+++ b/kernel/crates/gctrl-otel/src/gcal_routes.rs
@@ -1,0 +1,223 @@
+//! Google Calendar driver HTTP routes.
+//!
+//! Mounts `/api/gcal/*` onto the kernel router. Credentials come from the
+//! environment (`GCAL_CLIENT_ID`, `GCAL_CLIENT_SECRET`, `GCAL_REFRESH_TOKEN`)
+//! and are loaded lazily on first use; if any are missing, every route
+//! returns 503 so callers see a clear "driver offline" signal instead of a
+//! configuration crash.
+//!
+//! Permissions are gated by `GCAL_ALLOWED_SCOPES` (comma-separated; default
+//! `read`). Mutations require `write`. Deletion is intentionally not
+//! mounted — there is no DELETE handler at all so there is no flag that
+//! can flip it on.
+
+use std::sync::{Arc, OnceLock};
+
+use axum::{
+    extract::{Path, Query},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use gctrl_gcal::{EventInput, GcalClient, GcalCredentials, GcalError};
+use serde::Deserialize;
+use tokio::sync::OnceCell;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Scope {
+    Read,
+    Write,
+}
+
+fn allowed_scopes() -> Vec<Scope> {
+    static CACHED: OnceLock<Vec<Scope>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            std::env::var("GCAL_ALLOWED_SCOPES")
+                .ok()
+                .map(|raw| {
+                    raw.split(',')
+                        .map(|s| s.trim().to_lowercase())
+                        .filter(|s| !s.is_empty())
+                        .filter_map(|s| match s.as_str() {
+                            "read" => Some(Scope::Read),
+                            "write" => Some(Scope::Write),
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_else(|| vec![Scope::Read])
+        })
+        .clone()
+}
+
+fn require_scope(scope: Scope) -> Result<(), (StatusCode, String)> {
+    if allowed_scopes().contains(&scope) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "gcal permission denied: scope `{}` not in GCAL_ALLOWED_SCOPES",
+                match scope {
+                    Scope::Read => "read",
+                    Scope::Write => "write",
+                }
+            ),
+        ))
+    }
+}
+
+async fn client() -> Result<Arc<GcalClient>, (StatusCode, String)> {
+    static CELL: OnceCell<Option<Arc<GcalClient>>> = OnceCell::const_new();
+    let opt = CELL
+        .get_or_init(|| async {
+            match GcalCredentials::from_env() {
+                Ok(Some(creds)) => Some(Arc::new(GcalClient::new(reqwest::Client::new(), creds))),
+                _ => None,
+            }
+        })
+        .await
+        .clone();
+    opt.ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "gcal driver offline: set GCAL_CLIENT_ID, GCAL_CLIENT_SECRET, GCAL_REFRESH_TOKEN".into(),
+    ))
+}
+
+fn map_err(e: GcalError) -> (StatusCode, String) {
+    match e {
+        GcalError::MissingCredential(_) => (StatusCode::SERVICE_UNAVAILABLE, e.to_string()),
+        GcalError::OauthRefresh(_) => (StatusCode::BAD_GATEWAY, e.to_string()),
+        GcalError::Api { status, .. } => {
+            let s = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+            (s, e.to_string())
+        }
+        GcalError::Http(_) => (StatusCode::BAD_GATEWAY, e.to_string()),
+        GcalError::Parse(_) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ListEventsQuery {
+    #[serde(default)]
+    calendar_id: Option<String>,
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    to: Option<String>,
+    #[serde(default)]
+    max_results: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CalendarIdQuery {
+    #[serde(default)]
+    calendar_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateEventBody {
+    #[serde(default)]
+    calendar_id: Option<String>,
+    #[serde(flatten)]
+    event: EventInput,
+}
+
+fn calendar_id_or_default(id: Option<String>) -> String {
+    id.filter(|s| !s.is_empty()).unwrap_or_else(|| "primary".to_string())
+}
+
+async fn list_calendars() -> impl IntoResponse {
+    if let Err(e) = require_scope(Scope::Read) {
+        return e.into_response();
+    }
+    let client = match client().await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    match client.list_calendars().await {
+        Ok(items) => Json(items).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+async fn list_events(Query(q): Query<ListEventsQuery>) -> impl IntoResponse {
+    if let Err(e) = require_scope(Scope::Read) {
+        return e.into_response();
+    }
+    let client = match client().await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let cal = calendar_id_or_default(q.calendar_id);
+    match client
+        .list_events(&cal, q.from.as_deref(), q.to.as_deref(), q.max_results)
+        .await
+    {
+        Ok(items) => Json(items).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+async fn get_event(
+    Path(event_id): Path<String>,
+    Query(q): Query<CalendarIdQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = require_scope(Scope::Read) {
+        return e.into_response();
+    }
+    let client = match client().await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let cal = calendar_id_or_default(q.calendar_id);
+    match client.get_event(&cal, &event_id).await {
+        Ok(ev) => Json(ev).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+async fn create_event(Json(body): Json<CreateEventBody>) -> impl IntoResponse {
+    if let Err(e) = require_scope(Scope::Write) {
+        return e.into_response();
+    }
+    let client = match client().await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let cal = calendar_id_or_default(body.calendar_id);
+    match client.create_event(&cal, &body.event).await {
+        Ok(ev) => (StatusCode::CREATED, Json(ev)).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+async fn patch_event(
+    Path(event_id): Path<String>,
+    Query(q): Query<CalendarIdQuery>,
+    Json(input): Json<EventInput>,
+) -> impl IntoResponse {
+    if let Err(e) = require_scope(Scope::Write) {
+        return e.into_response();
+    }
+    let client = match client().await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let cal = calendar_id_or_default(q.calendar_id);
+    match client.patch_event(&cal, &event_id, &input).await {
+        Ok(ev) => Json(ev).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+/// Mount the gcal driver routes. DELETE is intentionally absent — adding it
+/// is a deliberate, reviewable change rather than a flag flip.
+pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
+    Router::new()
+        .route("/api/gcal/calendars", get(list_calendars))
+        .route("/api/gcal/events", get(list_events).post(create_event))
+        .route("/api/gcal/events/{event_id}", get(get_event).patch(patch_event))
+}

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contributions;
 pub mod event_bus;
+pub mod gcal_routes;
 pub mod receiver;
 pub mod rss;
 pub mod span_processor;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -342,6 +342,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         // Health
         .route("/health", get(health))
         .with_state(state)
+        // Google Calendar driver (LKM — read-by-default; writes gated by
+        // GCAL_ALLOWED_SCOPES; no DELETE handler is mounted at all).
+        .merge(crate::gcal_routes::router::<()>())
 }
 
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {


### PR DESCRIPTION
## Summary

- New `gctrl-gcal` crate: OAuth refresh-token client for Google Calendar API v3 (`list_calendars`, `list_events`, `get_event`, `create_event`, `patch_event`). Access tokens are cached in-memory and refreshed lazily ~60 s before expiry.
- New kernel HTTP routes under `/api/gcal/*` (`gctrl-otel/src/gcal_routes.rs`), merged onto the main router.
- Credentials come from env (`GCAL_CLIENT_ID`, `GCAL_CLIENT_SECRET`, `GCAL_REFRESH_TOKEN`); when any are missing the driver advertises itself offline (503) instead of crashing the daemon.

## Permission model

- `GCAL_ALLOWED_SCOPES` (comma-separated; default `read`) gates handlers. Mutations require `write`.
- **Deletion is intentionally absent** — there is no DELETE handler mounted at all, so no flag can flip it on. Adding it later is a deliberate, reviewable change.

## Routes

| Method | Path | Scope |
| --- | --- | --- |
| GET | `/api/gcal/calendars` | read |
| GET | `/api/gcal/events` | read |
| GET | `/api/gcal/events/{event_id}` | read |
| POST | `/api/gcal/events` | write |
| PATCH | `/api/gcal/events/{event_id}` | write |

`calendar_id` defaults to `primary` if omitted.

## Test plan

- [x] `cargo check -p gctrl-gcal -p gctrl-otel` clean
- [x] `cargo test -p gctrl-gcal` (1 unit test — `from_env_returns_none_when_missing`)
- [x] `cargo test -p gctrl-otel` (existing suite still passes after route merge)
- [ ] Smoke test against live Google Calendar with a provisioned refresh token (follow-up; requires out-of-band OAuth setup that is intentionally not in this PR)
- [ ] Add `gctrl uber gcal auth` interactive flow (follow-up PR)

## Follow-ups

- Interactive auth command (replaces env-var provisioning).
- Shell wrapper (`gctrl gcal ...`) routing through the kernel.
- Persist `etag` / change tokens to support incremental sync.
