### PR TITLE
spec(uebermensch): web onboarding without Obsidian; cloud-only mode

### DIFF
--- a/apps/uebermensch/PRD.md
+++ b/apps/uebermensch/PRD.md
@@ -1,6 +1,8 @@
 # Uebermensch — Product Requirements Document
 
-> Personal Chief of Staff for investors. Watches the topics you care about, files them into a Karpathy-style knowledge wiki stored as a plain-markdown Obsidian vault, syncs the vault across devices via R2, and delivers timely briefs + long-horizon analyses to the App, Telegram, and Discord. A native gctrl application.
+> Personal Chief of Staff for investors. Watches the topics you care about, files them into a Karpathy-style knowledge wiki stored as a plain-markdown vault, syncs the vault across devices via R2, and delivers timely briefs + long-horizon analyses to the Web, Telegram, and Discord. A native gctrl application.
+>
+> The vault is **Obsidian-compatible** (every file is CommonMark + YAML frontmatter), but Obsidian is **never required** — onboarding, channel configuration, and reading reports are all first-class on the web. See [§ Deployment Modes](#deployment-modes).
 >
 > Instantiates the [PRD template](../gctrl-board/vault/specs/workflows/prd-template.md).
 
@@ -15,7 +17,7 @@ flowchart TB
     CLI["CLI surface (gctrl uber ...)"]
     Svc["Services (Briefing, Curator, Deliverer, Evaluator)"]
   end
-  subgraph Vault["$UBER_VAULT_DIR (Obsidian-mountable)"]
+  subgraph Vault["$UBER_VAULT_DIR (markdown; Obsidian-compatible, optional)"]
     direction LR
     Authored["directives/ + output/ + action/\nprofile.md · topics.md · sources.md · theses/ · personas/ · prompts/ · action/events/"]
     Generated["input/\ninput/briefs/ · input/reports/ · input/raw/ · input/wiki/"]
@@ -45,8 +47,9 @@ flowchart TB
   Shell --> Kernel
   Kernel -->|read/write markdown| Vault
   Kernel --> Drivers
-  Sync -.->|30s debounce| R2[("R2 bucket")]
-  Vault -.->|mount| Obsidian(["Obsidian app"])
+  Sync -.->|30s debounce| R2[("R2 bucket\n(optional source of truth\nin cloud-only mode)")]
+  Vault -.->|optional mount| Obsidian(["Obsidian app\n(optional)"])
+  UI -.->|"web onboarding,\nchannel config,\nreports"| Browser(["Browser\n(no editor required)"])
 ```
 
 - **Table namespace:** `uber_*` (see Invariant #3 in [principles.md](../../vault/specs/principles.md))
@@ -79,17 +82,18 @@ The non-obvious bets:
 
 ## Principles
 
-1. **Vault is portable and Obsidian-mountable.** `$UBER_VAULT_DIR` is a git-versioned Obsidian vault outside the gctrl repo, readable without Uebermensch running. Every file is CommonMark markdown with YAML frontmatter; wikilinks use plain `[[slug]]` form (typed prefixes like `[[thesis:slug]]` are forbidden — they break Obsidian's resolver). The app MUST NOT write to the authored tier (`directives/`) without explicit user confirmation. The single exception: `directives/prompts/<slug>.md` frontmatter is updated in-place by the prompts processor (`gctrl uber prompts process`) to record `status`/`output`/`processed_at`; the body is never touched.
+1. **Vault is portable and Obsidian-compatible (not Obsidian-required).** The vault is a plain-markdown directory readable without Uebermensch running and openable in Obsidian for users who want a graph view — but Obsidian is never on the critical path. Every file is CommonMark markdown with YAML frontmatter; wikilinks use plain `[[slug]]` form (typed prefixes like `[[thesis:slug]]` are forbidden — they break Obsidian's resolver and our own). The app MUST NOT write to the authored tier (`directives/`) without explicit user confirmation, **whether the edit comes from a CLI command, a web onboarding wizard, or the user opening the file in Obsidian** — every authored-tier write is an atomic markdown rewrite plus a `VaultWatcher` reload. The single exception: `directives/prompts/<slug>.md` frontmatter is updated in-place by the prompts processor (`gctrl uber prompts process`) to record `status`/`output`/`processed_at`; the body is never touched.
 2. **Markdown is the source of truth.** Briefs, wiki pages, sources, and theses live on disk as markdown files. SQLite tables (`uber_briefs`, `uber_brief_items`, …) hold `vault_path` + `content_hash` only — pure index. Opening the vault in Obsidian MUST show everything; deleting SQLite MUST be recoverable by re-indexing.
 3. **Wiki compounds.** Every ingest MUST file at least one wiki page (source summary) and update relevant entity/topic pages. Drop-and-forget ingestion is a bug, not a feature.
 4. **Primary sources over commentary.** The curator MUST weight SEC filings, earnings transcripts, primary research, and official announcements above secondary commentary. Hype-tagged sources are tracked but never lead a brief.
 5. **Cite everything.** Every claim in a brief MUST link back to a source page in the wiki. No unsourced statements. "The LLM said so" is not a source.
 6. **Delivery is idempotent.** Sending the same brief twice to the same channel MUST NOT duplicate. Channel delivery state lives in kernel storage, not in messages.
 7. **Eval is continuous.** Every brief produced MUST be scoreable by the human (thumbs up/down, dimension scores) and by automated evaluators (citation coverage, hype ratio, scrape health). Scores flow into the kernel `scores` table and close the loop on prompt improvement. Evaluators read the brief markdown from the vault and pin results with `content_hash` so scores survive later edits.
-8. **Local-first, cloud-optional.** Briefs render locally, to the local vault. Vault sync to R2 is a first-class feature (not opt-in by M1) so a second device can mount the same vault; the local daemon is still authoritative and the user MUST be able to read yesterday's brief offline.
+8. **Local-first, cloud-symmetric.** Briefs render to a markdown vault — the only question is *where* the vault lives. In **local mode** the vault is on disk and R2 is a sync target; in **cloud-only mode** R2 is the vault (the byte store) and a hosted Worker reads/writes through it; in **hybrid mode** both coexist and a local daemon pulls a live mirror down from R2. All three modes share one data model — markdown + YAML — so a user can start cloud-only on a phone and later run `gctrl uber vault pull --from r2` to bring the same vault to a laptop with zero migration. See [§ Deployment Modes](#deployment-modes).
 9. **Agent-native.** Every surface (ingest, query, brief, deliver, score) MUST be reachable via CLI and HTTP API, so agents can run Uebermensch workflows and gctrl-board can dispatch Uebermensch tasks.
 10. **Cost-visible.** Each brief shows its accumulated LLM cost. A daily brief that exceeds the configured budget is paused, not silently truncated.
 11. **No opinion without a thesis.** Briefs tag items as `aligns-with`, `contradicts`, or `unrelated` to the user's active theses. An item that doesn't map to any thesis is either filed under "watch" or demoted from the brief.
+12. **Web is a primary surface, not a fallback.** The Web UI is the equal peer of CLI and Obsidian for the **user-facing surface** (onboarding, channel configuration, reading briefs and reports, scoring). Anything a user can do in Obsidian — edit a thesis, configure a topic, add a source, set delivery windows — must also be doable in the web UI without dropping to a markdown editor. Both surfaces produce the same atomic markdown commits via the same write path; neither is privileged.
 
 ## Target Users
 
@@ -120,6 +124,19 @@ The non-obvious bets:
 ### Tertiary: Any knowledge worker who wants a Chief of Staff
 
 Uebermensch is profile-parameterised. An ML researcher, policy wonk, or clinician can swap in a profile scoped to their topics and reuse the same pipeline.
+
+### Quaternary: Cloud-only user (no laptop / no editor / mobile-first)
+
+A user who never installs Obsidian, never runs the CLI, and may never own a workstation that runs the local daemon. They want to:
+
+| Need | Surface | Solution |
+|------|---------|----------|
+| "Sign up and get a brief without installing anything" | Web | Hosted Cloudflare Worker deployment; user lands on a URL, signs in, runs the onboarding wizard. Vault is created in R2 under `vault/<identity.slug>/` — no local daemon, no Obsidian. See [§ Deployment Modes](#deployment-modes). |
+| "Connect Telegram from my phone" | Web | Wizard step links the Telegram bot via deep link / QR; tokens land in the Worker's secret store (or kernel `driver-telegram` if a daemon is later attached). User confirms by replying `/start`. See [delivery.md § Channel Onboarding](vault/specs/delivery.md#channel-onboarding-web). |
+| "Connect Discord from my phone" | Web | Wizard step uses Discord's OAuth2 + bot-invite flow; the resulting webhook + interactions endpoint are stored in the Worker; user confirms with `/ping`. |
+| "Read today's brief on my phone with no editor" | Web | The Worker reads the brief markdown from R2 and renders sanitized HTML; same `[[slug]]` resolution as the desktop app. |
+| "Edit my topics or theses without an editor" | Web | The wizard's profile editor produces atomic markdown rewrites of `directives/profile.md`, `directives/topics.md`, and `directives/theses/<slug>.md` — same atomic-rename + content-hash protocol as the CLI / Obsidian path. |
+| "Later, pull everything down to a laptop" | CLI | `gctrl uber vault pull --from r2 --identity-slug <slug>` reconstructs the vault locally; from then on the local daemon and the cloud Worker share the same R2 bucket as the byte store. |
 
 ## Use Cases
 
@@ -202,18 +219,51 @@ Uebermensch is profile-parameterised. An ML researcher, policy wonk, or clinicia
 
 **Success metric:** Scrape failures surface within 24 h, not "user notices two weeks later."
 
+### UC-7: Cloud-Only Onboarding (no editor, no daemon)
+
+**Problem:** A first-time user opens the hosted Uebermensch URL on their phone. They have no Obsidian, no laptop with a daemon running, and no patience for a CLI. They want a working brief delivered to Telegram tomorrow morning.
+
+**Solution:**
+1. User visits `https://<host>/onboard` and signs in with the configured identity provider.
+2. **Wizard step 1 — identity:** asks for `identity.name` (display name); the Worker derives a slug-safe `identity.slug`. The Worker creates the R2 prefix `vault/<identity.slug>/` and atomic-writes a scaffold (the same template emitted by `gctrl uber vault init` — `directives/profile.md`, `directives/topics.md`, `directives/sources.md`, empty `directives/theses/`, `directives/prompts/`, `input/`, `output/`, `action/`).
+3. **Wizard step 2 — topics:** form fields collect 3–10 topics; on submit the Worker rewrites `directives/topics.md` (frontmatter `topics:` array) atomically — same content-hash + `vault.updated` event the local daemon emits. No raw markdown shown.
+4. **Wizard step 3 — channels:** the user clicks "Connect Telegram" → deep-link / QR opens `t.me/<bot>?start=<onboarding_token>`; the user replies `/start`; Worker captures `tg:chat:<id>` and writes the channel block into `directives/profile.md`. Same UX for Discord (OAuth2 + bot invite). Tokens go into the Worker's secret store, never the vault.
+5. **Wizard step 4 — schedule:** time-of-day picker → Worker rewrites `delivery.schedule` in `directives/profile.md`.
+6. Wizard exits to a feed view: "First brief tomorrow at 08:00 local. Latest brief will appear here, on Telegram, and on Discord."
+7. The next morning the kernel scheduler (or the Worker's Cron Triggers in cloud-only mode) fires the brief pipeline; the rendered markdown is written to `vault/<identity.slug>/input/briefs/<date>.md` in R2; the Worker reads it back and serves sanitized HTML at `/briefs/<date>` and the deliverer fans out to Telegram + Discord through `driver-telegram` / `driver-discord`.
+8. Later, the user installs the CLI on a laptop and runs `gctrl uber vault pull --from r2 --identity-slug <slug>` — every authored and generated file from the wizard appears as plain markdown in `~/uebermensch-vault`. Zero migration.
+
+**Success metric:** A first-time user lands on the onboarding URL, completes the wizard in ≤5 minutes on a phone, never opens a markdown editor, and receives a brief in their chosen channel the next morning. The vault produced by the wizard is byte-for-byte indistinguishable from one produced by `gctrl uber vault init` followed by hand-edits in Obsidian.
+
 ## What We're Building
 
-### Vault (external, Obsidian-mountable)
+### Deployment Modes
 
-A single directory at `$UBER_VAULT_DIR` (default `~/uebermensch-vault`) holding:
+Three supported topologies, all sharing the same data model (markdown + YAML in a `vault/<identity.slug>/` tree). The vault has one byte-store at any moment — local FS or R2 — and exactly one writer pattern; no two daemons writing to the same identity slug simultaneously.
 
-- **`directives/`** (git-tracked, authored tier): `profile.md`, `topics.md`, `sources.md`, `me.md`, `avoid.md`, `projects.md`, `theses/<slug>.md`, `personas/<persona>.md` (per-persona prompt overrides), `prompts/<slug>.md` (user-authored research queries) — edited by the user in Obsidian or any editor.
-- **`input/`** (gitignored, R2-synced): `input/raw/<slug>.md` (driver-fetched + manually-pulled URL summaries); `input/wiki/` (entities, topics, synthesis, questions, index, log — LLM-maintained knowledge graph); `input/briefs/<YYYY-MM-DD>.md` (daily briefs, CoS-written); `input/reports/<slug>.md` (deep-dives, prompt-driven research answers).
-- **`output/`** (git-tracked): the user's own writing — memos, notes, drafts — that CoS reviews and suggests.
-- **`action/`** (git-tracked + `action/events/generated/` gitignored): `action/events/<YYYY-MM-DD>--<slug>.md` (authored personal events); `action/events/generated/` (driver-pulled events); `action/strategies/`, `action/plans/`, `action/tasks/` — items awaiting the user's greenlight.
+| Mode | Vault byte-store | Authoritative writer | Channel secrets | Obsidian | Use when |
+|------|------------------|----------------------|-----------------|----------|----------|
+| **Local** (default) | Local filesystem at `$UBER_VAULT_DIR` | Local kernel daemon + Uebermensch daemon (single writer per process pair) | Kernel driver LKMs (`driver-telegram`, `driver-discord`) | Optional mount | User has a workstation; wants offline + git history |
+| **Cloud-only** | R2 bucket at `vault/<identity.slug>/` | Hosted Cloudflare Worker (single writer per slug) | Worker secret store (`wrangler secret`) — same shape as kernel driver tokens | Not installed | First-time user, mobile-first, no laptop; or multi-tenant SaaS deployments |
+| **Hybrid** | R2 bucket is the canonical byte-store; local FS is a live mirror pulled from R2 | Local daemon, with R2 as the synchronisation transport | Kernel driver LKMs (preferred) or Worker secret store (when the Worker is the active sender) | Optional mount | User has a workstation **and** wants the Worker to deliver while the laptop is asleep |
 
-Every file is CommonMark + YAML frontmatter. Wikilinks use plain `[[slug]]` — Obsidian and `gctrl-kb` share one resolver. A `VaultWatcher` fiber watches `fs.watch` events so user edits are reindexed without a restart. Full format in [vault/specs/profile.md](vault/specs/profile.md).
+In **all three modes**, the four invariants of the file model hold:
+
+1. Markdown + YAML frontmatter is the source of truth for everything a human reads or edits — there is no separate "cloud schema."
+2. The authored tier (`directives/`, `output/`, most of `action/`) is only ever modified by the user (or by the user-confirmed wizard steps in UC-7). The generated tier (`input/`, `action/events/generated/`) is owned by the curator / drivers.
+3. Channel tokens are NEVER written to the vault — they live in the kernel's secret store (local mode) or the Worker's secret store (cloud-only mode).
+4. Switching modes is a copy operation, not a migration: `gctrl uber vault pull --from r2` (cloud → local) and `gctrl uber vault push --to r2` (local → cloud) move bytes 1:1.
+
+### Vault (markdown directory; backed by FS or R2)
+
+A single directory tree (`$UBER_VAULT_DIR` on local, `vault/<identity.slug>/` on R2) holding:
+
+- **`directives/`** (authored tier — git-tracked locally; tracked-by-content-hash on R2): `profile.md`, `topics.md`, `sources.md`, `me.md`, `avoid.md`, `projects.md`, `theses/<slug>.md`, `personas/<persona>.md` (per-persona prompt overrides), `prompts/<slug>.md` (user-authored research queries) — edited by the user via the **Web UI onboarding wizard, the Web UI editor, the CLI, Obsidian, or any text editor**. All five surfaces produce the same atomic markdown rewrites.
+- **`input/`** (generated tier — gitignored locally; R2-synced): `input/raw/<slug>.md` (driver-fetched + manually-pulled URL summaries); `input/wiki/` (entities, topics, synthesis, questions, index, log — LLM-maintained knowledge graph); `input/briefs/<YYYY-MM-DD>.md` (daily briefs, CoS-written); `input/reports/<slug>.md` (deep-dives, prompt-driven research answers).
+- **`output/`** (authored tier — git-tracked locally): the user's own writing — memos, notes, drafts — that CoS reviews and suggests.
+- **`action/`** (mixed — `action/events/generated/` is generated; the rest is authored): `action/events/<YYYY-MM-DD>--<slug>.md` (authored personal events); `action/events/generated/` (driver-pulled events); `action/strategies/`, `action/plans/`, `action/tasks/` — items awaiting the user's greenlight.
+
+Every file is CommonMark + YAML frontmatter. Wikilinks use plain `[[slug]]` — Obsidian, the Web UI renderer, and `gctrl-kb` all share one resolver. In **local mode**, a `VaultWatcher` fiber watches `fs.watch` events so user edits are reindexed without a restart; in **cloud-only mode**, the Worker's authored-tier write routes emit the equivalent `vault.updated` event before returning success, so the index update path is identical. Full format in [vault/specs/profile.md](vault/specs/profile.md).
 
 ### Knowledge Base (investment-scoped)
 
@@ -234,11 +284,11 @@ Time-bound events live alongside the wiki. Personal commitments (`source: user`)
 
 ### Delivery Channels
 
-- **App** — web UI served by Uebermensch on a distinct port (mirrors gctrl-board pattern). Brief feed, wiki explorer, thesis tracker, prompt/eval dashboards.
-- **Telegram** — via `driver-telegram` kernel LKM. Bot commands: `/brief`, `/ingest`, `/deepdive <thesis>`, `/score`.
-- **Discord** — via `driver-discord` kernel LKM. Webhook posts + slash commands in configured channels.
+- **Web** — first-class user surface, served by the Uebermensch daemon (local mode) or by the hosted Cloudflare Worker (cloud-only mode). Brief feed, wiki explorer, thesis tracker, prompt/eval dashboards, **and the onboarding wizard** (UC-7) — including channel-connect flows for Telegram and Discord. Surfaces the rendered markdown as sanitized HTML; no editor required to read or score.
+- **Telegram** — via `driver-telegram` kernel LKM (local mode) or the Worker's Telegram client (cloud-only mode). Bot commands: `/brief`, `/ingest`, `/deepdive <thesis>`, `/score`. Token connection happens during the web onboarding wizard via deep-link / QR; secrets land in the kernel secret store (local) or `wrangler secret`s (cloud).
+- **Discord** — via `driver-discord` kernel LKM (local mode) or the Worker's Discord client (cloud-only mode). Webhook posts + slash commands in configured channels. OAuth2 + bot-invite flow is part of the web onboarding wizard.
 
-Full spec in [vault/specs/delivery.md](vault/specs/delivery.md).
+Full spec in [vault/specs/delivery.md](vault/specs/delivery.md), including the [§ Channel Onboarding (Web)](vault/specs/delivery.md#channel-onboarding-web) flow for first-time users.
 
 ### Eval & Monitoring
 
@@ -285,9 +335,10 @@ See [ROADMAP.md](ROADMAP.md) for the milestone → task breakdown.
 5. **Prompt regressions caught.** A deliberate prompt regression (e.g., strip citations) is detected by the evaluator within the next brief cycle. Eval results are pinned to the `content_hash` of the brief markdown file and survive later vault edits.
 6. **Vault portability.** Switching `UBER_VAULT_DIR` to a second vault produces different topics/brief without touching app code or data. Opening either vault directly in Obsidian MUST show the same content the app sees.
 7. **Multi-device via R2.** A fresh device running `gctrl uber vault pull --from r2` for the same `identity.name` mounts an identical vault and can render today's brief from the same inputs.
-8. **Three channels live.** App, Telegram, Discord each deliver the same brief idempotently. A user acts on an action item in any channel; other channels reflect the updated state within one brief cycle.
+8. **Three channels live.** Web, Telegram, Discord each deliver the same brief idempotently. A user acts on an action item in any channel; other channels reflect the updated state within one brief cycle.
 9. **Deep-dive utility.** At least one thesis deep-dive per month produces a `input/wiki/synthesis/thesis-*-update-<date>.md` vault file with ≥3 new evidence citations.
 10. **Scrape health visible.** The app shows per-domain scrape success over 7/30-day windows; any domain below 60% surfaces in the inbox.
+11. **Cloud-only onboarding works.** A first-time user lands on the hosted onboarding URL on a phone, completes the wizard in ≤5 minutes without an editor, has Telegram + Discord connected, and receives the next morning's brief in both channels. Running `gctrl uber vault pull --from r2 --identity-slug <slug>` later produces a vault byte-for-byte identical to one built locally.
 
 ## Open Questions
 

--- a/apps/uebermensch/README.md
+++ b/apps/uebermensch/README.md
@@ -1,6 +1,6 @@
 # Uebermensch
 
-> Chief-of-Staff app for investors. Vault-first, Obsidian-mountable, R2-synced.
+> Chief-of-Staff app for investors. Vault-first (markdown + YAML), R2-synced, Obsidian-compatible — but Obsidian is **never required**. First-time users can onboard, configure Telegram/Discord, and read briefs entirely from a web browser; see [PRD § Deployment Modes](PRD.md#deployment-modes).
 
 See [PRD.md](PRD.md) for vision, [ROADMAP.md](ROADMAP.md) for milestones, [WORKFLOW.md](WORKFLOW.md) for lifecycle, and `vault/specs/` for architecture details.
 
@@ -44,7 +44,8 @@ Env vars are loaded from the repo-root `.env` (plaintext, gitignored) or
 ## Vault layout
 
 The vault is markdown-first — every authored config file is CommonMark with YAML
-frontmatter so Obsidian reads it natively. Four canonical root folders:
+frontmatter so the Web UI, the CLI, and Obsidian all read it the same way.
+Four canonical root folders:
 
 | Path | Contents |
 |------|----------|

--- a/apps/uebermensch/ROADMAP.md
+++ b/apps/uebermensch/ROADMAP.md
@@ -43,9 +43,9 @@
 
 **Done when:** An investor with a populated vault can run Uebermensch against real RSS feeds + manual URL ingests; `gctrl uber brief` produces a brief grounded in today's wiki updates with ≥90% citation coverage; the vault pushes to R2 within 60s of a change; a fresh device pulls the vault and opens it in Obsidian without edits.
 
-## M2: Delivery & App UI — Planned
+## M2: Delivery & Web UI — Planned
 
-**Goal:** Briefs reach the user via App, Telegram, and Discord. The App is the primary surface.
+**Goal:** Briefs reach the user via Web, Telegram, and Discord. The Web UI is a first-class user surface — first-time users can complete onboarding (identity → topics → channels → schedule) without ever opening Obsidian or the CLI.
 
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
@@ -54,15 +54,19 @@
 | Deliverer service | Idempotent per (brief_id, channel) write to `uber_deliveries`; retry with backoff | P0 | drivers | TBD |
 | Channel router | Profile-driven: `delivery.channels.<name>.enabled`, time windows, silent mode | P0 | Deliverer | TBD |
 | Inbound ingest flow | User forwards URL to Telegram/Discord → ingest pipeline → reply with wiki citation | P0 | drivers | TBD |
-| App web UI: brief feed | SPA with brief list, detail view, citation chips, human score form | P0 | Renderer | TBD |
-| App web UI: wiki explorer | Browse wiki pages, follow `[[links]]`, view backlinks | P1 | M1 | TBD |
-| App web UI: thesis tracker | List theses, last-update, open deep-dive button | P1 | M1 | TBD |
-| App web UI: eval dashboard | Citation-coverage, hype-ratio, cost/day, per-brief scores | P1 | M1 | TBD |
-| App SSE | Live updates for new briefs + new ingest events | P1 | App UI | TBD |
-| App auth | Single-user bearer token from profile | P1 | App UI | TBD |
+| `VaultWriterPort` + adapters | Single port for authored-tier writes with `FsVaultWriter` adapter; emits `vault.updated` after fsync. Web UI + CLI + future Worker all use it. | P0 | M1 | TBD |
+| Web UI: onboarding wizard | Identity → topics → channels → schedule wizard producing atomic markdown rewrites of `directives/profile.md`, `directives/topics.md`, etc. via `VaultWriterPort` | P0 | `VaultWriterPort`, channel onboarding routes | TBD |
+| Web UI: channel onboarding routes | `/api/uber/onboard/{telegram,discord}/{start,callback}` per [delivery.md § Channel Onboarding (Web)](vault/specs/delivery.md#channel-onboarding-web) — tokens never written to vault | P0 | drivers | TBD |
+| Web UI: brief feed | SPA with brief list, detail view, citation chips, human score form — reads brief markdown from vault | P0 | Renderer | TBD |
+| Web UI: profile editor | Form-driven editor for `directives/profile.md` + `directives/topics.md` + `directives/theses/<slug>.md`; round-trips through `VaultWriterPort` | P0 | `VaultWriterPort` | TBD |
+| Web UI: wiki explorer | Browse wiki pages, follow `[[links]]`, view backlinks | P1 | M1 | TBD |
+| Web UI: thesis tracker | List theses, last-update, open deep-dive button | P1 | M1 | TBD |
+| Web UI: eval dashboard | Citation-coverage, hype-ratio, cost/day, per-brief scores | P1 | M1 | TBD |
+| Web UI: SSE | Live updates for new briefs, new ingest events, channel.bound | P1 | Web UI | TBD |
+| Web UI: auth | Single-user bearer token from profile (local mode) | P1 | Web UI | TBD |
 | Profile migration command | `gctrl uber profile migrate` with preview diff | P1 | — | TBD |
 
-**Done when:** The user receives the 08:00 brief on all three channels, can forward a URL from Telegram and see it filed within 30 s, and views the full brief in the App with working citations.
+**Done when:** A first-time user lands on the local Web UI, runs the onboarding wizard end-to-end (no Obsidian, no markdown editor, no CLI), connects Telegram + Discord via the in-browser flow, and receives the next morning's brief on all three channels. Forwarding a URL from Telegram files it within 30 s. The full brief renders in the Web UI with working citations.
 
 ## M3: Long-Horizon + Market Data — Planned
 
@@ -80,9 +84,9 @@
 
 **Done when:** A monthly thesis deep-dive produces a `input/wiki/synthesis/thesis-*-update-<date>.md` with ≥3 new citations since last update, and a Kalshi market move on a watched topic produces an inbox alert within 10 min.
 
-## M4: Eval Rigor + Index Sync — Planned
+## M4: Eval Rigor + Cloud-Only Mode — Planned
 
-**Goal:** Prompt regressions are automatically caught; the `uber_*` SQLite index syncs to D1 so the Cloudflare Worker deployment can read briefs by reading D1 + R2 (vault content already syncs via R2 from M1).
+**Goal:** Prompt regressions are automatically caught; Uebermensch runs as a hosted Cloudflare Worker so a first-time user with no laptop can onboard, configure channels, and read briefs entirely from a browser — see [PRD § Deployment Modes](PRD.md#deployment-modes) and [architecture.md § 0](vault/specs/architecture.md#0-deployment-modes).
 
 | Task | Description | Priority | Depends On | Issue |
 |------|-------------|----------|------------|-------|
@@ -92,10 +96,15 @@
 | LLM-as-judge evaluator | `uber-evaluator` persona scores briefs against rubric | P1 | M1 | TBD |
 | Prompt A/B harness | Run two prompt versions against same candidate set; compare scores | P2 | eval pipeline | TBD |
 | Scrape-health promotion | Graduate `gctrl uber scrape-health` CLI + dashboard (CLI shipped in M1 behind feature flag; M4 enables alerting) | P1 | M1 | TBD |
-| Sync: `uber_*` SQLite → D1 | Wire `uber_briefs`, `uber_brief_items`, `uber_deliveries` into kernel row-level sync | P1 | gctrl sync | TBD |
-| Cloudflare Worker deploy | Uebermensch web UI + API as Cloudflare Worker backed by D1 (for the index) + R2 (for the vault markdown bytes) | P2 | D1 index sync | TBD |
+| Sync: `uber_*` SQLite → D1 | Wire `uber_briefs`, `uber_brief_items`, `uber_deliveries` into kernel row-level sync | P0 | gctrl sync | TBD |
+| `R2VaultWriter` adapter | Implement `VaultWriterPort` against R2 with `If-Match: <etag>` optimistic concurrency; emit `vault.updated` after PUT | P0 | M2 `VaultWriterPort` | TBD |
+| Per-slug Durable Object lease | Replace `lock.json` with a Durable Object that serialises writes for a given `identity.slug` | P0 | `R2VaultWriter` | TBD |
+| Cloudflare Worker deploy | Uebermensch Web UI + API as Cloudflare Worker backed by D1 (index) + R2 (vault byte-store) + DO (per-slug write coordinator) | P0 | D1 sync, `R2VaultWriter` | TBD |
+| Worker secret store binding | Per-slug `wrangler secret`s for Telegram bot tokens, Discord bot tokens, LLM keys; enforce slug-scoped read on every fetch | P0 | Worker deploy | TBD |
+| Worker Cron Triggers for `uber.brief.daily` | Replace local kernel scheduler entry with a Cron Trigger; reuse the same job DSL | P0 | Worker deploy | TBD |
+| `gctrl uber vault pull --from r2` | Bootstrap a local mirror of an R2-resident vault; flips writer authority from Worker (DO lease) to local FS (lock.json). Already shipped in M1; M4 verifies it round-trips a vault first authored entirely on the Worker. | P0 | M1 vault pull, Worker deploy | TBD |
 
-**Done when:** An intentional prompt regression is flagged in the next brief's eval alert; a second device running the Worker reads the index from D1 and renders the brief markdown from R2 identically to the local daemon.
+**Done when:** An intentional prompt regression is flagged in the next brief's eval alert; a brand-new user with no laptop completes the wizard on a phone, receives a brief in Telegram + Discord the next morning, and a later `gctrl uber vault pull --from r2 --identity-slug <slug>` reproduces a byte-identical local vault.
 
 ## M5: SinkIn — Planned
 

--- a/apps/uebermensch/vault/specs/architecture.md
+++ b/apps/uebermensch/vault/specs/architecture.md
@@ -1,8 +1,56 @@
 # Uebermensch — Architecture
 
-> One-sentence summary: Uebermensch is a native gctrl application that turns a portable user profile + gctrl-kb into a daily Chief-of-Staff brief delivered across App, Telegram, and Discord, with end-to-end LLM and scrape observability.
+> One-sentence summary: Uebermensch is a native gctrl application that turns a portable user profile + gctrl-kb into a daily Chief-of-Staff brief delivered across Web, Telegram, and Discord, with end-to-end LLM and scrape observability — runnable as a local daemon, a hosted Cloudflare Worker, or both.
 
-See [PRD.md](../PRD.md) for the problem and goals. This document defines **how** the pieces fit together.
+See [PRD.md](../PRD.md) for the problem and goals. See [§ Deployment Modes](#0-deployment-modes) for the three supported topologies (local / cloud-only / hybrid). This document defines **how** the pieces fit together.
+
+## 0. Deployment Modes
+
+Uebermensch supports three deployment topologies. They share the same data model (markdown + YAML in a `vault/<identity.slug>/` tree), the same layered position, and the same hexagonal services. They differ in **where the vault bytes live, who writes to them, and where channel secrets are stored**.
+
+| Mode | Vault byte-store | Single writer | Channel secrets | Web UI host | Obsidian | Daemon required |
+|------|------------------|----------------|-----------------|-------------|----------|------------------|
+| **Local** (default) | Local FS at `$UBER_VAULT_DIR` | Uebermensch daemon (`:4319`) — single writer per process pair (kernel + uber daemon) | Kernel driver LKMs (`driver-telegram`, `driver-discord`) | Uebermensch daemon | Optional mount | Yes |
+| **Cloud-only** | R2 at `vault/<identity.slug>/` | Hosted Cloudflare Worker — single writer per slug | Worker secret store (`wrangler secret`); same shape as kernel driver tokens | Worker | Not installed | No |
+| **Hybrid** | R2 (canonical) + local FS (live mirror) | Local Uebermensch daemon (writes go FS-first then `gctrl-sync` pushes to R2 within 30s); the Worker, when present, is read-mostly and may **only** mutate the **generated tier** during scheduled jobs | Kernel driver LKMs preferred; Worker secret store when the Worker is the active sender | Either | Optional mount | Yes (and a Worker if you want it) |
+
+### Cross-mode invariants
+
+1. **One byte-store wins per identity slug at any moment.** Two daemons MUST NOT write to the same `vault/<identity.slug>/` concurrently. In hybrid mode the local daemon is authoritative for authored-tier writes; cloud-only and local modes are mutually exclusive at the *active-writer* level. Mode handoff is by `gctrl uber vault pull --from r2` / `gctrl uber vault push --to r2` — file copies, not migrations.
+2. **Same write protocol everywhere.** Authored-tier writes are atomic markdown rewrites (`<path>.tmp` → fsync → rename in local mode; `R2.put` with `If-Match: <etag>` in cloud-only mode), each followed by a `vault.updated` event that triggers index re-read. The Web UI, the CLI, and Obsidian all funnel into this single write path; none of them edits markdown out-of-band.
+3. **Channel tokens NEVER live in the vault.** They live in the kernel secret store (local mode) or the Worker secret store (cloud-only mode). The vault stores only `target_ref` (e.g. `tg:chat:<id>`) — the binding that lets a driver look up a token in its own secret namespace.
+4. **The web UI is mode-symmetric.** The same React build is served by the Uebermensch daemon (local) or the Cloudflare Worker (cloud-only). Routes diverge only at the `Vault*` ports — `FsVault` adapter on the daemon, `R2Vault` adapter in the Worker. The onboarding wizard, brief feed, channel-config, and scoring UI are byte-identical across modes.
+
+```mermaid
+flowchart LR
+  subgraph local["Local mode"]
+    L_FS[("FS vault")]:::store
+    L_D["uber daemon :4319\n+ kernel daemon :4318"]
+    L_W["Web UI"]
+    L_W --> L_D --> L_FS
+    L_FS -. R2 sync (optional) .-> R2[("R2\nvault/&lt;slug&gt;/")]
+  end
+  subgraph cloud["Cloud-only mode"]
+    C_W["Cloudflare Worker"]
+    C_R[("R2 (authoritative)\nvault/&lt;slug&gt;/")]:::store
+    C_UI["Web UI"]
+    C_UI --> C_W --> C_R
+  end
+  subgraph hybrid["Hybrid mode"]
+    H_FS[("FS vault\n(live mirror)")]:::store
+    H_D["uber daemon :4319"]
+    H_W["Cloudflare Worker\n(read-mostly)"]
+    H_R[("R2 (canonical)\nvault/&lt;slug&gt;/")]:::store
+    H_UI["Web UI"]
+    H_D --> H_FS
+    H_FS <-. bidirectional sync .-> H_R
+    H_W --> H_R
+    H_UI --> H_D
+  end
+  classDef store fill:#eef,stroke:#669
+```
+
+The remainder of this document describes the **local mode** by default (it is the richest topology); cloud-only differences are called out in each section under a *Cloud-only:* note.
 
 ## 1. Layered Position
 
@@ -44,7 +92,7 @@ flowchart TB
     Mkt["driver-markets"]
   end
   subgraph L0["L0 — External"]
-    Prof2["$UBER_VAULT_DIR\n(Obsidian vault, git + R2)"]
+    Prof2["Vault byte-store\n(local FS at $UBER_VAULT_DIR\nor R2 at vault/&lt;slug&gt;/)\nObsidian-compatible (optional)"]
     A["Cloudflare AI Gateway\n(→ Workers AI / Anthropic / OpenAI)"]
     TgX["Telegram"]
     DcX["Discord"]
@@ -88,7 +136,11 @@ Dependencies MUST flow inward only (see [principles.md § Architectural Invarian
 
 ## 3. Process Model
 
-Uebermensch runs as a **single daemon** alongside the gctrl kernel daemon. It exposes its own HTTP server (web UI + API) on a port separate from the kernel's `:4318`. All state-mutating operations travel kernel-ward via the kernel HTTP API. The daemon also runs a `VaultWatcher` fiber on `$UBER_VAULT_DIR` to detect authored-tier edits (including edits made in Obsidian) and trigger profile reloads / cache invalidations.
+Two process shapes, one per supported mode (hybrid combines them):
+
+**Local mode** — Uebermensch runs as a **single daemon** alongside the gctrl kernel daemon. It exposes its own HTTP server (web UI + API) on a port separate from the kernel's `:4318`. All state-mutating operations travel kernel-ward via the kernel HTTP API. The daemon also runs a `VaultWatcher` fiber on `$UBER_VAULT_DIR` to detect authored-tier edits (including edits made in Obsidian, the Web UI's onboarding wizard, or any text editor) and trigger profile reloads / cache invalidations.
+
+**Cloud-only mode** — Uebermensch runs as a **single Cloudflare Worker** with R2 as the byte-store, D1 for the index, Durable Objects for the per-slug write coordinator (the equivalent of "single writer per identity slug"), and Worker Cron Triggers for the schedule. The same `VaultWatcher`-equivalent — `R2VaultWatcher` — fires after every successful R2 write, derived from the write path itself rather than from filesystem events. Channel secrets live in `wrangler secret`s scoped per-slug; outbound calls to `driver-llm` / `driver-telegram` / `driver-discord` are made directly by the Worker's HTTP clients, replicating the kernel-driver invariant inside a single process.
 
 ```mermaid
 flowchart LR
@@ -120,12 +172,13 @@ flowchart LR
   ui -->|"HTTP :4319"| ud
 ```
 
-Enforced invariants:
+Enforced invariants (apply to whichever process is the active writer for a slug):
 
-1. Uebermensch daemon MUST NOT open `gctrl.duckdb`. Only the kernel daemon holds the DuckDB write lock (see [principles.md § Architectural Invariants #2](../../../../vault/specs/principles.md#architectural-invariants)).
-2. Uebermensch daemon MAY read `$UBER_VAULT_DIR` (authored + generated tiers) directly for rendering performance, but MUST route every mutation through kernel HTTP routes (`KbPort` → wiki, `BriefingService` → briefs). Direct vault writes from the Uebermensch process are forbidden except for the `.gctrl-uber/` metadata dir.
-3. Uebermensch daemon MUST NOT hold any external API key. All external calls go through kernel drivers.
-4. Obsidian edits are first-class — the `VaultWatcher` cannot distinguish `$EDITOR`, `git checkout`, and Obsidian writes, and all three follow the same reload path.
+1. **Local mode:** Uebermensch daemon MUST NOT open `gctrl.duckdb`. Only the kernel daemon holds the DuckDB write lock (see [principles.md § Architectural Invariants #2](../../../../vault/specs/principles.md#architectural-invariants)).  **Cloud-only mode:** the Worker's index is D1, not DuckDB; D1 is held by the Worker per binding.
+2. **Local mode:** Uebermensch daemon MAY read `$UBER_VAULT_DIR` (authored + generated tiers) directly for rendering performance, but MUST route every mutation through kernel HTTP routes (`KbPort` → wiki, `BriefingService` → briefs). Direct vault writes from the Uebermensch process are forbidden except for the `.gctrl-uber/` metadata dir.  **Cloud-only mode:** the Worker MAY read R2 directly via the bound `R2Bucket`, but every mutation goes through the per-slug Durable Object that serialises writes and emits the `vault.updated` event.
+3. Uebermensch daemon MUST NOT hold any external API key in **local mode** — all external calls go through kernel drivers. In **cloud-only mode** the Worker holds tokens scoped per slug in `wrangler secret`s; the same allowlist + correlation-id discipline as the LKM driver applies.
+4. Obsidian edits are first-class — the `VaultWatcher` cannot distinguish `$EDITOR`, `git checkout`, **the Web UI onboarding wizard**, and Obsidian writes, and all of them follow the same reload path. In cloud-only mode the equivalent "Web UI wizard / API call" path is the *only* entry, so this invariant collapses to "every mutation triggers exactly one `vault.updated`."
+5. **Mode mutual exclusion.** No more than one writer (local daemon OR Worker) holds the active-writer role for a given `identity.slug` at the same time. Mode handoff is explicit: `gctrl uber vault pull --from r2` (cloud → local) or `gctrl uber vault push --to r2` (local → cloud) flips the writer atomically by transferring the `.gctrl-uber/lock.json` (FS) or the per-slug Durable Object lease (R2).
 
 ## 4. Data Flow — Morning Brief
 
@@ -208,32 +261,45 @@ Service ports follow the [`arch-taste.md` Effect-TS pattern](../../../../debuggi
 
 ## 6. External Vault Integration
 
-The **authored tier** of the vault (`directives/**`, `output/**`, `action/**` excl. `action/events/generated/**`) is **read-only to the app**. The app watches the directory via `ProfileService`/`VaultWatcher`, which exposes a `Stream<ProfileChange>` to consumers. The **generated tier** (`input/**`, `action/events/generated/**`) is writable by the kernel + Uebermensch services.
+The **authored tier** of the vault (`directives/**`, `output/**`, `action/**` excl. `action/events/generated/**`) is **only writable through user-confirmed surfaces**: the CLI, an editor (Obsidian or `$EDITOR`), or the Web UI's onboarding wizard / profile editor (which produces atomic markdown rewrites confirmed by the user, not by an LLM). The app watches the byte-store via `ProfileService`/`VaultWatcher`, which exposes a `Stream<ProfileChange>` to consumers. The **generated tier** (`input/**`, `action/events/generated/**`) is writable by the kernel + Uebermensch services.
 
 ```ts
 class ProfilePort extends Context.Tag("uber/ProfilePort")<ProfilePort, {
   readonly current: Effect.Effect<Profile, ProfileInvalid>
   readonly changes: Stream.Stream<ProfileChange, ProfileInvalid>
 }>() {}
+
+// New port — emits the same kind of write whether the source is FS or R2.
+class VaultWriterPort extends Context.Tag("uber/VaultWriterPort")<VaultWriterPort, {
+  readonly writeAuthored: (path: VaultPath, body: string, expected: ContentHash | "new") => Effect.Effect<ContentHash, VaultWriteError>
+  readonly writeGenerated: (path: VaultPath, body: string) => Effect.Effect<ContentHash, VaultWriteError>
+}>() {}
 ```
 
-- `$UBER_VAULT_DIR` resolves to `~/uebermensch-vault` by default but is overridable (legacy alias: `UBER_PROFILE_DIR`).
-- The vault is Obsidian-mountable — every file is CommonMark + YAML frontmatter; wikilinks are bare `[[slug]]`.
-- The app MUST fail-closed on a missing / invalid authored tier: no brief is produced, a clear error is surfaced to CLI + HTTP.
-- Authored-tier writes happen only via `gctrl uber profile migrate` (idempotent, with preview diff) or by the user in Obsidian / their editor / git. No service MAY write to the authored tier in response to LLM output.
+Two adapters:
+
+- `FsVaultWriter` (local mode) — atomic-rename writer; emits `vault.updated` after fsync.
+- `R2VaultWriter` (cloud-only mode) — `R2.put` with conditional `If-Match: <etag>` for optimistic concurrency; emits `vault.updated` after a successful PUT.
+
+The Web UI talks only to `VaultWriterPort`, so the onboarding wizard's "Save topics" button has the same semantics as a CLI write or an Obsidian save: atomic, hashed, idempotent, and instrumented.
+
+- `$UBER_VAULT_DIR` resolves to `~/uebermensch-vault` by default in local mode (overridable; legacy alias `UBER_PROFILE_DIR`). In cloud-only mode the equivalent is the R2 prefix `vault/<identity.slug>/`, set per-slug at provisioning time.
+- The vault is Obsidian-compatible — every file is CommonMark + YAML frontmatter; wikilinks are bare `[[slug]]` — but Obsidian is **never on the critical path**.
+- The app MUST fail-closed on a missing / invalid authored tier: no brief is produced, a clear error is surfaced to CLI + HTTP, and (in cloud-only mode) the Web UI shows the onboarding wizard instead of a feed.
+- Authored-tier writes happen via `gctrl uber profile migrate` (idempotent, with preview diff), the Web UI onboarding wizard (idempotent, with preview diff), the user in Obsidian / `$EDITOR` / git. **No service MAY write to the authored tier in response to LLM output.**
 
 See [profile.md](profile.md) for the full format and [specs/knowledge-base.md](knowledge-base.md) for the vault layout.
 
 ## 7. Persistence
 
-Two stores, with clear ownership:
+Two stores, with clear ownership. The **byte-store** for the vault is filesystem (local) or R2 (cloud-only); the **index** is DuckDB (local) or D1 (cloud-only). Both byte-stores hold identical bytes per vault path, and both indexes hold identical rows per `(brief_id, channel)`, so a vault produced in one mode is perfectly usable in the other after a `pull` / `push`.
 
 | Store | Holds | Authoritative for | Sync target |
 |-------|-------|-------------------|-------------|
-| **Vault** (`$UBER_VAULT_DIR`) | Markdown + YAML — profile, theses, wiki pages, brief bodies, synthesis | Any content a human reads or edits | R2 (`gctrl-uber-vault`) |
-| **SQLite / DuckDB** | Index + event log — `uber_*` rows, kernel `sessions`/`spans`/`scores` | Metadata, timings, deliveries, scores | D1 (row-level) |
+| **Vault byte-store** — local FS at `$UBER_VAULT_DIR` (local mode) **or** R2 at `vault/<identity.slug>/` (cloud-only mode) | Markdown + YAML — profile, theses, wiki pages, brief bodies, synthesis | Any content a human reads or edits | R2 (`gctrl-uber-vault`) — push from local, native in cloud-only |
+| **Index** — kernel DuckDB (local mode) **or** Cloudflare D1 (cloud-only mode) | Index + event log — `uber_*` rows, kernel `sessions`/`spans`/`scores` | Metadata, timings, deliveries, scores | D1 (row-level) — native in cloud-only, sync target from local |
 
-Rebuilding SQLite from vault + kernel sessions MUST produce an equivalent index (see [domain-model.md § 10](domain-model.md#10-invariants) invariant #2). The reverse is not true — SQLite cannot reconstruct the vault.
+Rebuilding the index from vault + kernel sessions MUST produce an equivalent set of rows (see [domain-model.md § 10](domain-model.md#10-invariants) invariant #2) regardless of mode. The reverse is not true — the index cannot reconstruct the vault.
 
 ### Kernel-owned tables (see [kernel sync.md § 6](../../../../vault/specs/architecture/kernel/sync.md#6-syncable-tables))
 
@@ -282,12 +348,19 @@ $UBER_VAULT_DIR/
 
 The kernel `gctrl-kb` crate is configured with `context_root = $UBER_VAULT_DIR, wiki_subpath = "input/wiki"`, plus a secondary `raw_subpath = "input/raw"` mount for ingested source pages — there is no separate `~/.local/share/gctrl/context/wiki/` path when running under an Uebermensch workspace.
 
-### Filesystem artifacts
+### Filesystem artifacts (local + hybrid modes)
 
 - `$UBER_VAULT_DIR/` — the one true mount. Authoritative for every readable artifact.
 - `$UBER_VAULT_DIR/.gctrl-uber/` — daemon-local metadata (lock, vault index, tombstones). Gitignored; R2-synced except for `lock.json`.
-- `~/.local/share/gctrl/uber/briefs/<id>.html` — optional rendered HTML cache for App web UI. Derived from the vault markdown; safe to delete.
+- `~/.local/share/gctrl/uber/briefs/<id>.html` — optional rendered HTML cache for the Web UI. Derived from the vault markdown; safe to delete.
 - `~/.local/share/gctrl/gctrl.duckdb` — kernel index + event log. Held by the kernel daemon.
+
+### Cloud-only artifacts (Worker)
+
+- `vault/<identity.slug>/**` (R2) — authoritative bytes. Object metadata: `content-sha256`, `device-id` (always `worker-<region>` here), `updated-at`. Same key layout as [profile.md § Sync (R2)](profile.md#sync-r2) so a `pull` produces an identical FS layout.
+- `vault/<identity.slug>/.gctrl-uber/` (R2) — `lock.json` is replaced by a per-slug **Durable Object lease** (no lock object in R2); `tombstones.jsonl` and `index.jsonl` live in R2 the same as in local mode.
+- D1 database — `uber_*` rows + the kernel `sessions` / `spans` / `scores` rows that would otherwise be in DuckDB. Schema is the same; the kernel `sync` crate emits the migrations to D1 from a single source.
+- KV / Cache for HTML rendered briefs (bounded TTL) — derivative, safe to evict.
 
 ## 8. Cross-App Interaction
 
@@ -314,11 +387,14 @@ Uebermensch exchanges state with gctrl-board via kernel IPC events + HTTP API, N
 
 ## 10. Security
 
-1. **Secrets** — kernel drivers hold all external tokens (LLM, Telegram, Discord, EDGAR, Kalshi). Uebermensch daemon env has no external secrets.
-2. **Auth** — app HTTP port secured by a bearer token configured in profile (`delivery.app.bearer_token_env`). CORS locked to localhost by default.
-3. **Prompt injection** — ingest pipeline wraps source text in `<source>...</source>` sentinels before templating into prompts; curator prompts refuse to follow instructions inside source tags.
-4. **Outbound exfiltration** — guardrails allowlist outbound domains via `gctrl-net` proxy; drivers restricted to their declared endpoints.
-5. **Vault sharing** — vaults may contain watchlists and theses the user considers sensitive. `$UBER_VAULT_DIR` is user-owned; Uebermensch MUST NOT log authored-tier content at INFO level. R2 sync MUST use a per-user scoped bucket prefix `vault/<identity.slug>/` (see [profile.md § Sync (R2)](profile.md#sync-r2) for the full key layout) to prevent cross-user reads.
+1. **Secrets** —
+   - **Local mode:** kernel drivers hold all external tokens (LLM, Telegram, Discord, EDGAR, Kalshi). Uebermensch daemon env has no external secrets.
+   - **Cloud-only mode:** the Worker holds external tokens in `wrangler secret`s, scoped per `identity.slug` (one secret namespace per tenant). Token rotation is via `wrangler secret put` + a slug-scoped invalidation event. The Worker MUST NOT echo tokens into vault writes, response bodies, or logs.
+2. **Auth** — Web UI is secured by a bearer token configured in profile (`delivery.app.bearer_token_env`) for local mode, or by the Worker's identity-provider session (signed cookie + `identity.slug` claim) for cloud-only mode. CORS locked to the configured host (localhost or the Worker's hostname); never `*`.
+3. **Prompt injection** — ingest pipeline wraps source text in `<source>...</source>` sentinels before templating into prompts; curator prompts refuse to follow instructions inside source tags. Equally enforced in both modes.
+4. **Outbound exfiltration** — guardrails allowlist outbound domains via `gctrl-net` proxy (local mode) or via the Worker's `fetch` allowlist binding (cloud-only mode); drivers / Worker clients are restricted to their declared endpoints.
+5. **Vault sharing** — vaults may contain watchlists and theses the user considers sensitive. R2 storage MUST use a per-user scoped bucket prefix `vault/<identity.slug>/` (see [profile.md § Sync (R2)](profile.md#sync-r2) for the full key layout) to prevent cross-user reads. Uebermensch MUST NOT log authored-tier content at INFO level. In cloud-only mode the Worker MUST verify the session's `identity.slug` claim matches the slug of every vault key it reads or writes — multi-tenancy is enforced at the request boundary, not at the bucket boundary.
+6. **Channel onboarding (web)** — the Telegram and Discord onboarding flows MUST issue short-lived (≤10 min) one-time tokens encoded into the bot deep-link / OAuth `state` parameter, redeemable exactly once against the Worker's `/api/uber/onboard/{channel}/callback` endpoint. The tokens are scoped to the user's `identity.slug` so a leaked link cannot bind a stranger's account to a different slug.
 
 ## 11. Open Interfaces (new kernel ports)
 

--- a/apps/uebermensch/vault/specs/delivery.md
+++ b/apps/uebermensch/vault/specs/delivery.md
@@ -195,6 +195,86 @@ Supported inbound shapes:
 
 All inbound responses are written through the same `MessagingPort.send` — so they become `uber_deliveries` rows with `kind: reply` (new enum variant). This keeps the audit trail unified.
 
+## Channel Onboarding (Web)
+
+Both Telegram and Discord can be **bound to a user without leaving the browser**, so a first-time cloud-only user (UC-7 in PRD) never has to copy a token by hand. The wizard runs entirely on the Uebermensch daemon (local mode) or the hosted Worker (cloud-only mode); the steps are mode-symmetric.
+
+### Pre-conditions
+
+1. The user has completed the identity step of the onboarding wizard — i.e. the Worker / daemon knows the active `identity.slug`.
+2. The Telegram bot username (e.g. `@uebermensch_bot`) and Discord application id are static configuration on the Uebermensch deployment, not per-user secrets.
+3. A short-lived (≤10 min) one-time onboarding token (`onboarding_token`) is minted by the wizard, scoped to `(identity.slug, channel)`, redeemable exactly once.
+
+### Telegram flow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Web as Web UI
+  participant Uber as Uebermensch (daemon or Worker)
+  participant TG as Telegram
+  participant Drv as driver-telegram (LKM or Worker client)
+
+  Web->>Uber: POST /api/uber/onboard/telegram/start (identity.slug)
+  Uber-->>Web: { onboarding_token, deep_link: "https://t.me/uebermensch_bot?start=<token>" }
+  Web->>User: render QR + "Open Telegram" button
+  User->>TG: open deep link / scan QR
+  TG->>Drv: webhook update with /start <token>, from chat_id
+  Drv->>Uber: POST /api/uber/onboard/telegram/callback { token, chat_id, from }
+  Uber->>Uber: verify token, bind tg:chat:<chat_id> to identity.slug
+  Uber->>Uber: rewrite directives/profile.md → delivery.channels.telegram_primary.target_ref
+  Uber->>Drv: POST /api/telegram/send (welcome + first-brief preview)
+  Drv->>TG: deliver welcome
+  Uber-->>Web: SSE channel.bound { channel: telegram_primary, target_ref }
+  Web->>User: green check; "Connected as @<from.username>"
+```
+
+After the callback, the wizard's `directives/profile.md` rewrite adds:
+
+```yaml
+delivery:
+  channels:
+    telegram_primary:
+      driver: telegram
+      enabled: true
+      target_ref: "tg:chat:<chat_id>"
+      window: { start_local: "07:30", end_local: "22:30", tz: "Asia/Tokyo" }
+      silent: false
+```
+
+The bot **token** is not in the vault — it is in the kernel secret store (local mode) or `wrangler secret`s scoped to the deployment (cloud-only). The vault stores only `target_ref`.
+
+### Discord flow
+
+Discord uses OAuth2 + bot-invite + interactions endpoint:
+
+1. The wizard generates an OAuth2 URL with `scope=bot+applications.commands`, the application's `client_id`, the wizard's `onboarding_token` as `state`, and a per-deployment `permissions=` mask. The user clicks "Connect Discord" → standard Discord consent screen → returns to `/api/uber/onboard/discord/callback?code=...&state=...`.
+2. The Worker / daemon exchanges `code` for a guild-scoped bot token, verifies `state` against the `onboarding_token`, and persists the `(guild_id, channel_id, webhook_url)` tuple plus the bot token in the secret store.
+3. The wizard rewrites `directives/profile.md` → `delivery.channels.discord_feed`:
+
+   ```yaml
+   discord_feed:
+     driver: discord
+     enabled: true
+     target_ref: "dc:webhook:<webhook_id>"
+     interactions_target: "dc:interactions:<application_id>"
+   ```
+
+4. The driver posts a `/ping` confirmation and the wizard surfaces success via the same `channel.bound` SSE event.
+
+### Idempotency + reuse
+
+If the wizard is re-run (or the user later visits `/api/uber/channels` to add a second Discord server), the same flow produces an additional `delivery.channels.<name_2>` entry instead of clobbering the first — channel `name` is wizard-assigned (`telegram_primary`, `telegram_secondary`, `discord_feed`, `discord_team`, …) and surfaces in the UI for renaming. The `(brief_id, channel)` idempotency key in `uber_deliveries` continues to hold.
+
+### Failure modes
+
+| Failure | Recovery |
+|---------|----------|
+| User never opens the deep link / completes OAuth | Token expires after 10 min; wizard shows "didn't work — try again" with a fresh token. |
+| Token redeemed twice (replay) | Second redemption fails with `409 onboarding_token_already_used`. |
+| Discord bot lacks channel permissions | Driver `/ping` fails; wizard surfaces the specific missing scope and offers a "re-invite" link with the corrected permission mask. |
+| User declines Telegram start (closes Telegram) | Token sits unredeemed; wizard times out after 10 min and offers retry. |
+
 ## Authentication & Authorization
 
 Profile binds channels to targets; the user is the only authorized caller.
@@ -249,9 +329,14 @@ Served by the Uebermensch daemon on its own port (`:4319`).
 | GET | `/api/uber/briefs/{id}/deliveries` | List deliveries for a brief |
 | POST | `/api/uber/briefs/{id}/deliver` | Trigger fan-out (idempotent unless `force=true` body) |
 | POST | `/api/uber/briefs/{id}/deliver/{channel}` | Single-channel deliver |
-| GET | `/api/uber/sse` | SSE stream (new-brief, new-alert) |
+| GET | `/api/uber/sse` | SSE stream (new-brief, new-alert, channel.bound) |
 | POST | `/api/uber/webhooks/telegram` | Driver-authenticated inbound forwarder |
 | POST | `/api/uber/webhooks/discord` | Driver-authenticated inbound forwarder |
+| POST | `/api/uber/onboard/telegram/start` | Mint onboarding token + deep-link/QR |
+| POST | `/api/uber/onboard/telegram/callback` | Driver-forwarded `/start <token>` redemption |
+| GET | `/api/uber/onboard/discord/start` | Generate Discord OAuth2 URL with `state=<onboarding_token>` |
+| GET | `/api/uber/onboard/discord/callback` | OAuth2 redirect; binds bot to identity.slug |
+| GET | `/api/uber/channels` | List bound channels (for the wizard's "manage" view) |
 
 Kernel-owned driver routes used (via kernel `:4318`):
 

--- a/apps/uebermensch/vault/specs/profile.md
+++ b/apps/uebermensch/vault/specs/profile.md
@@ -1,19 +1,23 @@
 # Uebermensch — Profile & Vault
 
-> The profile directory is also the **Obsidian vault** — a single markdown-first root with exactly four top-level folders organised around the user's relationship with their Chief of Staff:
+> The profile directory is the **vault** — a single markdown-first root with exactly four top-level folders organised around the user's relationship with their Chief of Staff:
 >
 > - `directives/` — standing orders **for CoS** (config, theses, research interests, prompts)
 > - `input/` — material **for me to read**; CoS digests and surfaces it (raw fetches, wiki, briefs, reports)
 > - `output/` — **my own writing**; CoS reviews and suggests (drafts, memos, position papers)
 > - `action/` — things awaiting **my greenlight** (strategies, plans, calendar events, executive tasks)
 >
-> The user opens this directory in Obsidian; the app reads it; R2 syncs it.
+> The vault is **Obsidian-compatible** — open it in Obsidian for graph view if you want — but Obsidian is **never required**. The vault has equal-peer authoring surfaces: the **Web UI** (onboarding wizard + profile editor + channel-config), the CLI, Obsidian, and any text editor. All of them produce the same atomic markdown rewrites.
+>
+> The vault byte-store is either the local filesystem (`$UBER_VAULT_DIR`) or an R2 prefix (`vault/<identity.slug>/`); see [architecture.md § 0 Deployment Modes](architecture.md#0-deployment-modes). The same layout, same file contents, same sync protocol applies in both — switching is a `pull` / `push`, not a migration.
 
 ## Location & Identity
 
-- Default path: `~/uebermensch-vault` — overridable via `UBER_VAULT_DIR` (alias `UBER_PROFILE_DIR` retained for continuity).
-- The directory is a **git repository** the user owns *and* an **Obsidian vault** the user opens — one location, two hats.
+- **Local mode default path:** `~/uebermensch-vault` — overridable via `UBER_VAULT_DIR` (alias `UBER_PROFILE_DIR` retained for continuity).
+- **Cloud-only mode:** R2 prefix `vault/<identity.slug>/` in the `gctrl-uber-vault` bucket. The Worker resolves it from the session's `identity.slug` claim.
+- In local mode the directory is a **git repository** the user owns *and* (optionally) an **Obsidian vault** the user opens — one location, multiple hats.
 - `gctrl uber vault init` scaffolds an empty vault at `$UBER_VAULT_DIR` from the template (`directives/`, `input/`, `output/`, `action/`, `.gitignore`, `README.md`).
+- The Web UI's onboarding wizard scaffolds the same template under `vault/<identity.slug>/` in R2 (cloud-only mode) or under `$UBER_VAULT_DIR` via the daemon (local mode). The bytes produced are identical.
 
 The identity (`identity.slug` × machine fingerprint) gates sync: each vault is keyed to one user identity; vault content MUST NOT leak between identities in shared storage. `identity.slug` is the canonical machine id — lowercase, `[a-z0-9-]+`, derived from `identity.name` at vault-init time (user may override). `identity.name` is the display name used in UI + generated markdown; it MAY contain spaces, mixed case, and non-ASCII.
 
@@ -167,9 +171,22 @@ The four roots correspond to four directions of attention:
 
 Rule of thumb: if it renders as a page in Obsidian, it lives in the vault. If it's a row of metadata, it lives in SQLite.
 
+## Authoring Surfaces
+
+Four equal-peer ways to read and edit the vault. All of them produce the same atomic markdown rewrites with the same content-hash + `vault.updated` event protocol.
+
+| Surface | Best for | Notes |
+|---------|----------|-------|
+| **Web UI** | First-time onboarding, mobile, channel configuration, day-to-day reading | Served by the Uebermensch daemon (local) or Cloudflare Worker (cloud-only). Includes the onboarding wizard (UC-7 in PRD), profile editor, topic editor, channel-connect flow, brief feed, scoring. **Required path** for cloud-only users. |
+| **CLI** | Scripting, batch edits, vault init, vault pull/push | `gctrl uber vault init`, `gctrl uber profile validate`, `gctrl uber profile migrate`, `gctrl uber vault pull --from r2`, `gctrl uber vault push --to r2`. |
+| **Obsidian** | Graph view, backlink browsing, hand-curating wiki pages | Optional. See [§ Obsidian Integration](#obsidian-integration). |
+| **Any text editor** | Power users, `git diff`-driven workflows | The vault is plain markdown — `vim`, VS Code, `nano`, all work. The local daemon's `VaultWatcher` picks up edits automatically. |
+
+The Web UI's authoring routes (e.g. `POST /api/uber/vault/topics`, `POST /api/uber/vault/theses/{slug}`) take **structured form payloads**, render them to canonical markdown server-side, and then call `VaultWriterPort.writeAuthored(path, body, expected_hash)` — exactly the same call a CLI command would make. There is no separate "cloud schema": the form fields exist only at the request boundary; on disk and on R2 the bytes are CommonMark + YAML.
+
 ## Obsidian Integration
 
-- **Opening:** point Obsidian at `$UBER_VAULT_DIR`. The vault works out of the box with zero plugins.
+- **Opening:** point Obsidian at `$UBER_VAULT_DIR` (local mode only — Obsidian does not read R2 directly; cloud-only users either run `gctrl uber vault pull --from r2` or rely on the Web UI). The vault works out of the box with zero plugins.
 - **Graph view:** frontmatter + `[[wikilinks]]` light up Obsidian's native graph. Thesis pages act as hubs.
 - **Shipped `.obsidian/` defaults** (emitted by `gctrl uber vault init`):
   - `graph.json` — groups coloured by page_type (thesis=gold, source=grey, synthesis=blue, entity=green, topic=purple)
@@ -188,6 +205,14 @@ Rule of thumb: if it renders as a page in Obsidian, it lives in the vault. If it
 5. Generated content is self-contained — deleting `input/` and `action/events/generated/` does not corrupt the authored tier (`directives/`, `output/`, the rest of `action/`).
 
 ## Sync (R2)
+
+R2 plays one of two roles depending on deployment mode:
+
+- **Local mode:** R2 is a **sync target** behind the local FS. The kernel `gctrl-sync` crate replicates `$UBER_VAULT_DIR` to `vault/<identity.slug>/` with the push/pull protocol below.
+- **Cloud-only mode:** R2 **is** the vault byte-store. The Worker reads and writes R2 directly; there is no FS to sync from. The push/pull protocol below collapses to a single conditional `R2.put` per write (with `If-Match: <etag>` for optimistic concurrency) and a single `R2.get` per read. Writes still go through a per-slug Durable Object so two concurrent requests cannot clobber each other.
+- **Hybrid mode:** R2 is canonical; the local FS is a live mirror; the local daemon runs the local-mode push/pull protocol with the bidirectional flag set.
+
+The protocol below describes the **local mode** path; cloud-only differences are called out where they matter.
 
 The whole vault syncs to R2 — not just the wiki. Configured via kernel `SyncConfig` pointing at `$UBER_VAULT_DIR`:
 


### PR DESCRIPTION
## Summary

Updates the Uebermensch spec so a first-time user can **onboard, configure
Telegram + Discord, and read briefs entirely from a web browser** — without
ever installing Obsidian, running the CLI, or hosting a local daemon.

Preserves the file-first invariant in every mode: markdown + YAML remains the
source of truth. In cloud-only mode the bytes live in R2 under
`vault/<identity.slug>/`; running `gctrl uber vault pull --from r2 --identity-slug <slug>`
later produces a byte-identical local apps vault. Switching modes is a copy,
not a migration.

Spec-only PR — no code changes. Three deployment topologies are now
defined: **Local** (default), **Cloud-only** (Worker + R2 + D1), and **Hybrid**.

## Highlights

- **`PRD.md`** — softened principle #1 (Obsidian-compatible, not -required),
  rewrote #8 (Local-first, cloud-symmetric), added principle #12 (Web is a
  primary surface). Quaternary target user (mobile-first / no laptop). UC-7
  (Cloud-Only Onboarding) walks through the wizard. New Deployment Modes
  section.
- **`vault/specs/architecture.md`** — new §0 Deployment Modes (table +
  invariants + mermaid). Split §3 Process Model into local-mode daemon vs
  cloud-only Worker. Added `VaultWriterPort` with `FsVaultWriter` /
  `R2VaultWriter` adapters so the Web UI's "save topics" button has the same
  semantics as a CLI write or Obsidian save. Per-mode security rules incl.
  channel-onboarding token lifetime (≤10 min, scoped to identity.slug).
- **`vault/specs/profile.md`** — new "Authoring Surfaces" section: Web UI,
  CLI, Obsidian, and any text editor as four equal peers. R2 plays
  sync-target (local) or byte-store (cloud-only) role.
- **`vault/specs/delivery.md`** — new "Channel Onboarding (Web)" section
  with full Telegram (deep-link / QR + `/start <token>`) and Discord
  (OAuth2 + bot-invite) flows; sequence diagram, profile YAML output,
  idempotency, failure modes. Six new `/api/uber/onboard/*` routes.
- **`ROADMAP.md`** — M2 renamed "Delivery & Web UI" with onboarding wizard +
  `VaultWriterPort` + channel onboarding routes as P0. M4 renamed "Eval
  Rigor + Cloud-Only Mode" promoting D1 sync, `R2VaultWriter`, Durable
  Object lease, Worker deploy, and Cron Triggers to P0.
- **`README.md`** — opening line + vault layout note updated.

## Cross-mode invariants (now spec'd)

1. One byte-store wins per identity slug at any moment; mode handoff is
   `pull` / `push`, not migration.
2. Same atomic-write protocol from Web UI, CLI, Obsidian — single
   `VaultWriterPort` with FS / R2 adapters.
3. Channel tokens NEVER live in the vault — kernel secret store (local) or
   `wrangler secret`s scoped per-slug (cloud).
4. Web UI is mode-symmetric; only the `Vault*` adapters differ.

## Test plan

Spec-only — nothing to test in code. Validation is editorial:

- [ ] Reviewer reads `PRD.md § Deployment Modes` → understands the three
      topologies and which user each serves.
- [ ] Reviewer follows `architecture.md §0` → mermaid renders; cross-mode
      invariants are clear.
- [ ] Reviewer reads `delivery.md § Channel Onboarding (Web)` → Telegram and
      Discord flows are implementable; tokens never land in the vault.
- [ ] Reviewer confirms `profile.md` no longer treats Obsidian as required
      anywhere on the critical path.
- [ ] Reviewer confirms `ROADMAP.md` M2 / M4 reordering is acceptable
      (onboarding wizard now P0 in M2; Worker deploy now P0 in M4).

Follow-up PRs (not in this one) will implement `VaultWriterPort`, the
onboarding wizard, the `/api/uber/onboard/*` routes, and the `R2VaultWriter`
adapter — tracked under M2 / M4 in the updated roadmap.
