### PR TITLE
feat(gctrl-board): macOS Spaces panel + AX permission CTA

### DIFF
--- a/apps/gctrl-board/web/src/App.tsx
+++ b/apps/gctrl-board/web/src/App.tsx
@@ -11,6 +11,7 @@ import { ProjectSelector } from "./components/ProjectSelector"
 import { NavSidebar } from "./components/NavSidebar"
 import { InboxPage } from "./pages/InboxPage"
 import { AnalyticsPage } from "./pages/AnalyticsPage"
+import { MacosSpacesPage } from "./pages/MacosSpacesPage"
 import { api } from "./api/client"
 import type { Issue, InboxStats } from "./types"
 
@@ -232,7 +233,9 @@ export function App() {
       ? "inbox"
       : route.page === "analytics"
         ? "analytics"
-        : "board"
+        : route.page === "settings"
+          ? "settings"
+          : "board"
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-200 font-body grid-bg flex">
@@ -363,6 +366,8 @@ export function App() {
           </>
         ) : route.page === "inbox" ? (
           <InboxPage />
+        ) : route.page === "settings" ? (
+          <MacosSpacesPage />
         ) : (
           <AnalyticsPage route={route} navigate={navigate} />
         )}

--- a/apps/gctrl-board/web/src/api/client.test.ts
+++ b/apps/gctrl-board/web/src/api/client.test.ts
@@ -54,4 +54,66 @@ describe("api client base URL resolution", () => {
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe("http://127.0.0.1:4318/api/board/projects")
   })
+
+  // macOS driver routes live at the kernel root (`/api/macos/*`), not
+  // under `/api/board`. Regression guard: the renderer must hit the
+  // driver-macos LKM directly.
+  it("macos.health hits /api/macos/health (not /api/board/...)", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            os: "macos",
+            version: "15.2",
+            capabilities: [],
+            permissions: { accessibility: "not_requested" },
+            version_skew: false,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop({ apiBase: "http://127.0.0.1:4318" })
+    await api.macos.health()
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe("http://127.0.0.1:4318/api/macos/health")
+  })
+
+  it("macos.name posts to /api/macos/spaces/:id/name with JSON body", async () => {
+    fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.macos.name(3, "inbox")
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/macos/spaces/3/name")
+    expect(init?.method).toBe("POST")
+    expect(JSON.parse(init?.body as string)).toEqual({ name: "inbox" })
+  })
+
+  it("macos.unname DELETEs /api/macos/spaces/:id/name", async () => {
+    fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.macos.unname(7)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/macos/spaces/7/name")
+    expect(init?.method).toBe("DELETE")
+  })
+
+  it("macos.promptAccessibility POSTs /api/macos/permissions/accessibility/prompt", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ accessibility: "denied" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    const res = await api.macos.promptAccessibility()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/macos/permissions/accessibility/prompt")
+    expect(init?.method).toBe("POST")
+    expect(res.accessibility).toBe("denied")
+  })
 })

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -366,6 +366,56 @@ export const api = {
       return request<NetTrafficRecord[]>(`/api/net/logs${q ? `?${q}` : ""}`)
     },
   },
+
+  // macOS platform driver (driver-macos LKM). Routes mounted at
+  // /api/macos/* by the kernel; capabilities + permissions are
+  // surfaced through /health so the renderer can show the AX prompt
+  // CTA. See vault/specs/architecture/kernel/driver-macos.md.
+  macos: {
+    health: () => request<MacosHealth>(`/api/macos/health`),
+    spaces: () => request<MacosSpace[]>(`/api/macos/spaces`),
+    name: (spaceId: number, name: string) =>
+      request<null>(`/api/macos/spaces/${spaceId}/name`, {
+        method: "POST",
+        body: JSON.stringify({ name }),
+      }),
+    unname: (spaceId: number) =>
+      request<null>(`/api/macos/spaces/${spaceId}/name`, { method: "DELETE" }),
+    promptAccessibility: () =>
+      request<{ accessibility: MacosPermissionStatus }>(
+        `/api/macos/permissions/accessibility/prompt`,
+        { method: "POST" },
+      ),
+  },
+}
+
+export type MacosPermissionStatus =
+  | "granted"
+  | "denied"
+  | "not_requested"
+  | "not_promptable"
+
+export interface MacosHealth {
+  os: "macos" | "linux" | "windows" | "unknown"
+  version: string | null
+  capabilities: string[]
+  permissions: {
+    accessibility?: MacosPermissionStatus
+    notifications?: MacosPermissionStatus
+    screen_recording?: MacosPermissionStatus
+  }
+  version_skew: boolean
+}
+
+export interface MacosSpace {
+  id: number
+  display_id: number
+  display_uuid: string
+  index: number
+  kind: "user" | "fullscreen" | "tiled"
+  name: string | null
+  system_label: string
+  is_current: boolean
 }
 
 export interface AnalyticsSyncResource {

--- a/apps/gctrl-board/web/src/components/NavSidebar.tsx
+++ b/apps/gctrl-board/web/src/components/NavSidebar.tsx
@@ -54,6 +54,24 @@ function AnalyticsIcon({ active }: { active: boolean }) {
   )
 }
 
+function SettingsIcon({ active }: { active: boolean }) {
+  const color = active ? "text-emerald-400" : "text-zinc-500"
+  return (
+    <svg
+      className={`w-5 h-5 ${color} transition-colors duration-150`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      {/* Cog icon */}
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10 1a1 1 0 011 1v1.07a7 7 0 012.34 1.35l.93-.54a1 1 0 011.37.37l1 1.73a1 1 0 01-.37 1.37l-.93.54a7 7 0 010 2.7l.93.54a1 1 0 01.37 1.37l-1 1.73a1 1 0 01-1.37.37l-.93-.54A7 7 0 0111 16.93V18a1 1 0 11-2 0v-1.07a7 7 0 01-2.34-1.35l-.93.54a1 1 0 01-1.37-.37l-1-1.73a1 1 0 01.37-1.37l.93-.54a7 7 0 010-2.7l-.93-.54a1 1 0 01-.37-1.37l1-1.73a1 1 0 011.37-.37l.93.54A7 7 0 019 3.07V2a1 1 0 011-1zm0 6a3 3 0 100 6 3 3 0 000-6z"
+      />
+    </svg>
+  )
+}
+
 function GctlMark() {
   return (
     <div className="flex items-center justify-center">
@@ -70,6 +88,7 @@ export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
   const isBoardActive = route.page === "board"
   const isInboxActive = route.page === "inbox"
   const isAnalyticsActive = route.page === "analytics"
+  const isSettingsActive = route.page === "settings"
 
   return (
     <nav className="w-14 min-h-screen bg-zinc-950 border-r border-zinc-800 flex flex-col items-center py-4 gap-1 shrink-0">
@@ -110,6 +129,17 @@ export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
 
       {/* Spacer */}
       <div className="flex-1" />
+
+      {/* Settings nav item — pinned to bottom */}
+      <button
+        onClick={() => navigate("/settings/macos-spaces")}
+        data-testid="nav-settings"
+        className={`w-10 h-10 flex items-center justify-center rounded-md transition-all duration-150 cursor-pointer
+          ${isSettingsActive ? "bg-emerald-500/10" : "hover:bg-zinc-800/60"}`}
+        title="Settings"
+      >
+        <SettingsIcon active={isSettingsActive} />
+      </button>
 
       {/* Logo mark at bottom */}
       <GctlMark />

--- a/apps/gctrl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.ts
@@ -13,6 +13,7 @@ export type Route =
   | { page: "board"; projectKey: string | null; view: BoardView }
   | { page: "inbox"; threadId: string | null }
   | { page: "analytics"; tab: AnalyticsTab; sessionId: string | null }
+  | { page: "settings"; section: "macos-spaces" }
 
 function parseRoute(pathname: string): Route {
   // /analytics/sessions/:sessionId
@@ -32,6 +33,11 @@ function parseRoute(pathname: string): Route {
   // /analytics
   if (pathname === "/analytics" || pathname === "/analytics/") {
     return { page: "analytics", tab: "overview", sessionId: null }
+  }
+
+  // /settings/macos-spaces
+  if (pathname === "/settings/macos-spaces" || pathname === "/settings/macos-spaces/") {
+    return { page: "settings", section: "macos-spaces" }
   }
 
   // /inbox/:threadId

--- a/apps/gctrl-board/web/src/pages/MacosSpacesPage.tsx
+++ b/apps/gctrl-board/web/src/pages/MacosSpacesPage.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useState } from "react"
+import {
+  api,
+  type MacosHealth,
+  type MacosPermissionStatus,
+  type MacosSpace,
+} from "../api/client"
+
+/// Settings → macOS Spaces panel. Surfaces the AX permission state
+/// (driver-macos's only blocker for the overlay renderer), provides
+/// the "Grant Accessibility" CTA, and lists the user-named Spaces.
+///
+/// Health is polled every 5s while the panel is mounted so the
+/// permission grant flow updates without a manual refresh — granting
+/// permission in System Settings is asynchronous from the renderer's
+/// perspective.
+export function MacosSpacesPage() {
+  const [health, setHealth] = useState<MacosHealth | null>(null)
+  const [spaces, setSpaces] = useState<MacosSpace[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [prompting, setPrompting] = useState(false)
+  const [renaming, setRenaming] = useState<number | null>(null)
+  const [renameValue, setRenameValue] = useState("")
+
+  const refresh = useCallback(async () => {
+    try {
+      const [h, s] = await Promise.all([api.macos.health(), api.macos.spaces()])
+      setHealth(h)
+      setSpaces(s)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to reach kernel")
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const t = setInterval(refresh, 5000)
+    return () => clearInterval(t)
+  }, [refresh])
+
+  const handleGrant = useCallback(async () => {
+    setPrompting(true)
+    try {
+      await api.macos.promptAccessibility()
+      // Permission may take a few seconds to flip in TCC; polling
+      // catches it.
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "prompt failed")
+    } finally {
+      setPrompting(false)
+    }
+  }, [refresh])
+
+  const handleRename = useCallback(
+    async (spaceId: number) => {
+      const trimmed = renameValue.trim()
+      if (!trimmed) {
+        setRenaming(null)
+        return
+      }
+      try {
+        await api.macos.name(spaceId, trimmed)
+        setRenaming(null)
+        setRenameValue("")
+        await refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "rename failed")
+      }
+    },
+    [renameValue, refresh],
+  )
+
+  const handleClear = useCallback(
+    async (spaceId: number) => {
+      try {
+        await api.macos.unname(spaceId)
+        await refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "clear failed")
+      }
+    },
+    [refresh],
+  )
+
+  // ── render branches ──────────────────────────────────────────
+  if (!health) {
+    return (
+      <div className="p-6 text-zinc-500 font-mono text-sm">
+        {error ? (
+          <div className="text-rose-400" data-testid="macos-error">
+            {error}
+          </div>
+        ) : (
+          <span>loading driver-macos…</span>
+        )}
+      </div>
+    )
+  }
+
+  if (health.os !== "macos") {
+    return (
+      <div className="p-6 max-w-2xl">
+        <h2 className="font-display text-zinc-200 text-base mb-2">macOS Spaces</h2>
+        <p className="text-zinc-500 font-mono text-sm">
+          Named Mission Control Spaces are macOS-only. The kernel is
+          running on{" "}
+          <span className="text-zinc-300">{health.os}</span>; this panel
+          stays empty.
+        </p>
+      </div>
+    )
+  }
+
+  const ax = health.permissions.accessibility ?? "not_requested"
+  const spacesCapable = health.capabilities.includes("spaces")
+
+  return (
+    <div className="p-6 max-w-3xl space-y-6 font-mono">
+      <div>
+        <h2 className="font-display text-zinc-200 text-base mb-1">macOS Spaces</h2>
+        <p className="text-zinc-500 text-xs">
+          Named Mission Control Spaces — labels appear over thumbnails when
+          you enter Mission Control.
+        </p>
+      </div>
+
+      {error && (
+        <div
+          className="px-4 py-2 text-xs bg-rose-950/60 border border-rose-500/30 text-rose-300"
+          data-testid="macos-error"
+        >
+          {error}
+        </div>
+      )}
+
+      <PermissionCard
+        status={ax}
+        prompting={prompting}
+        onGrant={handleGrant}
+      />
+
+      <CapabilityRow capable={spacesCapable} versionSkew={health.version_skew} />
+
+      <SpacesList
+        spaces={spaces}
+        renaming={renaming}
+        renameValue={renameValue}
+        onStartRename={(id, current) => {
+          setRenaming(id)
+          setRenameValue(current ?? "")
+        }}
+        onChangeRename={setRenameValue}
+        onCommitRename={handleRename}
+        onCancelRename={() => {
+          setRenaming(null)
+          setRenameValue("")
+        }}
+        onClear={handleClear}
+      />
+    </div>
+  )
+}
+
+// ── sub-components ───────────────────────────────────────────────
+
+function PermissionCard({
+  status,
+  prompting,
+  onGrant,
+}: {
+  status: MacosPermissionStatus
+  prompting: boolean
+  onGrant: () => void
+}) {
+  if (status === "granted") {
+    return (
+      <div
+        className="px-4 py-3 bg-emerald-950/40 border border-emerald-500/30 flex items-center gap-3"
+        data-testid="ax-granted"
+      >
+        <span className="text-emerald-400 text-xs font-bold">✓ GRANTED</span>
+        <span className="text-zinc-400 text-xs">
+          Accessibility permission active — overlay renderer can draw labels.
+        </span>
+      </div>
+    )
+  }
+  const blurb =
+    "Named Mission Control Spaces requires Accessibility permission. " +
+    "Without it gctrl cannot draw labels on top of Mission Control."
+  return (
+    <div
+      className="p-4 bg-zinc-900/60 border border-zinc-700"
+      data-testid="ax-cta"
+    >
+      <div className="flex items-baseline gap-3 mb-3">
+        <span className="text-amber-400 text-xs font-bold uppercase tracking-wider">
+          permission required
+        </span>
+        <span className="text-zinc-500 text-xs">accessibility · {status}</span>
+      </div>
+      <p className="text-zinc-400 text-xs mb-3 leading-relaxed">{blurb}</p>
+      <button
+        onClick={onGrant}
+        disabled={prompting || status === "not_promptable"}
+        data-testid="grant-accessibility"
+        className="px-4 py-2 text-xs font-display tracking-wide bg-emerald-500/15 text-emerald-300 border border-emerald-500/35 hover:bg-emerald-500/25 disabled:opacity-40 disabled:cursor-not-allowed transition-all cursor-pointer"
+      >
+        {prompting ? "PROMPTING…" : "GRANT ACCESSIBILITY"}
+      </button>
+      {status === "not_promptable" && (
+        <p className="mt-3 text-zinc-500 text-[11px]">
+          The system can't surface the prompt automatically — open
+          System Settings → Privacy & Security → Accessibility and add
+          gctrl manually.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function CapabilityRow({
+  capable,
+  versionSkew,
+}: {
+  capable: boolean
+  versionSkew: boolean
+}) {
+  return (
+    <div className="flex items-center gap-3 text-xs text-zinc-500">
+      <span
+        data-testid="capability-spaces"
+        className={capable ? "text-emerald-400" : "text-zinc-600"}
+      >
+        spaces.{capable ? "on" : "off"}
+      </span>
+      {versionSkew && (
+        <span className="text-amber-400" data-testid="version-skew">
+          version_skew · layout fixture mismatch — overlay disabled
+        </span>
+      )}
+    </div>
+  )
+}
+
+function SpacesList({
+  spaces,
+  renaming,
+  renameValue,
+  onStartRename,
+  onChangeRename,
+  onCommitRename,
+  onCancelRename,
+  onClear,
+}: {
+  spaces: MacosSpace[] | null
+  renaming: number | null
+  renameValue: string
+  onStartRename: (id: number, current: string | null) => void
+  onChangeRename: (v: string) => void
+  onCommitRename: (id: number) => void
+  onCancelRename: () => void
+  onClear: (id: number) => void
+}) {
+  if (!spaces) return null
+  if (spaces.length === 0) {
+    return (
+      <div className="text-zinc-500 text-xs">
+        No labels yet. Spaces appear here once you name them.
+      </div>
+    )
+  }
+  return (
+    <ul className="divide-y divide-zinc-800 border border-zinc-800">
+      {spaces.map((s) => (
+        <li
+          key={s.id}
+          data-testid={`space-row-${s.index}`}
+          className="px-4 py-3 flex items-center gap-4 hover:bg-zinc-900/40"
+        >
+          <span className="text-zinc-500 text-xs w-24 shrink-0">
+            {s.system_label}
+          </span>
+          {renaming === s.id ? (
+            <input
+              autoFocus
+              value={renameValue}
+              onChange={(e) => onChangeRename(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onCommitRename(s.id)
+                else if (e.key === "Escape") onCancelRename()
+              }}
+              onBlur={() => onCommitRename(s.id)}
+              className="flex-1 bg-zinc-950 border border-emerald-500/40 px-2 py-1 text-sm text-zinc-200 outline-none"
+            />
+          ) : (
+            <span
+              className={`flex-1 text-sm cursor-pointer ${s.name ? "text-zinc-200" : "text-zinc-600 italic"}`}
+              onClick={() => onStartRename(s.id, s.name)}
+            >
+              {s.name ?? "click to name"}
+            </span>
+          )}
+          {s.is_current && (
+            <span className="text-emerald-400 text-[10px] font-bold tracking-wider">
+              CURRENT
+            </span>
+          )}
+          {s.name && renaming !== s.id && (
+            <button
+              onClick={() => onClear(s.id)}
+              className="text-zinc-600 hover:text-rose-400 text-[10px] tracking-wider cursor-pointer"
+            >
+              CLEAR
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}


### PR DESCRIPTION
## Summary

Closes ship-checklist item 8 from `vault/specs/implementation/kernel/driver-macos.md`. Adds a Settings → macOS Spaces panel in `gctrl-board` that surfaces the Accessibility permission state and provides the "Grant Accessibility" CTA the driver-macos overlay needs.

- New `MacosSpacesPage` (`web/src/pages/MacosSpacesPage.tsx`) polls `/api/macos/health` every 5s, renders the AX permission CTA when not granted, and lists named Spaces with inline rename/clear.
- New `api.macos` namespace + typed `MacosHealth` / `MacosSpace` / `MacosPermissionStatus`.
- New `/settings/macos-spaces` route + cog icon in `NavSidebar`.
- 4 regression tests in `web/src/api/client.test.ts` guard the URL routing — driver-macos lives at `/api/macos/*` (kernel root), not under `/api/board/*`.
- Renders inert when `health.os !== "macos"` (one-line note rather than the CTA), so the route is safe on Linux desktops.

Stack: gctrl-desktop electron renderer → preload `desktop.apiBase` → kernel `:4318` → `gctrl-driver-macos` LKM (#140).

## Test plan

- [x] `pnpm test` — 54 passing (4 new)
- [x] `pnpm run build:web` — clean rolldown bundle
- [ ] Manual: launch packaged `.app`, click Settings cog, click "Grant Accessibility", grant in System Settings, confirm CTA flips to ✓ GRANTED
- [ ] Manual: name Desktop 1 → "inbox", confirm row appears with `CURRENT` badge on the active Space
- [ ] Manual: enter Mission Control, confirm overlay label appears (requires #140 merged)