### PR TITLE
feat(uebermensch): wire VaultSecretGuard into production write path

### DIFF
--- a/apps/uebermensch/src/adapters/FileSystemVault.ts
+++ b/apps/uebermensch/src/adapters/FileSystemVault.ts
@@ -1,5 +1,4 @@
-import { createHash } from "node:crypto"
-import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises"
+import { readFile, readdir, stat } from "node:fs/promises"
 import { basename, extname, join, relative } from "node:path"
 import { Effect, Layer, Schema } from "effect"
 import matter from "gray-matter"
@@ -18,9 +17,9 @@ import {
   type ResearchInterest,
   type WikiPage,
 } from "../services/VaultService.js"
-
-const hashContent = (s: string) =>
-  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
+import { VaultWriterPort } from "../services/VaultWriterPort.js"
+import { FsVaultWriterLive } from "./FsVaultWriter.js"
+import { vaultSecretGuard } from "./VaultSecretGuard.js"
 
 type WalkEntry = { abs: string; rel: string; stat: Awaited<ReturnType<typeof stat>> }
 
@@ -77,188 +76,181 @@ const SLUG_DIRS = [
   INPUT_REPORTS_DIR,
 ] as const
 
-export const FileSystemVaultLive = (vaultDir: string) =>
-  Layer.succeed(VaultService, {
-    root: () => vaultDir,
-    listWikiPages: () =>
-      Effect.tryPromise({
-        try: async () => {
-          const files = await walkMarkdown(vaultDir, KB_DIRS)
-          return Promise.all(files.map(loadPage))
-        },
-        catch: (e) =>
-          new VaultError({ message: `list wiki failed: ${String(e)}`, path: vaultDir }),
-      }),
-    recentlyChanged: (sinceHours) =>
-      Effect.tryPromise({
-        try: async () => {
-          const cutoff = Date.now() - sinceHours * 3_600_000
-          const files = await walkMarkdown(vaultDir, KB_DIRS)
-          const recent = files.filter((f) => f.stat.mtime.getTime() >= cutoff)
-          return Promise.all(recent.map(loadPage))
-        },
-        catch: (e) =>
-          new VaultError({ message: `recent scan failed: ${String(e)}`, path: vaultDir }),
-      }),
-    listSlugs: () =>
-      Effect.tryPromise({
-        try: async () => {
-          const files = await walkMarkdown(vaultDir, SLUG_DIRS)
-          const slugs = new Set<string>()
-          for (const f of files) slugs.add(basename(f.abs, ".md"))
-          return slugs as ReadonlySet<string>
-        },
-        catch: (e) =>
-          new VaultError({ message: `list slugs failed: ${String(e)}`, path: vaultDir }),
-      }),
-    writeBrief: (date, content) =>
-      Effect.tryPromise({
-        try: async () => {
-          const relPath = `${INPUT_BRIEFS_DIR}/${date}.md`
-          const absPath = join(vaultDir, relPath)
-          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
-          await mkdir(join(vaultDir, INPUT_BRIEFS_DIR), { recursive: true })
-          await writeFile(tmpPath, content, "utf8")
-          await rename(tmpPath, absPath)
-          return { absPath, relPath, contentHash: hashContent(content) }
-        },
-        catch: (e) =>
-          new VaultError({ message: `write brief failed: ${String(e)}`, path: vaultDir }),
-      }),
-    listResearchInterests: () =>
-      Effect.gen(function* () {
-        const files = yield* Effect.tryPromise({
-          try: () => walkMarkdown(vaultDir, [DIRECTIVES_RESEARCH_DIR]),
-          catch: (e) =>
-            new VaultError({
-              message: `list research failed: ${String(e)}`,
-              path: vaultDir,
-              kind: "io_failure",
-            }),
-        })
-        const out: Array<ResearchInterest> = []
-        for (const f of files) {
-          const raw = yield* Effect.tryPromise({
-            try: () => readFile(f.abs, "utf8"),
+// VaultService implementation that depends on VaultWriterPort for all writes.
+// Read-side methods (listWikiPages, recentlyChanged, listSlugs,
+// listResearchInterests) walk the filesystem directly — they have a typed
+// shape that doesn't fit VaultWriterPort.list, and reads are not subject to
+// secret-leak scanning.
+const VaultServiceFromWriter = (vaultDir: string) =>
+  Layer.effect(
+    VaultService,
+    Effect.gen(function* () {
+      const writer = yield* VaultWriterPort
+
+      return {
+        root: () => vaultDir,
+        listWikiPages: () =>
+          Effect.tryPromise({
+            try: async () => {
+              const files = await walkMarkdown(vaultDir, KB_DIRS)
+              return Promise.all(files.map(loadPage))
+            },
             catch: (e) =>
-              new VaultError({
-                message: `read research file failed: ${String(e)}`,
-                path: f.abs,
-                kind: "io_failure",
-              }),
-          })
-          const parsed = matter(raw)
-          const data = (parsed.data ?? {}) as Record<string, unknown>
-          const decoded = yield* Schema.decodeUnknown(ResearchInterestFrontmatter)(data).pipe(
-            Effect.mapError(
-              (e) =>
-                new VaultError({
-                  message: `research interest ${f.rel} invalid: ${String(e)}`,
-                  path: f.abs,
-                  kind: "parse_failure",
-                }),
-            ),
-          )
-          out.push({
-            slug: decoded.slug,
-            title: decoded.title,
-            question: decoded.question ?? null,
-            topics: decoded.topics,
-            sources: decoded.sources ?? [],
-            horizon: decoded.horizon ?? null,
-            weight: decoded.weight ?? null,
-            fieldFamiliarity: decoded.field_familiarity ?? "expert",
-            notes: parsed.content.trim(),
-            relPath: f.rel,
-          })
-        }
-        return out
-      }),
-    writeReport: (slug, content) =>
-      Effect.tryPromise({
-        try: async () => {
-          const relPath = `${INPUT_REPORTS_DIR}/${slug}.md`
-          const absPath = join(vaultDir, relPath)
-          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
-          await mkdir(join(vaultDir, INPUT_REPORTS_DIR), { recursive: true })
-          await writeFile(tmpPath, content, "utf8")
-          await rename(tmpPath, absPath)
-          return { absPath, relPath, contentHash: hashContent(content) }
-        },
-        catch: (e) =>
-          new VaultError({
-            message: `write report failed: ${String(e)}`,
-            path: vaultDir,
-            kind: "io_failure",
+              new VaultError({ message: `list wiki failed: ${String(e)}`, path: vaultDir }),
           }),
-      }),
-    // Prompt-driven research answers also land in input/reports/ — they are
-    // CoS output the user reads. Kept as a distinct method so prompts.ts can
-    // stay readable; it just delegates.
-    writeResearch: (slug, content) =>
-      Effect.tryPromise({
-        try: async () => {
-          const relPath = `${INPUT_REPORTS_DIR}/${slug}.md`
-          const absPath = join(vaultDir, relPath)
-          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
-          await mkdir(join(vaultDir, INPUT_REPORTS_DIR), { recursive: true })
-          await writeFile(tmpPath, content, "utf8")
-          await rename(tmpPath, absPath)
-          return { absPath, relPath, contentHash: hashContent(content) }
-        },
-        catch: (e) =>
-          new VaultError({
-            message: `write research failed: ${String(e)}`,
-            path: vaultDir,
-            kind: "io_failure",
+        recentlyChanged: (sinceHours) =>
+          Effect.tryPromise({
+            try: async () => {
+              const cutoff = Date.now() - sinceHours * 3_600_000
+              const files = await walkMarkdown(vaultDir, KB_DIRS)
+              const recent = files.filter((f) => f.stat.mtime.getTime() >= cutoff)
+              return Promise.all(recent.map(loadPage))
+            },
+            catch: (e) =>
+              new VaultError({ message: `recent scan failed: ${String(e)}`, path: vaultDir }),
           }),
-      }),
-    writeSource: (slug, content, options) =>
-      Effect.gen(function* () {
-        const relPath = `${INPUT_RAW_DIR}/${slug}.md`
-        const absPath = join(vaultDir, relPath)
-
-        const existed = yield* Effect.tryPromise({
-          try: async () => {
-            try {
-              await stat(absPath)
-              return true
-            } catch {
-              return false
+        listSlugs: () =>
+          Effect.tryPromise({
+            try: async () => {
+              const files = await walkMarkdown(vaultDir, SLUG_DIRS)
+              const slugs = new Set<string>()
+              for (const f of files) slugs.add(basename(f.abs, ".md"))
+              return slugs as ReadonlySet<string>
+            },
+            catch: (e) =>
+              new VaultError({ message: `list slugs failed: ${String(e)}`, path: vaultDir }),
+          }),
+        writeBrief: (date, content) =>
+          Effect.gen(function* () {
+            const relPath = `${INPUT_BRIEFS_DIR}/${date}.md`
+            const written = yield* writer.write(relPath, content)
+            return {
+              absPath: join(vaultDir, relPath),
+              relPath,
+              contentHash: written.contentHash,
             }
-          },
-          catch: (e) =>
-            new VaultError({
-              message: `stat failed: ${String(e)}`,
-              path: absPath,
-              kind: "io_failure",
-            }),
-        })
+          }),
+        listResearchInterests: () =>
+          Effect.gen(function* () {
+            const files = yield* Effect.tryPromise({
+              try: () => walkMarkdown(vaultDir, [DIRECTIVES_RESEARCH_DIR]),
+              catch: (e) =>
+                new VaultError({
+                  message: `list research failed: ${String(e)}`,
+                  path: vaultDir,
+                  kind: "io_failure",
+                }),
+            })
+            const out: Array<ResearchInterest> = []
+            for (const f of files) {
+              const raw = yield* Effect.tryPromise({
+                try: () => readFile(f.abs, "utf8"),
+                catch: (e) =>
+                  new VaultError({
+                    message: `read research file failed: ${String(e)}`,
+                    path: f.abs,
+                    kind: "io_failure",
+                  }),
+              })
+              const parsed = matter(raw)
+              const data = (parsed.data ?? {}) as Record<string, unknown>
+              const decoded = yield* Schema.decodeUnknown(ResearchInterestFrontmatter)(data).pipe(
+                Effect.mapError(
+                  (e) =>
+                    new VaultError({
+                      message: `research interest ${f.rel} invalid: ${String(e)}`,
+                      path: f.abs,
+                      kind: "parse_failure",
+                    }),
+                ),
+              )
+              out.push({
+                slug: decoded.slug,
+                title: decoded.title,
+                question: decoded.question ?? null,
+                topics: decoded.topics,
+                sources: decoded.sources ?? [],
+                horizon: decoded.horizon ?? null,
+                weight: decoded.weight ?? null,
+                fieldFamiliarity: decoded.field_familiarity ?? "expert",
+                notes: parsed.content.trim(),
+                relPath: f.rel,
+              })
+            }
+            return out
+          }),
+        writeReport: (slug, content) =>
+          Effect.gen(function* () {
+            const relPath = `${INPUT_REPORTS_DIR}/${slug}.md`
+            const written = yield* writer.write(relPath, content)
+            return {
+              absPath: join(vaultDir, relPath),
+              relPath,
+              contentHash: written.contentHash,
+            }
+          }),
+        // Prompt-driven research answers also land in input/reports/ — they
+        // are CoS output the user reads. Kept as a distinct method so
+        // prompts.ts can stay readable; it just delegates.
+        writeResearch: (slug, content) =>
+          Effect.gen(function* () {
+            const relPath = `${INPUT_REPORTS_DIR}/${slug}.md`
+            const written = yield* writer.write(relPath, content)
+            return {
+              absPath: join(vaultDir, relPath),
+              relPath,
+              contentHash: written.contentHash,
+            }
+          }),
+        writeSource: (slug, content, options) =>
+          Effect.gen(function* () {
+            const relPath = `${INPUT_RAW_DIR}/${slug}.md`
+            const absPath = join(vaultDir, relPath)
 
-        if (existed && !options?.overwrite) {
-          return yield* Effect.fail(
-            new VaultError({
-              message: `source page already exists: ${relPath}`,
-              path: absPath,
-              kind: "collision",
-            }),
-          )
-        }
+            const existed = yield* Effect.tryPromise({
+              try: async () => {
+                try {
+                  await stat(absPath)
+                  return true
+                } catch {
+                  return false
+                }
+              },
+              catch: (e) =>
+                new VaultError({
+                  message: `stat failed: ${String(e)}`,
+                  path: absPath,
+                  kind: "io_failure",
+                }),
+            })
 
-        return yield* Effect.tryPromise({
-          try: async () => {
-            const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
-            await mkdir(join(vaultDir, INPUT_RAW_DIR), { recursive: true })
-            await writeFile(tmpPath, content, "utf8")
-            await rename(tmpPath, absPath)
-            return { absPath, relPath, contentHash: hashContent(content), existed }
-          },
-          catch: (e) =>
-            new VaultError({
-              message: `write source failed: ${String(e)}`,
-              path: absPath,
-              kind: "io_failure",
-            }),
-        })
-      }),
-  })
+            if (existed && !options?.overwrite) {
+              return yield* Effect.fail(
+                new VaultError({
+                  message: `source page already exists: ${relPath}`,
+                  path: absPath,
+                  kind: "collision",
+                }),
+              )
+            }
+
+            const written = yield* writer.write(relPath, content)
+            return {
+              absPath,
+              relPath,
+              contentHash: written.contentHash,
+              existed,
+            }
+          }),
+      }
+    }),
+  )
+
+// FileSystemVaultLive bundles VaultService + VaultSecretGuard + FsVaultWriter
+// into a single Layer with no remaining requirements. Call sites continue to
+// `Effect.provide(FileSystemVaultLive(vaultDir))` and the secret-leak guard is
+// load-bearing on every write.
+export const FileSystemVaultLive = (vaultDir: string): Layer.Layer<VaultService> =>
+  VaultServiceFromWriter(vaultDir).pipe(
+    Layer.provide(vaultSecretGuard(FsVaultWriterLive(vaultDir))),
+  )

--- a/apps/uebermensch/src/adapters/FsVaultWriter.ts
+++ b/apps/uebermensch/src/adapters/FsVaultWriter.ts
@@ -64,7 +64,7 @@ export const FsVaultWriterLive = (vaultDir: string): Layer.Layer<VaultWriterPort
         async () => {
           const start = join(vaultDir, prefix)
           const entries: Array<VaultEntry> = []
-          let dirents
+          let dirents: Array<import("node:fs").Dirent>
           try {
             dirents = await readdir(start, { recursive: true, withFileTypes: true })
           } catch (e) {

--- a/apps/uebermensch/src/adapters/FsVaultWriter.ts
+++ b/apps/uebermensch/src/adapters/FsVaultWriter.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto"
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
+import { Effect, Layer, Option } from "effect"
+import { VaultError, vaultIo } from "../errors.js"
+import {
+  VaultWriterPort,
+  type VaultEntry,
+  type VaultWriterPortShape,
+  type WrittenEntry,
+} from "../services/VaultWriterPort.js"
+
+const hashContent = (s: string) =>
+  `sha256:${createHash("sha256").update(s, "utf8").digest("hex")}`
+
+// Filesystem adapter for VaultWriterPort. Operates on vault-relative paths
+// rooted at `vaultDir`. Writes are atomic (tmp + rename) and create parent
+// directories as needed; reads return Option.none for missing files; deletes
+// are no-ops when the target is missing. Local filesystem is strongly
+// consistent so the R2 list write-cache requirement (see VaultWriterPort.list)
+// does not apply here.
+export const FsVaultWriterLive = (vaultDir: string): Layer.Layer<VaultWriterPort> =>
+  Layer.succeed(VaultWriterPort, {
+    write: (path, content) =>
+      vaultIo(
+        async () => {
+          const absPath = join(vaultDir, path)
+          const tmpPath = `${absPath}.tmp-${process.pid}-${Date.now()}`
+          await mkdir(dirname(absPath), { recursive: true })
+          await writeFile(tmpPath, content, "utf8")
+          await rename(tmpPath, absPath)
+          return { contentHash: hashContent(content) } satisfies WrittenEntry
+        },
+        { message: `write failed for ${path}`, path: join(vaultDir, path) },
+      ),
+    read: (path) =>
+      Effect.tryPromise({
+        try: async () => {
+          try {
+            const buf = await readFile(join(vaultDir, path), "utf8")
+            return Option.some(buf)
+          } catch (e) {
+            if ((e as NodeJS.ErrnoException).code === "ENOENT") return Option.none<string>()
+            throw e
+          }
+        },
+        catch: (e) =>
+          new VaultError({
+            message: `read failed for ${path}: ${String(e)}`,
+            path: join(vaultDir, path),
+            kind: "io_failure",
+          }),
+      }),
+    list: (prefix) =>
+      vaultIo(
+        async () => {
+          const start = join(vaultDir, prefix)
+          const entries: Array<VaultEntry> = []
+          let dirents
+          try {
+            dirents = await readdir(start, { recursive: true, withFileTypes: true })
+          } catch (e) {
+            if ((e as NodeJS.ErrnoException).code === "ENOENT") return entries
+            throw e
+          }
+          for (const d of dirents) {
+            if (!d.isFile()) continue
+            const name = String(d.name)
+            const parent = (d as unknown as { parentPath?: string }).parentPath ?? d.path ?? start
+            const abs = join(parent, name)
+            const st = await stat(abs)
+            entries.push({ path: relative(vaultDir, abs), mtime: st.mtime })
+          }
+          return entries
+        },
+        { message: `list failed for ${prefix}`, path: join(vaultDir, prefix) },
+      ),
+    delete: (path) =>
+      vaultIo(
+        async () => {
+          await rm(join(vaultDir, path), { force: true })
+        },
+        { message: `delete failed for ${path}`, path: join(vaultDir, path) },
+      ),
+  } satisfies VaultWriterPortShape)

--- a/apps/uebermensch/src/adapters/HttpIngest.ts
+++ b/apps/uebermensch/src/adapters/HttpIngest.ts
@@ -299,7 +299,22 @@ export const HttpIngestLive = Layer.effect(
 
           const written = yield* vault
             .writeSource(slug, full, { overwrite: req.overwrite })
-            .pipe(Effect.catchTag("VaultError", (e) => Effect.fail(vaultToIngest(req.url)(e))));
+            .pipe(
+              Effect.catchTags({
+                VaultError: (e) => Effect.fail(vaultToIngest(req.url)(e)),
+                // Ingested content matched a known credential pattern — refuse
+                // the page rather than persist it. Mapped to io_failure so the
+                // ingest queue treats it like any other rejected write.
+                VaultSecretLeakError: (e) =>
+                  Effect.fail(
+                    ingestErr(
+                      "io_failure",
+                      req.url,
+                      `secret-pattern leak blocked write: ${e.leaks.map((l) => l.name).join(", ")}`,
+                    ),
+                  ),
+              }),
+            );
 
           return {
             slug,

--- a/apps/uebermensch/src/adapters/LumaSuggester.ts
+++ b/apps/uebermensch/src/adapters/LumaSuggester.ts
@@ -5,7 +5,7 @@ import {
   eventTokens,
   scoreMatch,
 } from "../lib/event-match.js"
-import { fetchLumaEvents, LumaError, lumaCityUrl, type FetchFn } from "../lib/luma.js"
+import { fetchLumaEvents, type LumaError, lumaCityUrl, type FetchFn } from "../lib/luma.js"
 import { CalendarService, type SuggestionInput } from "../services/CalendarService.js"
 import {
   EventSuggesterService,

--- a/apps/uebermensch/src/services/VaultService.ts
+++ b/apps/uebermensch/src/services/VaultService.ts
@@ -1,5 +1,5 @@
 import { Context, type Effect } from "effect"
-import type { VaultError } from "../errors.js"
+import type { VaultError, VaultSecretLeakError } from "../errors.js"
 
 export type WikiPage = {
   readonly relPath: string
@@ -58,23 +58,28 @@ export interface VaultServiceShape {
     ReadonlyArray<ResearchInterest>,
     VaultError
   >
+  // Write methods may fail with VaultSecretLeakError when the underlying
+  // VaultWriterPort is wrapped by `vaultSecretGuard` — content matching a known
+  // credential pattern is rejected before persisting. Production layers
+  // (FileSystemVaultLive) bundle the guard, so callers must handle both error
+  // types in their error channel.
   readonly writeBrief: (
     date: string,
     content: string,
-  ) => Effect.Effect<WrittenBrief, VaultError>
+  ) => Effect.Effect<WrittenBrief, VaultError | VaultSecretLeakError>
   readonly writeSource: (
     slug: string,
     content: string,
     options?: { readonly overwrite?: boolean },
-  ) => Effect.Effect<WrittenSource, VaultError>
+  ) => Effect.Effect<WrittenSource, VaultError | VaultSecretLeakError>
   readonly writeReport: (
     slug: string,
     content: string,
-  ) => Effect.Effect<WrittenReport, VaultError>
+  ) => Effect.Effect<WrittenReport, VaultError | VaultSecretLeakError>
   readonly writeResearch: (
     slug: string,
     content: string,
-  ) => Effect.Effect<WrittenResearch, VaultError>
+  ) => Effect.Effect<WrittenResearch, VaultError | VaultSecretLeakError>
 }
 
 export class VaultService extends Context.Tag("uebermensch/VaultService")<

--- a/apps/uebermensch/tests/file-system-vault-guard.test.ts
+++ b/apps/uebermensch/tests/file-system-vault-guard.test.ts
@@ -1,0 +1,124 @@
+import { access, mkdtemp, readdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Exit } from "effect"
+import { describe, expect, it } from "vitest"
+import { FileSystemVaultLive } from "../src/adapters/FileSystemVault.js"
+import { VaultSecretLeakError } from "../src/errors.js"
+import { VaultService } from "../src/services/VaultService.js"
+
+// These tests prove the production VaultService write path is wrapped by
+// VaultSecretGuard — i.e. the guard is load-bearing, not just shipped. The
+// foundation PR (#145) introduced the guard but did not wire it. Slice 7
+// flips it on by routing FileSystemVaultLive's writes through VaultWriterPort,
+// which the guard middleware wraps. If a future refactor reintroduces a write
+// path that bypasses the port, the brief/source/report fixtures here will
+// start succeeding and the test fails.
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Split-prefix to keep GitHub's push-time secret scanner from flagging this
+// source file. Same trick as tests/vault-secret-guard.test.ts.
+const ANTHROPIC_LEAK = `${"sk-ant" + "-api03-DeadBeefDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef"}`
+
+const runWithVault = <A, E>(dir: string, eff: Effect.Effect<A, E, VaultService>) =>
+  Effect.runPromise(Effect.exit(Effect.provide(eff, FileSystemVaultLive(dir))))
+
+describe("FileSystemVaultLive — secret guard is load-bearing", () => {
+  it("writeBrief blocks content containing an Anthropic API key", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-vault-guard-"))
+    const exit = await runWithVault(
+      dir,
+      Effect.gen(function* () {
+        const vault = yield* VaultService
+        return yield* vault.writeBrief("2026-05-02", `# brief\n\ntoken: ${ANTHROPIC_LEAK}`)
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const err = (exit.cause as unknown as { error: unknown }).error
+      expect(err).toBeInstanceOf(VaultSecretLeakError)
+      const leak = err as VaultSecretLeakError
+      expect(leak.leaks[0]?.name).toBe("anthropic_api_key")
+    }
+
+    // Briefs dir should not even exist — the write was rejected before mkdir.
+    const briefsExists = await fileExists(join(dir, "input", "briefs"))
+    expect(briefsExists).toBe(false)
+  })
+
+  it("writeBrief allows clean content and writes the file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-vault-guard-"))
+    const exit = await runWithVault(
+      dir,
+      Effect.gen(function* () {
+        const vault = yield* VaultService
+        return yield* vault.writeBrief("2026-05-02", "# brief\n\nclean content here")
+      }),
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    const files = await readdir(join(dir, "input", "briefs"))
+    expect(files).toContain("2026-05-02.md")
+  })
+
+  it("writeSource blocks content containing a GitHub PAT", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-vault-guard-"))
+    const pat = `${"ghp" + "_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm"}`
+    const exit = await runWithVault(
+      dir,
+      Effect.gen(function* () {
+        const vault = yield* VaultService
+        return yield* vault.writeSource("evil-source", `body ${pat}`)
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const err = (exit.cause as unknown as { error: unknown }).error
+      expect(err).toBeInstanceOf(VaultSecretLeakError)
+    }
+    const rawExists = await fileExists(join(dir, "input", "raw", "evil-source.md"))
+    expect(rawExists).toBe(false)
+  })
+
+  it("writeReport blocks leaks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-vault-guard-"))
+    const exit = await runWithVault(
+      dir,
+      Effect.gen(function* () {
+        const vault = yield* VaultService
+        return yield* vault.writeReport("q2-thesis", `summary: ${ANTHROPIC_LEAK}`)
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const reportExists = await fileExists(join(dir, "input", "reports", "q2-thesis.md"))
+    expect(reportExists).toBe(false)
+  })
+
+  it("writeResearch blocks leaks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "uber-vault-guard-"))
+    const exit = await runWithVault(
+      dir,
+      Effect.gen(function* () {
+        const vault = yield* VaultService
+        return yield* vault.writeResearch("interest-x", `notes ${ANTHROPIC_LEAK}`)
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const researchExists = await fileExists(
+      join(dir, "input", "reports", "interest-x.md"),
+    )
+    expect(researchExists).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Slice 7 of the uebermensch ejection plan — makes `VaultSecretGuard` **load-bearing** on the production write path. Closes the explicit gap from PR #145: _"today the VaultSecretGuard middleware ships but is not yet wired into the production write path."_

- Adds `FsVaultWriter` (filesystem adapter for `VaultWriterPort` — atomic tmp+rename writes, ENOENT-as-`Option.none` reads, no-op deletes).
- Refactors `FileSystemVaultLive` to delegate `writeBrief` / `writeReport` / `writeResearch` / `writeSource` through `VaultWriterPort`. The Layer bundles `vaultSecretGuard(FsVaultWriterLive(vaultDir))` internally, so every existing call site (`Effect.provide(FileSystemVaultLive(vaultDir))`) is unchanged.
- Widens `VaultService` write-method error union to `VaultError | VaultSecretLeakError`. Single downstream caller (`HttpIngest`) updated to handle the new tag via `Effect.catchTags`.

Read-side methods (`listWikiPages`, `recentlyChanged`, `listSlugs`, `listResearchInterests`) keep walking the filesystem directly — their typed shape doesn't fit `VaultWriterPort.list`, and reads aren't subject to secret-leak scanning.

## How it works

```mermaid
flowchart LR
  Cmd[brief / report / ingest command] -->|writeBrief / writeSource / ...| VS[VaultService]
  VS -->|writer.write| Guard[VaultSecretGuard]
  Guard -->|scanForSecrets| Reject{leak?}
  Reject -- yes --> Err[VaultSecretLeakError]
  Reject -- no --> FS[FsVaultWriter]
  FS -->|atomic tmp+rename| Disk[(vault/)]
```

Before this PR the guard arrow was missing — commands wrote straight to disk via the old `FileSystemVaultLive` (`Layer.succeed`).

## Why this slice now

PR #145 (PR-A foundation) shipped the port, the middleware, and the secret-pattern library — but no production write path consumed any of it. This slice flips the switch with no behavior change for clean writes (which is everything in the test suite today) and starts rejecting the credential patterns the foundation defined.

## Test plan

- [x] `pnpm typecheck` (apps/uebermensch) — clean
- [x] `pnpm test` — **257 passing** (was 252, +5 new in `tests/file-system-vault-guard.test.ts`)
- [x] New tests use a real `mkdtemp` and the actual `FileSystemVaultLive`. They prove the guard is load-bearing — if a future refactor reintroduces a write that bypasses `VaultWriterPort`, these tests start failing:
  - `writeBrief` blocks Anthropic-API-key fixture; no file on disk
  - `writeBrief` allows clean content; file present
  - `writeSource` blocks GitHub PAT fixture; no file on disk
  - `writeReport` / `writeResearch` block Anthropic-API-key fixture
- [ ] Manual smoke against fixture vault unchanged from main (clean briefs continue to write)

## Three-PR sequence (eject plan)

- [x] **PR-A foundation** — #145 (merged)
- [ ] **PR-B kernel-less mode** — this PR is the first slice of PR-B; remaining slices: `AnthropicLlm` + `LMStudioLlm` direct adapters, `TelegramBotApi` + `DiscordWebhook` direct adapters, `buildModeLayer(mode)` factory, kernel-side `uber_*` table removal, `gctrl-app.toml` install protocol
- [ ] **PR-C repo carve** — `R2VaultWriter` + carve to `OpenHackersClub/uebermensch`
