### PR TITLE
fix(gctrl-desktop): unblock packaged renderer (API bridge + relative assets + traffic-light inset)

### DIFF
--- a/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
@@ -10,23 +10,30 @@ const baseConfig: SidecarConfig = {
 }
 
 describe("buildKernelArgs", () => {
-  it("emits the canonical serve command with port, data-dir, and loopback bind", () => {
+  it("emits the canonical serve command with port, db file, and loopback host", () => {
     expect(buildKernelArgs(baseConfig)).toEqual([
       "serve",
       "--port",
       "4318",
-      "--data-dir",
-      "/abs/data",
-      "--bind",
+      "--db",
+      "/abs/data/gctrl.duckdb",
+      "--host",
       "127.0.0.1",
     ])
   })
 
   it("always binds 127.0.0.1, never 0.0.0.0", () => {
     const args = buildKernelArgs({ ...baseConfig, port: 5555 })
-    const bindIdx = args.indexOf("--bind")
-    expect(bindIdx).toBeGreaterThanOrEqual(0)
-    expect(args[bindIdx + 1]).toBe("127.0.0.1")
+    const hostIdx = args.indexOf("--host")
+    expect(hostIdx).toBeGreaterThanOrEqual(0)
+    expect(args[hostIdx + 1]).toBe("127.0.0.1")
+  })
+
+  it("derives the DB file inside the data dir", () => {
+    const args = buildKernelArgs({ ...baseConfig, dataDir: "/tmp/gctrl" })
+    const dbIdx = args.indexOf("--db")
+    expect(dbIdx).toBeGreaterThanOrEqual(0)
+    expect(args[dbIdx + 1]).toBe("/tmp/gctrl/gctrl.duckdb")
   })
 
   it("stringifies the port", () => {

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -3,7 +3,8 @@
 // the preload bridge.
 
 import { app, BrowserWindow, Menu, ipcMain, shell } from "electron"
-import { autoUpdater } from "electron-updater"
+import electronUpdater from "electron-updater"
+const { autoUpdater } = electronUpdater
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -22,9 +23,8 @@ let mainWindow: BrowserWindow | undefined
 
 const createSidecar = (): KernelSidecar | undefined => {
   // Only spawn the kernel sidecar in packaged mode. In dev, contributors run
-  // `gctrl serve` separately to avoid double-binding port 4318. The lifecycle
-  // module is still wired here so PR-3's packaging brings it online with no
-  // further changes to this file.
+  // `gctrld serve` (or the launchd agent) separately to avoid double-binding
+  // port 4318.
   if (!app.isPackaged) return undefined
 
   const ctx = {
@@ -66,9 +66,10 @@ const createWindow = (): BrowserWindow => {
   if (app.isPackaged) {
     void win.loadFile(path.join(__dirname, "../renderer/index.html"))
   } else {
-    // Dev mode: point at the gctrl-board Vite dev server (or whatever
-    // GCTRL_DESKTOP_DEV_URL specifies). PR-3 wires the bundled SPA path.
-    const devUrl = process.env.GCTRL_DESKTOP_DEV_URL ?? "http://localhost:5173"
+    // Dev mode: point at the gctrl-board Vite dev server. The default
+    // matches gctrl-board's `web/vite.config.ts` (port 4200); override
+    // via GCTRL_DESKTOP_DEV_URL when running an alternate renderer.
+    const devUrl = process.env.GCTRL_DESKTOP_DEV_URL ?? "http://localhost:4200"
     void win.loadURL(devUrl)
   }
 

--- a/apps/gctrl-desktop/src/main/spawner.ts
+++ b/apps/gctrl-desktop/src/main/spawner.ts
@@ -14,12 +14,12 @@ export const buildKernelArgs = (config: SidecarConfig): readonly string[] => [
   "serve",
   "--port",
   String(config.port),
-  "--data-dir",
-  config.dataDir,
+  "--db",
+  `${config.dataDir}/gctrl.duckdb`,
   // Always bind loopback. Never `0.0.0.0` — the desktop kernel must not be
   // reachable from the network, both for security and to avoid Apple App
   // Store review pushback on inbound connections.
-  "--bind",
+  "--host",
   "127.0.0.1",
 ]
 
@@ -32,8 +32,8 @@ const wrap = (child: ChildProcess): SpawnedProcess => {
   let exitFired = false
 
   // Stream sidecar logs to the Electron main process console. In a packaged
-  // app these end up in the unified log; fine for v1. PR-3 may pipe to a
-  // file under userData/ for support diagnostics.
+  // app these end up in the unified log; piping to a file under userData/
+  // for support diagnostics is a future enhancement.
   child.stdout?.on("data", (chunk) => process.stdout.write(`[kernel] ${chunk}`))
   child.stderr?.on("data", (chunk) => process.stderr.write(`[kernel] ${chunk}`))
 

--- a/apps/gctrl-desktop/src/renderer/index.html
+++ b/apps/gctrl-desktop/src/renderer/index.html
@@ -16,8 +16,8 @@
     <div id="app">
       <div class="placeholder">
         <h2>gctrl desktop</h2>
-        <p>Packaged renderer not yet wired — PR-3 bundles the gctrl-board SPA into the app.</p>
-        <p>For dev: run <code>pnpm --filter gctrl-board dev</code> and reopen this window.</p>
+        <p>Renderer not bundled. Run <code>pnpm build:renderer-spa</code> before packaging,
+          or for dev start <code>pnpm --filter gctrl-board dev</code> and reopen this window.</p>
       </div>
     </div>
     <script type="module" src="./index.ts"></script>

--- a/apps/gctrl-desktop/src/renderer/index.ts
+++ b/apps/gctrl-desktop/src/renderer/index.ts
@@ -1,7 +1,7 @@
-// Placeholder renderer entry. PR-3 replaces this with logic that boots the
-// bundled gctrl-board SPA from `apps/gctrl-board/dist-web/`. For now this file
-// only exists so `electron-vite build` produces a valid renderer chunk; the
-// dev-mode flow loads `GCTRL_DESKTOP_DEV_URL` (defaults to the gctrl-board
-// Vite server on :5173) directly via `BrowserWindow.loadURL`.
+// Fallback renderer entry. The packaged build replaces this whole bundle
+// with the gctrl-board SPA via `pnpm build:renderer-spa` (which RM's
+// out/renderer/ and copies apps/gctrl-board/dist-web/ in its place). This
+// file only ships when packaging skipped that step; dev mode bypasses it
+// entirely via `BrowserWindow.loadURL(GCTRL_DESKTOP_DEV_URL)`.
 
 export {}


### PR DESCRIPTION
## Summary

Unblocks the packaged Electron app end-to-end. The previous PR landed packaging mechanics; this branch fixes the three things that kept the packaged window dark even after install:

- **Renderer can reach the kernel.** The SPA issued relative `/api/...` paths which resolve to `file:///api/...` from the `file://` origin. Preload reads `--gctrl-api-base=http://127.0.0.1:<port>` (passed via `webPreferences.additionalArguments`) and exposes `window.desktop.apiBase`. The board API client prefixes that base when present.
- **SPA assets actually load.** Vite emitted `<script src="/assets/…">`; under `file://` those don't resolve. Desktop build now sets `VITE_BASE=./` so vite emits relative refs.
- **macOS traffic lights don't cover the sidebar.** Main injects CSS via `webContents.insertCSS` to reserve 44px at the top of the nav and make the chrome draggable (with buttons opted out). Lights pinned to `{x:12, y:14}` via `trafficLightPosition`.

Also chains `build:renderer-spa` into `pack` so the SPA copy step can't be skipped.

## Test plan

- [x] Vitest 35/35 in `gctrl-desktop` (incl. 5 new for `parseApiBase` + 4 new build-wiring contract tests)
- [x] Vitest 9/9 in new `gctrl-board` web tests (`client.test.ts`, `desktop-env.test.ts`)
- [x] `pnpm pack` then `open /Applications/gctrl.app`: kernel sidecar binds `:4318`, `/health` returns ok, `/api/board/projects` reachable, board chrome clears traffic lights
- [x] Web build of gctrl-board unaffected (vite `base` defaults to `/` when `VITE_BASE` unset)

## TDD note

The original regression chained three independent breakages — each unit test passed while the integration was broken. New `build-wiring.test.ts` greps compiled `out/main`, `out/preload`, and `out/renderer` artifacts to assert main, preload, and renderer stay wired together; this would have caught the original chain at CI time.
