### PR TITLE
feat(uebermensch): require hosted link for TG/Discord (Pages or Tailscale)

### DIFF
--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -7,8 +7,9 @@ import { KernelLlmLive } from "../adapters/KernelLlm.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
+import { DeliveryError } from "../errors.js"
 import { selectCandidates, type CandidateRef } from "../lib/candidates.js"
-import { resolveChannels } from "../lib/channels.js"
+import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicReportUrl, resolveVaultDir } from "../lib/env.js"
 import {
   DIRECTIVES_RESEARCH_DIR,
@@ -530,7 +531,14 @@ export const report = Command.make(
         )
 
         const indexUrl = publicReportUrl(periodLabel)
-        const doSync = doSyncOpt || (doSend && indexUrl !== null)
+
+        // Hosted-Pages invariant (specs/delivery.md): if --send is requested
+        // and any chat channel is enabled, UBER_PUBLIC_BASE_URL must be set
+        // so chat messages can link to the deployed Pages report. We can't
+        // inspect channels here without resolving them, so the strict check
+        // happens just before the fan-out below; the sync is still scheduled
+        // up-front so chat content is live before delivery.
+        const doSync = doSyncOpt || doSend
         if (doSync) {
           yield* Console.log(`syncing vault → R2 ...`)
           const syncResult = yield* Effect.serviceOption(SyncService).pipe(
@@ -581,17 +589,32 @@ export const report = Command.make(
           return
         }
 
-        const deliveryContent = indexUrl
-          ? `🌐 ${indexUrl}\n\n${indexRendered.markdown}`
-          : indexRendered.markdown
-
         const deliverer = yield* DelivererService
         const channels = yield* resolveChannels(
           profile.profile.delivery.channels as Record<string, unknown>,
           null,
         )
         yield* Console.log(`  ${channels.length} channel(s) to deliver`)
+
+        // Hosted-Pages invariant: chat channels MUST link to a deployed
+        // Pages URL. If any chat channel is enabled and UBER_PUBLIC_BASE_URL
+        // is unset, fail rather than ship a chat message without a hosted
+        // link. App-driver channels are exempt.
+        const chatChannels = channels.filter(isChatChannel)
+        if (chatChannels.length > 0 && indexUrl === null) {
+          return yield* Effect.fail(
+            new DeliveryError({
+              message:
+                "UBER_PUBLIC_BASE_URL is not set; refusing to send weekly report to chat channels (telegram/discord) without a hosted Pages link. Set UBER_PUBLIC_BASE_URL=https://<your-pages-domain> or drop --send.",
+              kind: "config",
+            }),
+          )
+        }
+
         for (const ch of channels) {
+          const deliveryContent = isChatChannel(ch)
+            ? `🌐 ${indexUrl}\n\n${indexRendered.markdown}`
+            : indexRendered.markdown
           const result = yield* deliverer
             .send({
               channel: ch.name,

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -10,7 +10,7 @@ import { StubLlmLive } from "../adapters/StubLlm.js"
 import { DeliveryError } from "../errors.js"
 import { selectCandidates, type CandidateRef } from "../lib/candidates.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
-import { publicReportUrl, resolveVaultDir } from "../lib/env.js"
+import { publicBaseUrl, publicReportUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
 import {
   DIRECTIVES_RESEARCH_DIR,
   DIRECTIVES_SOURCES_FILE,
@@ -532,13 +532,15 @@ export const report = Command.make(
 
         const indexUrl = publicReportUrl(periodLabel)
 
-        // Hosted-Pages invariant (specs/delivery.md): if --send is requested
+        // Hosted-link invariant (specs/delivery.md): if --send is requested
         // and any chat channel is enabled, UBER_PUBLIC_BASE_URL must be set
-        // so chat messages can link to the deployed Pages report. We can't
-        // inspect channels here without resolving them, so the strict check
-        // happens just before the fan-out below; the sync is still scheduled
-        // up-front so chat content is live before delivery.
-        const doSync = doSyncOpt || doSend
+        // so chat messages can link to a hosted report (Cloudflare Pages,
+        // Tailscale Serve, etc.). The strict channel check happens just
+        // before the fan-out below; sync is scheduled up-front so chat
+        // content is live before delivery. R2 sync only applies to the
+        // Cloudflare Pages backend — Tailscale / localhost setups serve the
+        // vault directly and skip the upload.
+        const doSync = (doSyncOpt || doSend) && requiresR2Sync(publicBaseUrl())
         if (doSync) {
           yield* Console.log(`syncing vault → R2 ...`)
           const syncResult = yield* Effect.serviceOption(SyncService).pipe(
@@ -596,16 +598,17 @@ export const report = Command.make(
         )
         yield* Console.log(`  ${channels.length} channel(s) to deliver`)
 
-        // Hosted-Pages invariant: chat channels MUST link to a deployed
-        // Pages URL. If any chat channel is enabled and UBER_PUBLIC_BASE_URL
-        // is unset, fail rather than ship a chat message without a hosted
-        // link. App-driver channels are exempt.
+        // Hosted-link invariant: chat channels MUST link to a hosted URL
+        // (Cloudflare Pages, Tailscale Serve, or any HTTPS host). If any chat
+        // channel is enabled and UBER_PUBLIC_BASE_URL is unset, fail rather
+        // than ship a chat message without a hosted link. App-driver channels
+        // are exempt.
         const chatChannels = channels.filter(isChatChannel)
         if (chatChannels.length > 0 && indexUrl === null) {
           return yield* Effect.fail(
             new DeliveryError({
               message:
-                "UBER_PUBLIC_BASE_URL is not set; refusing to send weekly report to chat channels (telegram/discord) without a hosted Pages link. Set UBER_PUBLIC_BASE_URL=https://<your-pages-domain> or drop --send.",
+                "UBER_PUBLIC_BASE_URL is not set; refusing to send weekly report to chat channels (telegram/discord) without a hosted link. Set UBER_PUBLIC_BASE_URL=https://<host> (Cloudflare Pages, Tailscale Serve `https://<device>.<tailnet>.ts.net`, or any HTTPS host serving the vault) or drop --send.",
               kind: "config",
             }),
           )

--- a/apps/uebermensch/src/commands/run-daily.ts
+++ b/apps/uebermensch/src/commands/run-daily.ts
@@ -10,7 +10,7 @@ import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { selectCandidates } from "../lib/candidates.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
-import { publicBriefUrl, resolveVaultDir } from "../lib/env.js"
+import { publicBaseUrl, publicBriefUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
 import {
   INPUT_BRIEFS_DIR,
   INPUT_RAW_DIR,
@@ -113,10 +113,12 @@ const runBriefGeneration = (
 // Fans out the brief content to all configured channels.
 // Returns { successes, failures } counts; never fails — errors are counted.
 //
-// Hosted-Pages invariant (specs/delivery.md): chat channels (telegram /
-// discord) must link to a deployed Pages URL. If any chat channel is enabled,
-// require UBER_PUBLIC_BASE_URL and sync the vault to R2 first. The app driver
-// is exempt and is delivered to even if the chat path is short-circuited.
+// Hosted-link invariant (specs/delivery.md): chat channels (telegram /
+// discord) must link to a hosted URL (Cloudflare Pages, Tailscale Serve, or
+// any HTTPS host). If any chat channel is enabled, require UBER_PUBLIC_BASE_URL.
+// R2 sync runs only for the Cloudflare Pages backend; Tailscale / localhost /
+// self-hosted setups serve the vault directly. The app driver is exempt and is
+// delivered to even if the chat path is short-circuited.
 const runSend = (
   date: string,
   vaultDir: string,
@@ -158,12 +160,12 @@ const runSend = (
     let chatAllowed = true
     if (chatChannels.length > 0 && briefUrl === null) {
       yield* Console.error(
-        "  UBER_PUBLIC_BASE_URL is not set — refusing to send brief to chat channels (telegram/discord) without a hosted Pages link. Configure UBER_PUBLIC_BASE_URL or remove chat channels from profile.",
+        "  UBER_PUBLIC_BASE_URL is not set — refusing to send brief to chat channels (telegram/discord) without a hosted link. Configure UBER_PUBLIC_BASE_URL=https://<host> (Cloudflare Pages, Tailscale Serve `https://<device>.<tailnet>.ts.net`, or any HTTPS host serving the vault) or remove chat channels from profile.",
       )
       chatAllowed = false
     }
 
-    if (chatAllowed && chatChannels.length > 0) {
+    if (chatAllowed && chatChannels.length > 0 && requiresR2Sync(publicBaseUrl())) {
       yield* Console.log(`  syncing vault → R2 (briefs/reports/raw/wiki) ...`)
       const sync = yield* SyncService
       const syncResult = yield* sync

--- a/apps/uebermensch/src/commands/run-daily.ts
+++ b/apps/uebermensch/src/commands/run-daily.ts
@@ -6,15 +6,22 @@ import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
 import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
 import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { selectCandidates } from "../lib/candidates.js"
-import { resolveChannels } from "../lib/channels.js"
+import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicBriefUrl, resolveVaultDir } from "../lib/env.js"
-import { INPUT_BRIEFS_DIR } from "../lib/vault-paths.js"
+import {
+  INPUT_BRIEFS_DIR,
+  INPUT_RAW_DIR,
+  INPUT_REPORTS_DIR,
+  INPUT_WIKI_DIR,
+} from "../lib/vault-paths.js"
 import { DelivererService } from "../services/DelivererService.js"
 import { LlmService } from "../services/LlmService.js"
 import { ProfileService } from "../services/ProfileService.js"
 import { RendererService } from "../services/RendererService.js"
+import { SyncService } from "../services/SyncService.js"
 import { VaultService } from "../services/VaultService.js"
 
 const today = () => new Date().toISOString().slice(0, 10)
@@ -105,11 +112,20 @@ const runBriefGeneration = (
 
 // Fans out the brief content to all configured channels.
 // Returns { successes, failures } counts; never fails — errors are counted.
+//
+// Hosted-Pages invariant (specs/delivery.md): chat channels (telegram /
+// discord) must link to a deployed Pages URL. If any chat channel is enabled,
+// require UBER_PUBLIC_BASE_URL and sync the vault to R2 first. The app driver
+// is exempt and is delivered to even if the chat path is short-circuited.
 const runSend = (
   date: string,
   vaultDir: string,
   content: string,
-): Effect.Effect<{ successes: number; failures: number }, never, ProfileService | DelivererService> =>
+): Effect.Effect<
+  { successes: number; failures: number },
+  never,
+  ProfileService | DelivererService | SyncService
+> =>
   Effect.gen(function* () {
     const briefRel = `${INPUT_BRIEFS_DIR}/${date}.md`
     yield* Console.log(`sending ${briefRel} from ${vaultDir}`)
@@ -136,11 +152,58 @@ const runSend = (
     yield* Console.log(`  ${channels.length} channel(s) to deliver`)
 
     const briefUrl = publicBriefUrl(date)
-    const deliveryContent = briefUrl ? `${briefUrl}\n\n${content}` : content
+    const chatChannels = channels.filter(isChatChannel)
+    const appChannels = channels.filter((c) => !isChatChannel(c))
+
+    let chatAllowed = true
+    if (chatChannels.length > 0 && briefUrl === null) {
+      yield* Console.error(
+        "  UBER_PUBLIC_BASE_URL is not set — refusing to send brief to chat channels (telegram/discord) without a hosted Pages link. Configure UBER_PUBLIC_BASE_URL or remove chat channels from profile.",
+      )
+      chatAllowed = false
+    }
+
+    if (chatAllowed && chatChannels.length > 0) {
+      yield* Console.log(`  syncing vault → R2 (briefs/reports/raw/wiki) ...`)
+      const sync = yield* SyncService
+      const syncResult = yield* sync
+        .run({
+          vaultDir,
+          prefixes: [
+            INPUT_BRIEFS_DIR,
+            INPUT_REPORTS_DIR,
+            INPUT_RAW_DIR,
+            INPUT_WIKI_DIR,
+          ],
+          dryRun: false,
+          force: false,
+        })
+        .pipe(Effect.either)
+      if (Either.isLeft(syncResult)) {
+        const err = syncResult.left
+        yield* Console.error(
+          `  R2 sync failed (${err.kind}): ${err.message} — refusing to send chat messages whose hosted link would 404`,
+        )
+        chatAllowed = false
+      } else {
+        yield* Console.log(
+          `    uploaded=${syncResult.right.uploaded} skipped=${syncResult.right.skipped} failed=${syncResult.right.failed}`,
+        )
+      }
+    }
 
     let successes = 0
     let failures = 0
-    for (const ch of channels) {
+    const eligible = chatAllowed ? channels : appChannels
+    if (eligible.length === 0 && channels.length > 0) {
+      // All channels were chat and we short-circuited — count as failure so
+      // run-daily exits non-zero and the scheduler retries / surfaces it.
+      failures = chatChannels.length
+    }
+    for (const ch of eligible) {
+      const deliveryContent = isChatChannel(ch)
+        ? `${briefUrl}\n\n${content}`
+        : content
       const result = yield* deliverer
         .send({
           channel: ch.name,
@@ -196,8 +259,15 @@ export const runDaily = Command.make("run-daily", {}, () =>
 
     const briefContent = briefResult.right
 
+    const syncLayer = R2SyncLive.pipe(Layer.provide(R2SyncConfigFromEnv))
     const { successes, failures } = yield* runSend(date, vaultDir, briefContent).pipe(
-      Effect.provide(Layer.mergeAll(FileSystemProfileLive(vaultDir), HttpDelivererLive)),
+      Effect.provide(
+        Layer.mergeAll(
+          FileSystemProfileLive(vaultDir),
+          HttpDelivererLive,
+          syncLayer,
+        ),
+      ),
     )
 
     yield* Console.log(`delivery: ${successes} ok, ${failures} failed`)

--- a/apps/uebermensch/src/commands/send.ts
+++ b/apps/uebermensch/src/commands/send.ts
@@ -7,7 +7,7 @@ import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { DeliveryError, VaultError } from "../errors.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
-import { publicBriefUrl, resolveVaultDir } from "../lib/env.js"
+import { publicBaseUrl, publicBriefUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
 import {
   INPUT_BRIEFS_DIR,
   INPUT_RAW_DIR,
@@ -76,23 +76,25 @@ export const send = Command.make(
           return
         }
 
-        // Hosted-Pages invariant (specs/delivery.md): chat channels must link
-        // to a deployed Pages URL. If any chat channel is enabled, require
-        // UBER_PUBLIC_BASE_URL and sync the vault to R2 before sending. The
-        // app driver is exempt — it renders the brief in-app from the vault.
+        // Hosted-link invariant (specs/delivery.md): chat channels must link
+        // to a hosted URL (Cloudflare Pages, Tailscale Serve, or any HTTPS
+        // host). UBER_PUBLIC_BASE_URL is required for chat fan-out. The app
+        // driver is exempt — it renders the brief in-app from the vault.
         const briefUrl = publicBriefUrl(date)
         const chatChannels = channels.filter(isChatChannel)
         if (chatChannels.length > 0 && briefUrl === null) {
           return yield* Effect.fail(
             new DeliveryError({
               message:
-                "UBER_PUBLIC_BASE_URL is not set; refusing to send brief to chat channels (telegram/discord) without a hosted Pages link. Set UBER_PUBLIC_BASE_URL=https://<your-pages-domain> or restrict to --channel <app-channel>.",
+                "UBER_PUBLIC_BASE_URL is not set; refusing to send brief to chat channels (telegram/discord) without a hosted link. Set UBER_PUBLIC_BASE_URL=https://<host> (Cloudflare Pages, Tailscale Serve `https://<device>.<tailnet>.ts.net`, or any HTTPS host serving the vault) or restrict to --channel <app-channel>.",
               kind: "config",
             }),
           )
         }
 
-        if (chatChannels.length > 0) {
+        // R2 sync only applies to the Cloudflare Pages backend. Tailscale-
+        // served / localhost / self-hosted setups serve the vault directly.
+        if (chatChannels.length > 0 && requiresR2Sync(publicBaseUrl())) {
           yield* Console.log(`syncing vault → R2 (briefs/reports/raw/wiki) ...`)
           const sync = yield* SyncService
           const result = yield* sync

--- a/apps/uebermensch/src/commands/send.ts
+++ b/apps/uebermensch/src/commands/send.ts
@@ -1,15 +1,22 @@
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { Command, Options } from "@effect/cli"
-import { Console, Effect, Option } from "effect"
+import { Console, Effect, Layer, Option } from "effect"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
-import { VaultError } from "../errors.js"
-import { resolveChannels } from "../lib/channels.js"
+import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
+import { DeliveryError, VaultError } from "../errors.js"
+import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicBriefUrl, resolveVaultDir } from "../lib/env.js"
-import { INPUT_BRIEFS_DIR } from "../lib/vault-paths.js"
+import {
+  INPUT_BRIEFS_DIR,
+  INPUT_RAW_DIR,
+  INPUT_REPORTS_DIR,
+  INPUT_WIKI_DIR,
+} from "../lib/vault-paths.js"
 import { DelivererService } from "../services/DelivererService.js"
 import { ProfileService } from "../services/ProfileService.js"
+import { SyncService } from "../services/SyncService.js"
 
 const dateOpt = Options.text("date").pipe(
   Options.withDescription("Brief date (YYYY-MM-DD); defaults to today"),
@@ -69,9 +76,55 @@ export const send = Command.make(
           return
         }
 
+        // Hosted-Pages invariant (specs/delivery.md): chat channels must link
+        // to a deployed Pages URL. If any chat channel is enabled, require
+        // UBER_PUBLIC_BASE_URL and sync the vault to R2 before sending. The
+        // app driver is exempt — it renders the brief in-app from the vault.
         const briefUrl = publicBriefUrl(date)
-        const deliveryContent = briefUrl ? `🌐 ${briefUrl}\n\n${content}` : content
+        const chatChannels = channels.filter(isChatChannel)
+        if (chatChannels.length > 0 && briefUrl === null) {
+          return yield* Effect.fail(
+            new DeliveryError({
+              message:
+                "UBER_PUBLIC_BASE_URL is not set; refusing to send brief to chat channels (telegram/discord) without a hosted Pages link. Set UBER_PUBLIC_BASE_URL=https://<your-pages-domain> or restrict to --channel <app-channel>.",
+              kind: "config",
+            }),
+          )
+        }
+
+        if (chatChannels.length > 0) {
+          yield* Console.log(`syncing vault → R2 (briefs/reports/raw/wiki) ...`)
+          const sync = yield* SyncService
+          const result = yield* sync
+            .run({
+              vaultDir,
+              prefixes: [
+                INPUT_BRIEFS_DIR,
+                INPUT_REPORTS_DIR,
+                INPUT_RAW_DIR,
+                INPUT_WIKI_DIR,
+              ],
+              dryRun: false,
+              force: false,
+            })
+            .pipe(
+              Effect.mapError(
+                (e) =>
+                  new DeliveryError({
+                    message: `R2 sync failed before chat send (${e.kind}): ${e.message}; refusing to send chat messages whose hosted link would 404.`,
+                    kind: "unreachable",
+                  }),
+              ),
+            )
+          yield* Console.log(
+            `  uploaded=${result.uploaded} skipped=${result.skipped} failed=${result.failed}`,
+          )
+        }
+
         for (const ch of channels) {
+          const deliveryContent = isChatChannel(ch)
+            ? `🌐 ${briefUrl}\n\n${content}`
+            : content
           const result = yield* deliverer
             .send({
               channel: ch.name,
@@ -96,9 +149,11 @@ export const send = Command.make(
         }
       })
 
+      const syncLayer = R2SyncLive.pipe(Layer.provide(R2SyncConfigFromEnv))
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(HttpDelivererLive),
+        Effect.provide(syncLayer),
       )
     }),
 ).pipe(

--- a/apps/uebermensch/src/lib/channels.ts
+++ b/apps/uebermensch/src/lib/channels.ts
@@ -10,6 +10,14 @@ export type ResolvedChannel = {
   readonly silent: boolean
 }
 
+// Chat channels (telegram, discord, future email) deliver to external surfaces
+// where the rendered markdown is a poor preview — they MUST link back to a
+// hosted Cloudflare Pages URL. The `app` driver renders the brief inside the
+// uebermensch app itself and is exempt. See specs/delivery.md § Hosted-Pages
+// requirement.
+export const isChatChannel = (ch: ResolvedChannel): boolean =>
+  ch.driver !== "app"
+
 export const resolveChannels = (
   channelsRaw: Record<string, unknown>,
   only: string | null,

--- a/apps/uebermensch/src/lib/env.ts
+++ b/apps/uebermensch/src/lib/env.ts
@@ -20,6 +20,27 @@ export const publicBriefUrl = (date: string): string | null => {
   return base ? `${base}/briefs/${encodeURIComponent(date)}` : null
 }
 
+// Whether the configured hosted-link backend requires an R2 upload before chat
+// fan-out. Cloudflare Pages reads the vault from R2 → sync required. Tailscale
+// Serve / localhost / any self-hosted setup serves the vault directly from the
+// local filesystem → sync not applicable. Override with UBER_HOSTED_SYNC=none.
+export const requiresR2Sync = (baseUrl: string | null): boolean => {
+  const override = (process.env.UBER_HOSTED_SYNC ?? "").trim().toLowerCase()
+  if (override === "none" || override === "off" || override === "false") return false
+  if (override === "r2" || override === "on" || override === "true") return true
+  if (!baseUrl) return true
+  let host: string
+  try {
+    host = new URL(baseUrl).hostname.toLowerCase()
+  } catch {
+    return true
+  }
+  if (host.endsWith(".ts.net")) return false
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") return false
+  if (host.endsWith(".local")) return false
+  return true
+}
+
 export const resolveVaultDir = () =>
   Effect.gen(function* () {
     const env = process.env.UBER_VAULT_DIR

--- a/apps/uebermensch/vault/specs/delivery.md
+++ b/apps/uebermensch/vault/specs/delivery.md
@@ -16,6 +16,19 @@ Three entry points, all converging on `DelivererService`:
 
 Recurring delivery is fired by the **kernel scheduler** (`gctrl-scheduler`) using `target_kind: exec` rows registered via `uber schedule sync` from `directives/schedules.md`. There is no uebermensch HTTP daemon listening for scheduler callbacks — the kernel scheduler exec's the `uber` CLI directly. See [scheduling.md](scheduling.md) for the wiring.
 
+## Hosted-Pages requirement (Telegram / Discord)
+
+Briefs and reports delivered to **chat channels** (Telegram, Discord, future email) MUST link to a deployed Cloudflare Pages URL. Raw markdown without a hosted link is not an acceptable fallback for these channels — chat-rendered content loses headings, citations, callouts, and visualizations that the hosted page renders correctly.
+
+Invariant:
+
+1. The vault content MUST be live on `${UBER_PUBLIC_BASE_URL}` before the chat send fires. The pipeline (`uber report --send`, `uber send`, `uber run-daily`) MUST run an R2 sync of `input/{briefs,reports,raw,wiki}` before invoking `DelivererService` for any chat channel. The Astro Worker at [`apps/uebermensch-pages`](../../uebermensch-pages) reads R2 at request time, so a successful sync makes the content live without a separate `wrangler deploy`. The Worker itself is deployed out-of-band (CI / `pnpm -F uebermensch-pages run deploy`) and is a one-time-per-version concern.
+2. The chat message body MUST include the deployed Pages URL (`${UBER_PUBLIC_BASE_URL}/briefs/<date>` or `${UBER_PUBLIC_BASE_URL}/reports/<slug>`) above the content. The link is the canonical artifact; the chat body is a preview.
+3. If `UBER_PUBLIC_BASE_URL` is unset, the pipeline MUST fail loudly **before** any Telegram/Discord call. Sending raw content to chat is a hard error, not a fallback.
+4. If the R2 sync fails, the chat send for that run MUST be skipped and surfaced (`uber_alerts` row with `kind: delivery_stalled`). Better to miss a brief than ship a chat message whose link 404s.
+
+The `app` driver (in-app SSE feed) is **exempt** — the user is already inside the app, so the SSE payload + `/api/uber/briefs/{id}/body` route serve the content directly from the vault. App delivery does not require `UBER_PUBLIC_BASE_URL`.
+
 ## Responsibilities
 
 `DelivererService` (Effect-TS, `apps/uebermensch/src/services/deliverer.ts`):
@@ -81,6 +94,7 @@ Each driver gets a `Message` matching [domain-model.md § 7.2](domain-model.md#7
 - Driver: `driver-telegram` (`gctrl-driver-telegram` LKM).
 - Source: vault markdown at `uber_briefs.vault_path`.
 - Rendering target: **MarkdownV2** — Telegram's native format with forced escaping of special chars.
+- **Hosted link header** (required, see [Hosted-Pages requirement](#hosted-pages-requirement-telegram--discord)): the first line of the first chunk is `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>` for weekly reports), followed by a blank line, then the content. The link is what recipients are expected to click — the inline body is a preview.
 - Long briefs: split across messages at natural boundaries (item boundaries), with continuation markers `(1/3)` etc.
 - `[[slug]]` → bare URL `https://<app-host>/wiki/<slug>` (or app deep link `uber://wiki/<slug>` if custom scheme configured). Citations resolve by the target's frontmatter `page_type` — theses get bolded labels, sources get domain chips (see Link Rendering below).
 - Quick-replies (inline keyboard):
@@ -106,6 +120,7 @@ Example rendered Telegram message (MarkdownV2-escaped):
 - Driver: `driver-discord` (`gctrl-driver-discord` LKM).
 - Source: vault markdown at `uber_briefs.vault_path`, parsed into Discord's markdown subset.
 - Rendering target: **Discord embeds** — richer cards, color-coded by `kind`.
+- **Hosted link header** (required, see [Hosted-Pages requirement](#hosted-pages-requirement-telegram--discord)): the message `content` field carries `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>`); the embed `url` field also points to the same hosted page so the embed title is clickable. The embed body is a preview; the hosted page is the canonical artifact.
 - Brief = 1 embed per item (up to 10 per message; overflow splits across messages).
 - Embed fields:
   - Title: item title
@@ -221,6 +236,8 @@ Stages 2–5 run in parallel across channels (Effect fiber per channel), then jo
 
 | Error | Brief status | Alert? | Next action |
 |-------|--------------|--------|-------------|
+| `UBER_PUBLIC_BASE_URL` unset, but a chat channel (telegram/discord) is enabled | `rendered` (no `delivered` transition for chat) | `kind=delivery_stalled, urgency=warn` | User configures hosted Pages URL; no chat send is attempted |
+| R2 sync failed before chat send | `rendered` for chat channels (app-driver still delivers) | `kind=delivery_stalled, urgency=warn` | Inspect wrangler/R2 creds; next run retries |
 | All channels `MessagingError::Invalid` | `rendered` (no `delivered` transition) | `kind=delivery_stalled, urgency=warn` | User inspects profile config |
 | One channel fails, others succeed | `delivered` | none (row error_message captured) | Next brief retries failed channel; if 3 briefs in a row fail → alert |
 | Target unreachable for > 6h | `delivered` (earlier) | `kind=delivery_stalled, urgency=warn` | Check driver connectivity |

--- a/apps/uebermensch/vault/specs/delivery.md
+++ b/apps/uebermensch/vault/specs/delivery.md
@@ -16,18 +16,29 @@ Three entry points, all converging on `DelivererService`:
 
 Recurring delivery is fired by the **kernel scheduler** (`gctrl-scheduler`) using `target_kind: exec` rows registered via `uber schedule sync` from `directives/schedules.md`. There is no uebermensch HTTP daemon listening for scheduler callbacks — the kernel scheduler exec's the `uber` CLI directly. See [scheduling.md](scheduling.md) for the wiring.
 
-## Hosted-Pages requirement (Telegram / Discord)
+## Hosted-link requirement (Telegram / Discord)
 
-Briefs and reports delivered to **chat channels** (Telegram, Discord, future email) MUST link to a deployed Cloudflare Pages URL. Raw markdown without a hosted link is not an acceptable fallback for these channels — chat-rendered content loses headings, citations, callouts, and visualizations that the hosted page renders correctly.
+Briefs and reports delivered to **chat channels** (Telegram, Discord, future email) MUST link to a hosted URL. Raw markdown without a hosted link is not an acceptable fallback for these channels — chat-rendered content loses headings, citations, callouts, and visualizations that the hosted page renders correctly.
+
+The hosted backend is pluggable. Two supported deployments today:
+
+| Backend | `UBER_PUBLIC_BASE_URL` | Sync mechanism | When to use |
+|---------|-----------------------|----------------|-------------|
+| **Cloudflare Pages** | `https://<your-pages-domain>` | R2 upload of `input/{briefs,reports,raw,wiki}` (the Astro Worker at [`apps/uebermensch-pages`](../../uebermensch-pages) reads R2 at request time) | Public / cross-device hosting |
+| **Tailscale Serve** | `https://<device>.<tailnet>.ts.net` (or `/<sub-path>`) | None — the local Astro/static server reads the vault directly from the filesystem | Local network / single-user / private |
+
+Other HTTPS hosts (`localhost`, `*.local`, self-hosted) are also supported; treat them like the Tailscale row (no R2 sync). The `UBER_HOSTED_SYNC=none` env var forces sync off regardless of URL; `UBER_HOSTED_SYNC=r2` forces it on.
 
 Invariant:
 
-1. The vault content MUST be live on `${UBER_PUBLIC_BASE_URL}` before the chat send fires. The pipeline (`uber report --send`, `uber send`, `uber run-daily`) MUST run an R2 sync of `input/{briefs,reports,raw,wiki}` before invoking `DelivererService` for any chat channel. The Astro Worker at [`apps/uebermensch-pages`](../../uebermensch-pages) reads R2 at request time, so a successful sync makes the content live without a separate `wrangler deploy`. The Worker itself is deployed out-of-band (CI / `pnpm -F uebermensch-pages run deploy`) and is a one-time-per-version concern.
-2. The chat message body MUST include the deployed Pages URL (`${UBER_PUBLIC_BASE_URL}/briefs/<date>` or `${UBER_PUBLIC_BASE_URL}/reports/<slug>`) above the content. The link is the canonical artifact; the chat body is a preview.
+1. The vault content MUST be live on `${UBER_PUBLIC_BASE_URL}` before the chat send fires. For the **Cloudflare Pages** backend the pipeline (`uber report --send`, `uber send`, `uber run-daily`) MUST run an R2 sync of `input/{briefs,reports,raw,wiki}` before invoking `DelivererService` for any chat channel — a successful sync makes the content live without a separate `wrangler deploy` (the Worker itself is deployed out-of-band via CI / `pnpm -F uebermensch-pages run deploy`). For **Tailscale Serve** / localhost / self-hosted the operator is responsible for ensuring the local server is running and serving the vault; no R2 sync is performed.
+2. The chat message body MUST include the hosted URL (`${UBER_PUBLIC_BASE_URL}/briefs/<date>` or `${UBER_PUBLIC_BASE_URL}/reports/<slug>`) above the content. The link is the canonical artifact; the chat body is a preview.
 3. If `UBER_PUBLIC_BASE_URL` is unset, the pipeline MUST fail loudly **before** any Telegram/Discord call. Sending raw content to chat is a hard error, not a fallback.
-4. If the R2 sync fails, the chat send for that run MUST be skipped and surfaced (`uber_alerts` row with `kind: delivery_stalled`). Better to miss a brief than ship a chat message whose link 404s.
+4. If the R2 sync fails (Cloudflare Pages backend only), the chat send for that run MUST be skipped and surfaced (`uber_alerts` row with `kind: delivery_stalled`). Better to miss a brief than ship a chat message whose link 404s.
 
 The `app` driver (in-app SSE feed) is **exempt** — the user is already inside the app, so the SSE payload + `/api/uber/briefs/{id}/body` route serve the content directly from the vault. App delivery does not require `UBER_PUBLIC_BASE_URL`.
+
+Backend detection happens in `lib/env.ts::requiresR2Sync(url)`: hosts ending in `.ts.net` (Tailscale), `localhost`, `127.0.0.1`, `::1`, and `*.local` skip R2 sync; everything else syncs by default. `UBER_HOSTED_SYNC` overrides the auto-detection.
 
 ## Responsibilities
 
@@ -94,7 +105,7 @@ Each driver gets a `Message` matching [domain-model.md § 7.2](domain-model.md#7
 - Driver: `driver-telegram` (`gctrl-driver-telegram` LKM).
 - Source: vault markdown at `uber_briefs.vault_path`.
 - Rendering target: **MarkdownV2** — Telegram's native format with forced escaping of special chars.
-- **Hosted link header** (required, see [Hosted-Pages requirement](#hosted-pages-requirement-telegram--discord)): the first line of the first chunk is `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>` for weekly reports), followed by a blank line, then the content. The link is what recipients are expected to click — the inline body is a preview.
+- **Hosted link header** (required, see [Hosted-link requirement](#hosted-link-requirement-telegram--discord)): the first line of the first chunk is `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>` for weekly reports), followed by a blank line, then the content. The link is what recipients are expected to click — the inline body is a preview. The URL may resolve to Cloudflare Pages, Tailscale Serve, or any HTTPS host; the renderer treats them identically.
 - Long briefs: split across messages at natural boundaries (item boundaries), with continuation markers `(1/3)` etc.
 - `[[slug]]` → bare URL `https://<app-host>/wiki/<slug>` (or app deep link `uber://wiki/<slug>` if custom scheme configured). Citations resolve by the target's frontmatter `page_type` — theses get bolded labels, sources get domain chips (see Link Rendering below).
 - Quick-replies (inline keyboard):
@@ -120,7 +131,7 @@ Example rendered Telegram message (MarkdownV2-escaped):
 - Driver: `driver-discord` (`gctrl-driver-discord` LKM).
 - Source: vault markdown at `uber_briefs.vault_path`, parsed into Discord's markdown subset.
 - Rendering target: **Discord embeds** — richer cards, color-coded by `kind`.
-- **Hosted link header** (required, see [Hosted-Pages requirement](#hosted-pages-requirement-telegram--discord)): the message `content` field carries `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>`); the embed `url` field also points to the same hosted page so the embed title is clickable. The embed body is a preview; the hosted page is the canonical artifact.
+- **Hosted link header** (required, see [Hosted-link requirement](#hosted-link-requirement-telegram--discord)): the message `content` field carries `🌐 ${UBER_PUBLIC_BASE_URL}/briefs/<date>` (or `/reports/<slug>`); the embed `url` field also points to the same hosted page so the embed title is clickable. The embed body is a preview; the hosted page (Pages, Tailscale, or any HTTPS host) is the canonical artifact.
 - Brief = 1 embed per item (up to 10 per message; overflow splits across messages).
 - Embed fields:
   - Title: item title
@@ -236,8 +247,8 @@ Stages 2–5 run in parallel across channels (Effect fiber per channel), then jo
 
 | Error | Brief status | Alert? | Next action |
 |-------|--------------|--------|-------------|
-| `UBER_PUBLIC_BASE_URL` unset, but a chat channel (telegram/discord) is enabled | `rendered` (no `delivered` transition for chat) | `kind=delivery_stalled, urgency=warn` | User configures hosted Pages URL; no chat send is attempted |
-| R2 sync failed before chat send | `rendered` for chat channels (app-driver still delivers) | `kind=delivery_stalled, urgency=warn` | Inspect wrangler/R2 creds; next run retries |
+| `UBER_PUBLIC_BASE_URL` unset, but a chat channel (telegram/discord) is enabled | `rendered` (no `delivered` transition for chat) | `kind=delivery_stalled, urgency=warn` | User configures a hosted URL (Cloudflare Pages, Tailscale Serve, or any HTTPS host); no chat send is attempted |
+| R2 sync failed before chat send (Cloudflare Pages backend) | `rendered` for chat channels (app-driver still delivers) | `kind=delivery_stalled, urgency=warn` | Inspect wrangler/R2 creds; next run retries. N/A for Tailscale/self-hosted backends |
 | All channels `MessagingError::Invalid` | `rendered` (no `delivered` transition) | `kind=delivery_stalled, urgency=warn` | User inspects profile config |
 | One channel fails, others succeed | `delivered` | none (row error_message captured) | Next brief retries failed channel; if 3 briefs in a row fail → alert |
 | Target unreachable for > 6h | `delivered` (earlier) | `kind=delivery_stalled, urgency=warn` | Check driver connectivity |


### PR DESCRIPTION
## Summary

Briefs and reports posted to chat channels (Telegram, Discord, future email) now MUST link to a hosted URL. The chat body is a preview; the hosted page is the canonical artifact (citations, callouts, visualizations that chat renderers drop).

The hosted backend is **pluggable** — Cloudflare Pages is one option, **Tailscale Serve** (`https://<device>.<tailnet>.ts.net`) is another, and any HTTPS host that serves the vault works. R2 sync is the Cloudflare Pages mechanism; for Tailscale / localhost / self-hosted setups the local server reads the vault directly and R2 sync is skipped.

- **Spec** — `apps/uebermensch/vault/specs/delivery.md`: new "Hosted-link requirement" section with a backend table (Pages + R2 vs Tailscale Serve / self-hosted), per-channel hosted-link headers, and error-table rows for "URL unset" and "R2 sync failed (Pages backend)". App driver is exempt (renders in-app from the vault).
- **Backend detection** — `lib/env.ts::requiresR2Sync(url)`: hosts ending in `.ts.net`, plus `localhost` / `127.0.0.1` / `::1` / `*.local`, skip R2 sync. Override with `UBER_HOSTED_SYNC=none|r2`.
- **Apps**:
  - `lib/channels.ts:18` — new `isChatChannel(ch)` helper (`driver !== "app"`).
  - `commands/send.ts` — when any chat channel is enabled: require `UBER_PUBLIC_BASE_URL`, R2-sync `briefs/reports/raw/wiki` before send (only when `requiresR2Sync` returns true), fail loudly on sync error, prepend `🌐 ${briefUrl}` to chat content. App channels still work URL-less.
  - `commands/run-daily.ts` — same enforcement in `runSend`; chat short-circuit still delivers to app channels and counts the chat fan-out as failures so the scheduler exit reflects it.
  - `commands/report.ts` — `--send` syncs only when the backend requires it; fails before fan-out if chat channels enabled without URL; raw-only fallback removed for chat.

Error messages now name Tailscale Serve and any HTTPS host as valid alongside Cloudflare Pages.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 214/214 tests pass (delivery-related: `send.test.ts` 14, `run-daily.test.ts` 5, `report.test.ts` 1)
- [ ] Manual (Cloudflare Pages backend): with `UBER_PUBLIC_BASE_URL=https://uber.example.pages.dev`, `uber run-daily` R2-syncs then posts to Telegram + Discord with the hosted link header
- [ ] Manual (Tailscale Serve backend): with `UBER_PUBLIC_BASE_URL=https://<device>.<tailnet>.ts.net` and `tailscale serve --bg <local-port>` running, `uber run-daily` skips R2 sync and posts with the tailnet link header
- [ ] Manual: with `UBER_PUBLIC_BASE_URL` unset, `uber run-daily` exits non-zero with the "refusing to send" error and does not call any TG/Discord driver
- [ ] Manual: with chat channels disabled and only `app` driver enabled, no URL or R2 sync is required
