### PR TITLE
feat(uebermensch): direct LLM adapters — AnthropicLlm + LMStudioLlm

### DIFF
--- a/apps/uebermensch/src/adapters/AnthropicLlm.ts
+++ b/apps/uebermensch/src/adapters/AnthropicLlm.ts
@@ -1,0 +1,183 @@
+// AnthropicLlm — direct adapter against api.anthropic.com.
+//
+// Bypasses the gctrl kernel entirely so uebermensch in `--mode=local-direct`
+// (and the future cloud-only Worker target) can run without a daemon.
+// API key resolves via SecretsService at request time so rotation through
+// the secrets backend takes effect on the next call.
+//
+// Surface = full LlmServiceShape via makeLlmServiceShape; only the transport
+// (`anthropicPostLlm`) and Layer wiring live here.
+
+import { Agent } from "undici"
+import { Effect, Layer, Option } from "effect"
+import { LlmError } from "../errors.js"
+import type { JsonResponseFormat } from "../lib/llm-prompts.js"
+import { makeLlmServiceShape } from "../lib/llm-service-factory.js"
+import {
+  type AnthropicResponse,
+  classifyHttpStatus,
+  isConnRefused,
+  llmErr,
+  type NormalizedResponse,
+  SERVICE_NAME,
+  sessionIdFor,
+  type ThinkingMode,
+  thinkingBody,
+} from "../lib/llm-shared.js"
+import { LlmService } from "../services/LlmService.js"
+import { SecretsService } from "../services/SecretsService.js"
+
+// Same long-running-completion rationale as KernelLlm — disable undici
+// header/body timeouts so a 10-min Opus + extended-thinking call doesn't
+// surface as `TypeError: fetch failed`.
+const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 })
+
+const DEFAULT_MODEL = "claude-opus-4-7"
+const DEFAULT_SUMMARY_MODEL = "claude-haiku-4-5"
+const ANTHROPIC_VERSION = "2023-06-01"
+const SECRET_KEY = "ANTHROPIC_API_KEY"
+
+const apiBase = (): string =>
+  (process.env.UBER_ANTHROPIC_BASE_URL ?? "https://api.anthropic.com").replace(/\/+$/, "")
+
+const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL
+
+const summaryModelFor = (): string =>
+  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL
+
+const missingKeyErr = (): LlmError =>
+  llmErr(
+    "invalid",
+    `${SECRET_KEY} not provisioned — set the secret via your SecretsService backend ` +
+      `(env: export ${SECRET_KEY}=sk-ant-…) or run uebermensch in --mode=local-kernel.`,
+  )
+
+const upstreamDownErr = (path: string): LlmError =>
+  llmErr(
+    "unavailable",
+    `${apiBase()}${path} unreachable — check network connectivity ` +
+      `(or override with UBER_ANTHROPIC_BASE_URL for tests).`,
+  )
+
+const fetchAnthropic = (
+  path: string,
+  body: unknown,
+  apiKey: string,
+): Effect.Effect<string, LlmError> =>
+  Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${apiBase()}${path}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": apiKey,
+            "anthropic-version": ANTHROPIC_VERSION,
+            // Identity headers — preserved across kernel/direct so dashboards
+            // group runs by session id consistently.
+            "x-session-id": sessionIdFor(),
+            "x-service-name": SERVICE_NAME,
+          },
+          body: JSON.stringify(body),
+          dispatcher: llmFetchAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: undici-specific option
+        } as any),
+      catch: (e) => {
+        if (isConnRefused(e)) return upstreamDownErr(path)
+        const cause = (e as { cause?: unknown })?.cause
+        const causeStr = cause ? ` cause=${String(cause)}` : ""
+        return llmErr(
+          "unavailable",
+          `anthropic ${path} fetch failed: ${String(e)}${causeStr}`,
+        )
+      },
+    })
+    const raw = yield* Effect.tryPromise({
+      try: () => res.text(),
+      catch: (e) =>
+        llmErr("unavailable", `anthropic ${path} body read failed: ${String(e)}`),
+    })
+    if (!res.ok) {
+      return yield* Effect.fail(
+        llmErr(
+          classifyHttpStatus(res.status),
+          `anthropic ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
+        ),
+      )
+    }
+    return raw
+  })
+
+const makeAnthropicPostLlm =
+  (
+    getApiKey: () => Effect.Effect<string, LlmError>,
+  ): ((
+    model: string,
+    system: string,
+    userPrompt: string,
+    maxTokens: number,
+    thinking: ThinkingMode,
+    thinkingBudgetTokens: number,
+    jsonFormat: JsonResponseFormat | null,
+  ) => Effect.Effect<NormalizedResponse, LlmError>) =>
+  (model, system, userPrompt, maxTokens, thinking, thinkingBudgetTokens, _jsonFormat) =>
+    Effect.gen(function* () {
+      const apiKey = yield* getApiKey()
+      // Anthropic's /v1/messages does not honor `response_format: json_schema`
+      // in the same way OpenAI-compat backends do — the prompt itself enforces
+      // JSON. Drop jsonFormat on this transport.
+      const body: Record<string, unknown> = {
+        model,
+        max_tokens: maxTokens,
+        system,
+        messages: [{ role: "user", content: userPrompt }],
+        ...thinkingBody(thinking, thinkingBudgetTokens),
+      }
+      const raw = yield* fetchAnthropic("/v1/messages", body, apiKey)
+      const parsed = yield* Effect.try({
+        try: () =>
+          raw.length > 0 ? (JSON.parse(raw) as AnthropicResponse) : ({} as AnthropicResponse),
+        catch: (e) =>
+          llmErr("invalid", `anthropic /v1/messages JSON.parse failed: ${String(e)}`),
+      })
+      const textBlock = (parsed.content ?? []).find(
+        (b): b is { type: string; text: string } =>
+          b.type === "text" && typeof b.text === "string",
+      )
+      if (!textBlock) {
+        return yield* Effect.fail(
+          llmErr("invalid", "anthropic response missing text content block"),
+        )
+      }
+      return {
+        text: textBlock.text,
+        inputTokens: parsed.usage?.input_tokens ?? 0,
+        outputTokens: parsed.usage?.output_tokens ?? 0,
+        model: parsed.model ?? model,
+      }
+    })
+
+export const AnthropicLlmLive = Layer.effect(
+  LlmService,
+  Effect.gen(function* () {
+    const secrets = yield* SecretsService
+    const getApiKey = (): Effect.Effect<string, LlmError> =>
+      secrets.get(SECRET_KEY).pipe(
+        Effect.mapError((e) =>
+          llmErr("unavailable", `secrets backend failure reading ${SECRET_KEY}: ${e.message}`),
+        ),
+        Effect.flatMap((opt) =>
+          Option.match(opt, {
+            onNone: () => Effect.fail(missingKeyErr()),
+            onSome: (k) => Effect.succeed(k),
+          }),
+        ),
+      )
+    return makeLlmServiceShape({
+      name: () => `anthropic-direct@${modelFor()}`,
+      postLlm: makeAnthropicPostLlm(getApiKey),
+      modelFor,
+      summaryModelFor,
+    })
+  }),
+)

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,6 +1,6 @@
-import { Agent } from "undici";
-import { Effect, Layer } from "effect";
-import { LlmError } from "../errors.js";
+import { Agent } from "undici"
+import { Effect, Layer } from "effect"
+import { LlmError } from "../errors.js"
 
 // Constrained decoding under `response_format: json_schema` can run for many
 // minutes on local backends (LMStudio + gemma) when the target schema has
@@ -10,18 +10,15 @@ import { LlmError } from "../errors.js";
 // the `dispatcher` option so the LLM stage isn't artificially capped — global
 // fetch behavior is unchanged, so tests that mock `globalThis.fetch` and
 // other consumers of fetch are unaffected.
-const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
-import { sha256 } from "../lib/hash.js";
+const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 })
+
 import {
-  briefJsonFormat,
   buildInterestReportUserPrompt,
   buildResearchQueryUserPrompt,
   buildSubtopicUserPrompt,
   buildSummaryUserPrompt,
   buildUserPrompt,
-  decodeLlmJson,
   extractJson,
-  interestReportJsonFormat,
   InterestReportOutputSchema,
   type JsonResponseFormat,
   LlmOutputSchema,
@@ -29,202 +26,56 @@ import {
   REPORT_SYSTEM_PROMPT,
   RESEARCH_SYSTEM_PROMPT,
   SUBTOPIC_SYSTEM_PROMPT,
-  subtopicJsonFormat,
   SubtopicProposeOutputSchema,
-  SUMMARY_INPUT_CHARS_CAP,
-  SUMMARY_MAX_TOKENS,
   SUMMARY_SYSTEM_PROMPT,
   SYSTEM_PROMPT,
-} from "../lib/llm-prompts.js";
-import { LlmService } from "../services/LlmService.js";
-import type { CuratedItem } from "../services/RendererService.js";
+} from "../lib/llm-prompts.js"
+import { makeLlmServiceShape } from "../lib/llm-service-factory.js"
+import {
+  type AnthropicResponse,
+  classifyHttpStatus,
+  effortConfigFor,
+  effortFromEnv,
+  isAnthropicModel,
+  isConnRefused,
+  isOpenAiCompatModel,
+  isWorkersAiModel,
+  llmErr,
+  type NormalizedResponse,
+  type OpenAiChatResponse,
+  SERVICE_NAME,
+  sessionIdFor,
+  type ThinkingMode,
+  thinkingBody,
+} from "../lib/llm-shared.js"
+import { LlmService } from "../services/LlmService.js"
 
 // Local-first default: kernel /api/llm/completions routes to LM Studio at
 // 127.0.0.1:1234 unless GCTRL_LLM_PROVIDER=cloudflare is set on the kernel.
 // Override with UBER_LLM_MODEL to match the model id loaded in your LM Studio
 // instance (LM Studio typically echoes whatever model name it has loaded).
-const DEFAULT_MODEL = "google/gemma-4-31b";
-const DEFAULT_MAX_TOKENS = 16000;
-
-// Per-model USD/Mtok rates (input, output). Workers AI / local backends bill
-// kernel-side (or are free), so they collapse to 0 here. Anthropic rates
-// matter because uebermensch persists per-report `cost_usd` in vault
-// frontmatter — stale numbers there propagate into eval/dashboards.
-type CostRates = readonly [input: number, output: number];
-
-const ANTHROPIC_RATES: ReadonlyArray<readonly [RegExp, CostRates]> = [
-  // Order matters: more specific patterns first.
-  [/^claude-opus-4-/, [15.0, 75.0]],
-  [/^claude-sonnet-4-/, [3.0, 15.0]],
-  [/^claude-haiku-4-/, [1.0, 5.0]],
-  // Older 3.x families (kept for back-compat — kernel may still relay).
-  [/^claude-3-5-sonnet-/, [3.0, 15.0]],
-  [/^claude-3-5-haiku-/, [1.0, 5.0]],
-  [/^claude-3-opus-/, [15.0, 75.0]],
-];
-
-const ratesForModel = (model: string): CostRates => {
-  if (!isAnthropicModel(model)) return [0, 0];
-  for (const [pattern, rates] of ANTHROPIC_RATES) {
-    if (pattern.test(model)) return rates;
-  }
-  // Unknown claude-* — fall back to Sonnet rates (mid-range guess) rather
-  // than zero, so a new model id surfaces in cost telemetry instead of
-  // silently being free.
-  return [3.0, 15.0];
-};
-
-// Effort tier — operator-facing knob for how much LLM work to spend on a
-// run. Maps to (max output tokens, thinking config). The lower-level
-// per-provider billing concern (subscription vs metered, AI Gateway vs
-// BYOK) lives in the kernel's driver-llm — uebermensch should not know
-// or care.
-type Effort = "low" | "medium" | "high";
-
-const effortFromEnv = (): Effort => {
-  const raw = process.env.UBER_LLM_EFFORT?.toLowerCase().trim();
-  if (raw === "low" || raw === "high") return raw;
-  return "medium";
-};
-
-// Anthropic `thinking` parameter shapes:
-// - "off"      → no thinking field (model answers directly)
-// - "adaptive" → `{ type: "adaptive" }` — model decides budget
-// - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
-type ThinkingMode = "off" | "adaptive" | "extended";
-
-type EffortConfig = {
-  readonly maxTokens: number;
-  readonly thinking: ThinkingMode;
-  readonly thinkingBudgetTokens: number;
-};
-
-const effortConfigFor = (effort: Effort): EffortConfig => {
-  switch (effort) {
-    case "low":
-      // Tight cap, no thinking. Single-pass, fast, cheap.
-      return { maxTokens: 4000, thinking: "off", thinkingBudgetTokens: 0 };
-    case "high":
-      // Generous output budget + explicit extended-thinking budget for
-      // deeper synthesis. Doubles default max for long deep-dives.
-      return { maxTokens: 32000, thinking: "extended", thinkingBudgetTokens: 16000 };
-    default:
-      // Adaptive thinking — model decides budget. Current default behavior.
-      return { maxTokens: DEFAULT_MAX_TOKENS, thinking: "adaptive", thinkingBudgetTokens: 0 };
-  }
-};
+const DEFAULT_MODEL = "google/gemma-4-31b"
 
 // Per-article summarization shares the curator default by design — LM Studio
 // typically has a single model loaded and echoes that name regardless of the
 // `model` field. Override with UBER_LLM_SUMMARY_MODEL when running a separate
 // smaller model on a second backend.
-const DEFAULT_SUMMARY_MODEL = "google/gemma-4-31b";
-const SUMMARY_INPUT_COST_PER_MTOK = 1.0;
-const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0;
+const DEFAULT_SUMMARY_MODEL = "google/gemma-4-31b"
 
-const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL;
+const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL
 
 const summaryModelFor = (): string =>
-  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL;
-
-// Anthropic-shaped models go through /api/llm/messages. Everything else
-// (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
-// LM Studio / Ollama) goes through /api/llm/completions.
-const isAnthropicModel = (model: string): boolean => model.startsWith("claude-");
-// Back-compat alias — older callers/tests still import this name.
-const isWorkersAiModel = (model: string): boolean => !isAnthropicModel(model);
+  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL
 
 const kernelBase = (): string =>
-  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
-
-// Identity headers consumed by the kernel's driver-llm capture path
-// (vault/specs/implementation/llm-relay.md § "Convergence with driver-llm").
-// Setting `x-session-id` makes the kernel persist a `prompt_bodies` row
-// per turn and emit a generation span — uebermensch then shows up in
-// /api/sessions and the analytics dashboard alongside opencode and the
-// rest. `UBER_SESSION_ID` is the operator's hook for tying a logical run
-// (e.g. one daily-brief invocation, one profile cycle) to a single
-// session; the fallback is a process-lifetime UUID so a forgotten env
-// var still produces *some* aggregated session rather than orphans.
-const SERVICE_NAME = "uebermensch";
-let processSessionId: string | null = null;
-const sessionIdFor = (): string => {
-  const explicit = process.env.UBER_SESSION_ID;
-  if (explicit && explicit.length > 0) return explicit;
-  if (processSessionId === null) {
-    processSessionId =
-      typeof globalThis.crypto?.randomUUID === "function"
-        ? globalThis.crypto.randomUUID()
-        : `uber-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-  return processSessionId;
-};
-
-type AnthropicResponse = {
-  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
-  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number };
-  readonly model?: string;
-};
-
-type OpenAiChatResponse = {
-  readonly choices?: ReadonlyArray<{ readonly message?: { readonly content?: string } }>;
-  readonly usage?: { readonly prompt_tokens?: number; readonly completion_tokens?: number };
-  readonly model?: string;
-};
-
-type NormalizedResponse = {
-  readonly text: string;
-  readonly inputTokens: number;
-  readonly outputTokens: number;
-  readonly model: string;
-};
-
-const llmErr = (kind: LlmError["kind"], message: string): LlmError =>
-  new LlmError({ kind, message });
-
-const classifyKernelStatus = (status: number): LlmError["kind"] => {
-  if (status === 503) return "unavailable";
-  if (status === 429) return "rate_limited";
-  if (status === 400 || status === 401 || status === 403) return "invalid";
-  if (status >= 500) return "unavailable";
-  return "invalid";
-};
-
-// Node's fetch surfaces a connection refusal as `TypeError: fetch failed`
-// with a nested `cause` carrying `code: ECONNREFUSED`. Walk the chain so we
-// can tell the user the kernel daemon is simply down vs. some other failure.
-const isConnRefused = (e: unknown): boolean => {
-  let cur: unknown = e;
-  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
-    const code = (cur as { code?: string }).code;
-    if (
-      code === "ECONNREFUSED" ||
-      code === "ENOTFOUND" ||
-      code === "EHOSTUNREACH" ||
-      code === "ECONNRESET"
-    ) {
-      return true;
-    }
-    const errors = (cur as { errors?: ReadonlyArray<unknown> }).errors;
-    if (Array.isArray(errors) && errors.some(isConnRefused)) return true;
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return false;
-};
+  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
 
 const kernelDownErr = (path: string): LlmError =>
   llmErr(
     "unavailable",
     `kernel daemon not reachable at ${kernelBase()}${path} — start it with: ` +
       `gctrld serve --port 4318 (or set GCTRL_KERNEL_URL to point at a running kernel)`,
-  );
-
-const tokensCost = (
-  inputTokens: number,
-  outputTokens: number,
-  inputRate: number,
-  outputRate: number,
-): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000;
+  )
 
 // POST a JSON body to `${kernelBase()}${path}` and return the raw response
 // text. Connection-level failures (ECONNREFUSED etc.) become a "kernel daemon
@@ -250,38 +101,27 @@ const fetchKernel = (
           // biome-ignore lint/suspicious/noExplicitAny: undici-specific option
         } as any),
       catch: (e) => {
-        if (isConnRefused(e)) return kernelDownErr(path);
-        const cause = (e as { cause?: unknown })?.cause;
-        const causeStr = cause ? ` cause=${String(cause)}` : "";
-        return llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}${causeStr}`);
+        if (isConnRefused(e)) return kernelDownErr(path)
+        const cause = (e as { cause?: unknown })?.cause
+        const causeStr = cause ? ` cause=${String(cause)}` : ""
+        return llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}${causeStr}`)
       },
-    });
+    })
     const raw = yield* Effect.tryPromise({
       try: () => res.text(),
       catch: (e) =>
         llmErr("unavailable", `kernel ${path} body read failed: ${String(e)}`),
-    });
+    })
     if (!res.ok) {
       return yield* Effect.fail(
         llmErr(
-          classifyKernelStatus(res.status),
+          classifyHttpStatus(res.status),
           `kernel ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
         ),
-      );
+      )
     }
-    return raw;
-  });
-
-const thinkingBody = (
-  thinking: ThinkingMode,
-  budgetTokens: number,
-): Record<string, unknown> => {
-  if (thinking === "off") return {};
-  if (thinking === "extended") {
-    return { thinking: { type: "enabled", budget_tokens: budgetTokens } };
-  }
-  return { thinking: { type: "adaptive" } };
-};
+    return raw
+  })
 
 const postAnthropic = (
   model: string,
@@ -298,32 +138,32 @@ const postAnthropic = (
       system,
       messages: [{ role: "user", content: userPrompt }],
       ...thinkingBody(thinking, thinkingBudgetTokens),
-    };
-    const raw = yield* fetchKernel("/api/llm/messages", body);
+    }
+    const raw = yield* fetchKernel("/api/llm/messages", body)
     const parsed = yield* Effect.try({
       try: () =>
         (raw.length > 0 ? (JSON.parse(raw) as AnthropicResponse) : ({} as AnthropicResponse)),
       catch: (e) =>
         llmErr("invalid", `kernel /api/llm/messages JSON.parse failed: ${String(e)}`),
-    });
+    })
     const textBlock = (parsed.content ?? []).find(
       (b): b is { type: string; text: string } =>
         b.type === "text" && typeof b.text === "string",
-    );
+    )
     if (!textBlock) {
       return yield* Effect.fail(
         llmErr("invalid", "kernel response missing text content block"),
-      );
+      )
     }
     return {
       text: textBlock.text,
       inputTokens: parsed.usage?.input_tokens ?? 0,
       outputTokens: parsed.usage?.output_tokens ?? 0,
       model: parsed.model ?? model,
-    };
-  });
+    }
+  })
 
-const postWorkersAi = (
+const postOpenAiCompat = (
   model: string,
   system: string,
   userPrompt: string,
@@ -350,28 +190,31 @@ const postWorkersAi = (
             },
           }
         : {}),
-    };
-    const raw = yield* fetchKernel("/api/llm/completions", body);
+    }
+    const raw = yield* fetchKernel("/api/llm/completions", body)
     const parsed = yield* Effect.try({
       try: () =>
         (raw.length > 0 ? (JSON.parse(raw) as OpenAiChatResponse) : ({} as OpenAiChatResponse)),
       catch: (e) =>
         llmErr("invalid", `kernel /api/llm/completions JSON.parse failed: ${String(e)}`),
-    });
-    const content = parsed.choices?.[0]?.message?.content;
+    })
+    const content = parsed.choices?.[0]?.message?.content
     if (typeof content !== "string") {
       return yield* Effect.fail(
         llmErr("invalid", "kernel response missing choices[0].message.content string"),
-      );
+      )
     }
     return {
       text: content,
       inputTokens: parsed.usage?.prompt_tokens ?? 0,
       outputTokens: parsed.usage?.completion_tokens ?? 0,
       model: parsed.model ?? model,
-    };
-  });
+    }
+  })
 
+// Anthropic-shaped models go through /api/llm/messages. Everything else
+// (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
+// LM Studio / Ollama) goes through /api/llm/completions.
 const postLlm = (
   model: string,
   system: string,
@@ -381,212 +224,24 @@ const postLlm = (
   thinkingBudgetTokens: number,
   jsonFormat: JsonResponseFormat | null,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
-  isWorkersAiModel(model)
-    ? postWorkersAi(model, system, userPrompt, maxTokens, jsonFormat)
-    : postAnthropic(model, system, userPrompt, maxTokens, thinking, thinkingBudgetTokens);
+  isOpenAiCompatModel(model)
+    ? postOpenAiCompat(model, system, userPrompt, maxTokens, jsonFormat)
+    : postAnthropic(model, system, userPrompt, maxTokens, thinking, thinkingBudgetTokens)
 
-// USD cost for a normalized LLM response. Workers AI / local models
-// always cost $0. Anthropic models look up rates by model id so Opus 4.7
-// ($15/$75) and Sonnet 4.6 ($3/$15) bill correctly without a redeploy.
-// Optional rate overrides keep the summary lane (which used custom rates)
-// working unchanged.
-const costForResponse = (
-  res: NormalizedResponse,
-  inputRateOverride?: number,
-  outputRateOverride?: number,
-): number => {
-  if (isWorkersAiModel(res.model)) return 0;
-  if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
-    return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride);
-  }
-  const [inputRate, outputRate] = ratesForModel(res.model);
-  return tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate);
-};
-
-export const KernelLlmLive = Layer.succeed(LlmService, {
-  name: () => `kernel-llm@${modelFor()}`,
-  generateBrief: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildUserPrompt(req);
-      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
-      const res = yield* postLlm(
-        model,
-        SYSTEM_PROMPT,
-        userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
-        briefJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
-      const costUsd = costForResponse(res);
-      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
-        kind: i.kind,
-        title: i.title,
-        summary_md: i.summary_md,
-        topic: i.topic,
-        thesis: i.thesis,
-        source_candidate_ids: i.source_candidate_ids,
-        suggested_action: i.suggested_action,
-      }));
-      return {
-        items,
-        topicsCovered: decoded.topicsCovered,
-        thesesCovered: decoded.thesesCovered,
-        promptHash,
-        costUsd,
-        model: res.model,
-      };
-    }),
-  proposeSubtopic: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildSubtopicUserPrompt(req);
-      const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
-      const res = yield* postLlm(
-        model,
-        SUBTOPIC_SYSTEM_PROMPT,
-        userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
-        subtopicJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(
-        res.text,
-        SubtopicProposeOutputSchema,
-        "kernel subtopic",
-      );
-      const proposalSlugs = new Set(decoded.proposals.map((p) => p.slug));
-      const selectedSlug = proposalSlugs.has(decoded.selected_slug)
-        ? decoded.selected_slug
-        : decoded.proposals[0].slug;
-      const candidateIds = new Set(req.interest.candidates.map((c) => c.id));
-      const proposals = decoded.proposals.map((p) => ({
-        slug: p.slug,
-        title: p.title,
-        rationale: p.rationale,
-        relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
-      }));
-      const costUsd = costForResponse(res);
-      return {
-        selectedSlug,
-        proposals,
-        promptHash,
-        costUsd,
-        inputTokens: res.inputTokens,
-        outputTokens: res.outputTokens,
-        model: res.model,
-      };
-    }),
-  generateInterestReport: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildInterestReportUserPrompt(req);
-      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
-      const res = yield* postLlm(
-        model,
-        REPORT_SYSTEM_PROMPT,
-        userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
-        interestReportJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(
-        res.text,
-        InterestReportOutputSchema,
-        "kernel interest report",
-      );
-      const costUsd = costForResponse(res);
-      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
-        kind: i.kind,
-        title: i.title,
-        summary_md: i.summary_md,
-        topic: i.topic,
-        thesis: i.thesis,
-        source_candidate_ids: i.source_candidate_ids,
-        suggested_action: i.suggested_action,
-      }));
-      return {
-        interestSlug: req.interest.slug,
-        analysis_md: decoded.analysis_md,
-        items,
-        promptHash,
-        costUsd,
-        inputTokens: res.inputTokens,
-        outputTokens: res.outputTokens,
-        model: res.model,
-      };
-    }),
-  researchQuery: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildResearchQueryUserPrompt(req);
-      const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
-      const res = yield* postLlm(
-        model,
-        RESEARCH_SYSTEM_PROMPT,
-        userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
-        null,
-      );
-      const answerMd = res.text.trim();
-      if (answerMd.length === 0) {
-        return yield* Effect.fail(llmErr("invalid", "kernel researchQuery returned empty body"));
-      }
-      const costUsd = costForResponse(res);
-      return { answerMd, promptHash, costUsd, model: res.model };
-    }),
-  summarizeSource: (req) =>
-    Effect.gen(function* () {
-      const capped =
-        req.text.length > SUMMARY_INPUT_CHARS_CAP
-          ? `${req.text.slice(0, SUMMARY_INPUT_CHARS_CAP)}…`
-          : req.text;
-      const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
-      const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      // Summary lane is always low-effort: short, cheap, no thinking. Not
-      // operator-tunable — bumping summarization to "high" would 10x the
-      // ingest spend with negligible quality lift.
-      const res = yield* postLlm(
-        summaryModelFor(),
-        SUMMARY_SYSTEM_PROMPT,
-        userPrompt,
-        SUMMARY_MAX_TOKENS,
-        "off",
-        0,
-        null,
-      );
-      const insightsMd = normalizeInsights(res.text);
-      if (insightsMd.length === 0) {
-        return yield* Effect.fail(llmErr("invalid", "kernel summarize returned empty insights"));
-      }
-      const costUsd = costForResponse(
-        res,
-        SUMMARY_INPUT_COST_PER_MTOK,
-        SUMMARY_OUTPUT_COST_PER_MTOK,
-      );
-      return {
-        insightsMd,
-        promptHash,
-        costUsd,
-        model: res.model,
-      };
-    }),
-});
+export const KernelLlmLive = Layer.succeed(
+  LlmService,
+  makeLlmServiceShape({
+    name: () => `kernel-llm@${modelFor()}`,
+    postLlm,
+    modelFor,
+    summaryModelFor,
+  }),
+)
 
 // Re-export prompt/schema material for tests that historically reach into
 // `_internal`. Tests should migrate to importing directly from
 // `lib/llm-prompts.ts`, but keeping the shape stable here avoids touching
-// every test in this PR — they get rewritten in the AnthropicLlm follow-up.
+// every test in this PR.
 export const _internal = {
   buildUserPrompt,
   buildInterestReportUserPrompt,
@@ -616,4 +271,4 @@ export const _internal = {
   isWorkersAiModel,
   effortFromEnv,
   effortConfigFor,
-};
+}

--- a/apps/uebermensch/src/adapters/LMStudioLlm.ts
+++ b/apps/uebermensch/src/adapters/LMStudioLlm.ts
@@ -1,0 +1,149 @@
+// LMStudioLlm — direct adapter against an OpenAI-compat local backend
+// (LM Studio at 127.0.0.1:1234, Ollama at 11434, llama.cpp server, etc.).
+//
+// No API key required — local backends are typically wide open on loopback.
+// All responses cost $0 (handled by costForResponse via isOpenAiCompatModel).
+//
+// Surface = full LlmServiceShape via makeLlmServiceShape.
+
+import { Agent } from "undici"
+import { Effect, Layer } from "effect"
+import { LlmError } from "../errors.js"
+import type { JsonResponseFormat } from "../lib/llm-prompts.js"
+import { makeLlmServiceShape } from "../lib/llm-service-factory.js"
+import {
+  classifyHttpStatus,
+  isConnRefused,
+  llmErr,
+  type NormalizedResponse,
+  type OpenAiChatResponse,
+  SERVICE_NAME,
+  sessionIdFor,
+  type ThinkingMode,
+} from "../lib/llm-shared.js"
+import { LlmService } from "../services/LlmService.js"
+
+const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 })
+
+const DEFAULT_MODEL = "google/gemma-4-31b"
+const DEFAULT_BASE_URL = "http://127.0.0.1:1234"
+
+const apiBase = (): string =>
+  (process.env.UBER_LMSTUDIO_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "")
+
+const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL
+
+const summaryModelFor = (): string =>
+  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL
+
+const lmStudioDownErr = (path: string): LlmError =>
+  llmErr(
+    "unavailable",
+    `${apiBase()}${path} unreachable — start LM Studio (or your OpenAI-compat backend) ` +
+      `and load a model, then retry. Override base URL with UBER_LMSTUDIO_BASE_URL.`,
+  )
+
+const fetchLMStudio = (
+  path: string,
+  body: unknown,
+): Effect.Effect<string, LlmError> =>
+  Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetch(`${apiBase()}${path}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-session-id": sessionIdFor(),
+            "x-service-name": SERVICE_NAME,
+          },
+          body: JSON.stringify(body),
+          dispatcher: llmFetchAgent,
+          // biome-ignore lint/suspicious/noExplicitAny: undici-specific option
+        } as any),
+      catch: (e) => {
+        if (isConnRefused(e)) return lmStudioDownErr(path)
+        const cause = (e as { cause?: unknown })?.cause
+        const causeStr = cause ? ` cause=${String(cause)}` : ""
+        return llmErr(
+          "unavailable",
+          `lmstudio ${path} fetch failed: ${String(e)}${causeStr}`,
+        )
+      },
+    })
+    const raw = yield* Effect.tryPromise({
+      try: () => res.text(),
+      catch: (e) =>
+        llmErr("unavailable", `lmstudio ${path} body read failed: ${String(e)}`),
+    })
+    if (!res.ok) {
+      return yield* Effect.fail(
+        llmErr(
+          classifyHttpStatus(res.status),
+          `lmstudio ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
+        ),
+      )
+    }
+    return raw
+  })
+
+const lmStudioPostLlm = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  maxTokens: number,
+  _thinking: ThinkingMode,
+  _thinkingBudgetTokens: number,
+  jsonFormat: JsonResponseFormat | null,
+): Effect.Effect<NormalizedResponse, LlmError> =>
+  Effect.gen(function* () {
+    const body: Record<string, unknown> = {
+      model,
+      max_tokens: maxTokens,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: userPrompt },
+      ],
+      ...(jsonFormat
+        ? {
+            response_format: {
+              type: "json_schema",
+              json_schema: {
+                name: jsonFormat.name,
+                strict: true,
+                schema: jsonFormat.schema,
+              },
+            },
+          }
+        : {}),
+    }
+    const raw = yield* fetchLMStudio("/v1/chat/completions", body)
+    const parsed = yield* Effect.try({
+      try: () =>
+        raw.length > 0 ? (JSON.parse(raw) as OpenAiChatResponse) : ({} as OpenAiChatResponse),
+      catch: (e) =>
+        llmErr("invalid", `lmstudio /v1/chat/completions JSON.parse failed: ${String(e)}`),
+    })
+    const content = parsed.choices?.[0]?.message?.content
+    if (typeof content !== "string") {
+      return yield* Effect.fail(
+        llmErr("invalid", "lmstudio response missing choices[0].message.content string"),
+      )
+    }
+    return {
+      text: content,
+      inputTokens: parsed.usage?.prompt_tokens ?? 0,
+      outputTokens: parsed.usage?.completion_tokens ?? 0,
+      model: parsed.model ?? model,
+    }
+  })
+
+export const LMStudioLlmLive = Layer.succeed(
+  LlmService,
+  makeLlmServiceShape({
+    name: () => `lmstudio-direct@${modelFor()}`,
+    postLlm: lmStudioPostLlm,
+    modelFor,
+    summaryModelFor,
+  }),
+)

--- a/apps/uebermensch/src/lib/llm-service-factory.ts
+++ b/apps/uebermensch/src/lib/llm-service-factory.ts
@@ -1,0 +1,238 @@
+// makeLlmServiceShape — single implementation of the five LlmServiceShape
+// methods (generateBrief, proposeSubtopic, generateInterestReport,
+// researchQuery, summarizeSource) parameterized by a transport.
+//
+// Every adapter (KernelLlm, AnthropicLlm, LMStudioLlm) provides:
+//   - `postLlm`: how to send a prompt + receive a NormalizedResponse
+//   - `modelFor` / `summaryModelFor`: which model id to use per lane
+//   - `name`: human-readable id (e.g. "anthropic-direct@claude-opus-4-7")
+//
+// All other behavior — prompt construction, JSON decoding, cost math,
+// effort tier wiring — is shared, so adapters cannot drift on the
+// per-method shape. The factory exists because the previous KernelLlmLive
+// implementation reproduced the same five-method recipe inline (~200 LOC),
+// and we now need three transports without three copies of the recipe.
+
+import { Effect } from "effect"
+import { sha256 } from "./hash.js"
+import {
+  briefJsonFormat,
+  buildInterestReportUserPrompt,
+  buildResearchQueryUserPrompt,
+  buildSubtopicUserPrompt,
+  buildSummaryUserPrompt,
+  buildUserPrompt,
+  decodeLlmJson,
+  interestReportJsonFormat,
+  InterestReportOutputSchema,
+  LlmOutputSchema,
+  normalizeInsights,
+  REPORT_SYSTEM_PROMPT,
+  RESEARCH_SYSTEM_PROMPT,
+  SUBTOPIC_SYSTEM_PROMPT,
+  subtopicJsonFormat,
+  SubtopicProposeOutputSchema,
+  SUMMARY_INPUT_CHARS_CAP,
+  SUMMARY_MAX_TOKENS,
+  SUMMARY_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+} from "./llm-prompts.js"
+import {
+  costForResponse,
+  effortConfigFor,
+  effortFromEnv,
+  llmErr,
+  type PostLlm,
+} from "./llm-shared.js"
+import type { CuratedItem } from "../services/RendererService.js"
+import type { LlmServiceShape } from "../services/LlmService.js"
+
+// Summary lane bills a fixed cheap rate when the underlying model is
+// Anthropic-shaped (matches the historical KernelLlm hard-coding). For
+// OpenAI-compat / local models, costForResponse already collapses to 0.
+const SUMMARY_INPUT_COST_PER_MTOK = 1.0
+const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0
+
+export type LlmServiceFactoryOpts = {
+  /** Identity string surfaced in spans + logs (e.g. "anthropic-direct@<model>"). */
+  readonly name: () => string
+  /** Per-call transport — the only real provider seam. */
+  readonly postLlm: PostLlm
+  /** Model id to use for the curator lane (briefs, subtopics, reports, research). */
+  readonly modelFor: () => string
+  /** Model id to use for the summarization lane (per-source insights). */
+  readonly summaryModelFor: () => string
+}
+
+export const makeLlmServiceShape = (opts: LlmServiceFactoryOpts): LlmServiceShape => ({
+  name: opts.name,
+  generateBrief: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildUserPrompt(req)
+      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv())
+      const res = yield* opts.postLlm(
+        model,
+        SYSTEM_PROMPT,
+        userPrompt,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
+        briefJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "generateBrief")
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
+      }))
+      return {
+        items,
+        topicsCovered: decoded.topicsCovered,
+        thesesCovered: decoded.thesesCovered,
+        promptHash,
+        costUsd: costForResponse(res),
+        model: res.model,
+      }
+    }),
+  proposeSubtopic: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildSubtopicUserPrompt(req)
+      const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv())
+      const res = yield* opts.postLlm(
+        model,
+        SUBTOPIC_SYSTEM_PROMPT,
+        userPrompt,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
+        subtopicJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(res.text, SubtopicProposeOutputSchema, "proposeSubtopic")
+      const proposalSlugs = new Set(decoded.proposals.map((p) => p.slug))
+      const selectedSlug = proposalSlugs.has(decoded.selected_slug)
+        ? decoded.selected_slug
+        : decoded.proposals[0].slug
+      const candidateIds = new Set(req.interest.candidates.map((c) => c.id))
+      const proposals = decoded.proposals.map((p) => ({
+        slug: p.slug,
+        title: p.title,
+        rationale: p.rationale,
+        relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
+      }))
+      return {
+        selectedSlug,
+        proposals,
+        promptHash,
+        costUsd: costForResponse(res),
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
+        model: res.model,
+      }
+    }),
+  generateInterestReport: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildInterestReportUserPrompt(req)
+      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv())
+      const res = yield* opts.postLlm(
+        model,
+        REPORT_SYSTEM_PROMPT,
+        userPrompt,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
+        interestReportJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(
+        res.text,
+        InterestReportOutputSchema,
+        "generateInterestReport",
+      )
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
+      }))
+      return {
+        interestSlug: req.interest.slug,
+        analysis_md: decoded.analysis_md,
+        items,
+        promptHash,
+        costUsd: costForResponse(res),
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
+        model: res.model,
+      }
+    }),
+  researchQuery: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildResearchQueryUserPrompt(req)
+      const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv())
+      const res = yield* opts.postLlm(
+        model,
+        RESEARCH_SYSTEM_PROMPT,
+        userPrompt,
+        eff.maxTokens,
+        eff.thinking,
+        eff.thinkingBudgetTokens,
+        null,
+      )
+      const answerMd = res.text.trim()
+      if (answerMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "researchQuery returned empty body"))
+      }
+      return {
+        answerMd,
+        promptHash,
+        costUsd: costForResponse(res),
+        model: res.model,
+      }
+    }),
+  summarizeSource: (req) =>
+    Effect.gen(function* () {
+      const capped =
+        req.text.length > SUMMARY_INPUT_CHARS_CAP
+          ? `${req.text.slice(0, SUMMARY_INPUT_CHARS_CAP)}…`
+          : req.text
+      const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped)
+      const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const res = yield* opts.postLlm(
+        opts.summaryModelFor(),
+        SUMMARY_SYSTEM_PROMPT,
+        userPrompt,
+        SUMMARY_MAX_TOKENS,
+        "off",
+        0,
+        null,
+      )
+      const insightsMd = normalizeInsights(res.text)
+      if (insightsMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "summarize returned empty insights"))
+      }
+      return {
+        insightsMd,
+        promptHash,
+        costUsd: costForResponse(
+          res,
+          SUMMARY_INPUT_COST_PER_MTOK,
+          SUMMARY_OUTPUT_COST_PER_MTOK,
+        ),
+        model: res.model,
+      }
+    }),
+})

--- a/apps/uebermensch/src/lib/llm-shared.ts
+++ b/apps/uebermensch/src/lib/llm-shared.ts
@@ -1,0 +1,202 @@
+// Shared LLM types + cost math used by every LlmService adapter
+// (KernelLlm via /api/llm, AnthropicLlm direct, LMStudioLlm direct).
+// Lives separately from llm-prompts.ts because prompts are pure strings/
+// schemas; this module owns the request/response shape + provider rates.
+
+import { Effect } from "effect"
+import { LlmError } from "../errors.js"
+import type { JsonResponseFormat } from "./llm-prompts.js"
+
+// ---------------------------------------------------------------------------
+// Provider-agnostic response shape — every transport normalizes to this.
+// ---------------------------------------------------------------------------
+export type NormalizedResponse = {
+  readonly text: string
+  readonly inputTokens: number
+  readonly outputTokens: number
+  readonly model: string
+}
+
+// Anthropic native messages response shape (used by both /api/llm/messages
+// kernel proxy and direct api.anthropic.com).
+export type AnthropicResponse = {
+  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>
+  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number }
+  readonly model?: string
+}
+
+// OpenAI-compat chat completions shape (used by both /api/llm/completions
+// kernel proxy and direct LMStudio / Workers AI).
+export type OpenAiChatResponse = {
+  readonly choices?: ReadonlyArray<{ readonly message?: { readonly content?: string } }>
+  readonly usage?: { readonly prompt_tokens?: number; readonly completion_tokens?: number }
+  readonly model?: string
+}
+
+// ---------------------------------------------------------------------------
+// Effort tier + thinking config (operator-tunable via UBER_LLM_EFFORT)
+// ---------------------------------------------------------------------------
+export type Effort = "low" | "medium" | "high"
+
+// Anthropic `thinking` parameter shapes:
+// - "off"      → no thinking field (model answers directly)
+// - "adaptive" → `{ type: "adaptive" }` — model decides budget
+// - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
+export type ThinkingMode = "off" | "adaptive" | "extended"
+
+export type EffortConfig = {
+  readonly maxTokens: number
+  readonly thinking: ThinkingMode
+  readonly thinkingBudgetTokens: number
+}
+
+const DEFAULT_MAX_TOKENS = 16000
+
+export const effortFromEnv = (): Effort => {
+  const raw = process.env.UBER_LLM_EFFORT?.toLowerCase().trim()
+  if (raw === "low" || raw === "high") return raw
+  return "medium"
+}
+
+export const effortConfigFor = (effort: Effort): EffortConfig => {
+  switch (effort) {
+    case "low":
+      return { maxTokens: 4000, thinking: "off", thinkingBudgetTokens: 0 }
+    case "high":
+      return { maxTokens: 32000, thinking: "extended", thinkingBudgetTokens: 16000 }
+    default:
+      return { maxTokens: DEFAULT_MAX_TOKENS, thinking: "adaptive", thinkingBudgetTokens: 0 }
+  }
+}
+
+export const thinkingBody = (
+  thinking: ThinkingMode,
+  budgetTokens: number,
+): Record<string, unknown> => {
+  if (thinking === "off") return {}
+  if (thinking === "extended") {
+    return { thinking: { type: "enabled", budget_tokens: budgetTokens } }
+  }
+  return { thinking: { type: "adaptive" } }
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic per-model USD/Mtok rates (input, output). Local + Workers AI
+// models bill upstream (or are free), so they collapse to 0.
+// ---------------------------------------------------------------------------
+type CostRates = readonly [input: number, output: number]
+
+const ANTHROPIC_RATES: ReadonlyArray<readonly [RegExp, CostRates]> = [
+  [/^claude-opus-4-/, [15.0, 75.0]],
+  [/^claude-sonnet-4-/, [3.0, 15.0]],
+  [/^claude-haiku-4-/, [1.0, 5.0]],
+  [/^claude-3-5-sonnet-/, [3.0, 15.0]],
+  [/^claude-3-5-haiku-/, [1.0, 5.0]],
+  [/^claude-3-opus-/, [15.0, 75.0]],
+]
+
+export const isAnthropicModel = (model: string): boolean => model.startsWith("claude-")
+export const isOpenAiCompatModel = (model: string): boolean => !isAnthropicModel(model)
+// Back-compat alias for older imports.
+export const isWorkersAiModel = isOpenAiCompatModel
+
+const ratesForModel = (model: string): CostRates => {
+  if (!isAnthropicModel(model)) return [0, 0]
+  for (const [pattern, rates] of ANTHROPIC_RATES) {
+    if (pattern.test(model)) return rates
+  }
+  // Unknown claude-* — guess Sonnet rates so a new id surfaces in cost
+  // telemetry instead of silently being free.
+  return [3.0, 15.0]
+}
+
+export const tokensCost = (
+  inputTokens: number,
+  outputTokens: number,
+  inputRate: number,
+  outputRate: number,
+): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000
+
+export const costForResponse = (
+  res: NormalizedResponse,
+  inputRateOverride?: number,
+  outputRateOverride?: number,
+): number => {
+  if (isOpenAiCompatModel(res.model)) return 0
+  if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
+    return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride)
+  }
+  const [inputRate, outputRate] = ratesForModel(res.model)
+  return tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate)
+}
+
+// ---------------------------------------------------------------------------
+// Transport function type — every adapter implements this. Takes a fully
+// resolved request (model + system + prompt + caps + json format) and
+// returns a normalized response. Errors typed as LlmError.
+// ---------------------------------------------------------------------------
+export type PostLlm = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  maxTokens: number,
+  thinking: ThinkingMode,
+  thinkingBudgetTokens: number,
+  jsonFormat: JsonResponseFormat | null,
+) => Effect.Effect<NormalizedResponse, LlmError>
+
+// ---------------------------------------------------------------------------
+// Connection-level error walking (ECONNREFUSED → "kernel down" hint, etc.)
+// ---------------------------------------------------------------------------
+export const isConnRefused = (e: unknown): boolean => {
+  let cur: unknown = e
+  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
+    const code = (cur as { code?: string }).code
+    if (
+      code === "ECONNREFUSED" ||
+      code === "ENOTFOUND" ||
+      code === "EHOSTUNREACH" ||
+      code === "ECONNRESET"
+    ) {
+      return true
+    }
+    const errors = (cur as { errors?: ReadonlyArray<unknown> }).errors
+    if (Array.isArray(errors) && errors.some(isConnRefused)) return true
+    cur = (cur as { cause?: unknown }).cause
+  }
+  return false
+}
+
+export const llmErr = (kind: LlmError["kind"], message: string): LlmError =>
+  new LlmError({ kind, message })
+
+export const classifyHttpStatus = (status: number): LlmError["kind"] => {
+  if (status === 503) return "unavailable"
+  if (status === 429) return "rate_limited"
+  if (status === 400 || status === 401 || status === 403) return "invalid"
+  if (status >= 500) return "unavailable"
+  return "invalid"
+}
+
+// Identity for `x-session-id` / `x-service-name` headers consumed by
+// driver-llm capture path. Kept here so every adapter sets the same
+// headers (kernel-routed and direct alike).
+export const SERVICE_NAME = "uebermensch"
+
+let processSessionId: string | null = null
+export const sessionIdFor = (): string => {
+  const explicit = process.env.UBER_SESSION_ID
+  if (explicit && explicit.length > 0) return explicit
+  if (processSessionId === null) {
+    processSessionId =
+      typeof globalThis.crypto?.randomUUID === "function"
+        ? globalThis.crypto.randomUUID()
+        : `uber-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  }
+  return processSessionId
+}
+
+// Test hook — clears the cached session id so a beforeEach can isolate runs.
+export const _resetSessionIdForTests = (): void => {
+  processSessionId = null
+}

--- a/apps/uebermensch/tests/anthropic-llm.test.ts
+++ b/apps/uebermensch/tests/anthropic-llm.test.ts
@@ -1,0 +1,217 @@
+import { Effect, Exit, Layer, Option } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AnthropicLlmLive } from "../src/adapters/AnthropicLlm.js"
+import { EnvSecretsLive } from "../src/adapters/EnvSecrets.js"
+import { LlmService } from "../src/services/LlmService.js"
+import { SecretsService } from "../src/services/SecretsService.js"
+
+const TEST_BASE = "https://anthropic.test"
+const TEST_MODEL = "claude-opus-4-7"
+
+const anthropicJson = (jsonBlock: unknown, usage = { input_tokens: 100, output_tokens: 200 }) => ({
+  model: TEST_MODEL,
+  usage,
+  content: [
+    {
+      type: "text",
+      text: `\`\`\`json\n${JSON.stringify(jsonBlock)}\n\`\`\``,
+    },
+  ],
+})
+
+describe("AnthropicLlm direct adapter", () => {
+  const originalFetch = globalThis.fetch
+  const prevBase = process.env.UBER_ANTHROPIC_BASE_URL
+  const prevModel = process.env.UBER_LLM_MODEL
+  const prevSummaryModel = process.env.UBER_LLM_SUMMARY_MODEL
+  const prevApiKey = process.env.ANTHROPIC_API_KEY
+
+  beforeEach(() => {
+    process.env.UBER_ANTHROPIC_BASE_URL = TEST_BASE
+    process.env.UBER_LLM_MODEL = TEST_MODEL
+    process.env.UBER_LLM_SUMMARY_MODEL = TEST_MODEL
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-fixture"
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.env.UBER_ANTHROPIC_BASE_URL = prevBase
+    if (prevModel === undefined) delete process.env.UBER_LLM_MODEL
+    else process.env.UBER_LLM_MODEL = prevModel
+    if (prevSummaryModel === undefined) delete process.env.UBER_LLM_SUMMARY_MODEL
+    else process.env.UBER_LLM_SUMMARY_MODEL = prevSummaryModel
+    if (prevApiKey === undefined) delete process.env.ANTHROPIC_API_KEY
+    else process.env.ANTHROPIC_API_KEY = prevApiKey
+  })
+
+  it("POSTs directly to api.anthropic.com/v1/messages with x-api-key", async () => {
+    const payload = anthropicJson({
+      items: [
+        {
+          kind: "news",
+          title: "Direct anthropic call",
+          summary_md: "Body referencing [[2026-04-18--foo]].",
+          topic: "alpha",
+          thesis: null,
+          source_candidate_ids: ["cand-0000"],
+          suggested_action: null,
+        },
+      ],
+      topicsCovered: ["alpha"],
+      thesesCovered: [],
+    })
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: ["alpha"],
+        thesesSlugs: [],
+        candidates: [
+          {
+            id: "cand-0000",
+            page: {
+              relPath: "input/raw/2026-04-18--foo.md",
+              stem: "2026-04-18--foo",
+              frontmatter: { page_type: "source", slug: "2026-04-18--foo", topics: ["alpha"] },
+              body: "Foo body.",
+              mtime: new Date("2026-04-20T12:00:00Z"),
+            },
+            score: 0.9,
+          },
+        ],
+        maxItems: 5,
+      })
+    })
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(AnthropicLlmLive.pipe(Layer.provide(EnvSecretsLive)))),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${TEST_BASE}/v1/messages`)
+    expect(init.method).toBe("POST")
+    expect(init.headers["x-api-key"]).toBe("sk-ant-test-fixture")
+    expect(init.headers["anthropic-version"]).toBe("2023-06-01")
+    expect(init.headers["x-service-name"]).toBe("uebermensch")
+    const body = JSON.parse(init.body)
+    expect(body.model).toBe(TEST_MODEL)
+    expect(body.system).toContain("brief")
+    expect(body.messages).toEqual([{ role: "user", content: expect.any(String) }])
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].title).toBe("Direct anthropic call")
+    expect(result.model).toBe(TEST_MODEL)
+    expect(result.costUsd).toBeGreaterThan(0)
+  })
+
+  it("fails with a typed LlmError when ANTHROPIC_API_KEY is unset", async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: ["alpha"],
+        thesesSlugs: [],
+        candidates: [],
+        maxItems: 5,
+      })
+    })
+
+    const exit = await Effect.runPromiseExit(
+      program.pipe(Effect.provide(AnthropicLlmLive.pipe(Layer.provide(EnvSecretsLive)))),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+    if (Exit.isFailure(exit)) {
+      const failure = JSON.stringify(exit.cause)
+      expect(failure).toMatch(/ANTHROPIC_API_KEY/)
+    }
+  })
+
+  it("uses an injected SecretsService over process.env", async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    const payload = anthropicJson({
+      items: [],
+      topicsCovered: [],
+      thesesCovered: [],
+    })
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const InMemorySecrets = Layer.succeed(SecretsService, {
+      get: (key) =>
+        Effect.succeed(
+          key === "ANTHROPIC_API_KEY"
+            ? Option.some("sk-ant-from-keychain")
+            : Option.none(),
+        ),
+      has: (key) => Effect.succeed(key === "ANTHROPIC_API_KEY"),
+    })
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: ["alpha"],
+        thesesSlugs: [],
+        candidates: [],
+        maxItems: 5,
+      })
+    })
+
+    await Effect.runPromise(
+      program.pipe(Effect.provide(AnthropicLlmLive.pipe(Layer.provide(InMemorySecrets)))),
+    )
+    const init = fetchMock.mock.calls[0][1]
+    expect(init.headers["x-api-key"]).toBe("sk-ant-from-keychain")
+  })
+
+  it("classifies HTTP 429 as rate_limited", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => '{"error":"rate_limited"}',
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: [],
+        thesesSlugs: [],
+        candidates: [],
+        maxItems: 5,
+      })
+    })
+
+    const exit = await Effect.runPromiseExit(
+      program.pipe(Effect.provide(AnthropicLlmLive.pipe(Layer.provide(EnvSecretsLive)))),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failure = JSON.stringify(exit.cause)
+      expect(failure).toMatch(/rate_limited|429/)
+    }
+  })
+})

--- a/apps/uebermensch/tests/lmstudio-llm.test.ts
+++ b/apps/uebermensch/tests/lmstudio-llm.test.ts
@@ -1,0 +1,153 @@
+import { Effect, Exit } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { LMStudioLlmLive } from "../src/adapters/LMStudioLlm.js"
+import { LlmService } from "../src/services/LlmService.js"
+
+const TEST_BASE = "http://lmstudio.test:9999"
+const TEST_MODEL = "google/gemma-4-31b"
+
+const openAiCompatJson = (
+  jsonBlock: unknown,
+  usage = { prompt_tokens: 100, completion_tokens: 200 },
+) => ({
+  model: TEST_MODEL,
+  usage,
+  choices: [
+    {
+      message: {
+        role: "assistant",
+        content: JSON.stringify(jsonBlock),
+      },
+    },
+  ],
+})
+
+describe("LMStudioLlm direct adapter", () => {
+  const originalFetch = globalThis.fetch
+  const prevBase = process.env.UBER_LMSTUDIO_BASE_URL
+  const prevModel = process.env.UBER_LLM_MODEL
+  const prevSummaryModel = process.env.UBER_LLM_SUMMARY_MODEL
+
+  beforeEach(() => {
+    process.env.UBER_LMSTUDIO_BASE_URL = TEST_BASE
+    process.env.UBER_LLM_MODEL = TEST_MODEL
+    process.env.UBER_LLM_SUMMARY_MODEL = TEST_MODEL
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.env.UBER_LMSTUDIO_BASE_URL = prevBase
+    if (prevModel === undefined) delete process.env.UBER_LLM_MODEL
+    else process.env.UBER_LLM_MODEL = prevModel
+    if (prevSummaryModel === undefined) delete process.env.UBER_LLM_SUMMARY_MODEL
+    else process.env.UBER_LLM_SUMMARY_MODEL = prevSummaryModel
+  })
+
+  it("POSTs directly to OpenAI-compat /v1/chat/completions, no auth header", async () => {
+    const payload = openAiCompatJson({
+      items: [
+        {
+          kind: "news",
+          title: "Local LMStudio call",
+          summary_md: "Body referencing [[2026-04-18--foo]].",
+          topic: "alpha",
+          thesis: null,
+          source_candidate_ids: ["cand-0000"],
+          suggested_action: null,
+        },
+      ],
+      topicsCovered: ["alpha"],
+      thesesCovered: [],
+    })
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: ["alpha"],
+        thesesSlugs: [],
+        candidates: [
+          {
+            id: "cand-0000",
+            page: {
+              relPath: "input/raw/2026-04-18--foo.md",
+              stem: "2026-04-18--foo",
+              frontmatter: { page_type: "source", slug: "2026-04-18--foo", topics: ["alpha"] },
+              body: "Foo body.",
+              mtime: new Date("2026-04-20T12:00:00Z"),
+            },
+            score: 0.9,
+          },
+        ],
+        maxItems: 5,
+      })
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(LMStudioLlmLive)))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`${TEST_BASE}/v1/chat/completions`)
+    expect(init.method).toBe("POST")
+    expect(init.headers["x-api-key"]).toBeUndefined()
+    expect(init.headers["authorization"]).toBeUndefined()
+    expect(init.headers["x-service-name"]).toBe("uebermensch")
+
+    const body = JSON.parse(init.body)
+    expect(body.model).toBe(TEST_MODEL)
+    expect(body.messages).toHaveLength(2)
+    expect(body.messages[0].role).toBe("system")
+    expect(body.messages[1].role).toBe("user")
+    // brief lane sets a json_schema response_format
+    expect(body.response_format?.type).toBe("json_schema")
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].title).toBe("Local LMStudio call")
+    // Local backend → 0 cost
+    expect(result.costUsd).toBe(0)
+  })
+
+  it("classifies HTTP 503 as unavailable", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "model not loaded",
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.generateBrief({
+        date: "2026-04-22",
+        profileName: "Test",
+        topics: [],
+        thesesSlugs: [],
+        candidates: [],
+        maxItems: 5,
+      })
+    })
+
+    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(LMStudioLlmLive)))
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failure = JSON.stringify(exit.cause)
+      expect(failure).toMatch(/unavailable|503/)
+    }
+  })
+
+  it("name() echoes the configured model", async () => {
+    const program = Effect.gen(function* () {
+      const llm = yield* LlmService
+      return llm.name()
+    })
+    const name = await Effect.runPromise(program.pipe(Effect.provide(LMStudioLlmLive)))
+    expect(name).toBe(`lmstudio-direct@${TEST_MODEL}`)
+  })
+})


### PR DESCRIPTION
## Summary

Slice 2 of the uebermensch eject plan (**PR-B**). Stacks on #147.

Adds two `LlmService` adapters that bypass the gctrl kernel entirely so uebermensch can run in `--mode=local-direct` (and the future cloud-only Worker target):

- **`AnthropicLlm`** — POSTs directly to `api.anthropic.com/v1/messages`. API key resolved via `SecretsService.get("ANTHROPIC_API_KEY")` at request time so rotation through the secrets backend takes effect immediately.
- **`LMStudioLlm`** — POSTs directly to `127.0.0.1:1234/v1/chat/completions` (no auth — local backends are typically open on loopback). All responses cost $0 via the existing rates table.

Both reuse `lib/llm-prompts.ts` so prompts cannot drift across transports, and both wire through a new `makeLlmServiceShape` factory that owns the five `LlmServiceShape` methods (`generateBrief`, `proposeSubtopic`, `generateInterestReport`, `researchQuery`, `summarizeSource`).

## How it works

```mermaid
flowchart TD
  Cmd[brief / report / research / ingest] --> LS[LlmService]
  LS -.local-kernel.-> KL[KernelLlmLive]
  LS -.local-direct.-> AL[AnthropicLlmLive]
  LS -.local-direct.-> ML[LMStudioLlmLive]
  KL --> KP[POST kernel /api/llm/messages or /completions]
  AL --> SS[SecretsService.get ANTHROPIC_API_KEY]
  AL --> AP[POST api.anthropic.com/v1/messages]
  ML --> LP[POST 127.0.0.1:1234/v1/chat/completions]
  KL & AL & ML -. shared .-> F[makeLlmServiceShape factory]
  F --> P[lib/llm-prompts.ts]
  F --> S[lib/llm-shared.ts: rates, effort, sessionId]
```

`KernelLlm.ts` shrinks **619 → 263 lines** (the five method bodies move to the shared factory).

## What stays the same

- Identity headers (`x-session-id`, `x-service-name`) preserved across all three adapters → dashboards group runs by session id consistently regardless of routing mode.
- Effort tier (`UBER_LLM_EFFORT=low|medium|high`) + thinking budget logic.
- Cost math (Anthropic per-model rates table, summary lane fixed rate, OpenAI-compat = $0).
- All five `LlmServiceShape` methods behave identically — only the transport changes.

## Mode selection

This PR adds the adapters but does **not** wire them through `buildModeLayer` yet. That is the next slice (PR-B slice 4). For now, downstream callers continue to consume `KernelLlmLive` unchanged.

Override knobs introduced for testing + operators:
- `UBER_ANTHROPIC_BASE_URL` — point AnthropicLlm at a fixture/proxy
- `UBER_LMSTUDIO_BASE_URL` — point LMStudioLlm at a different host/port
- `ANTHROPIC_API_KEY` — read via `EnvSecretsLive` (transitional)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — **264 passing** (was 257, +7 new)
- [x] `pnpm exec biome lint shell/*/src/ apps/*/src/` — 0 errors (29 pre-existing warnings unchanged)
- [x] `tests/anthropic-llm.test.ts` (4): URL/headers/body shape, missing key fails before fetch, injected `SecretsService` overrides env, 429 → `rate_limited` classification.
- [x] `tests/lmstudio-llm.test.ts` (3): URL/body, no auth header, 503 → `unavailable` classification, `name()` formatting.
- [ ] Manual smoke against fixture vault — deferred to slice 4 (when `--mode=local-direct` is wired through `brief`/`report` commands).

## Eject sequence

- [x] PR-A foundation — #145 (merged)
- [x] **PR-B slice 7a** — wire VaultSecretGuard into write path — #147 (this PR stacks on it)
- [x] **PR-B slice 2** — direct LLM adapters — **this PR**
- [ ] PR-B slice 3 — direct deliverer adapters (Telegram + Discord)
- [ ] PR-B slice 4 — `buildModeLayer(mode)` factory + wire through commands
- [ ] PR-B slice 5 — remove kernel `uber_*` tables + routes
- [ ] PR-B slice 6 — `gctrl-app.toml` install protocol
- [ ] PR-C — `R2VaultWriter` + repo carve to `OpenHackersClub/uebermensch`
