### PR TITLE
feat(uebermensch): direct deliverer adapter — Telegram + Discord no-kernel

### DIFF
--- a/apps/uebermensch/src/adapters/DirectDeliverer.ts
+++ b/apps/uebermensch/src/adapters/DirectDeliverer.ts
@@ -1,0 +1,224 @@
+// DirectDeliverer — talks to Telegram Bot API and Discord webhooks directly,
+// bypassing the gctrl kernel. Used in `--mode=local-direct` and the future
+// cloud-only Worker target.
+//
+// Telegram needs `TELEGRAM_BOT_TOKEN` from SecretsService at request time.
+// Discord webhooks are unauthenticated — the URL itself is the credential, so
+// resolveRef returns the webhook URL and we POST to it directly.
+
+import { Effect, Layer, Match, Option } from "effect"
+import { DeliveryError } from "../errors.js"
+import {
+  chunkPrefix,
+  classifyHttpStatus,
+  configErr,
+  DC_MAX,
+  resolveEnvRef,
+  resolveRef,
+  splitBrief,
+  splitChunks,
+  stripFrontmatter,
+  TG_MAX,
+  unreachableErr,
+} from "../lib/deliverer-shared.js"
+import {
+  DelivererService,
+  type DeliverInput,
+  type DeliveryResult,
+} from "../services/DelivererService.js"
+import { SecretsService, type SecretsServiceImpl } from "../services/SecretsService.js"
+
+const TELEGRAM_BOT_TOKEN_KEY = "TELEGRAM_BOT_TOKEN"
+
+const telegramApiBase = (): string =>
+  (process.env.UBER_TELEGRAM_API_URL ?? "https://api.telegram.org").replace(/\/+$/, "")
+
+// Discord webhooks live on `discord.com/api/webhooks/...`. The webhook URL is
+// resolved per-channel via target_ref, but we let tests rebase it via env so
+// fixtures can serve a mock without a real webhook.
+const discordRebasedUrl = (resolvedUrl: string): string => {
+  const override = process.env.UBER_DISCORD_API_URL
+  if (!override) return resolvedUrl
+  // Rebase only the host, preserve path. If the original URL is malformed,
+  // return as-is — DirectDeliverer's fetch will surface the error.
+  try {
+    const parsed = new URL(resolvedUrl)
+    return new URL(parsed.pathname + parsed.search, override).toString()
+  } catch {
+    return resolvedUrl
+  }
+}
+
+const postJson = (
+  url: string,
+  body: unknown,
+  channel: string,
+  driver: string,
+): Effect.Effect<{ readonly status: number; readonly text: string }, DeliveryError> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      catch: (e) => unreachableErr(url, channel, driver, `fetch failed: ${String(e)}`),
+    })
+    const text = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (e) => unreachableErr(url, channel, driver, `body read failed: ${String(e)}`),
+    })
+    if (!response.ok) {
+      return yield* Effect.fail(
+        new DeliveryError({
+          message: `${url} HTTP ${response.status}: ${text.slice(0, 500)}`,
+          channel,
+          driver,
+          kind: classifyHttpStatus(response.status),
+          status: response.status,
+        }),
+      )
+    }
+    return { status: response.status, text }
+  })
+
+const requireBotToken = (
+  secrets: SecretsServiceImpl,
+  channel: string,
+): Effect.Effect<string, DeliveryError> =>
+  secrets.get(TELEGRAM_BOT_TOKEN_KEY).pipe(
+    Effect.catchTag("SecretsError", (e) =>
+      Effect.fail(
+        configErr(
+          channel,
+          "telegram",
+          `secret lookup failed for ${TELEGRAM_BOT_TOKEN_KEY}: ${e.message}`,
+        ),
+      ),
+    ),
+    Effect.flatMap(
+      Option.match({
+        onNone: () =>
+          Effect.fail(
+            configErr(
+              channel,
+              "telegram",
+              `${TELEGRAM_BOT_TOKEN_KEY} not provisioned — set the secret via your ` +
+                `SecretsService backend (env: export ${TELEGRAM_BOT_TOKEN_KEY}=…) or run ` +
+                `uebermensch in --mode=local-kernel.`,
+            ),
+          ),
+        onSome: Effect.succeed,
+      }),
+    ),
+  )
+
+const sendTelegramDirect = (
+  secrets: SecretsServiceImpl,
+  input: DeliverInput,
+): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.gen(function* () {
+    const [chatId, botToken] = yield* Effect.all([
+      resolveRef(secrets, input.targetRef, "tg:chat:", input.channel, input.driver),
+      requireBotToken(secrets, input.channel),
+    ])
+    const url = `${telegramApiBase()}/bot${botToken}/sendMessage`
+    const chunks = splitBrief(input.content, TG_MAX)
+    const responses = yield* Effect.forEach(chunks, (chunk, i) =>
+      postJson(
+        url,
+        {
+          chat_id: chatId,
+          text: `${chunkPrefix(i, chunks.length)}${chunk}`,
+          disable_notification: input.silent,
+        },
+        input.channel,
+        input.driver,
+      ).pipe(
+        Effect.flatMap(({ text }) =>
+          Effect.try({
+            try: () =>
+              JSON.parse(text) as {
+                readonly result?: { readonly message_id?: number | null }
+              },
+            catch: (e) =>
+              new DeliveryError({
+                message: `telegram response JSON parse failed: ${String(e)}`,
+                channel: input.channel,
+                driver: input.driver,
+                kind: "invalid",
+              }),
+          }),
+        ),
+      ),
+    )
+    const externalIds = responses
+      .map((r) => r.result?.message_id)
+      .filter((id): id is number => typeof id === "number")
+      .map(String)
+    return {
+      channel: input.channel,
+      driver: input.driver,
+      externalIds,
+      parts: chunks.length,
+    }
+  })
+
+const sendDiscordDirect = (
+  secrets: SecretsServiceImpl,
+  input: DeliverInput,
+): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.gen(function* () {
+    const webhook = yield* resolveRef(
+      secrets,
+      input.targetRef,
+      "dc:webhook:",
+      input.channel,
+      input.driver,
+    )
+    const url = discordRebasedUrl(webhook)
+    const chunks = splitBrief(input.content, DC_MAX)
+    yield* Effect.forEach(chunks, (chunk, i) => {
+      const prefix = chunkPrefix(i, chunks.length)
+      const content = input.silent ? `@silent ${prefix}${chunk}` : `${prefix}${chunk}`
+      return postJson(url, { content }, input.channel, input.driver)
+    })
+    return {
+      channel: input.channel,
+      driver: input.driver,
+      externalIds: [],
+      parts: chunks.length,
+    }
+  })
+
+const sendApp = (input: DeliverInput): Effect.Effect<DeliveryResult, DeliveryError> =>
+  Effect.succeed({
+    channel: input.channel,
+    driver: input.driver,
+    externalIds: [],
+    parts: 1,
+  })
+
+// DirectDelivererLive — same DelivererService surface as HttpDelivererLive,
+// but no kernel hop. Mode wiring (PR-B slice 4) picks this Layer for
+// `--mode=local-direct`.
+export const DirectDelivererLive = Layer.effect(
+  DelivererService,
+  Effect.gen(function* () {
+    const secrets = yield* SecretsService
+    return {
+      send: (input: DeliverInput): Effect.Effect<DeliveryResult, DeliveryError> =>
+        Match.value(input.driver).pipe(
+          Match.when("telegram", () => sendTelegramDirect(secrets, input)),
+          Match.when("discord", () => sendDiscordDirect(secrets, input)),
+          Match.when("app", () => sendApp(input)),
+          Match.orElse(() =>
+            Effect.fail(
+              configErr(input.channel, input.driver, `unknown driver: ${input.driver}`),
+            ),
+          ),
+        ),
+    }
+  }),
+)

--- a/apps/uebermensch/src/adapters/HttpDeliverer.ts
+++ b/apps/uebermensch/src/adapters/HttpDeliverer.ts
@@ -1,5 +1,18 @@
-import { Effect, Layer, Match, Option } from "effect"
+import { Effect, Layer, Match } from "effect"
 import { DeliveryError } from "../errors.js"
+import {
+  chunkPrefix,
+  classifyHttpStatus,
+  configErr,
+  DC_MAX,
+  resolveEnvRef,
+  resolveRef,
+  splitBrief,
+  splitChunks,
+  stripFrontmatter,
+  TG_MAX,
+  unreachableErr,
+} from "../lib/deliverer-shared.js"
 import {
   DelivererService,
   type DeliverInput,
@@ -7,144 +20,8 @@ import {
 } from "../services/DelivererService.js"
 import { SecretsService, type SecretsServiceImpl } from "../services/SecretsService.js"
 
-const TG_MAX = 3800
-const DC_MAX = 1900
-
-const splitChunks = (content: string, max: number): ReadonlyArray<string> => {
-  if (content.length <= max) return [content]
-  const chunks: Array<string> = []
-  const lines = content.split("\n")
-  let buf = ""
-  for (const line of lines) {
-    const next = buf.length === 0 ? line : `${buf}\n${line}`
-    if (next.length > max && buf.length > 0) {
-      chunks.push(buf)
-      buf = line
-    } else if (next.length > max) {
-      for (let i = 0; i < line.length; i += max) chunks.push(line.slice(i, i + max))
-      buf = ""
-    } else {
-      buf = next
-    }
-  }
-  if (buf.length > 0) chunks.push(buf)
-  return chunks
-}
-
-const stripFrontmatter = (md: string): string => {
-  if (!md.startsWith("---\n")) return md
-  const end = md.indexOf("\n---\n", 4)
-  if (end === -1) return md
-  return md.slice(end + 5).replace(/^\n+/, "")
-}
-
-const ITEM_HEADING = /^## \d+\. /m
-
-const splitBrief = (content: string, max: number): ReadonlyArray<string> => {
-  const body = stripFrontmatter(content)
-  if (!ITEM_HEADING.test(body)) return splitChunks(body, max)
-  const withoutH1 = body.replace(/^#\s+[^\n]*\n+/, "")
-  const parts = withoutH1
-    .split(/(?=^## \d+\. )/m)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-  const out: Array<string> = []
-  for (const p of parts) {
-    if (p.length <= max) out.push(p)
-    else for (const c of splitChunks(p, max)) out.push(c)
-  }
-  return out
-}
-
-// Parse a `prefix`-scoped target ref into either a literal value or an env
-// key name. Returns `null` when the prefix does not match. Env-backed refs
-// have the form `<prefix>env:<ENV_VAR_NAME>`; literal refs are
-// `<prefix><value>`. Pure parser — never touches `process.env`; that read is
-// the exclusive responsibility of the `SecretsService` adapter.
-const resolveEnvRef = (
-  targetRef: string,
-  prefix: string,
-): { kind: "env"; key: string } | { kind: "literal"; value: string } | null => {
-  if (!targetRef.startsWith(prefix)) return null
-  const rest = targetRef.slice(prefix.length)
-  if (rest.startsWith("env:")) return { kind: "env", key: rest.slice(4) }
-  return { kind: "literal", value: rest }
-}
-
-const configErr = (channel: string, driver: string, message: string): DeliveryError =>
-  new DeliveryError({ message, channel, driver, kind: "config" })
-
-// Resolve a prefixed target ref to its concrete string value. Literal refs
-// are returned synchronously; env-backed refs (`env:<KEY>`) are resolved via
-// `SecretsService.get` so the actual `process.env` read is isolated to the
-// EnvSecretsLive adapter — future adapters (kernel secrets, keychain) swap in
-// without touching this file. `secrets` is captured at Layer-build time, not
-// requested as a Service requirement, so the returned Effect's R channel is
-// `never`.
-const resolveRef = (
-  secrets: SecretsServiceImpl,
-  targetRef: string,
-  prefix: string,
-  channel: string,
-  driver: string,
-): Effect.Effect<string, DeliveryError> => {
-  const unresolved = () =>
-    configErr(channel, driver, `unresolved target_ref for ${driver}: ${targetRef}`)
-  const parsed = resolveEnvRef(targetRef, prefix)
-  if (parsed === null) return Effect.fail(unresolved())
-  return Match.value(parsed).pipe(
-    Match.discriminator("kind")("literal", ({ value }) => Effect.succeed(value)),
-    Match.discriminator("kind")("env", ({ key }) =>
-      secrets.get(key).pipe(
-        Effect.catchTag("SecretsError", (e) =>
-          Effect.fail(
-            configErr(
-              channel,
-              driver,
-              `secret lookup failed for ${driver} (key=${key}): ${e.message}`,
-            ),
-          ),
-        ),
-        Effect.flatMap(
-          Option.match({
-            onNone: () => Effect.fail(unresolved()),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ),
-    ),
-    Match.exhaustive,
-  )
-}
-
-// HTTP status → DeliveryError kind. 5xx is network/health (retry); 4xx is a
-// client/config problem (don't retry).
-const classifyKernelStatus = (
-  status: number,
-): "config" | "unreachable" | "rate_limited" | "invalid" | "io_failure" =>
-  Match.value(status).pipe(
-    Match.when(429, () => "rate_limited" as const),
-    Match.whenOr(502, 503, 504, () => "unreachable" as const),
-    Match.when((n) => n >= 500, () => "unreachable" as const),
-    Match.whenOr(400, 401, 403, 404, () => "invalid" as const),
-    Match.orElse(() => "io_failure" as const),
-  )
-
 const kernelBase = () =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
-
-const unreachableErr = (
-  path: string,
-  channel: string,
-  driver: string,
-  reason: string,
-): DeliveryError =>
-  new DeliveryError({
-    message: `kernel ${path} ${reason}`,
-    channel,
-    driver,
-    kind: "unreachable",
-  })
 
 const postToKernel = (
   path: string,
@@ -160,11 +37,13 @@ const postToKernel = (
           headers: { "content-type": "application/json" },
           body: JSON.stringify(body),
         }),
-      catch: (e) => unreachableErr(path, channel, driver, `fetch failed: ${String(e)}`),
+      catch: (e) =>
+        unreachableErr(`kernel ${path}`, channel, driver, `fetch failed: ${String(e)}`),
     })
     const text = yield* Effect.tryPromise({
       try: () => response.text(),
-      catch: (e) => unreachableErr(path, channel, driver, `body read failed: ${String(e)}`),
+      catch: (e) =>
+        unreachableErr(`kernel ${path}`, channel, driver, `body read failed: ${String(e)}`),
     })
     if (!response.ok) {
       return yield* Effect.fail(
@@ -172,7 +51,7 @@ const postToKernel = (
           message: `kernel ${path} HTTP ${response.status}: ${text.slice(0, 500)}`,
           channel,
           driver,
-          kind: classifyKernelStatus(response.status),
+          kind: classifyHttpStatus(response.status),
           status: response.status,
         }),
       )
@@ -189,9 +68,6 @@ const postToKernel = (
         }),
     })
   })
-
-const chunkPrefix = (i: number, total: number): string =>
-  total > 1 ? `(${i + 1}/${total})\n` : ""
 
 const sendTelegram = (
   secrets: SecretsServiceImpl,
@@ -294,6 +170,8 @@ export const HttpDelivererLive = Layer.effect(
   }),
 )
 
+// Kept for back-compat with existing tests that destructure `_internal`.
+// New code should import directly from `lib/deliverer-shared.ts`.
 export const _internal = {
   splitChunks,
   splitBrief,
@@ -301,5 +179,5 @@ export const _internal = {
   resolveEnvRef,
   kernelBase,
   resolveRef,
-  classifyKernelStatus,
+  classifyKernelStatus: classifyHttpStatus,
 }

--- a/apps/uebermensch/src/lib/deliverer-shared.ts
+++ b/apps/uebermensch/src/lib/deliverer-shared.ts
@@ -1,0 +1,146 @@
+// Shared helpers for every DelivererService adapter (HttpDeliverer via
+// kernel proxy, DirectDeliverer hitting providers directly). Lives here so
+// the chunking / target-ref-resolution logic cannot drift across adapters.
+
+import { Effect, Match, Option } from "effect"
+import { DeliveryError } from "../errors.js"
+import type { SecretsServiceImpl } from "../services/SecretsService.js"
+
+// ---------------------------------------------------------------------------
+// Per-channel max chunk lengths. Telegram's hard cap is 4096 chars, Discord
+// 2000 — leave headroom for chunk-prefix + UTF8 safety.
+// ---------------------------------------------------------------------------
+export const TG_MAX = 3800
+export const DC_MAX = 1900
+
+export const splitChunks = (content: string, max: number): ReadonlyArray<string> => {
+  if (content.length <= max) return [content]
+  const chunks: Array<string> = []
+  const lines = content.split("\n")
+  let buf = ""
+  for (const line of lines) {
+    const next = buf.length === 0 ? line : `${buf}\n${line}`
+    if (next.length > max && buf.length > 0) {
+      chunks.push(buf)
+      buf = line
+    } else if (next.length > max) {
+      for (let i = 0; i < line.length; i += max) chunks.push(line.slice(i, i + max))
+      buf = ""
+    } else {
+      buf = next
+    }
+  }
+  if (buf.length > 0) chunks.push(buf)
+  return chunks
+}
+
+export const stripFrontmatter = (md: string): string => {
+  if (!md.startsWith("---\n")) return md
+  const end = md.indexOf("\n---\n", 4)
+  if (end === -1) return md
+  return md.slice(end + 5).replace(/^\n+/, "")
+}
+
+const ITEM_HEADING = /^## \d+\. /m
+
+export const splitBrief = (content: string, max: number): ReadonlyArray<string> => {
+  const body = stripFrontmatter(content)
+  if (!ITEM_HEADING.test(body)) return splitChunks(body, max)
+  const withoutH1 = body.replace(/^#\s+[^\n]*\n+/, "")
+  const parts = withoutH1
+    .split(/(?=^## \d+\. )/m)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  const out: Array<string> = []
+  for (const p of parts) {
+    if (p.length <= max) out.push(p)
+    else for (const c of splitChunks(p, max)) out.push(c)
+  }
+  return out
+}
+
+export const chunkPrefix = (i: number, total: number): string =>
+  total > 1 ? `(${i + 1}/${total})\n` : ""
+
+// ---------------------------------------------------------------------------
+// Target-ref resolution — `<prefix>env:<KEY>` → secrets.get(KEY),
+// `<prefix><value>` → literal. Pure parser delegates env reads to
+// SecretsService so a future LocalKeychain/KernelSecrets adapter swaps in
+// without touching this file.
+// ---------------------------------------------------------------------------
+export const resolveEnvRef = (
+  targetRef: string,
+  prefix: string,
+): { kind: "env"; key: string } | { kind: "literal"; value: string } | null => {
+  if (!targetRef.startsWith(prefix)) return null
+  const rest = targetRef.slice(prefix.length)
+  if (rest.startsWith("env:")) return { kind: "env", key: rest.slice(4) }
+  return { kind: "literal", value: rest }
+}
+
+export const configErr = (channel: string, driver: string, message: string): DeliveryError =>
+  new DeliveryError({ message, channel, driver, kind: "config" })
+
+export const resolveRef = (
+  secrets: SecretsServiceImpl,
+  targetRef: string,
+  prefix: string,
+  channel: string,
+  driver: string,
+): Effect.Effect<string, DeliveryError> => {
+  const unresolved = () =>
+    configErr(channel, driver, `unresolved target_ref for ${driver}: ${targetRef}`)
+  const parsed = resolveEnvRef(targetRef, prefix)
+  if (parsed === null) return Effect.fail(unresolved())
+  return Match.value(parsed).pipe(
+    Match.discriminator("kind")("literal", ({ value }) => Effect.succeed(value)),
+    Match.discriminator("kind")("env", ({ key }) =>
+      secrets.get(key).pipe(
+        Effect.catchTag("SecretsError", (e) =>
+          Effect.fail(
+            configErr(
+              channel,
+              driver,
+              `secret lookup failed for ${driver} (key=${key}): ${e.message}`,
+            ),
+          ),
+        ),
+        Effect.flatMap(
+          Option.match({
+            onNone: () => Effect.fail(unresolved()),
+            onSome: Effect.succeed,
+          }),
+        ),
+      ),
+    ),
+    Match.exhaustive,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// HTTP status → DeliveryError kind. 5xx is network/health (retry-eligible);
+// 4xx is a client/config problem (don't retry).
+// ---------------------------------------------------------------------------
+export const classifyHttpStatus = (
+  status: number,
+): "config" | "unreachable" | "rate_limited" | "invalid" | "io_failure" =>
+  Match.value(status).pipe(
+    Match.when(429, () => "rate_limited" as const),
+    Match.whenOr(502, 503, 504, () => "unreachable" as const),
+    Match.when((n) => n >= 500, () => "unreachable" as const),
+    Match.whenOr(400, 401, 403, 404, () => "invalid" as const),
+    Match.orElse(() => "io_failure" as const),
+  )
+
+export const unreachableErr = (
+  path: string,
+  channel: string,
+  driver: string,
+  reason: string,
+): DeliveryError =>
+  new DeliveryError({
+    message: `${path} ${reason}`,
+    channel,
+    driver,
+    kind: "unreachable",
+  })

--- a/apps/uebermensch/tests/direct-deliverer.test.ts
+++ b/apps/uebermensch/tests/direct-deliverer.test.ts
@@ -1,0 +1,284 @@
+import { Effect, Exit, Layer, Option } from "effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DirectDelivererLive } from "../src/adapters/DirectDeliverer.js"
+import { EnvSecretsLive } from "../src/adapters/EnvSecrets.js"
+import { DelivererService } from "../src/services/DelivererService.js"
+import { SecretsService } from "../src/services/SecretsService.js"
+
+const TG_BASE = "https://telegram.test"
+const DC_BASE = "https://discord.test"
+
+const DirectWithEnv = DirectDelivererLive.pipe(Layer.provide(EnvSecretsLive))
+
+describe("DirectDeliverer telegram", () => {
+  const originalFetch = globalThis.fetch
+  const prevTgUrl = process.env.UBER_TELEGRAM_API_URL
+  const prevToken = process.env.TELEGRAM_BOT_TOKEN
+  const prevChatId = process.env.TEST_CHAT_ID
+
+  beforeEach(() => {
+    process.env.UBER_TELEGRAM_API_URL = TG_BASE
+    process.env.TELEGRAM_BOT_TOKEN = "9876:test-bot-token"
+    process.env.TEST_CHAT_ID = "42"
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (prevTgUrl === undefined) delete process.env.UBER_TELEGRAM_API_URL
+    else process.env.UBER_TELEGRAM_API_URL = prevTgUrl
+    if (prevToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN
+    else process.env.TELEGRAM_BOT_TOKEN = prevToken
+    if (prevChatId === undefined) delete process.env.TEST_CHAT_ID
+    else process.env.TEST_CHAT_ID = prevChatId
+  })
+
+  it("POSTs directly to api.telegram.org/bot<token>/sendMessage", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, result: { message_id: 4242 } }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "---\nx: 1\n---\n\n# Brief\n\nhi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+
+    expect(result.externalIds).toEqual(["4242"])
+    expect(result.parts).toBe(1)
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(`${TG_BASE}/bot9876:test-bot-token/sendMessage`)
+    expect((init as { method: string }).method).toBe("POST")
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.chat_id).toBe("42")
+    expect(body.text).toBe("# Brief\n\nhi")
+    expect(body.disable_notification).toBe(false)
+  })
+
+  it("fails with config error when TELEGRAM_BOT_TOKEN is unset", async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+    if (Exit.isFailure(exit)) {
+      const failure = JSON.stringify(exit.cause)
+      expect(failure).toMatch(/TELEGRAM_BOT_TOKEN/)
+    }
+  })
+
+  it("uses an injected SecretsService over process.env", async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, result: { message_id: 1 } }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const InMemorySecrets = Layer.succeed(SecretsService, {
+      get: (key) =>
+        Effect.succeed(
+          key === "TELEGRAM_BOT_TOKEN"
+            ? Option.some("1111:keychain-token")
+            : key === "TEST_CHAT_ID"
+              ? Option.some("99")
+              : Option.none(),
+        ),
+      has: (key) => Effect.succeed(key === "TELEGRAM_BOT_TOKEN" || key === "TEST_CHAT_ID"),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectDelivererLive.pipe(Layer.provide(InMemorySecrets)))),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(`${TG_BASE}/bot1111:keychain-token/sendMessage`)
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.chat_id).toBe("99")
+  })
+
+  it("classifies HTTP 429 as rate_limited", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => "rate limited",
+    }) as unknown as typeof fetch
+
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failure = JSON.stringify(exit.cause)
+      expect(failure).toMatch(/rate_limited/)
+    }
+  })
+})
+
+describe("DirectDeliverer discord", () => {
+  const originalFetch = globalThis.fetch
+  const prevDcUrl = process.env.UBER_DISCORD_API_URL
+  const prevWebhook = process.env.TEST_WEBHOOK
+
+  beforeEach(() => {
+    process.env.UBER_DISCORD_API_URL = DC_BASE
+    process.env.TEST_WEBHOOK = "https://discord.com/api/webhooks/1/abc"
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (prevDcUrl === undefined) delete process.env.UBER_DISCORD_API_URL
+    else process.env.UBER_DISCORD_API_URL = prevDcUrl
+    if (prevWebhook === undefined) delete process.env.TEST_WEBHOOK
+    else process.env.TEST_WEBHOOK = prevWebhook
+  })
+
+  it("POSTs directly to the resolved webhook URL (rebased to UBER_DISCORD_API_URL)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => "",
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "discord_feed",
+          driver: "discord",
+          targetRef: "dc:webhook:env:TEST_WEBHOOK",
+          silent: false,
+          content: "hello world",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    // host rebased onto DC_BASE, path preserved
+    expect(url).toBe(`${DC_BASE}/api/webhooks/1/abc`)
+    expect((init as { method: string }).method).toBe("POST")
+    const body = JSON.parse((init as { body: string }).body)
+    expect(body.content).toBe("hello world")
+    expect(body.webhook_url).toBeUndefined() // direct mode doesn't pass webhook in body
+  })
+
+  it("prefixes silent sends with @silent", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => "",
+    }) as unknown as typeof fetch
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "discord_feed",
+          driver: "discord",
+          targetRef: "dc:webhook:env:TEST_WEBHOOK",
+          silent: true,
+          content: "hush",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+
+    const [, init] = (globalThis.fetch as unknown as { mock: { calls: Array<[string, RequestInit]> } })
+      .mock.calls[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.content).toBe("@silent hush")
+  })
+})
+
+describe("DirectDeliverer routing", () => {
+  it("rejects unknown drivers with a config error", async () => {
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "x",
+          driver: "smoke-signal",
+          targetRef: "ss:cloud:big",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(JSON.stringify(exit.cause)).toMatch(/unknown driver/)
+    }
+  })
+
+  it("app driver returns success without HTTP", async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "app_inbox",
+          driver: "app",
+          targetRef: "app:inbox",
+          silent: false,
+          content: "x",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(DirectWithEnv)),
+    )
+    expect(result.parts).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Slice 3 of the uebermensch eject plan (**PR-B**). Stacks on #153.

Adds `DirectDelivererLive`, the no-kernel-hop counterpart to `HttpDelivererLive`. Same `DelivererService` surface, but talks straight to providers:

- **Telegram** — POSTs to `https://api.telegram.org/bot{token}/sendMessage`. Token resolves via `SecretsService.get("TELEGRAM_BOT_TOKEN")` at request time; `chat_id` continues to resolve via the existing `tg:chat:env:KEY` target_ref scheme.
- **Discord** — POSTs directly to the resolved webhook URL. Webhooks are unauthenticated (URL is the credential), so no extra secret is needed beyond the existing `dc:webhook:env:KEY` target_ref.
- **App** — unchanged (in-process success).

## How it works

```mermaid
flowchart TD
  Cmd[uber send / report] --> DS[DelivererService]
  DS -.local-kernel.-> HD[HttpDelivererLive]
  DS -.local-direct.-> DD[DirectDelivererLive]
  HD --> KR[POST kernel /api/telegram/send & /api/discord/send]
  DD -->|telegram| TG[POST api.telegram.org/bot{token}/sendMessage]
  DD -->|discord| DC[POST resolved webhook URL]
  HD & DD -. shared .-> Sh[lib/deliverer-shared.ts: chunking, target-ref, status mapping]
  DD -->|telegram| Sec[SecretsService.get TELEGRAM_BOT_TOKEN]
```

`HttpDeliverer.ts` shrinks **305 → 183 lines** (chunking, frontmatter strip, target-ref resolution, status classification all moved to the shared module). Both adapters now share one source of truth for those rules.

## What stays the same

- `DelivererService` surface (`send(input): Effect<DeliveryResult, DeliveryError>`).
- Target-ref scheme (`tg:chat:env:KEY`, `dc:webhook:env:KEY`).
- Chunking limits (TG_MAX 3800, DC_MAX 1900) and `(i/N)` chunk prefix.
- Frontmatter stripping + per-numbered-item splitting on briefs.

## Override knobs

- `UBER_TELEGRAM_API_URL` — point telegram POSTs at a fixture (default `https://api.telegram.org`).
- `UBER_DISCORD_API_URL` — rebase the host of resolved webhook URLs at a fixture (default keeps the original host).

## Mode wiring

This PR adds the adapter but does **not** wire it through `buildModeLayer` yet (next slice, PR-B slice 4). Downstream callers continue to consume `HttpDelivererLive` unchanged.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — **272 passing** (was 264, +8 new)
- [x] `pnpm exec biome lint shell/*/src/ apps/*/src/` — 0 errors (30 pre-existing warnings unchanged)
- [x] `tests/direct-deliverer.test.ts` (8): URL/headers/body shape for Telegram + Discord; missing `TELEGRAM_BOT_TOKEN` fails before fetch; injected `SecretsService` overrides env; `@silent` prefix on Discord; unknown driver → config error; app driver bypasses HTTP; 429 → `rate_limited` classification.
- [x] Existing 16 `tests/send.test.ts` (HttpDeliverer + helpers) still pass — proves the helper extraction is non-breaking.
- [ ] Manual smoke against fixture vault — deferred to slice 4 (when `--mode=local-direct` wires through `uber send`).

## Eject sequence

- [x] PR-A foundation — #145 (merged)
- [x] PR-B slice 7a — wire VaultSecretGuard into write path — #147 (CI green, awaiting merge)
- [x] PR-B slice 2 — direct LLM adapters — #153 (CI in flight)
- [x] **PR-B slice 3** — direct deliverer adapter — **this PR**
- [ ] PR-B slice 4 — `buildModeLayer(mode)` factory + wire through commands
- [ ] PR-B slice 5 — remove kernel `uber_*` tables + routes
- [ ] PR-B slice 6 — `gctrl-app.toml` install protocol
- [ ] PR-C — `R2VaultWriter` + repo carve to `OpenHackersClub/uebermensch`
