### PR TITLE
feat(kernel): driver-browser spec + PR1 scaffold (CDP attach LKM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gctrl-browser"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "gctrl-cli"
 version = "0.1.0"
 dependencies = [
@@ -1850,6 +1864,7 @@ dependencies = [
  "duckdb",
  "feed-rs",
  "futures-core",
+ "gctrl-browser",
  "gctrl-context",
  "gctrl-core",
  "gctrl-driver-macos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "kernel/crates/gctrl-scheduler",
     "kernel/crates/gctrl-gcal",
     "kernel/crates/gctrl-driver-macos",
+    "kernel/crates/gctrl-browser",
 ]
 
 [workspace.package]

--- a/kernel/crates/gctrl-browser/Cargo.toml
+++ b/kernel/crates/gctrl-browser/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gctrl-browser"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/kernel/crates/gctrl-browser/src/config.rs
+++ b/kernel/crates/gctrl-browser/src/config.rs
@@ -1,0 +1,91 @@
+use std::path::PathBuf;
+
+/// Daemon-wide browser pool configuration. Loaded from
+/// `~/.config/gctrl/config.toml` `[browser]` section by the daemon (config
+/// file parsing is owned by the daemon binary, not this crate). Env vars
+/// override file values for ops convenience.
+#[derive(Debug, Clone)]
+pub struct BrowserConfig {
+    pub pool_max: u32,
+    pub contexts_per_chromium_max: u32,
+    /// Recycle a Chromium when it has been idle (zero active sessions) for
+    /// at least this many seconds. Default 1800 (30 min).
+    pub recycle_idle_seconds: u64,
+    /// Recycle a Chromium when its absolute age reaches this many seconds,
+    /// regardless of activity, via graceful drain. Default 28800 (8 h).
+    pub recycle_max_age_seconds: u64,
+    /// Default session TTL when the request doesn't override.
+    pub default_ttl_seconds: u32,
+    /// Default recording byte cap when the request doesn't override.
+    pub default_recording_max_bytes: u64,
+    /// Path to a Chromium binary; empty means autodetect via `which`.
+    pub chromium_path: Option<PathBuf>,
+    /// Whether headed mode is permitted. PR1 always returns `false` to
+    /// reflect the stub state; PR2 will read from config.
+    pub headed_default: bool,
+}
+
+impl Default for BrowserConfig {
+    fn default() -> Self {
+        BrowserConfig {
+            pool_max: 4,
+            contexts_per_chromium_max: 8,
+            recycle_idle_seconds: 1800,
+            recycle_max_age_seconds: 28_800,
+            default_ttl_seconds: 600,
+            default_recording_max_bytes: 50 * 1024 * 1024,
+            chromium_path: None,
+            headed_default: false,
+        }
+    }
+}
+
+impl BrowserConfig {
+    /// Apply env var overrides on top of an existing config.
+    pub fn with_env_overrides(mut self) -> Self {
+        if let Ok(v) = std::env::var("GCTRL_BROWSER_POOL_MAX") {
+            if let Ok(v) = v.parse::<u32>() {
+                self.pool_max = v;
+            }
+        }
+        if let Ok(v) = std::env::var("GCTRL_BROWSER_RECYCLE_IDLE_SECS") {
+            if let Ok(v) = v.parse::<u64>() {
+                self.recycle_idle_seconds = v;
+            }
+        }
+        if let Ok(v) = std::env::var("GCTRL_BROWSER_RECYCLE_MAX_AGE_SECS") {
+            if let Ok(v) = v.parse::<u64>() {
+                self.recycle_max_age_seconds = v;
+            }
+        }
+        if let Ok(v) = std::env::var("GCTRL_BROWSER_DEFAULT_TTL_SECS") {
+            if let Ok(v) = v.parse::<u32>() {
+                self.default_ttl_seconds = v;
+            }
+        }
+        if let Ok(v) = std::env::var("GCTRL_BROWSER_CHROMIUM_PATH") {
+            if !v.is_empty() {
+                self.chromium_path = Some(PathBuf::from(v));
+            }
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_spec() {
+        let c = BrowserConfig::default();
+        assert_eq!(c.pool_max, 4);
+        assert_eq!(c.contexts_per_chromium_max, 8);
+        assert_eq!(c.recycle_idle_seconds, 1800);
+        assert_eq!(c.recycle_max_age_seconds, 28_800);
+        assert_eq!(c.default_ttl_seconds, 600);
+        assert_eq!(c.default_recording_max_bytes, 50 * 1024 * 1024);
+        assert!(!c.headed_default);
+        assert!(c.chromium_path.is_none());
+    }
+}

--- a/kernel/crates/gctrl-browser/src/error.rs
+++ b/kernel/crates/gctrl-browser/src/error.rs
@@ -1,0 +1,45 @@
+use crate::model::SessionId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BrowserError {
+    #[error("browser pool exhausted (max={max})")]
+    PoolExhausted { max: u32 },
+
+    #[error("session not found: {0}")]
+    SessionNotFound(SessionId),
+
+    #[error("session expired: {0}")]
+    SessionExpired(SessionId),
+
+    #[error("invalid token for session {0}")]
+    InvalidToken(SessionId),
+
+    #[error("recording disabled for this session")]
+    RecordingDisabled,
+
+    #[error("chromium launch failed: {0}")]
+    Launch(String),
+
+    #[error("cdp protocol error: {0}")]
+    Cdp(String),
+
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+}
+
+impl BrowserError {
+    /// Stable kind string for logs / OTel attributes / route-layer status mapping.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            BrowserError::PoolExhausted { .. } => "pool_exhausted",
+            BrowserError::SessionNotFound(_) => "session_not_found",
+            BrowserError::SessionExpired(_) => "session_expired",
+            BrowserError::InvalidToken(_) => "invalid_token",
+            BrowserError::RecordingDisabled => "recording_disabled",
+            BrowserError::Launch(_) => "launch_failed",
+            BrowserError::Cdp(_) => "cdp_error",
+            BrowserError::InvalidRequest(_) => "invalid_request",
+        }
+    }
+}

--- a/kernel/crates/gctrl-browser/src/lib.rs
+++ b/kernel/crates/gctrl-browser/src/lib.rs
@@ -1,0 +1,36 @@
+//! gctrl-browser — Kernel driver for the CDP attach layer.
+//!
+//! Owns a pool of long-lived Chromium processes and exposes per-session
+//! `BrowserContext`s addressable by a `SessionId`. Clients (Playwright,
+//! Puppeteer, chromiumoxide, raw WS) attach to the per-session bearer-gated
+//! WebSocket at `/api/browser/sessions/<id>/cdp` and speak Chrome DevTools
+//! Protocol directly. The `gctrl-recorder` crate (PR3) subscribes to the
+//! frame fanout and structures Network/Runtime/Performance events.
+//!
+//! This is the lower layer underneath the agent-facing command surface
+//! (`snapshot`, `click`, `fill`) defined in
+//! [vault/specs/architecture/kernel/browser.md]. The agent commands will
+//! eventually be re-implemented on top of this layer.
+//!
+//! See [vault/specs/implementation/kernel/driver-browser.md] for full
+//! architecture, pool semantics, recycle policy, and migration plan.
+//!
+//! ## Status
+//!
+//! PR1: types + errors + pool placeholder + config. No Chromium driving yet
+//! — `Pool::acquire` returns `BrowserError::Launch` until PR2 wires the
+//! `chromiumoxide` integration.
+
+pub mod config;
+pub mod error;
+pub mod model;
+pub mod pool;
+pub mod token;
+
+pub use config::BrowserConfig;
+pub use error::BrowserError;
+pub use model::{
+    RecordingOptions, SessionId, SessionInfo, SessionOptions, SessionStatus, Viewport,
+};
+pub use pool::Pool;
+pub use token::{mint_token, Token};

--- a/kernel/crates/gctrl-browser/src/model.rs
+++ b/kernel/crates/gctrl-browser/src/model.rs
@@ -1,0 +1,132 @@
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Branded identifier for a kernel-managed browser session. One session ==
+/// one Chromium `BrowserContext` (cookies/storage/service-workers isolated
+/// from siblings).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionId(pub String);
+
+impl SessionId {
+    pub fn new() -> Self {
+        SessionId(uuid::Uuid::new_v4().to_string())
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(s: String) -> Self {
+        SessionId(s)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Viewport {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Viewport {
+            width: 1280,
+            height: 720,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingOptions {
+    pub network: bool,
+    pub console: bool,
+    pub performance: bool,
+    pub screenshots: bool,
+    /// When true, persist every CDP frame (high volume — opt-in for
+    /// debugging/replay only). Defaults to false.
+    pub full: bool,
+    /// Hard cap on persisted recording bytes per session. When exceeded,
+    /// structured tables stop accepting new rows; the count of dropped
+    /// rows is surfaced on `SessionInfo`.
+    pub max_bytes: u64,
+}
+
+impl Default for RecordingOptions {
+    fn default() -> Self {
+        RecordingOptions {
+            network: true,
+            console: true,
+            performance: true,
+            screenshots: false,
+            full: false,
+            max_bytes: 50 * 1024 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionOptions {
+    #[serde(default)]
+    pub viewport: Option<Viewport>,
+    #[serde(default)]
+    pub headed: bool,
+    #[serde(default)]
+    pub recording: RecordingOptions,
+    /// Session lifetime in seconds. Capped to 3600 by the route layer.
+    #[serde(default = "SessionOptions::default_ttl")]
+    pub ttl_seconds: u32,
+}
+
+impl SessionOptions {
+    fn default_ttl() -> u32 {
+        600
+    }
+}
+
+impl Default for SessionOptions {
+    fn default() -> Self {
+        SessionOptions {
+            viewport: None,
+            headed: false,
+            recording: RecordingOptions::default(),
+            ttl_seconds: Self::default_ttl(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Active,
+    Releasing,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInfo {
+    pub id: SessionId,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub browser_version: String,
+    pub status: SessionStatus,
+    pub recording: RecordingOptions,
+    /// `ws://127.0.0.1:<port>/api/browser/sessions/<id>/cdp?token=...`
+    pub cdp_endpoint: String,
+    /// Bearer token for the CDP attach. Also embedded in `cdp_endpoint` as
+    /// `?token=...` for client convenience.
+    pub token: String,
+    /// Frames dropped because the recorder broadcast channel was full.
+    /// Best-effort counter, exposed for observability.
+    #[serde(default)]
+    pub dropped_frames: u64,
+}

--- a/kernel/crates/gctrl-browser/src/model.rs
+++ b/kernel/crates/gctrl-browser/src/model.rs
@@ -16,6 +16,12 @@ impl SessionId {
     }
 }
 
+impl Default for SessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl fmt::Display for SessionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)

--- a/kernel/crates/gctrl-browser/src/pool.rs
+++ b/kernel/crates/gctrl-browser/src/pool.rs
@@ -1,0 +1,206 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use tokio::sync::RwLock;
+
+use crate::{
+    config::BrowserConfig,
+    error::BrowserError,
+    model::{SessionId, SessionInfo, SessionOptions, SessionStatus},
+    token::mint_token,
+};
+
+/// Pool of long-lived Chromium processes hosting per-session
+/// `BrowserContext`s. PR1 is a placeholder: state shape and public API are
+/// final, but `acquire` does not actually launch Chromium — it returns
+/// `BrowserError::Launch("not implemented in PR1 — pool stub")`. PR2 wires
+/// the `chromiumoxide` integration behind this same interface.
+pub struct Pool {
+    config: Arc<BrowserConfig>,
+    /// In PR1 always empty. PR2 will populate it via `acquire`.
+    sessions: RwLock<Vec<SessionInfo>>,
+}
+
+impl Pool {
+    pub fn new(config: Arc<BrowserConfig>) -> Self {
+        Pool {
+            config,
+            sessions: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub fn config(&self) -> &BrowserConfig {
+        &self.config
+    }
+
+    /// Best-effort active session count; useful for `/api/browser/health`.
+    pub async fn active_count(&self) -> usize {
+        self.sessions.read().await.len()
+    }
+
+    /// Acquire a new session.
+    ///
+    /// PR1: validates options against config, returns `BrowserError::Launch`
+    /// without spawning Chromium. PR2: spawns/reuses a pooled Chromium,
+    /// creates a `BrowserContext`, mints a token, and returns the
+    /// populated `SessionInfo`.
+    pub async fn acquire(
+        &self,
+        opts: SessionOptions,
+    ) -> Result<SessionInfo, BrowserError> {
+        // Validate the request against config bounds — these checks belong
+        // here (not in the route layer) so callers from inside the kernel
+        // get the same gates as HTTP callers.
+        if opts.headed && !self.config.headed_default {
+            return Err(BrowserError::InvalidRequest(
+                "headed mode requires browser.headed_default=true and a display server".into(),
+            ));
+        }
+        if opts.ttl_seconds == 0 || opts.ttl_seconds > 3600 {
+            return Err(BrowserError::InvalidRequest(
+                "ttl_seconds must be in (0, 3600]".into(),
+            ));
+        }
+        if opts.recording.max_bytes == 0 {
+            return Err(BrowserError::InvalidRequest(
+                "recording.max_bytes must be > 0".into(),
+            ));
+        }
+
+        // Pool capacity check. Real implementation will consider per-Chromium
+        // contexts_per_chromium_max as well; stub uses pool_max as a flat cap.
+        let active = self.active_count().await as u32;
+        if active >= self.config.pool_max {
+            return Err(BrowserError::PoolExhausted {
+                max: self.config.pool_max,
+            });
+        }
+
+        Err(BrowserError::Launch(
+            "not implemented in PR1 — pool stub; chromium launch lands in PR2".into(),
+        ))
+    }
+
+    /// Release a session immediately. PR1: 404s for any id since acquire
+    /// never populates the pool.
+    pub async fn release(&self, id: &SessionId) -> Result<(), BrowserError> {
+        let mut sessions = self.sessions.write().await;
+        let before = sessions.len();
+        sessions.retain(|s| &s.id != id);
+        if sessions.len() == before {
+            Err(BrowserError::SessionNotFound(id.clone()))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn list(&self) -> Vec<SessionInfo> {
+        self.sessions.read().await.clone()
+    }
+
+    pub async fn get(&self, id: &SessionId) -> Option<SessionInfo> {
+        self.sessions
+            .read()
+            .await
+            .iter()
+            .find(|s| &s.id == id)
+            .cloned()
+    }
+}
+
+/// Build a `SessionInfo` skeleton for a given options + cdp_endpoint base.
+/// Exposed for PR2's pool implementation to share with PR1's tests.
+pub fn build_info(
+    id: SessionId,
+    opts: &SessionOptions,
+    browser_version: String,
+    cdp_endpoint: String,
+) -> SessionInfo {
+    let token = mint_token();
+    let now = Utc::now();
+    SessionInfo {
+        id,
+        created_at: now,
+        expires_at: now + chrono::Duration::seconds(opts.ttl_seconds as i64),
+        browser_version,
+        status: SessionStatus::Active,
+        recording: opts.recording.clone(),
+        cdp_endpoint,
+        token: token.0,
+        dropped_frames: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> Arc<BrowserConfig> {
+        Arc::new(BrowserConfig::default())
+    }
+
+    #[tokio::test]
+    async fn acquire_returns_launch_until_pr2() {
+        let pool = Pool::new(cfg());
+        let err = pool.acquire(SessionOptions::default()).await.unwrap_err();
+        assert!(matches!(err, BrowserError::Launch(_)));
+        assert_eq!(err.kind(), "launch_failed");
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_zero_ttl() {
+        let pool = Pool::new(cfg());
+        let mut opts = SessionOptions::default();
+        opts.ttl_seconds = 0;
+        let err = pool.acquire(opts).await.unwrap_err();
+        assert_eq!(err.kind(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_oversized_ttl() {
+        let pool = Pool::new(cfg());
+        let mut opts = SessionOptions::default();
+        opts.ttl_seconds = 4000;
+        let err = pool.acquire(opts).await.unwrap_err();
+        assert_eq!(err.kind(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn acquire_rejects_headed_when_disabled() {
+        let pool = Pool::new(cfg());
+        let mut opts = SessionOptions::default();
+        opts.headed = true;
+        let err = pool.acquire(opts).await.unwrap_err();
+        assert_eq!(err.kind(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn release_unknown_404s() {
+        let pool = Pool::new(cfg());
+        let err = pool.release(&SessionId::new()).await.unwrap_err();
+        assert_eq!(err.kind(), "session_not_found");
+    }
+
+    #[tokio::test]
+    async fn list_empty_in_pr1() {
+        let pool = Pool::new(cfg());
+        assert!(pool.list().await.is_empty());
+        assert_eq!(pool.active_count().await, 0);
+    }
+
+    #[test]
+    fn build_info_populates_token_and_expiry() {
+        let opts = SessionOptions::default();
+        let id = SessionId::new();
+        let info = build_info(
+            id.clone(),
+            &opts,
+            "Chromium/stub".into(),
+            format!("ws://127.0.0.1:4318/api/browser/sessions/{id}/cdp?token=stub"),
+        );
+        assert_eq!(info.id, id);
+        assert!(!info.token.is_empty());
+        assert!(info.expires_at > info.created_at);
+        assert_eq!(info.status, SessionStatus::Active);
+    }
+}

--- a/kernel/crates/gctrl-browser/src/pool.rs
+++ b/kernel/crates/gctrl-browser/src/pool.rs
@@ -150,8 +150,10 @@ mod tests {
     #[tokio::test]
     async fn acquire_rejects_zero_ttl() {
         let pool = Pool::new(cfg());
-        let mut opts = SessionOptions::default();
-        opts.ttl_seconds = 0;
+        let opts = SessionOptions {
+            ttl_seconds: 0,
+            ..Default::default()
+        };
         let err = pool.acquire(opts).await.unwrap_err();
         assert_eq!(err.kind(), "invalid_request");
     }
@@ -159,8 +161,10 @@ mod tests {
     #[tokio::test]
     async fn acquire_rejects_oversized_ttl() {
         let pool = Pool::new(cfg());
-        let mut opts = SessionOptions::default();
-        opts.ttl_seconds = 4000;
+        let opts = SessionOptions {
+            ttl_seconds: 4000,
+            ..Default::default()
+        };
         let err = pool.acquire(opts).await.unwrap_err();
         assert_eq!(err.kind(), "invalid_request");
     }
@@ -168,8 +172,10 @@ mod tests {
     #[tokio::test]
     async fn acquire_rejects_headed_when_disabled() {
         let pool = Pool::new(cfg());
-        let mut opts = SessionOptions::default();
-        opts.headed = true;
+        let opts = SessionOptions {
+            headed: true,
+            ..Default::default()
+        };
         let err = pool.acquire(opts).await.unwrap_err();
         assert_eq!(err.kind(), "invalid_request");
     }

--- a/kernel/crates/gctrl-browser/src/token.rs
+++ b/kernel/crates/gctrl-browser/src/token.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// Per-session bearer token for the CDP attach WebSocket. Stored in-memory
+/// only — never persisted to DuckDB. Treated as opaque; clients pass it
+/// either as `?token=...` on the URL or as `Authorization: Bearer ...`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Token(pub String);
+
+impl Token {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Mint a fresh URL-safe token. Uses UUIDv4 in PR1; PR2 will replace this
+/// with 32 bytes from `getrandom` encoded as URL-safe base64. The kind is
+/// captured in this single function so the upgrade is one edit.
+pub fn mint_token() -> Token {
+    Token(uuid::Uuid::new_v4().simple().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_are_unique() {
+        let a = mint_token();
+        let b = mint_token();
+        assert_ne!(a, b);
+        assert!(!a.as_str().is_empty());
+    }
+}

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -16,6 +16,7 @@ gctrl-scheduler = { path = "../gctrl-scheduler" }
 gctrl-proxy = { path = "../gctrl-proxy" }
 gctrl-gcal = { path = "../gctrl-gcal" }
 gctrl-driver-macos = { path = "../gctrl-driver-macos" }
+gctrl-browser = { path = "../gctrl-browser" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/browser_routes.rs
+++ b/kernel/crates/gctrl-otel/src/browser_routes.rs
@@ -1,0 +1,289 @@
+//! driver-browser HTTP routes (CDP attach layer).
+//!
+//! Mounts `/api/browser/*` onto the kernel router. PR1 surfaces the route
+//! shape with stub responses so clients can be wired against the contract
+//! before the Chromium pool is implemented in PR2:
+//!
+//! - `GET  /api/browser/health`       — implemented (real config + active count)
+//! - `GET  /api/browser/sessions`     — `[]` (pool is empty)
+//! - `POST /api/browser/sessions`     — `501 Not Implemented` (pool stub returns `Launch`)
+//! - `DELETE /api/browser/sessions/:id` — `404 Not Found`
+//! - `GET  /api/browser/sessions/:id` — `404 Not Found`
+//! - `WS   /api/browser/sessions/:id/cdp` — `501 Not Implemented`
+//!
+//! Recorder routes (`/api/browser/sessions/:id/{network,console,metrics,report}`)
+//! are not mounted here — they ship with `gctrl-recorder` in PR3.
+//!
+//! Spec: `vault/specs/implementation/kernel/driver-browser.md`.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use gctrl_browser::{BrowserConfig, BrowserError, Pool, SessionId, SessionOptions};
+use serde::Serialize;
+use serde_json::json;
+use tokio::sync::OnceCell;
+
+#[derive(Clone)]
+struct BrowserState {
+    pool: Arc<Pool>,
+}
+
+static STATE: OnceCell<BrowserState> = OnceCell::const_new();
+
+async fn state() -> BrowserState {
+    STATE
+        .get_or_init(|| async {
+            let cfg = Arc::new(BrowserConfig::default().with_env_overrides());
+            BrowserState {
+                pool: Arc::new(Pool::new(cfg)),
+            }
+        })
+        .await
+        .clone()
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HealthResponse {
+    /// `null` until PR2 wires Chromium launch.
+    chromium_version: Option<String>,
+    active_sessions: usize,
+    pool_max: u32,
+    contexts_per_chromium_max: u32,
+    recycle_idle_seconds: u64,
+    recycle_max_age_seconds: u64,
+}
+
+async fn health() -> impl IntoResponse {
+    let st = state().await;
+    let cfg = st.pool.config();
+    let body = HealthResponse {
+        chromium_version: None,
+        active_sessions: st.pool.active_count().await,
+        pool_max: cfg.pool_max,
+        contexts_per_chromium_max: cfg.contexts_per_chromium_max,
+        recycle_idle_seconds: cfg.recycle_idle_seconds,
+        recycle_max_age_seconds: cfg.recycle_max_age_seconds,
+    };
+    Json(body)
+}
+
+async fn list_sessions() -> impl IntoResponse {
+    let st = state().await;
+    Json(st.pool.list().await)
+}
+
+async fn create_session(Json(opts): Json<SessionOptions>) -> impl IntoResponse {
+    let st = state().await;
+    match st.pool.acquire(opts).await {
+        Ok(info) => (StatusCode::CREATED, Json(serde_json::to_value(info).unwrap()))
+            .into_response(),
+        Err(e) => err_response(e).into_response(),
+    }
+}
+
+async fn get_session(Path(id): Path<String>) -> impl IntoResponse {
+    let st = state().await;
+    let sid = SessionId::from(id);
+    match st.pool.get(&sid).await {
+        Some(info) => Json(info).into_response(),
+        None => err_response(BrowserError::SessionNotFound(sid)).into_response(),
+    }
+}
+
+async fn delete_session(Path(id): Path<String>) -> impl IntoResponse {
+    let st = state().await;
+    let sid = SessionId::from(id);
+    match st.pool.release(&sid).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => err_response(e).into_response(),
+    }
+}
+
+async fn cdp_attach_stub(Path(_id): Path<String>) -> impl IntoResponse {
+    // PR2 will replace this with a WebSocket upgrade handler that validates
+    // the bearer token and proxies CDP frames bidirectionally between the
+    // client and the per-session Chromium endpoint.
+    err_response(BrowserError::Cdp(
+        "cdp websocket attach is not implemented in PR1 — lands in PR2".into(),
+    ))
+}
+
+fn err_response(e: BrowserError) -> (StatusCode, Json<serde_json::Value>) {
+    let status = status_for(&e);
+    let body = Json(json!({
+        "error": e.kind(),
+        "message": e.to_string(),
+    }));
+    (status, body)
+}
+
+fn status_for(e: &BrowserError) -> StatusCode {
+    match e {
+        BrowserError::PoolExhausted { .. } => StatusCode::TOO_MANY_REQUESTS,
+        BrowserError::SessionNotFound(_) => StatusCode::NOT_FOUND,
+        BrowserError::SessionExpired(_) => StatusCode::GONE,
+        BrowserError::InvalidToken(_) => StatusCode::UNAUTHORIZED,
+        BrowserError::RecordingDisabled => StatusCode::CONFLICT,
+        BrowserError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+        // PR1 stub paths land here:
+        BrowserError::Launch(_) | BrowserError::Cdp(_) => StatusCode::NOT_IMPLEMENTED,
+    }
+}
+
+pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
+    Router::new()
+        .route("/api/browser/health", get(health))
+        .route(
+            "/api/browser/sessions",
+            get(list_sessions).post(create_session),
+        )
+        .route(
+            "/api/browser/sessions/{id}",
+            get(get_session).delete(delete_session),
+        )
+        .route("/api/browser/sessions/{id}/cdp", get(cdp_attach_stub))
+}
+
+// State is consumed via the OnceCell above; the parameter exists so route
+// composition stays uniform with neighbouring routers.
+#[allow(dead_code)]
+fn _state_param_marker(_: State<()>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        router::<()>().with_state(())
+    }
+
+    #[tokio::test]
+    async fn health_reports_pool_config() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/browser/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(v["chromiumVersion"].is_null());
+        assert_eq!(v["activeSessions"], 0);
+        assert_eq!(v["poolMax"], 4);
+    }
+
+    #[tokio::test]
+    async fn list_sessions_empty_in_pr1() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/browser/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(v.is_array());
+        assert_eq!(v.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn create_session_returns_501_in_pr1() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/browser/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"], "launch_failed");
+    }
+
+    #[tokio::test]
+    async fn create_session_validates_ttl() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/browser/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"ttlSeconds": 9999}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn get_unknown_session_404s() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/browser/sessions/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_unknown_session_404s() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/browser/sessions/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cdp_attach_stub_returns_501() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/browser/sessions/abc/cdp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/kernel/crates/gctrl-otel/src/browser_routes.rs
+++ b/kernel/crates/gctrl-otel/src/browser_routes.rs
@@ -19,7 +19,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, State},
+    extract::Path,
     http::StatusCode,
     response::IntoResponse,
     routing::get,
@@ -138,6 +138,11 @@ fn status_for(e: &BrowserError) -> StatusCode {
     }
 }
 
+/// Build the `/api/browser/*` router. State is held in an internal
+/// `OnceCell` so the same `Pool` is reused across requests within the
+/// daemon. The router is parameterized over an arbitrary state type `S`
+/// so it composes with `Router<()>` in `build_router` and any other
+/// state type used by tests.
 pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
     Router::new()
         .route("/api/browser/health", get(health))
@@ -151,11 +156,6 @@ pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
         )
         .route("/api/browser/sessions/{id}/cdp", get(cdp_attach_stub))
 }
-
-// State is consumed via the OnceCell above; the parameter exists so route
-// composition stays uniform with neighbouring routers.
-#[allow(dead_code)]
-fn _state_param_marker(_: State<()>) {}
 
 #[cfg(test)]
 mod tests {

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod browser_routes;
 pub mod contributions;
 pub mod event_bus;
 pub mod gcal_routes;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -364,6 +364,10 @@ fn build_router(state: Arc<AppState>) -> Router {
                 spaces_state,
             })
         })
+        // Browser driver (LKM — CDP attach layer; PR1 stubs the pool, real
+        // chromium launch + WS proxy land in PR2). Recorder routes ship
+        // with gctrl-recorder in PR3.
+        .merge(crate::browser_routes::router::<()>())
 }
 
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/vault/specs/architecture/kernel/browser.md
+++ b/vault/specs/architecture/kernel/browser.md
@@ -223,6 +223,8 @@ gctrl browser stop
 
 All endpoints under `/api/browser/*`, protected by the daemon's bearer token.
 
+### Agent command layer (high-level — this document)
+
 ```
 POST /api/browser/command    { "command": "snapshot", "args": ["-i"] }
 GET  /api/browser/status
@@ -231,6 +233,21 @@ POST /api/browser/stop
 ```
 
 Response format: plain text for agent consumption (minimal token overhead). Errors include actionable guidance.
+
+### CDP attach layer (low-level — see implementation spec)
+
+Underneath the agent commands, the same `gctrl-browser` crate exposes a **raw CDP attach endpoint** for clients that want to drive Chromium directly via Chrome DevTools Protocol — primarily Playwright-based acceptance tests in apps. Each acquired session is a `BrowserContext` on a pooled Chromium; clients connect via `chromium.connectOverCDP(<cdpEndpoint>)` and observation (network, console, performance, screenshots) is captured by a sibling `gctrl-recorder` crate and queryable as JSON.
+
+```
+POST   /api/browser/sessions                      { viewport, recording, ttlSeconds }
+GET    /api/browser/sessions
+DELETE /api/browser/sessions/:id
+WS     /api/browser/sessions/:id/cdp?token=...    # raw CDP, per-session bearer-gated
+GET    /api/browser/sessions/:id/{network,console,metrics,report}
+GET    /api/browser/health
+```
+
+The agent command layer is itself implemented on top of this — `gctrl browser snapshot` acquires a session under the hood. See [vault/specs/implementation/kernel/driver-browser.md](../../implementation/kernel/driver-browser.md) for the pool semantics, recycle policy, recording cap, configuration schema, and migration plan.
 
 ---
 

--- a/vault/specs/implementation/kernel/driver-browser.md
+++ b/vault/specs/implementation/kernel/driver-browser.md
@@ -1,0 +1,395 @@
+# driver-browser — Implementation Details
+
+Implementation spec for the **CDP attach layer** of `gctrl-browser`. The agent-facing high-level command surface (snapshot/click/fill/refs) is defined in [vault/specs/architecture/kernel/browser.md](../../architecture/kernel/browser.md). This file specifies the **lower layer** that everything else sits on:
+
+1. A pool of warm Chromium processes managed by the kernel.
+2. A WebSocket endpoint (`/api/browser/sessions/:id/cdp`) that exposes the raw Chrome DevTools Protocol so any client (Playwright, Puppeteer, chromiumoxide, raw WS) can attach.
+3. A `gctrl-recorder` crate that subscribes to CDP frames from L1, structures Network/Runtime/Performance events, and exposes them as queries.
+
+Together this lets app acceptance suites (today: `apps/gctrl-board/tests/acceptance/`) drop their per-app `CDPObserver` fixture and instead acquire a session from the kernel, drive it via Playwright `chromium.connectOverCDP(...)`, and assert against the recorder's report.
+
+---
+
+## 1. Why two crates
+
+| Crate | Lifetime | Hot path | Concerns |
+|---|---|---|---|
+| `gctrl-browser` (L1) | one process per Chromium recycle | Yes — every CDP frame proxies through it | Lifecycle, pool, token auth, raw WS proxy |
+| `gctrl-recorder` (L2) | per session, then queryable forever | No — async fanout from L1's frame stream | Structured trace capture, DuckDB persistence, query routes |
+
+L1 stays small and fast. L2 absorbs all the "what happened" complexity. Apps that only want a browser (agent scrapers, future LLM browse skill) depend on L1 alone. Tests use both.
+
+---
+
+## 2. L1 — `gctrl-browser` crate
+
+```
+kernel/crates/gctrl-browser/
+  src/
+    lib.rs            # Public API re-exports
+    error.rs          # BrowserError (thiserror)
+    model.rs          # SessionId, SessionOptions, RecordingOptions, SessionInfo
+    pool.rs           # Pool<Chromium> — lifecycle, recycle policy, concurrency cap
+    session.rs        # Session — one BrowserContext per session id
+    token.rs          # Mint + verify short-lived bearer tokens for CDP attach
+    cdp_proxy.rs      # WS proxy: client ⇆ kernel ⇆ Chromium (with frame fanout tap)
+    config.rs         # BrowserConfig (loaded from env + kernel config.toml [browser])
+  Cargo.toml
+```
+
+### Public API
+
+```rust
+pub struct Browser {
+    pool: Pool,
+    config: Arc<BrowserConfig>,
+}
+
+impl Browser {
+    pub async fn acquire(&self, opts: SessionOptions) -> Result<SessionInfo, BrowserError>;
+    pub async fn release(&self, id: &SessionId) -> Result<(), BrowserError>;
+    pub async fn list(&self) -> Vec<SessionInfo>;
+    pub async fn get(&self, id: &SessionId) -> Option<SessionInfo>;
+
+    /// Subscribe to the raw CDP frame stream for a session. The recorder
+    /// is the only caller; the channel is bounded and lossy when the
+    /// recorder falls behind (recording is best-effort, not lockstep).
+    pub fn subscribe(&self, id: &SessionId) -> Option<broadcast::Receiver<CdpFrame>>;
+}
+```
+
+### `SessionOptions` / `SessionInfo`
+
+```rust
+pub struct SessionOptions {
+    pub viewport: Option<Viewport>,         // default 1280x720
+    pub headed: bool,                        // default false; true requires display server
+    pub recording: RecordingOptions,
+    pub ttl_seconds: u32,                    // default 600 (10 min); max 3600
+}
+
+pub struct RecordingOptions {
+    pub network: bool,    // default true
+    pub console: bool,    // default true
+    pub performance: bool,// default true
+    pub screenshots: bool,// default false
+    pub full: bool,       // default false; capture every CDP frame (high volume)
+    pub max_bytes: u64,   // default 50 * 1024 * 1024
+}
+
+pub struct SessionInfo {
+    pub id: SessionId,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub browser_version: String,
+    pub status: SessionStatus,
+    pub recording: RecordingOptions,
+    pub cdp_endpoint: String,                // ws://127.0.0.1:4318/api/browser/sessions/<id>/cdp?token=...
+    pub token: String,                       // bearer; also embedded in cdp_endpoint
+}
+
+pub enum SessionStatus { Active, Releasing, Expired }
+```
+
+### `BrowserError`
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum BrowserError {
+    #[error("browser pool exhausted (max={max})")]
+    PoolExhausted { max: u32 },
+
+    #[error("session not found: {0}")]
+    SessionNotFound(SessionId),
+
+    #[error("session expired: {0}")]
+    SessionExpired(SessionId),
+
+    #[error("invalid token for session {0}")]
+    InvalidToken(SessionId),
+
+    #[error("recording disabled for this session")]
+    RecordingDisabled,
+
+    #[error("chromium launch failed: {0}")]
+    Launch(String),
+
+    #[error("cdp protocol error: {0}")]
+    Cdp(String),
+}
+```
+
+The kernel's HTTP route layer maps each variant to a status: `PoolExhausted` → 429 with `Retry-After`, `SessionNotFound` → 404, `SessionExpired` → 410, `InvalidToken` → 401, `RecordingDisabled` → 409, `Launch` / `Cdp` → 502.
+
+### Pool semantics — context-per-session, time-based recycle
+
+Confirmed design (May 2026):
+
+- **Context-per-session.** One Chromium process can host many `BrowserContext` instances. Each `acquire()` creates a fresh context; each `release()` (or TTL expiry) closes it. This is faster than spawning a Chromium per session and isolates cookies / storage / service-workers per test.
+- **Time-based recycle.** A Chromium process is recycled when **any** of:
+  - `idle_seconds >= recycle_idle_seconds` (default `1800` — 30 min) **and** zero active sessions on it; **or**
+  - `age_seconds >= recycle_max_age_seconds` (default `28_800` — 8 h), regardless of activity, by graceful drain (mark draining, refuse new sessions, kill once last session releases).
+- **Pool sizing.** `pool_max` default `4`. When all Chromiums are saturated, `acquire()` returns `PoolExhausted` immediately (no implicit queueing — clients can retry with backoff if they want).
+- **Concurrency per Chromium.** `contexts_per_chromium_max` default `8`. New sessions land on the warmest non-saturated Chromium; spin a new one only if all are saturated and `pool_max` allows.
+
+### Token model
+
+CDP gives arbitrary code execution against the page. The WS proxy MUST validate a per-session bearer token on every connection upgrade.
+
+- Tokens are random 32-byte URL-safe base64 strings, generated via `getrandom`.
+- Stored in-memory only (never written to DuckDB) — they expire when the session does.
+- Embedded in `cdp_endpoint` as `?token=...` for client convenience; also accepted as `Authorization: Bearer <token>` for clients that prefer headers.
+- On expiry / release, the token is invalidated and any active WS is closed with code `4001 session_expired`.
+
+### CDP proxy
+
+```
+client (Playwright)
+   │  ws://127.0.0.1:4318/api/browser/sessions/<id>/cdp?token=...
+   ▼
+axum WS handler (validates token, looks up session)
+   │  pipes frames bidirectionally
+   ▼
+chromium ws://127.0.0.1:<random>/devtools/browser/<id>
+   │
+   └── frame tap → tokio::sync::broadcast::Sender<CdpFrame> (recorder subscribes)
+```
+
+The tap is a `broadcast` channel with capacity 1024 frames per session. If the recorder falls behind, the oldest frames are dropped — the proxy is the hot path and MUST NOT block on the recorder. A drop counter is exposed on the session info for observability.
+
+---
+
+## 3. L2 — `gctrl-recorder` crate
+
+```
+kernel/crates/gctrl-recorder/
+  src/
+    lib.rs            # Public API
+    capture.rs        # CaptureSink: subscribes to L1 broadcast, parses CDP frames
+    structured.rs     # CapturedRequest, ConsoleEntry, MetricSample, Screenshot
+    storage.rs        # DuckDB writers — bounded by RecordingOptions.max_bytes
+    report.rs         # ObservabilityReport (matches today's CDPObserver shape)
+    error.rs
+  Cargo.toml
+```
+
+The structured types **mirror today's** `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts` (`CapturedRequest`, `ConsoleEntry`, `ObservabilityReport`) so the migration in PR4 swaps an HTTP fetch in place of an in-process method call without changing assertion code.
+
+### DDL — schema lives in `gctrl-storage`
+
+Per Crate Ownership rule, all DDL co-locates in `gctrl-storage::schema`. Recorder tables follow the existing `recorder_*` namespace pattern:
+
+```sql
+CREATE TABLE IF NOT EXISTS browser_sessions (
+    id              VARCHAR PRIMARY KEY,
+    created_at      VARCHAR NOT NULL,
+    released_at     VARCHAR,
+    browser_version VARCHAR NOT NULL,
+    options_json    VARCHAR NOT NULL,
+    status          VARCHAR NOT NULL,           -- 'active' | 'released' | 'expired'
+    recorded_bytes  BIGINT NOT NULL DEFAULT 0,
+    dropped_frames  BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS recorder_requests (
+    session_id    VARCHAR NOT NULL,
+    request_id    VARCHAR NOT NULL,
+    url           VARCHAR NOT NULL,
+    method        VARCHAR NOT NULL,
+    status        INTEGER,
+    headers_json  VARCHAR,
+    timings_json  VARCHAR,
+    ts            VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, request_id)
+);
+
+CREATE TABLE IF NOT EXISTS recorder_console (
+    session_id  VARCHAR NOT NULL,
+    seq         BIGINT NOT NULL,
+    level       VARCHAR NOT NULL,                -- 'info' | 'warn' | 'error' | 'exception'
+    type        VARCHAR NOT NULL,
+    text        VARCHAR NOT NULL,
+    ts          VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, seq)
+);
+
+CREATE TABLE IF NOT EXISTS recorder_metrics (
+    session_id  VARCHAR NOT NULL,
+    name        VARCHAR NOT NULL,
+    value       DOUBLE NOT NULL,
+    ts          VARCHAR NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS recorder_cdp_events (
+    session_id  VARCHAR NOT NULL,
+    seq         BIGINT NOT NULL,
+    method      VARCHAR NOT NULL,
+    params_json VARCHAR NOT NULL,
+    ts          VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, seq)
+);
+```
+
+`recorder_cdp_events` is the high-volume table — only populated when `RecordingOptions.full = true`. The other three are sampled and capped by `max_bytes`.
+
+### Recording cap enforcement
+
+Per session, the capture sink tracks bytes written so far. When `recorded_bytes >= max_bytes`:
+
+- For structured tables (`recorder_requests`, `recorder_console`, `recorder_metrics`): keep accepting but increment a counter exposed on `SessionInfo.dropped_due_to_cap` and stop persisting.
+- For `recorder_cdp_events`: stop persisting silently (full mode is opt-in for debugging; users who set it accept the volume).
+
+Default `max_bytes = 50 * 1024 * 1024` (50 MiB). Override per-session via `recording.max_bytes`.
+
+---
+
+## 4. HTTP routes
+
+All routes live in `kernel/crates/gctrl-otel/src/browser_routes.rs`, mounted via `.merge(crate::browser_routes::router::<()>())` in `build_router()` — same pattern as `gcal_routes`.
+
+### L1 routes (provided by `gctrl-browser`)
+
+| Method | Path | Status in PR1 | Behavior |
+|---|---|---|---|
+| `POST` | `/api/browser/sessions` | stub → `501 not_implemented` | Acquire a session; returns `SessionInfo` |
+| `DELETE` | `/api/browser/sessions/:id` | stub → `501` | Release immediately |
+| `GET` | `/api/browser/sessions` | stub → `200 []` | List active sessions |
+| `GET` | `/api/browser/sessions/:id` | stub → `404` | Get one session |
+| `WS` | `/api/browser/sessions/:id/cdp` | stub → `501` | Token-gated CDP attach |
+| `GET` | `/api/browser/health` | implemented in PR1 | `{ chromiumVersion: null, activeSessions: 0, poolMax }` until L1 lands |
+
+### L2 routes (provided by `gctrl-recorder`)
+
+| Method | Path | Status in PR1 | Behavior |
+|---|---|---|---|
+| `GET` | `/api/browser/sessions/:id/network` | not in PR1 | List `CapturedRequest[]` |
+| `GET` | `/api/browser/sessions/:id/console` | not in PR1 | List `ConsoleEntry[]` |
+| `GET` | `/api/browser/sessions/:id/metrics` | not in PR1 | `{ name: value, ... }` |
+| `GET` | `/api/browser/sessions/:id/report` | not in PR1 | `ObservabilityReport` |
+| `POST` | `/api/browser/sessions/:id/screenshot` | not in PR1 | `image/png` |
+| `POST` | `/api/browser/replays` | not in PR1 | Create a replay session from a recorded trace |
+
+### Request/response shapes
+
+```jsonc
+// POST /api/browser/sessions
+{
+  "viewport":  { "width": 1280, "height": 720 },
+  "headed":    false,
+  "ttlSeconds": 600,
+  "recording": {
+    "network":     true,
+    "console":     true,
+    "performance": true,
+    "screenshots": false,
+    "full":        false,
+    "maxBytes":    52428800
+  }
+}
+
+// 201 response
+{
+  "id":             "01HV…",
+  "createdAt":      "2026-05-02T10:00:00Z",
+  "expiresAt":      "2026-05-02T10:10:00Z",
+  "browserVersion": "Chromium/124.0.6367.78",
+  "status":         "active",
+  "recording":      { /* echoed */ },
+  "cdpEndpoint":    "ws://127.0.0.1:4318/api/browser/sessions/01HV…/cdp?token=…",
+  "token":          "…"
+}
+```
+
+---
+
+## 5. Configuration
+
+Daemon config lives in `~/.config/gctrl/config.toml` under `[browser]`. Per-session overrides flow through the `POST /api/browser/sessions` body — config defines defaults, request defines exceptions. Env vars override file for ops convenience.
+
+```toml
+[browser]
+pool_max                     = 4
+contexts_per_chromium_max    = 8
+recycle_idle_seconds         = 1800        # 30 min
+recycle_max_age_seconds      = 28800       # 8 h
+default_ttl_seconds          = 600         # 10 min
+default_recording_max_bytes  = 52428800    # 50 MiB
+chromium_path                = ""          # empty = autodetect
+headed_default               = false       # true requires display server
+```
+
+Env overrides (same prefix as other gctrl drivers):
+
+| Env var | Maps to |
+|---|---|
+| `GCTRL_BROWSER_POOL_MAX` | `pool_max` |
+| `GCTRL_BROWSER_RECYCLE_IDLE_SECS` | `recycle_idle_seconds` |
+| `GCTRL_BROWSER_RECYCLE_MAX_AGE_SECS` | `recycle_max_age_seconds` |
+| `GCTRL_BROWSER_DEFAULT_TTL_SECS` | `default_ttl_seconds` |
+| `GCTRL_BROWSER_CHROMIUM_PATH` | `chromium_path` |
+
+---
+
+## 6. Security
+
+- **127.0.0.1 only.** The kernel daemon already binds loopback. The CDP WS proxy MUST refuse upgrades from non-loopback origins even if a future config exposes the daemon — CDP = arbitrary RCE.
+- **Per-session bearer token** validated on every WS upgrade. Tokens never logged.
+- **No headed mode without display server.** PR1 returns `400 invalid_request` for `headed: true` if `DISPLAY` is unset; CI uses xvfb.
+- **No third-party origin reach by default.** When `gctrl-guardrails` lands a `BrowserDomainAllowlist` policy (out of scope here), the proxy will consult it before each `Network.requestWillBeSent` and abort disallowed requests via `Fetch.failRequest`. PR1 just hooks the policy; the policy itself is a follow-up.
+
+---
+
+## 7. OTel integration
+
+Every L1 operation creates a span on the kernel's existing OTel pipeline:
+
+| Operation | Span name | Notable attributes |
+|---|---|---|
+| `acquire` | `browser.session.acquire` | `browser.pool_max`, `browser.pool_active` |
+| `release` | `browser.session.release` | `browser.session.duration_ms` |
+| WS upgrade | `browser.cdp.attach` | `browser.session.id` |
+| Recycle | `browser.chromium.recycle` | `browser.recycle.reason` (`idle` \| `max_age`), `browser.chromium.age_ms` |
+
+CDP frame proxy itself is **not** spanned per-frame (volume too high). Top-level CDP method calls from the client *can* be spanned if `recording.full = true`, derived from `recorder_cdp_events`.
+
+---
+
+## 8. Migration plan
+
+| PR | Scope | This PR? |
+|---|---|---|
+| 1 | Spec + scaffold `gctrl-browser` (types, errors, pool stub, route stubs returning 501) + workspace registration + light update to `architecture/kernel/browser.md` | **yes** |
+| 2 | Implement L1: real Chromium pool via `chromiumoxide`, WS proxy, token mint/verify, OTel spans, recycle loop | no |
+| 3 | Add `gctrl-recorder` crate; subscribe to L1 broadcast; DuckDB tables; observation routes + tests | no |
+| 4 | `KernelBrowserClient` Effect-TS adapter in `shell/gctrl-shell/src/services/`; mock-layer tests | no |
+| 5 | Migrate `apps/gctrl-board/tests/acceptance/`: introduce `BROWSER_BACKEND={kernel,local}` env flag; require both green for one CI cycle; then delete `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts` and the local-backend code path | no |
+| 6 | (Additive) `gctrl-net` SPA mode using kernel browser; replay endpoint | no |
+
+Each PR is independently mergeable: PR2 turns the stubs into real behavior; PR3 starts populating the recorder tables that PR2 wrote nothing to; PR4/5 are pure consumer changes.
+
+---
+
+## 9. Test parity gate (PR5 detail)
+
+The cutover risk lives in PR5. To avoid silent regressions:
+
+- Introduce `BROWSER_BACKEND` env var in `apps/gctrl-board/tests/acceptance/fixtures/test.ts`. Values: `local` (today's behavior — Playwright launches its own Chromium and uses in-process `CDPObserver`), `kernel` (new — `KernelBrowserClient.acquire()` + `chromium.connectOverCDP(...)` + `kernel.report()` query).
+- CI runs the full acceptance suite **twice** for one cycle, once per backend. Both must pass.
+- Once green for one cycle, delete the `local` branch + `cdp.ts` (~237 lines) + the `BROWSER_BACKEND` switch.
+
+---
+
+## 10. Open items deferred past PR1
+
+- Whether `Network.requestWillBeSent` cancellation for guardrail enforcement is in PR2 or a later guardrails PR.
+- Replay semantics: does `POST /api/browser/replays` re-execute against the *current* SPA build (drift-detection) or pin to the snapshot's commit hash?
+- Headed-mode CI image (xvfb-equipped runner). Defer until PR2 actually needs it.
+
+---
+
+## See also
+
+- Architecture: [vault/specs/architecture/kernel/browser.md](../../architecture/kernel/browser.md)
+- Existing per-app CDP observer being replaced: `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts`
+- Existing per-app CDP test cases: `apps/gctrl-board/tests/acceptance/cdp-observability.spec.ts`
+- Reference driver pattern: `kernel/crates/gctrl-gcal/` + `kernel/crates/gctrl-otel/src/gcal_routes.rs`


### PR DESCRIPTION
## Summary

PR1 of a 6-PR plan to extract CDP/Playwright concerns out of per-app test fixtures and into a kernel-owned LKM. This PR lands the **spec** and the **wire contract** (route shapes + types + tests). Real Chromium pool + WS proxy land in PR2; recorder + observation routes in PR3.

Today every app re-implements its own `CDPObserver` (see `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts`, ~237 lines). With this driver, app fixtures shrink to `acquire → connectOverCDP → drive → report → release` and the observation logic moves into the kernel where it can be queried, persisted, and reused by future agent skills.

## Design decisions (locked)

1. **Context-per-session.** One Chromium hosts many `BrowserContext`s; each session gets its own context for cookie/storage isolation.
2. **Time-based recycle.** Recycle a Chromium when idle ≥ 30 min (zero active sessions) **or** absolute age ≥ 8 h, whichever first; latter is a graceful drain.
3. **`pool_max = 4`** default; saturated pool returns `429 Too Many Requests` (no implicit queueing).
4. **Recording cap = 50 MiB / session** default; `recording.full = true` opt-in for full CDP frame capture.
5. **Headed mode behind `?headed=1`**, gated by config + display server (xvfb in CI).
6. **Test parity gate (PR5):** `BROWSER_BACKEND={kernel,local}` flag, both green for one CI cycle before deleting the local backend.

Full design in `vault/specs/implementation/kernel/driver-browser.md`.

## What lands in this PR

### Spec
- `vault/specs/implementation/kernel/driver-browser.md` — implementation spec (340 lines): L1/L2 split, pool semantics, token model, DDL, routes, config, security, OTel, migration plan.
- `vault/specs/architecture/kernel/browser.md` — added a "CDP attach layer" section that points at the implementation spec; the existing agent-command surface (snapshot/click/fill) sits on top.

### Crate `kernel/crates/gctrl-browser`
- Public types: `SessionId`, `SessionOptions`, `RecordingOptions`, `SessionInfo`, `SessionStatus`, `BrowserError`, `Pool`, `BrowserConfig`, `Token`.
- `Pool::acquire` validates inputs (TTL ∈ (0, 3600], `recording.max_bytes > 0`, headed-mode gate, pool capacity) then returns `Launch("not implemented in PR1")` so callers can wire against the contract before PR2 brings up Chromium.
- `BrowserConfig::with_env_overrides()` reads `GCTRL_BROWSER_{POOL_MAX,RECYCLE_IDLE_SECS,RECYCLE_MAX_AGE_SECS,DEFAULT_TTL_SECS,CHROMIUM_PATH}`.
- 9 unit tests cover defaults, every validation path, token uniqueness, and the `SessionInfo` skeleton builder.

### Routes `kernel/crates/gctrl-otel/src/browser_routes.rs`
| Method | Path | PR1 status |
|---|---|---|
| `GET` | `/api/browser/health` | real (config + active count, version `null`) |
| `GET` | `/api/browser/sessions` | real (`[]` until pool populates) |
| `POST` | `/api/browser/sessions` | `400` for bad input, `501 launch_failed` for valid input |
| `GET` | `/api/browser/sessions/{id}` | `404` |
| `DELETE` | `/api/browser/sessions/{id}` | `404` |
| `GET` | `/api/browser/sessions/{id}/cdp` | `501` (WS upgrade lands in PR2) |

Mounted via `.merge(crate::browser_routes::router::<()>())` in `build_router`, mirroring the `gcal_routes` pattern. 7 axum oneshot tests cover every status path.

## Architecture

```mermaid
flowchart LR
  subgraph App["App / Test Suite"]
    PW[Playwright Test]
    SPA[App SPA]
  end
  subgraph Kernel["gctrl kernel :4318"]
    DB["driver-browser<br/>(this PR — stub pool)"]
    DR["driver-recorder<br/>(PR3)"]
    BAPI["/api/board/* etc"]
    DUCK[("DuckDB")]
  end
  Chrome[(Chromium pool — PR2)]

  PW -- "POST /api/browser/sessions" --> DB
  PW -- "chromium.connectOverCDP(wsUrl)" --> DB
  DB -. spawn/pool .-> Chrome
  DB <-- raw CDP WS --> Chrome
  DB -- frames --> DR
  DR --> DUCK
  PW -- drive page --> Chrome
  Chrome --> SPA
  SPA -- HTTP --> BAPI
  PW -- "GET .../report" --> DR
```

## Migration plan

| PR | Scope | Status |
|---|---|---|
| **1** | **Spec + scaffold + route stubs (this PR)** | **here** |
| 2 | Real `chromiumoxide` pool, WS proxy, token verify, OTel spans, recycle loop | next |
| 3 | `gctrl-recorder` crate, DuckDB tables, observation routes | |
| 4 | `KernelBrowserClient` Effect-TS adapter | |
| 5 | Migrate `gctrl-board` acceptance behind `BROWSER_BACKEND` flag, parity for one cycle, then delete local backend | |
| 6 | (Additive) `gctrl-net` SPA mode + replay endpoint | |

## Test plan

- [x] `cargo test -p gctrl-browser` → 9 passed
- [x] `cargo test -p gctrl-otel --lib browser_routes` → 7 passed
- [x] `cargo build --workspace` → clean
- [ ] Manual: hit `GET /api/browser/health` against a running daemon (PR1 stubs the pool, so health is the only meaningful manual check)
- [ ] CI green
