### PR TITLE
test(gctrl-desktop): /api/macos/health acceptance test + boot-panic fix

### DIFF
--- a/apps/gctrl-desktop/src/main/__tests__/macos-health.integration.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/macos-health.integration.test.ts
@@ -1,0 +1,220 @@
+// Acceptance test for the macOS platform driver — closes ship-checklist
+// item 10 from `vault/specs/implementation/kernel/driver-macos.md`.
+//
+// Spawns the real `gctrld` binary on a random port, polls `/health`
+// until ready, then asserts the shape of `/api/macos/health`. This is
+// the contract the desktop renderer relies on when surfacing the AX
+// permission CTA (PR #149) — if the kernel ever stops mounting the
+// macOS driver routes, this test fails before the renderer breaks
+// silently.
+//
+// CI: this test runs after `cargo build --bin gctrld --locked` has
+// produced `target/debug/gctrld`. Locally it skips itself with a
+// helpful message if the binary isn't present, so `pnpm test` on a
+// fresh checkout (no Rust build yet) doesn't fail.
+
+import { spawn, type ChildProcess } from "node:child_process"
+import { mkdtempSync, rmSync, existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+const PROJECT_ROOT = path.resolve(__dirname, "../../../../..")
+const KERNEL_BIN =
+  process.env.GCTRLD_BIN ??
+  path.join(PROJECT_ROOT, "target", "debug", "gctrld")
+
+const KERNEL_AVAILABLE = existsSync(KERNEL_BIN)
+
+/// Returns a port that's unused at the moment of asking. Race-prone
+/// on principle; ample margin in practice for an integration test
+/// where we're the only contender for the port.
+async function findFreePort(): Promise<number> {
+  const net = await import("node:net")
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.unref()
+    srv.on("error", reject)
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address()
+      if (addr && typeof addr === "object") {
+        const port = addr.port
+        srv.close(() => resolve(port))
+      } else {
+        srv.close(() => reject(new Error("address() returned no port")))
+      }
+    })
+  })
+}
+
+async function waitForHealth(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let lastErr: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`)
+      if (res.ok) return
+      lastErr = new Error(`status ${res.status}`)
+    } catch (e) {
+      lastErr = e
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(
+    `kernel did not become healthy in ${timeoutMs}ms (last: ${String(lastErr)})`,
+  )
+}
+
+describe.skipIf(!KERNEL_AVAILABLE)(
+  "/api/macos/health (live kernel)",
+  () => {
+    let proc: ChildProcess | null = null
+    let port = 0
+    let dataDir = ""
+
+    beforeAll(async () => {
+      port = await findFreePort()
+      dataDir = mkdtempSync(path.join(tmpdir(), "gctrld-acceptance-"))
+      proc = spawn(
+        KERNEL_BIN,
+        [
+          "serve",
+          "--port",
+          String(port),
+          "--host",
+          "127.0.0.1",
+          "--db",
+          path.join(dataDir, "gctrl.duckdb"),
+          "--no-watch",
+          "--no-relay",
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, RUST_LOG: "warn" },
+        },
+      )
+      // Surface daemon failures (port already bound, missing migrations,
+      // etc.) with their actual stderr instead of a 30s timeout.
+      let stderrBuf = ""
+      proc.stderr?.on("data", (chunk) => {
+        stderrBuf += String(chunk)
+      })
+      proc.on("exit", (code, signal) => {
+        if (code !== null && code !== 0) {
+          // Stash so the assertion reports something useful.
+          // eslint-disable-next-line no-console
+          console.error(
+            `gctrld exited code=${code} signal=${signal}\n${stderrBuf}`,
+          )
+        }
+      })
+      await waitForHealth(port, 30_000)
+    }, 45_000)
+
+    afterAll(async () => {
+      if (proc && !proc.killed) {
+        proc.kill("SIGTERM")
+        // Give it a moment for graceful shutdown; SIGKILL if it lingers.
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(() => {
+            proc?.kill("SIGKILL")
+            resolve()
+          }, 3000)
+          proc?.on("exit", () => {
+            clearTimeout(t)
+            resolve()
+          })
+        })
+      }
+      if (dataDir && existsSync(dataDir)) {
+        rmSync(dataDir, { recursive: true, force: true })
+      }
+    })
+
+    it("returns the platform-driver health shape", async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/api/macos/health`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        os: string
+        version: string | null
+        capabilities: string[]
+        permissions: { accessibility?: string }
+        version_skew: boolean
+      }
+      // `os` is the host platform discriminator the driver baked in at
+      // compile time — on macOS hosts it's "macos"; on Linux CI the
+      // driver still mounts the routes but reports "unknown" or the
+      // host OS, since the FFI body is excluded by cfg(target_os).
+      expect(["macos", "linux", "windows", "unknown"]).toContain(body.os)
+      // capabilities is always an array, even when empty (when AX is
+      // not granted). The driver reports `["spaces"]` when both AX is
+      // granted AND the FfiSpaces port construction succeeds.
+      expect(Array.isArray(body.capabilities)).toBe(true)
+      // Accessibility status tri-state. On Linux/non-FFI builds the
+      // stub probe returns `not_requested`. On macOS+FFI it'll be
+      // `granted` or `denied` based on TCC. `not_promptable` is rare
+      // (sandboxed daemons that can't surface the prompt at all).
+      const ax = body.permissions.accessibility
+      expect(ax === undefined || [
+        "granted",
+        "denied",
+        "not_requested",
+        "not_promptable",
+      ].includes(ax)).toBe(true)
+      // version_skew is only true when the layout fixture mismatches
+      // a live thumbnail count; a fresh boot can't trigger it.
+      expect(body.version_skew).toBe(false)
+    })
+
+    it("/api/macos/spaces returns an array (empty on a fresh DB)", async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/api/macos/spaces`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as unknown[]
+      expect(Array.isArray(body)).toBe(true)
+    })
+
+    it("rejects empty space names with 400", async () => {
+      const res = await fetch(
+        `http://127.0.0.1:${port}/api/macos/spaces/1/name`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "  " }),
+        },
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("persistence round-trips: POST 204, DELETE 204", async () => {
+      // The name+unname pipeline writes/clears a row in
+      // `macos_space_labels` regardless of live CGS state. We verify
+      // the storage contract (POST 204 → DELETE 204) here; the
+      // /spaces *list* shape is platform-dependent (macOS+FFI joins
+      // live CGS data, Linux echoes stored labels), so it's covered
+      // by the previous "returns an array" test.
+      const post = await fetch(
+        `http://127.0.0.1:${port}/api/macos/spaces/42/name`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "acceptance-test" }),
+        },
+      )
+      expect(post.status).toBe(204)
+
+      const del = await fetch(
+        `http://127.0.0.1:${port}/api/macos/spaces/42/name`,
+        { method: "DELETE" },
+      )
+      expect(del.status).toBe(204)
+    })
+  },
+)
+
+if (!KERNEL_AVAILABLE) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[macos-health.integration] gctrld not found at ${KERNEL_BIN}; ` +
+      `skipping. Run \`cargo build --bin gctrld\` first, or set GCTRLD_BIN.`,
+  )
+}

--- a/kernel/crates/gctrl-driver-macos/src/app_loop.rs
+++ b/kernel/crates/gctrl-driver-macos/src/app_loop.rs
@@ -2,7 +2,6 @@
 // main thread before any tokio work runs (the tokio runtime moves to
 // a worker thread when this path is taken). Blocks until terminate.
 
-use objc2::msg_send;
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
 use objc2_foundation::MainThreadMarker;
 
@@ -17,10 +16,8 @@ pub fn run() {
     let app = NSApplication::sharedApplication(mtm);
     // Accessory: kernel daemon doesn't put a Dock icon up. The overlay
     // windows are screen-saver-level and join all Spaces, so the Dock
-    // entry would be misleading.
-    let _: () = unsafe {
-        msg_send![&*app, setActivationPolicy: NSApplicationActivationPolicy::Accessory]
-    };
+    // entry would be misleading. Returns BOOL (success); ignore.
+    let _ = app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
     // Run the loop. Returns when `[NSApp terminate:]` is sent.
     unsafe { app.run() };
 }


### PR DESCRIPTION
## Summary

Closes ship-checklist item 10 from `vault/specs/implementation/kernel/driver-macos.md`. Adds a vitest integration test in `apps/gctrl-desktop` that spawns the real `gctrld` binary, polls `/health`, then asserts the `/api/macos/health` shape — the exact contract the desktop renderer's macOS Spaces panel (#149) and the macOS Spaces overlay rely on.

Includes a hot fix: while writing the test, I discovered the kernel daemon panics at startup on macOS+ffi. The `let _: () = msg_send![&*app, setActivationPolicy: ...]` in `app_loop.rs` (merged in #140) declared the return type wrong — objc2's runtime type-check aborts on the BOOL/void mismatch and the kernel exits 101 before binding `:4318`. Switched to the typed `NSApplication::setActivationPolicy` from `objc2-app-kit`.

## Why this matters

Without the fix, `gctrld serve` is broken on macOS as of #140 — every Mac user pulling main right now will hit a boot-time panic. The integration test would have caught this in #140 if it had existed; landing it now closes the regression hole.

## Test plan

- [x] `cargo build --bin gctrld` — clean
- [x] `pnpm --filter gctrl-desktop test` — integration test passes (4 assertions)
- [x] `RUSTFLAGS=-D warnings cargo build --workspace` — clean (Linux CI invariant)
- [x] Test skips with helpful warning when `target/debug/gctrld` is missing (verified by removing the binary and re-running)
- [ ] CI: `cargo build --bin gctrld --locked` step still produces the binary for the desktop test job to consume
- [ ] Manual on macOS: `gctrld serve` boots without panicking; `curl localhost:4318/api/macos/health` returns the health shape with `permissions.accessibility = "denied" | "granted" | "not_requested"`

## Notes

The 4th original assertion (POST a label, GET /spaces, expect to see it in the list) was dropped — on macOS+ffi, `/api/macos/spaces` joins live CGS Space data with stored labels, so an arbitrary index doesn't surface. The persistence contract is now verified via POST 204 → DELETE 204; list shape is covered separately.