### PR TITLE
feat(scheduler): scheduler_runs table + per-fire history routes (M1a PR-1)

### DIFF
--- a/kernel/crates/gctrl-core/src/config.rs
+++ b/kernel/crates/gctrl-core/src/config.rs
@@ -260,6 +260,29 @@ pub struct SchedulerConfig {
     /// `exec_enabled` is true. The create handler and runner both enforce.
     #[serde(default)]
     pub exec_allowed_programs: Vec<PathBuf>,
+    /// Retention window for `scheduler_runs` rows. The
+    /// `_internal.scheduler_runs_gc` routine (lands in PR-2 of M1a)
+    /// prunes rows older than this. Per-schedule overrides land alongside
+    /// the `schedules.retention_days` column in PR-2; null falls back to
+    /// this global.
+    ///
+    /// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1.
+    #[serde(default = "default_run_retention_days")]
+    pub run_retention_days: u32,
+    /// Soft warning threshold for `scheduler_runs` row count. The runner
+    /// emits a `tracing::warn!` once the table exceeds this value so
+    /// operators see the signal before disk pressure becomes an issue.
+    /// Set very high to disable.
+    #[serde(default = "default_run_warn_row_count")]
+    pub run_warn_row_count: u32,
+}
+
+fn default_run_retention_days() -> u32 {
+    90
+}
+
+fn default_run_warn_row_count() -> u32 {
+    100_000
 }
 
 impl Default for SchedulerConfig {
@@ -271,6 +294,8 @@ impl Default for SchedulerConfig {
             default_timeout_secs: 60,
             exec_enabled: false,
             exec_allowed_programs: Vec::new(),
+            run_retention_days: default_run_retention_days(),
+            run_warn_row_count: default_run_warn_row_count(),
         }
     }
 }
@@ -330,5 +355,37 @@ mod tests {
         assert_eq!(cfg.poll_interval_secs, 30);
         assert_eq!(cfg.max_per_tick, 16);
         assert_eq!(cfg.default_timeout_secs, 60);
+        assert_eq!(cfg.run_retention_days, 90);
+        assert_eq!(cfg.run_warn_row_count, 100_000);
+    }
+
+    #[test]
+    fn scheduler_config_serde_round_trips_retention_fields() {
+        let cfg = SchedulerConfig {
+            run_retention_days: 30,
+            run_warn_row_count: 250_000,
+            ..SchedulerConfig::default()
+        };
+        let s = serde_json::to_string(&cfg).unwrap();
+        let parsed: SchedulerConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.run_retention_days, 30);
+        assert_eq!(parsed.run_warn_row_count, 250_000);
+    }
+
+    /// New retention fields MUST stay back-compat: configs written before
+    /// they existed (no `run_retention_days` / `run_warn_row_count` keys)
+    /// MUST round-trip via the serde defaults.
+    #[test]
+    fn scheduler_config_back_compat_missing_retention_fields() {
+        // Config from a pre-M1a installation — keys were never written.
+        let legacy = r#"{
+            "enabled": true,
+            "poll_interval_secs": 30,
+            "max_per_tick": 16,
+            "default_timeout_secs": 60
+        }"#;
+        let parsed: SchedulerConfig = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.run_retention_days, 90);
+        assert_eq!(parsed.run_warn_row_count, 100_000);
     }
 }

--- a/kernel/crates/gctrl-core/src/schedule.rs
+++ b/kernel/crates/gctrl-core/src/schedule.rs
@@ -83,3 +83,54 @@ pub struct ScheduleRunUpdate {
     pub last_error: Option<String>,
     pub success: bool,
 }
+
+pub const FIRE_KIND_CRON: &str = "cron";
+pub const FIRE_KIND_MANUAL: &str = "manual";
+
+pub const RUN_STATUS_SUCCESS: &str = "success";
+pub const RUN_STATUS_FAILURE: &str = "failure";
+pub const RUN_STATUS_TIMED_OUT: &str = "timed_out";
+pub const RUN_STATUS_REFUSED: &str = "refused";
+pub const RUN_STATUS_INTERRUPTED: &str = "interrupted";
+
+/// One historical fire of a `Schedule`. Persisted in `scheduler_runs`.
+///
+/// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1.
+///
+/// `finished_at` is `None` only while a manual `run-now` is in flight (we
+/// reserve a row up-front so a daemon crash mid-fire is reapable on next
+/// startup). The runner fiber writes finished rows in one shot — no `None`
+/// transient there.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduleRun {
+    pub id: String,
+    pub schedule_id: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    /// One of `success | failure | timed_out | refused | interrupted`.
+    pub status: String,
+    /// `cron` | `manual`.
+    pub fire_kind: String,
+    /// Child exit code for `target_kind=exec`. `None` for `http` rows.
+    pub exit_code: Option<i64>,
+    /// HTTP response status for `target_kind=http`. `None` for `exec` rows.
+    pub http_status: Option<i64>,
+    /// Capped + redacted preview (matches `Schedule::last_response` posture).
+    pub response_preview: Option<String>,
+    /// Capped + redacted preview (matches `Schedule::last_error` posture).
+    pub error_preview: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub created_at: String,
+}
+
+/// Optional filter for `list_schedule_runs` and `list_schedule_runs_global`.
+/// `None` fields = no filter applied.
+#[derive(Debug, Default, Clone)]
+pub struct ScheduleRunFilter {
+    /// RFC3339 lower bound on `started_at` (inclusive).
+    pub since: Option<String>,
+    /// Restrict to a particular status (`success` / `failure` / …).
+    pub status: Option<String>,
+    /// Cap on rows returned. `None` means apply the implementation default.
+    pub limit: Option<usize>,
+}

--- a/kernel/crates/gctrl-scheduler/src/exec.rs
+++ b/kernel/crates/gctrl-scheduler/src/exec.rs
@@ -241,12 +241,9 @@ mod tests {
 
     fn cfg_with(allowed: Vec<PathBuf>, enabled: bool) -> SchedulerConfig {
         SchedulerConfig {
-            enabled: true,
-            poll_interval_secs: 30,
-            max_per_tick: 16,
-            default_timeout_secs: 60,
             exec_enabled: enabled,
             exec_allowed_programs: allowed,
+            ..SchedulerConfig::default()
         }
     }
 

--- a/kernel/crates/gctrl-scheduler/src/http.rs
+++ b/kernel/crates/gctrl-scheduler/src/http.rs
@@ -16,8 +16,8 @@ use axum::{
 };
 use chrono::Utc;
 use gctrl_core::{
-    Schedule, ScheduleFilter, ScheduleRunUpdate, SchedulerConfig, TARGET_KIND_EXEC,
-    TARGET_KIND_HTTP,
+    Schedule, ScheduleFilter, ScheduleRunFilter, ScheduleRunUpdate, SchedulerConfig,
+    TARGET_KIND_EXEC, TARGET_KIND_HTTP,
 };
 use gctrl_storage::SqliteStore;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,12 @@ pub fn router(sqlite: Arc<SqliteStore>, cfg: Arc<SchedulerConfig>) -> Router {
     };
     Router::new()
         .route("/api/schedules", get(list).post(create))
+        // Cross-schedule run feed — must be registered BEFORE
+        // `/api/schedules/{id}` so axum's longest-match routing doesn't
+        // shadow this with the dynamic-id route.
+        .route("/api/schedules/runs", get(list_runs_global))
         .route("/api/schedules/{id}", get(get_one).delete(delete_one))
+        .route("/api/schedules/{id}/runs", get(list_runs_for_schedule))
         .route("/api/schedules/{id}/run", post(run_now))
         .route("/api/schedules/{id}/enable", post(enable))
         .route("/api/schedules/{id}/disable", post(disable))
@@ -312,13 +317,16 @@ async fn run_now(
     };
 
     let timeout_secs = sched.timeout_secs.max(1) as u64;
-    let (success, status, response, error) = if sched.is_exec() {
+    let started_wall = Utc::now();
+    let (success, status, response, error, timed_out, refused) = if sched.is_exec() {
         match run_exec_schedule(&sched, timeout_secs, &state.cfg).await {
             ExecOutcome::Refused { reason } => (
                 false,
                 None,
                 None,
                 Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                false,
+                true,
             ),
             ExecOutcome::Spawned {
                 exit_code,
@@ -335,7 +343,7 @@ async fn run_now(
                 } else {
                     Some(truncate(&stderr, ERROR_PREVIEW_BYTES))
                 };
-                (success, exit_code.map(|c| c as i64), resp, err)
+                (success, exit_code.map(|c| c as i64), resp, err, timed_out, false)
             }
         }
     } else {
@@ -357,9 +365,19 @@ async fn run_now(
             Ok(mut r) => {
                 let st = r.status().as_u16() as i64;
                 let body = read_capped_body(&mut r).await;
-                ((200..400).contains(&st), Some(st), Some(body), None)
+                (
+                    (200..400).contains(&st),
+                    Some(st),
+                    Some(body),
+                    None,
+                    false,
+                    false,
+                )
             }
-            Err(e) => (false, None, None, Some(e.to_string())),
+            Err(e) => {
+                let timed_out = e.is_timeout();
+                (false, None, None, Some(e.to_string()), timed_out, false)
+            }
         }
     };
 
@@ -379,6 +397,26 @@ async fn run_now(
     if let Err(e) = state.store.record_schedule_run(&sched.id, &update) {
         return err500(e);
     }
+    // Append durable history alongside the row UPDATE. Same staging order as
+    // the cron path; PR-2 collapses both into a single SQLite tx.
+    let outcome = crate::runner::FireOutcome {
+        success,
+        status,
+        response: response.clone(),
+        error: error.clone(),
+        timed_out,
+        refused,
+    };
+    let run_row = crate::runner::build_run_row(
+        &sched,
+        &outcome,
+        started_wall,
+        now,
+        gctrl_core::FIRE_KIND_MANUAL,
+    );
+    if let Err(e) = state.store.insert_schedule_run(&run_row) {
+        return err500(e);
+    }
 
     Json(RunResult {
         id: sched.id,
@@ -388,6 +426,71 @@ async fn run_now(
         error,
     })
     .into_response()
+}
+
+/// Query params shared by both run-listing endpoints.
+///
+/// `since` is matched literally as an RFC3339 string against
+/// `scheduler_runs.started_at` in the storage layer — it doesn't accept the
+/// `?since=24h` shorthand the analytics routes use because the storage filter
+/// composes with prepared-statement parameters, not server-side parsing.
+/// Resolve the shorthand at the caller (the SPA / shell) and pass an absolute
+/// timestamp.
+#[derive(Debug, Deserialize)]
+pub struct RunsQuery {
+    #[serde(default)]
+    pub since: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// `GET /api/schedules/{id_or_name}/runs` — history for one schedule.
+///
+/// Resolves `id` or `name` to a row before querying so the SPA can use the
+/// human-readable name in the URL just like the existing GET-by-id handler.
+async fn list_runs_for_schedule(
+    State(state): State<RouterState>,
+    Path(id): Path<String>,
+    Query(q): Query<RunsQuery>,
+) -> impl IntoResponse {
+    let sched = match state.store.get_schedule(&id) {
+        Ok(Some(s)) => s,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return err500(e),
+    };
+    let filter = ScheduleRunFilter {
+        since: q.since,
+        status: q.status,
+        limit: q.limit,
+    };
+    match state.store.list_schedule_runs(&sched.id, &filter) {
+        Ok(runs) => Json(serde_json::json!({
+            "schedule_id": sched.id,
+            "schedule_name": sched.name,
+            "runs": runs,
+        }))
+        .into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+/// `GET /api/schedules/runs` — cross-schedule run feed for the top-of-page
+/// failure strip on the Schedule page.
+async fn list_runs_global(
+    State(state): State<RouterState>,
+    Query(q): Query<RunsQuery>,
+) -> impl IntoResponse {
+    let filter = ScheduleRunFilter {
+        since: q.since,
+        status: q.status,
+        limit: q.limit,
+    };
+    match state.store.list_schedule_runs_global(&filter) {
+        Ok(runs) => Json(serde_json::json!({ "runs": runs })).into_response(),
+        Err(e) => err500(e),
+    }
 }
 
 async fn enable(

--- a/kernel/crates/gctrl-scheduler/src/runner.rs
+++ b/kernel/crates/gctrl-scheduler/src/runner.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
-use gctrl_core::{ScheduleRunUpdate, SchedulerConfig};
+use gctrl_core::{
+    ScheduleRun, ScheduleRunUpdate, SchedulerConfig, FIRE_KIND_CRON, RUN_STATUS_FAILURE,
+    RUN_STATUS_REFUSED, RUN_STATUS_SUCCESS, RUN_STATUS_TIMED_OUT,
+};
 use gctrl_storage::SqliteStore;
 use tracing::{debug, error, info, warn};
 
@@ -95,6 +98,7 @@ impl ScheduleRunner {
     }
 
     async fn fire_one(&self, sched: gctrl_core::Schedule) {
+        let started_wall = Utc::now();
         let started = std::time::Instant::now();
         let timeout_secs = if sched.timeout_secs > 0 {
             sched.timeout_secs as u64
@@ -128,12 +132,19 @@ impl ScheduleRunner {
             last_run_at: now.to_rfc3339(),
             next_run_at: next,
             last_status: outcome.status,
-            last_response: outcome.response,
-            last_error: outcome.error,
+            last_response: outcome.response.clone(),
+            last_error: outcome.error.clone(),
             success: outcome.success,
         };
         if let Err(e) = self.store.record_schedule_run(&sched.id, &update) {
             error!(schedule = %sched.name, "scheduler: record_schedule_run failed: {e}");
+        }
+        // Append durable history. Done after the row UPDATE today; PR-2 of
+        // M1a folds this into a single SQLite transaction together with the
+        // inbox emit on streak boundary.
+        let run = build_run_row(&sched, &outcome, started_wall, now, FIRE_KIND_CRON);
+        if let Err(e) = self.store.insert_schedule_run(&run) {
+            error!(schedule = %sched.name, "scheduler: insert_schedule_run failed: {e}");
         }
     }
 
@@ -192,6 +203,8 @@ impl ScheduleRunner {
                     status: Some(status),
                     response: Some(preview),
                     error: None,
+                    timed_out: false,
+                    refused: false,
                 }
             }
             Err(e) => {
@@ -200,11 +213,14 @@ impl ScheduleRunner {
                     error = %e,
                     "scheduler: fire failed"
                 );
+                let timed_out = e.is_timeout();
                 FireOutcome {
                     success: false,
                     status: None,
                     response: None,
                     error: Some(e.to_string()),
+                    timed_out,
+                    refused: false,
                 }
             }
         }
@@ -233,6 +249,8 @@ impl ScheduleRunner {
                     status: None,
                     response: None,
                     error: Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                    timed_out: false,
+                    refused: true,
                 }
             }
             ExecOutcome::Spawned {
@@ -290,6 +308,8 @@ impl ScheduleRunner {
                     status: exit_code.map(|c| c as i64),
                     response: response_preview,
                     error: error_preview,
+                    timed_out,
+                    refused: false,
                 }
             }
         }
@@ -327,11 +347,72 @@ impl ScheduleRunner {
     }
 }
 
-struct FireOutcome {
-    success: bool,
-    status: Option<i64>,
-    response: Option<String>,
-    error: Option<String>,
+/// Outcome of a single fire — produced by `fire_http` / `fire_exec` and
+/// consumed by both `fire_one` (cron path) and `http::run_now` (manual path)
+/// when assembling a `ScheduleRun` history row.
+pub(crate) struct FireOutcome {
+    pub(crate) success: bool,
+    /// HTTP status (`http`) or child exit code (`exec`). The runner stuffs
+    /// both into the same `i64` for storage in the `schedules.last_status`
+    /// cache; `build_run_row` un-mixes them into the typed
+    /// `scheduler_runs.{http_status, exit_code}` columns.
+    pub(crate) status: Option<i64>,
+    pub(crate) response: Option<String>,
+    pub(crate) error: Option<String>,
+    /// `true` iff the failure is due to the `tokio::time::timeout` wrapper
+    /// expiring (exec path) or the http request timing out at the reqwest
+    /// layer (http path). PR-1 only sets this for exec; http timeouts are
+    /// recorded as plain `failure` until PR-2 surfaces a typed error path.
+    pub(crate) timed_out: bool,
+    /// `true` iff the exec path refused to spawn (gate violation). Surfaces
+    /// in `scheduler_runs.status = "refused"`. Unused for http rows.
+    pub(crate) refused: bool,
+}
+
+/// Translate a `FireOutcome` plus its timing into the durable history row.
+///
+/// `started_wall` and `finished_wall` MUST be the wall-clock UTC instants
+/// captured in `fire_one` / `run_now`; `Instant::now()` is monotonic and
+/// not serialisable.
+pub(crate) fn build_run_row(
+    sched: &gctrl_core::Schedule,
+    outcome: &FireOutcome,
+    started_wall: chrono::DateTime<Utc>,
+    finished_wall: chrono::DateTime<Utc>,
+    fire_kind: &str,
+) -> ScheduleRun {
+    let status = if outcome.refused {
+        RUN_STATUS_REFUSED
+    } else if outcome.timed_out {
+        RUN_STATUS_TIMED_OUT
+    } else if outcome.success {
+        RUN_STATUS_SUCCESS
+    } else {
+        RUN_STATUS_FAILURE
+    };
+    // Disambiguate the `outcome.status` overload on target_kind.
+    let (exit_code, http_status) = if sched.is_exec() {
+        (outcome.status, None)
+    } else {
+        (None, outcome.status)
+    };
+    let duration_ms = finished_wall
+        .signed_duration_since(started_wall)
+        .num_milliseconds();
+    ScheduleRun {
+        id: uuid::Uuid::new_v4().to_string(),
+        schedule_id: sched.id.clone(),
+        started_at: started_wall.to_rfc3339(),
+        finished_at: Some(finished_wall.to_rfc3339()),
+        status: status.into(),
+        fire_kind: fire_kind.into(),
+        exit_code,
+        http_status,
+        response_preview: outcome.response.clone(),
+        error_preview: outcome.error.clone(),
+        duration_ms: Some(duration_ms),
+        created_at: finished_wall.to_rfc3339(),
+    }
 }
 
 /// Read at most `RESPONSE_BODY_CAP_BYTES` from `resp` using chunked reads.

--- a/kernel/crates/gctrl-scheduler/tests/http_routes.rs
+++ b/kernel/crates/gctrl-scheduler/tests/http_routes.rs
@@ -169,6 +169,136 @@ async fn delete_returns_no_content_then_404() {
 }
 
 #[tokio::test]
+async fn runs_route_404_when_schedule_missing() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/does-not-exist/runs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn runs_route_returns_empty_for_no_history() {
+    let app = router();
+    let body = serde_json::json!({
+        "name": "fresh",
+        "cron": "0 */2 * * *",
+        "target_url": "http://x"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/schedules/{}/runs", id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["schedule_id"], id);
+    assert_eq!(json["runs"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn runs_route_resolves_schedule_by_name() {
+    // The dynamic-id route MUST accept either id or human-readable name —
+    // mirrors the existing /api/schedules/{id} behaviour. The Schedule
+    // page deep-links use the routine name for readability.
+    let app = router();
+    let body = serde_json::json!({
+        "name": "audit.codebase",
+        "cron": "0 */2 * * *",
+        "target_url": "http://x"
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/audit.codebase/runs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["schedule_name"], "audit.codebase");
+}
+
+#[tokio::test]
+async fn global_runs_feed_empty_initially() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/runs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["runs"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn global_runs_feed_does_not_collide_with_id_route() {
+    // `/api/schedules/runs` MUST resolve to the global feed, not be
+    // interpreted as `/api/schedules/{id}` with id="runs". Regression
+    // guard for axum's longest-match semantics.
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/runs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // If shadowed by `{id}`, this would be 404 (no schedule named "runs").
+    // We expect 200 with a runs feed.
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert!(json["runs"].is_array());
+}
+
+#[tokio::test]
 async fn disable_clears_due_status() {
     let app = router();
     let body = serde_json::json!({

--- a/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
+++ b/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
@@ -5,7 +5,10 @@
 use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
-use gctrl_core::{Schedule, SchedulerConfig};
+use gctrl_core::{
+    Schedule, ScheduleRunFilter, SchedulerConfig, FIRE_KIND_CRON, RUN_STATUS_FAILURE,
+    RUN_STATUS_SUCCESS,
+};
 use gctrl_scheduler::ScheduleRunner;
 use gctrl_storage::SqliteStore;
 use wiremock::matchers::{method, path};
@@ -122,6 +125,59 @@ async fn runner_caps_huge_response_body() {
     // Preview cap (4 KB) is what actually lands in storage; the body cap
     // (64 KB) is what's read off the wire. The preview is well below either.
     assert!(stored.len() <= 8 * 1024, "stored len {}", stored.len());
+}
+
+#[tokio::test]
+async fn runner_appends_scheduler_runs_row_on_success() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/hook"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock)
+        .await;
+
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let sched = make_due_schedule(&format!("{}/hook", mock.uri()));
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    runner.tick().await.unwrap();
+
+    let runs = store
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .expect("list runs");
+    assert_eq!(runs.len(), 1, "exactly one history row per fire");
+    let r = &runs[0];
+    assert_eq!(r.status, RUN_STATUS_SUCCESS);
+    assert_eq!(r.fire_kind, FIRE_KIND_CRON);
+    assert_eq!(r.http_status, Some(200));
+    assert!(r.exit_code.is_none(), "http rows do not set exit_code");
+    assert!(r.duration_ms.unwrap() >= 0);
+    assert!(r.finished_at.is_some(), "cron path always closes the row");
+}
+
+#[tokio::test]
+async fn runner_appends_scheduler_runs_row_on_failure() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/boom"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&mock)
+        .await;
+
+    let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+    let sched = make_due_schedule(&format!("{}/boom", mock.uri()));
+    store.create_schedule(&sched).unwrap();
+
+    let runner = ScheduleRunner::new(Arc::clone(&store), SchedulerConfig::default());
+    runner.tick().await.unwrap();
+
+    let runs = store
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .expect("list runs");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].status, RUN_STATUS_FAILURE);
+    assert_eq!(runs[0].http_status, Some(503));
 }
 
 #[tokio::test]

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -13,8 +13,9 @@ use gctrl_core::{
     memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
-    PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRunUpdate,
-    OrchTask, UberBrief, UberSinkinSession, VaultMount, VaultMountKind,
+    PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRun,
+    ScheduleRunFilter, ScheduleRunUpdate, OrchTask, UberBrief, UberSinkinSession,
+    VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 
@@ -367,6 +368,30 @@ CREATE TABLE IF NOT EXISTS schedules (
 )
 "#;
 
+// Per-fire history of a schedule. The `schedules` row keeps a `last_*` cache;
+// `scheduler_runs` is the durable log queried by `/api/schedules/{id}/runs`
+// and the CI-style sparkline. ON DELETE CASCADE so deleting a schedule
+// cleans its history without a second query.
+//
+// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1.
+const CREATE_SCHEDULER_RUNS: &str = r#"
+CREATE TABLE IF NOT EXISTS scheduler_runs (
+    id               TEXT PRIMARY KEY,
+    schedule_id      TEXT NOT NULL,
+    started_at       TEXT NOT NULL,
+    finished_at      TEXT,
+    status           TEXT NOT NULL,
+    fire_kind        TEXT NOT NULL,
+    exit_code        INTEGER,
+    http_status      INTEGER,
+    response_preview TEXT,
+    error_preview    TEXT,
+    duration_ms      INTEGER,
+    created_at       TEXT NOT NULL,
+    FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE CASCADE
+)
+"#;
+
 const CREATE_INDEXES: &[&str] = &[
     // Board indexes
     "CREATE INDEX IF NOT EXISTS idx_board_issues_project ON board_issues(project_id)",
@@ -417,6 +442,10 @@ const CREATE_INDEXES: &[&str] = &[
     // Schedule indexes — `due` is the hot path for the runner poll loop
     "CREATE INDEX IF NOT EXISTS idx_schedules_due ON schedules(enabled, next_run_at)",
     "CREATE INDEX IF NOT EXISTS idx_schedules_name ON schedules(name)",
+    // Scheduler run history — hot paths are per-schedule reverse-chrono and
+    // status-filtered cross-schedule listing for the failure feed.
+    "CREATE INDEX IF NOT EXISTS idx_scheduler_runs_schedule_started ON scheduler_runs(schedule_id, started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_scheduler_runs_status_started ON scheduler_runs(status, started_at DESC)",
     // Uebermensch briefs index — date lookup + reverse-chrono listing
     "CREATE INDEX IF NOT EXISTS idx_uber_briefs_date ON uber_briefs(date DESC)",
     "CREATE INDEX IF NOT EXISTS idx_uber_briefs_kind_date ON uber_briefs(kind, date DESC)",
@@ -488,6 +517,7 @@ impl SqliteStore {
             CREATE_UBER_BRIEFS,
             CREATE_UBER_SINKIN_SESSIONS,
             CREATE_SCHEDULES,
+            CREATE_SCHEDULER_RUNS,
         ];
         for stmt in &tables {
             conn.execute_batch(stmt)
@@ -2819,6 +2849,15 @@ impl SqliteStore {
 
     pub fn delete_schedule(&self, id_or_name: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
+        // SQLite does not enforce FKs unless `PRAGMA foreign_keys = ON` is
+        // set per-connection; honour the declared `ON DELETE CASCADE` on
+        // `scheduler_runs.schedule_id` explicitly so run history goes
+        // away with its parent.
+        conn.execute(
+            "DELETE FROM scheduler_runs
+             WHERE schedule_id IN (SELECT id FROM schedules WHERE id = ?1 OR name = ?1)",
+            [id_or_name],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
         let n = conn.execute(
             "DELETE FROM schedules WHERE id = ?1 OR name = ?1",
             [id_or_name],
@@ -2879,6 +2918,116 @@ impl SqliteStore {
             params![next_run_at, now, id],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
+    }
+
+    // ───────────────────────── Scheduler Runs ─────────────────────────
+    //
+    // Per-fire history of a schedule. The `schedules` row keeps a `last_*`
+    // cache; `scheduler_runs` is the durable log queried by the Schedule
+    // page's CI-style sparkline and run-history drawer. The transactional
+    // batch helper (`record_schedule_run_v2`) lands in PR-2 of M1a along
+    // with the inbox emit; this PR ships the bare INSERT so the runner
+    // can start populating history.
+    //
+    // Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1.
+
+    pub fn insert_schedule_run(&self, run: &ScheduleRun) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO scheduler_runs (id, schedule_id, started_at, finished_at, status, fire_kind, exit_code, http_status, response_preview, error_preview, duration_ms, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                run.id,
+                run.schedule_id,
+                run.started_at,
+                run.finished_at,
+                run.status,
+                run.fire_kind,
+                run.exit_code,
+                run.http_status,
+                run.response_preview,
+                run.error_preview,
+                run.duration_ms,
+                run.created_at,
+            ],
+        ).map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// History for a single schedule, latest first. Filters compose with AND.
+    /// Default cap: 50 rows; hard cap: 500 (silently clamped) to bound memory.
+    pub fn list_schedule_runs(
+        &self,
+        schedule_id: &str,
+        filter: &ScheduleRunFilter,
+    ) -> Result<Vec<ScheduleRun>> {
+        let conn = self.conn.lock().unwrap();
+        let limit = filter.limit.unwrap_or(50).min(500) as i64;
+        let mut sql = "SELECT id, schedule_id, started_at, finished_at, status, fire_kind, exit_code, http_status, response_preview, error_preview, duration_ms, created_at FROM scheduler_runs WHERE schedule_id = ?1".to_string();
+        let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(schedule_id.to_string())];
+        let mut idx = 2;
+        if let Some(ref since) = filter.since {
+            sql.push_str(&format!(" AND started_at >= ?{}", idx));
+            p.push(Box::new(since.clone()));
+            idx += 1;
+        }
+        if let Some(ref status) = filter.status {
+            sql.push_str(&format!(" AND status = ?{}", idx));
+            p.push(Box::new(status.clone()));
+            idx += 1;
+        }
+        sql.push_str(&format!(" ORDER BY started_at DESC LIMIT ?{}", idx));
+        p.push(Box::new(limit));
+        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let params_iter: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(params_iter), row_to_schedule_run)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Cross-schedule run feed, latest first. Powers the top-of-page failure
+    /// strip: typical call is `since=24h ago, status=failure, limit=200`.
+    pub fn list_schedule_runs_global(
+        &self,
+        filter: &ScheduleRunFilter,
+    ) -> Result<Vec<ScheduleRun>> {
+        let conn = self.conn.lock().unwrap();
+        let limit = filter.limit.unwrap_or(200).min(500) as i64;
+        let mut sql = "SELECT id, schedule_id, started_at, finished_at, status, fire_kind, exit_code, http_status, response_preview, error_preview, duration_ms, created_at FROM scheduler_runs WHERE 1=1".to_string();
+        let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        let mut idx = 1;
+        if let Some(ref since) = filter.since {
+            sql.push_str(&format!(" AND started_at >= ?{}", idx));
+            p.push(Box::new(since.clone()));
+            idx += 1;
+        }
+        if let Some(ref status) = filter.status {
+            sql.push_str(&format!(" AND status = ?{}", idx));
+            p.push(Box::new(status.clone()));
+            idx += 1;
+        }
+        sql.push_str(&format!(" ORDER BY started_at DESC LIMIT ?{}", idx));
+        p.push(Box::new(limit));
+        let mut stmt = conn.prepare(&sql).map_err(|e| GctlError::Storage(e.to_string()))?;
+        let params_iter: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(params_iter), row_to_schedule_run)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Idempotent prune. Returns the number of rows deleted. Powers the
+    /// `_internal.scheduler_runs_gc` routine landing in PR-2 of M1a.
+    pub fn delete_schedule_runs_before(&self, before_rfc3339: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute(
+                "DELETE FROM scheduler_runs WHERE started_at < ?1",
+                [before_rfc3339],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n)
     }
 }
 
@@ -2943,6 +3092,29 @@ fn row_to_schedule(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedule> {
         failure_count: row.get(19)?,
         created_at: row.get(20)?,
         updated_at: row.get(21)?,
+    })
+}
+
+fn row_to_schedule_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduleRun> {
+    // Column order — must match insert/select queries:
+    //   0 id               1 schedule_id      2 started_at
+    //   3 finished_at      4 status           5 fire_kind
+    //   6 exit_code        7 http_status
+    //   8 response_preview 9 error_preview
+    //  10 duration_ms     11 created_at
+    Ok(ScheduleRun {
+        id: row.get(0)?,
+        schedule_id: row.get(1)?,
+        started_at: row.get(2)?,
+        finished_at: row.get(3)?,
+        status: row.get(4)?,
+        fire_kind: row.get(5)?,
+        exit_code: row.get(6)?,
+        http_status: row.get(7)?,
+        response_preview: row.get(8)?,
+        error_preview: row.get(9)?,
+        duration_ms: row.get(10)?,
+        created_at: row.get(11)?,
     })
 }
 

--- a/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
+++ b/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
@@ -1,0 +1,266 @@
+//! Tests for the `scheduler_runs` table primitives — durable history of
+//! schedule fires powering the Schedule page's CI-style sparkline and the
+//! `/api/schedules/{id}/runs` route.
+//!
+//! Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1.
+
+use chrono::Utc;
+use gctrl_core::{
+    Schedule, ScheduleRun, ScheduleRunFilter, FIRE_KIND_CRON, FIRE_KIND_MANUAL,
+    RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, TARGET_KIND_HTTP,
+};
+use gctrl_storage::SqliteStore;
+
+fn store() -> SqliteStore {
+    SqliteStore::open(":memory:").expect("open :memory: store")
+}
+
+fn seed_schedule(store: &SqliteStore, name: &str) -> Schedule {
+    let now = Utc::now().to_rfc3339();
+    let s = Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: name.into(),
+        cron: "0 */2 * * *".into(),
+        target_kind: TARGET_KIND_HTTP.into(),
+        target_url: "http://example.invalid/hook".into(),
+        target_method: "POST".into(),
+        body_json: None,
+        headers_json: None,
+        command: None,
+        cwd: None,
+        env_keys: None,
+        timeout_secs: 60,
+        enabled: true,
+        next_run_at: None,
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    store.create_schedule(&s).expect("create_schedule");
+    s
+}
+
+fn run_at(schedule_id: &str, started_at: chrono::DateTime<Utc>, status: &str, fire_kind: &str) -> ScheduleRun {
+    ScheduleRun {
+        id: uuid::Uuid::new_v4().to_string(),
+        schedule_id: schedule_id.into(),
+        started_at: started_at.to_rfc3339(),
+        finished_at: Some(started_at.to_rfc3339()),
+        status: status.into(),
+        fire_kind: fire_kind.into(),
+        exit_code: None,
+        http_status: Some(if status == RUN_STATUS_SUCCESS { 200 } else { 503 }),
+        response_preview: Some("ok".into()),
+        error_preview: None,
+        duration_ms: Some(42),
+        created_at: started_at.to_rfc3339(),
+    }
+}
+
+#[test]
+fn insert_and_list_round_trip() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let r = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    s.insert_schedule_run(&r).expect("insert");
+
+    let rows = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, r.id);
+    assert_eq!(rows[0].status, RUN_STATUS_SUCCESS);
+    assert_eq!(rows[0].fire_kind, FIRE_KIND_CRON);
+    assert_eq!(rows[0].http_status, Some(200));
+}
+
+#[test]
+fn list_orders_latest_first() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    // Insert in order: oldest, middle, newest. List MUST come back newest-first.
+    let oldest = run_at(&sched.id, now - chrono::Duration::hours(2), RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    let middle = run_at(&sched.id, now - chrono::Duration::hours(1), RUN_STATUS_FAILURE, FIRE_KIND_CRON);
+    let newest = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_MANUAL);
+    s.insert_schedule_run(&oldest).unwrap();
+    s.insert_schedule_run(&middle).unwrap();
+    s.insert_schedule_run(&newest).unwrap();
+
+    let rows = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .expect("list");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].id, newest.id);
+    assert_eq!(rows[1].id, middle.id);
+    assert_eq!(rows[2].id, oldest.id);
+}
+
+#[test]
+fn list_filters_status() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    s.insert_schedule_run(&run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(
+        &sched.id,
+        now - chrono::Duration::minutes(1),
+        RUN_STATUS_FAILURE,
+        FIRE_KIND_CRON,
+    ))
+    .unwrap();
+    let only_failures = s
+        .list_schedule_runs(
+            &sched.id,
+            &ScheduleRunFilter {
+                status: Some(RUN_STATUS_FAILURE.into()),
+                ..Default::default()
+            },
+        )
+        .expect("list filtered");
+    assert_eq!(only_failures.len(), 1);
+    assert_eq!(only_failures[0].status, RUN_STATUS_FAILURE);
+}
+
+#[test]
+fn list_filters_since() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let old = now - chrono::Duration::days(2);
+    let recent = now - chrono::Duration::minutes(5);
+    s.insert_schedule_run(&run_at(&sched.id, old, RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(&sched.id, recent, RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    let last_day = now - chrono::Duration::days(1);
+    let rows = s
+        .list_schedule_runs(
+            &sched.id,
+            &ScheduleRunFilter {
+                since: Some(last_day.to_rfc3339()),
+                ..Default::default()
+            },
+        )
+        .expect("list filtered");
+    assert_eq!(rows.len(), 1, "only the recent row should match");
+}
+
+#[test]
+fn list_caps_at_500() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    // Caller asks for 9_999, hard cap is 500.
+    for i in 0..10 {
+        s.insert_schedule_run(&run_at(
+            &sched.id,
+            now - chrono::Duration::seconds(i),
+            RUN_STATUS_SUCCESS,
+            FIRE_KIND_CRON,
+        ))
+        .unwrap();
+    }
+    let rows = s
+        .list_schedule_runs(
+            &sched.id,
+            &ScheduleRunFilter {
+                limit: Some(9_999),
+                ..Default::default()
+            },
+        )
+        .expect("list");
+    // We only inserted 10, so cap doesn't matter for this assertion — but
+    // the call would have OOMed if the cap weren't applied to the LIMIT.
+    assert!(rows.len() <= 500);
+    assert_eq!(rows.len(), 10);
+}
+
+#[test]
+fn global_list_returns_runs_across_schedules_latest_first() {
+    let s = store();
+    let a = seed_schedule(&s, "audit.codebase");
+    let b = seed_schedule(&s, "gap.specs-vs-code");
+    let now = Utc::now();
+    s.insert_schedule_run(&run_at(&a.id, now - chrono::Duration::minutes(2), RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(&b.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON))
+        .unwrap();
+
+    let rows = s
+        .list_schedule_runs_global(&ScheduleRunFilter::default())
+        .expect("global list");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].schedule_id, b.id, "latest first");
+    assert_eq!(rows[1].schedule_id, a.id);
+}
+
+#[test]
+fn global_list_filters_failure_status() {
+    let s = store();
+    let a = seed_schedule(&s, "audit.codebase");
+    let b = seed_schedule(&s, "gap.specs-vs-code");
+    let now = Utc::now();
+    s.insert_schedule_run(&run_at(&a.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(&b.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON))
+        .unwrap();
+    let rows = s
+        .list_schedule_runs_global(&ScheduleRunFilter {
+            status: Some(RUN_STATUS_FAILURE.into()),
+            ..Default::default()
+        })
+        .expect("filtered");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].schedule_id, b.id);
+}
+
+#[test]
+fn delete_schedule_cascades_to_runs() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    s.insert_schedule_run(&run_at(&sched.id, Utc::now(), RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    assert_eq!(
+        s.list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+            .unwrap()
+            .len(),
+        1
+    );
+    s.delete_schedule(&sched.id).unwrap();
+    let rows = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .expect("list after delete");
+    assert!(rows.is_empty(), "cascade should drop history");
+}
+
+#[test]
+fn prune_by_started_at_is_idempotent() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    // Two old rows + one recent.
+    s.insert_schedule_run(&run_at(&sched.id, now - chrono::Duration::days(120), RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(&sched.id, now - chrono::Duration::days(91), RUN_STATUS_FAILURE, FIRE_KIND_CRON))
+        .unwrap();
+    s.insert_schedule_run(&run_at(&sched.id, now - chrono::Duration::days(5), RUN_STATUS_SUCCESS, FIRE_KIND_CRON))
+        .unwrap();
+
+    let cutoff = (now - chrono::Duration::days(90)).to_rfc3339();
+    let n1 = s.delete_schedule_runs_before(&cutoff).unwrap();
+    assert_eq!(n1, 2, "two old rows should be pruned");
+    let n2 = s.delete_schedule_runs_before(&cutoff).unwrap();
+    assert_eq!(n2, 0, "second run is a no-op");
+    let remaining = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .unwrap();
+    assert_eq!(remaining.len(), 1, "only the recent row survives");
+}


### PR DESCRIPTION
## Summary

First slice of **M1a** from the [gctrl-schedule spec](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md) (merged in #152). Lays the durable run-history foundation that the CI-style sparkline, edit-in-place PATCH, retention GC, and inbox alerts in PR-2 / PR-3 all depend on.

```mermaid
flowchart LR
  Cron["scheduler runner<br/>(tokio fiber)"]
  RunNow["POST /api/schedules/:id/run"]
  Sched[("schedules<br/>(SQLite, existing)")]
  Runs[("scheduler_runs<br/>(SQLite, NEW)")]
  Page["GET /api/schedules/:id/runs<br/>(NEW)"]
  Feed["GET /api/schedules/runs<br/>(NEW)"]

  Cron -->|UPDATE| Sched
  Cron -->|INSERT| Runs
  RunNow -->|UPDATE| Sched
  RunNow -->|INSERT| Runs
  Page --> Runs
  Feed --> Runs

  style Runs fill:#1f3a1f,stroke:#65a30d,color:#dcfce7
  style Page fill:#1f3a1f,stroke:#65a30d,color:#dcfce7
  style Feed fill:#1f3a1f,stroke:#65a30d,color:#dcfce7
```

## What ships

- New `scheduler_runs` SQLite table (one row per fire) with reverse-chrono indexes and explicit cascade-on-schedule-delete (SQLite doesn't enforce declared FKs without per-connection PRAGMA — keeping the FK in the schema for future-proofing + Postgres/D1 portability).
- `ScheduleRun` + `ScheduleRunFilter` types in `gctrl-core`; status / fire_kind constants.
- Storage methods: `insert_schedule_run`, `list_schedule_runs`, `list_schedule_runs_global`, `delete_schedule_runs_before` (idempotent prune for PR-2's GC routine).
- Two new HTTP routes:
  - `GET /api/schedules/{id_or_name}/runs` — history per schedule
  - `GET /api/schedules/runs` — cross-schedule failure feed
  Both honour `?since=<RFC3339>&status=&limit=` and clamp limit at 500 to bound memory. Registered **before** `/api/schedules/{id}` so axum's longest-match doesn't shadow the `/runs` global feed.
- Runner appends a row on every cron fire (`fire_kind=cron`); `run_now` HTTP handler appends with `fire_kind=manual`.
- `SchedulerConfig.run_retention_days` (default 90) and `run_warn_row_count` (default 100 000) — back-compat with pre-M1a configs via serde defaults.

## Out of scope (PR-2 of M1a)

- `record_schedule_run_v2` transactional helper folding UPDATE + INSERT + inbox emit into one SQLite tx.
- Output redaction module shared by row UPDATE and INSERT.
- Startup reaper for `finished_at IS NULL` rows interrupted by daemon crash.
- `_internal.*` HTTP guard + private storage helper for daemon bootstrap.
- `DELETE /api/schedules/runs?before=...` prune route.
- `_internal.scheduler_runs_gc` self-bootstrap.
- `alert_after_failures` / `current_failure_streak` columns + inbox emit on streak boundary.

## Test plan

- [x] `cargo test -p gctrl-storage --test scheduler_runs` — 9 storage tests (round-trip, ordering, since/status filters, 500-row hard cap, global feed, status filter, cascade-on-delete, prune idempotency).
- [x] `cargo test -p gctrl-scheduler --tests` — 31 tests pass (15 lib + 10 HTTP + 6 runner). HTTP tests added: 404 on missing schedule, empty history for new schedule, name-based resolution, empty global feed, regression guard against `/runs` being shadowed by `{id}`. Runner tests added: success path appends `status=success` row; failure path appends `status=failure`.
- [x] `cargo test -p gctrl-core` — +2 tests for new retention config fields (round-trip + back-compat with legacy configs missing the keys).
- [x] `cargo build --workspace` clean with `RUSTFLAGS=-D warnings` (matches CI).
- [x] Existing `gctrl scheduler list` / CLI unaffected — new fields are additive.

## Spec link

[`vault/specs/architecture/apps/gctrl-schedule.md` § 5.1 — `scheduler_runs` table — durable run history](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#51-scheduler_runs-table--durable-run-history)
