### PR TITLE
feat(uebermensch): buildModeLayer factory + wire through all commands

### DIFF
--- a/apps/uebermensch/src/commands/brief.ts
+++ b/apps/uebermensch/src/commands/brief.ts
@@ -1,12 +1,14 @@
 import { Command, Options } from "@effect/cli"
 import { Console, Effect, Option } from "effect"
+import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
-import { KernelLlmLive } from "../adapters/KernelLlm.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
+import { buildLlmLayer } from "../lib/build-mode-layer.js"
 import { selectCandidates } from "../lib/candidates.js"
 import { resolveVaultDir } from "../lib/env.js"
+import { resolveMode } from "../lib/mode.js"
 import { LlmService } from "../services/LlmService.js"
 import { ProfileService } from "../services/ProfileService.js"
 import { RendererService } from "../services/RendererService.js"
@@ -149,12 +151,13 @@ export const brief = Command.make(
       const date = Option.getOrElse(dateOptVal, today)
       yield* Console.log(`generating brief for ${date} from ${vaultDir} (llm=${llmKind})`)
       const program = makeBriefProgram({ date, sinceHours, maxItemsOpt: maxItemsOptVal, dryRun })
-      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
+      const llmLayer = llmKind === "stub" ? StubLlmLive : buildLlmLayer(resolveMode())
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(FileSystemVaultLive(vaultDir)),
         Effect.provide(llmLayer),
         Effect.provide(StrictRendererLive),
+        Effect.provide(EnvSecretsLive),
       )
     }),
 ).pipe(Command.withDescription("Generate a daily brief from wiki pages + stub LLM"))

--- a/apps/uebermensch/src/commands/ingest.ts
+++ b/apps/uebermensch/src/commands/ingest.ts
@@ -1,12 +1,14 @@
 import { Command, Options } from "@effect/cli";
 import { Console, Effect, Either, Layer, Option } from "effect";
+import { EnvSecretsLive } from "../adapters/EnvSecrets.js";
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js";
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js";
 import { HttpFeedDefaultConfig, HttpFeedLive } from "../adapters/HttpFeed.js";
 import { HttpIngestDefaultConfig, HttpIngestLive } from "../adapters/HttpIngest.js";
-import { KernelLlmLive } from "../adapters/KernelLlm.js";
+import { buildLlmLayer } from "../lib/build-mode-layer.js";
 import { personFeedUrls } from "../lib/discovery.js";
 import { resolveVaultDir } from "../lib/env.js";
+import { resolveMode } from "../lib/mode.js";
 import { FeedService } from "../services/FeedService.js";
 import { IngestService } from "../services/IngestService.js";
 import { ProfileService } from "../services/ProfileService.js";
@@ -88,12 +90,18 @@ const url = Command.make(
       const ingestLayer = HttpIngestLive.pipe(
         Layer.provide(Layer.mergeAll(vaultLayer, HttpIngestDefaultConfig)),
       );
-      // KernelLlmLive is merged at the outer level (not consumed by Layer.provide)
+      // LlmService is merged at the outer level (not consumed by Layer.provide)
       // so HttpIngest's runtime Effect.serviceOption(LlmService) can see it.
       yield* program.pipe(
         Effect.provide(
-          Layer.mergeAll(FileSystemProfileLive(vaultDir), vaultLayer, ingestLayer, KernelLlmLive),
+          Layer.mergeAll(
+            FileSystemProfileLive(vaultDir),
+            vaultLayer,
+            ingestLayer,
+            buildLlmLayer(resolveMode()),
+          ),
         ),
+        Effect.provide(EnvSecretsLive),
       );
     }),
 ).pipe(Command.withDescription("Fetch a URL and write input/raw/<date>--<domain>.md"));
@@ -291,9 +299,10 @@ const sources = Command.make(
             vaultLayer,
             ingestLayer,
             feedLayer,
-            KernelLlmLive,
+            buildLlmLayer(resolveMode()),
           ),
         ),
+        Effect.provide(EnvSecretsLive),
       );
     }),
 ).pipe(
@@ -497,9 +506,10 @@ const person = Command.make(
             vaultLayer,
             ingestLayer,
             feedLayer,
-            KernelLlmLive,
+            buildLlmLayer(resolveMode()),
           ),
         ),
+        Effect.provide(EnvSecretsLive),
       );
     }),
 ).pipe(

--- a/apps/uebermensch/src/commands/prompts.ts
+++ b/apps/uebermensch/src/commands/prompts.ts
@@ -1,12 +1,14 @@
 import { createHash } from "node:crypto"
 import { Args, Command, Options } from "@effect/cli"
 import { Console, Effect, Either, Option } from "effect"
+import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemQueryLive } from "../adapters/FileSystemQuery.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
-import { KernelLlmLive } from "../adapters/KernelLlm.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
+import { buildLlmLayer } from "../lib/build-mode-layer.js"
 import { resolveVaultDir } from "../lib/env.js"
+import { resolveMode } from "../lib/mode.js"
 import { DIRECTIVES_PROMPTS_DIR, INPUT_REPORTS_DIR } from "../lib/vault-paths.js"
 import {
   LlmService,
@@ -266,12 +268,13 @@ const process_ = Command.make(
         }
       })
 
-      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
+      const llmLayer = llmKind === "stub" ? StubLlmLive : buildLlmLayer(resolveMode())
       yield* program.pipe(
         Effect.provide(FileSystemQueryLive(vaultDir)),
         Effect.provide(FileSystemVaultLive(vaultDir)),
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(llmLayer),
+        Effect.provide(EnvSecretsLive),
       )
     }),
 ).pipe(

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -3,15 +3,15 @@ import { Console, Effect, Either, Layer, Option } from "effect"
 import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
-import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
-import { KernelLlmLive } from "../adapters/KernelLlm.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
 import { DeliveryError } from "../errors.js"
+import { buildDelivererLayer, buildLlmLayer } from "../lib/build-mode-layer.js"
 import { selectCandidates, type CandidateRef } from "../lib/candidates.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicBaseUrl, publicReportUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
+import { resolveMode } from "../lib/mode.js"
 import {
   DIRECTIVES_RESEARCH_DIR,
   DIRECTIVES_SOURCES_FILE,
@@ -643,14 +643,15 @@ export const report = Command.make(
         }
       })
 
-      const llmLayer = llmKind === "stub" ? StubLlmLive : KernelLlmLive
+      const mode = resolveMode()
+      const llmLayer = llmKind === "stub" ? StubLlmLive : buildLlmLayer(mode)
       const syncLayer = R2SyncLive.pipe(Layer.provide(R2SyncConfigFromEnv))
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
         Effect.provide(FileSystemVaultLive(vaultDir)),
         Effect.provide(llmLayer),
         Effect.provide(StrictRendererLive),
-        Effect.provide(HttpDelivererLive),
+        Effect.provide(buildDelivererLayer(mode)),
         Effect.provide(EnvSecretsLive),
         Effect.provide(syncLayer),
       )

--- a/apps/uebermensch/src/commands/run-daily.ts
+++ b/apps/uebermensch/src/commands/run-daily.ts
@@ -5,8 +5,8 @@ import { Console, Effect, Either, Layer } from "effect"
 import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
-import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
-import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { buildDelivererLayer, buildLlmLayer } from "../lib/build-mode-layer.js"
+import { resolveMode } from "../lib/mode.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { selectCandidates } from "../lib/candidates.js"
@@ -246,15 +246,17 @@ export const runDaily = Command.make("run-daily", {}, () =>
     const date = today()
     yield* Console.log(`uber run-daily ${date}`)
 
+    const mode = resolveMode()
     const briefLayer = Layer.mergeAll(
       FileSystemProfileLive(vaultDir),
       FileSystemVaultLive(vaultDir),
-      KernelLlmLive,
+      buildLlmLayer(mode),
       StrictRendererLive,
     )
 
     const briefResult = yield* runBriefGeneration(date, vaultDir).pipe(
       Effect.provide(briefLayer),
+      Effect.provide(EnvSecretsLive),
       Effect.either,
     )
 
@@ -270,7 +272,7 @@ export const runDaily = Command.make("run-daily", {}, () =>
       Effect.provide(
         Layer.mergeAll(
           FileSystemProfileLive(vaultDir),
-          HttpDelivererLive,
+          buildDelivererLayer(mode),
           syncLayer,
         ),
       ),

--- a/apps/uebermensch/src/commands/send.ts
+++ b/apps/uebermensch/src/commands/send.ts
@@ -4,11 +4,12 @@ import { Command, Options } from "@effect/cli"
 import { Console, Effect, Layer, Option } from "effect"
 import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
-import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { DeliveryError, VaultError } from "../errors.js"
+import { buildDelivererLayer } from "../lib/build-mode-layer.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicBaseUrl, publicBriefUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
+import { resolveMode } from "../lib/mode.js"
 import {
   INPUT_BRIEFS_DIR,
   INPUT_RAW_DIR,
@@ -155,7 +156,7 @@ export const send = Command.make(
       const syncLayer = R2SyncLive.pipe(Layer.provide(R2SyncConfigFromEnv))
       yield* program.pipe(
         Effect.provide(FileSystemProfileLive(vaultDir)),
-        Effect.provide(HttpDelivererLive),
+        Effect.provide(buildDelivererLayer(resolveMode())),
         Effect.provide(EnvSecretsLive),
         Effect.provide(syncLayer),
       )

--- a/apps/uebermensch/src/lib/build-mode-layer.ts
+++ b/apps/uebermensch/src/lib/build-mode-layer.ts
@@ -1,0 +1,73 @@
+// buildModeLayer — picks the LlmService and DelivererService Layers that
+// match the resolved deployment Mode.
+//
+// Mode → adapter mapping (today):
+//
+//   local-kernel  → KernelLlm + HttpDeliverer
+//                   (kernel daemon owns LLM + messaging proxy + secret injection)
+//
+//   local-direct  → AnthropicLlm | LMStudioLlm + DirectDeliverer
+//                   (no daemon; tokens resolved via SecretsService at request time)
+//
+//   cloud-only    → AnthropicLlm + DirectDeliverer
+//                   (Worker / hosted target; AnthropicLlm honors
+//                    UBER_ANTHROPIC_BASE_URL so the operator can route through
+//                    Cloudflare AI Gateway by setting that env)
+//
+// LLM provider selection in --mode=local-direct is by model id: claude-* →
+// Anthropic, anything else → LMStudio. Set UBER_LLM_MODEL to switch.
+
+import { Layer } from "effect"
+import { AnthropicLlmLive } from "../adapters/AnthropicLlm.js"
+import { DirectDelivererLive } from "../adapters/DirectDeliverer.js"
+import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
+import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { LMStudioLlmLive } from "../adapters/LMStudioLlm.js"
+import { DelivererService } from "../services/DelivererService.js"
+import { LlmService } from "../services/LlmService.js"
+import { SecretsService } from "../services/SecretsService.js"
+import { type Mode } from "./mode.js"
+
+const isAnthropicModel = (model: string): boolean => model.startsWith("claude-")
+
+const modelHint = (): string => process.env.UBER_LLM_MODEL ?? ""
+
+/**
+ * Pick the LlmService Layer for `mode`. May require `SecretsService`
+ * (Anthropic direct does; kernel + LMStudio do not — TypeScript widens the
+ * R channel to the most-restrictive variant).
+ *
+ * `model` is an explicit override for the UBER_LLM_MODEL hint, useful in
+ * tests so they don't have to mutate process.env.
+ */
+export const buildLlmLayer = (
+  mode: Mode,
+  model: string = modelHint(),
+): Layer.Layer<LlmService, never, SecretsService> => {
+  if (mode === "local-kernel") return KernelLlmLive
+  // local-direct + cloud-only both bypass the kernel; pick provider by model.
+  if (model === "" || isAnthropicModel(model)) return AnthropicLlmLive
+  return LMStudioLlmLive
+}
+
+/**
+ * Pick the DelivererService Layer for `mode`. Both adapters require
+ * SecretsService at construction time (target_ref `env:` resolution).
+ */
+export const buildDelivererLayer = (
+  mode: Mode,
+): Layer.Layer<DelivererService, never, SecretsService> => {
+  if (mode === "local-kernel") return HttpDelivererLive
+  return DirectDelivererLive
+}
+
+/**
+ * Convenience composition — both adapters merged. Caller still needs to
+ * provide `SecretsService` (typically `EnvSecretsLive` today; future
+ * KernelSecretsLive / LocalKeychainLive).
+ */
+export const buildModeLayer = (
+  mode: Mode,
+  model: string = modelHint(),
+): Layer.Layer<LlmService | DelivererService, never, SecretsService> =>
+  Layer.mergeAll(buildLlmLayer(mode, model), buildDelivererLayer(mode))

--- a/apps/uebermensch/tests/build-mode-layer.test.ts
+++ b/apps/uebermensch/tests/build-mode-layer.test.ts
@@ -1,0 +1,190 @@
+import { Effect, Layer } from "effect"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { EnvSecretsLive } from "../src/adapters/EnvSecrets.js"
+import { buildDelivererLayer, buildLlmLayer, buildModeLayer } from "../src/lib/build-mode-layer.js"
+import { DelivererService } from "../src/services/DelivererService.js"
+import { LlmService } from "../src/services/LlmService.js"
+
+// These tests don't actually exercise the full LLM/Deliverer pipeline — they
+// verify that buildModeLayer wires the right adapter for each mode by checking
+// the URL the resulting Layer fetches, which is the cheapest behavioral
+// fingerprint for "is this KernelLlm or AnthropicLlm or LMStudioLlm".
+
+const originalFetch = globalThis.fetch
+const ENVS_TO_RESTORE = [
+  "GCTRL_KERNEL_URL",
+  "UBER_ANTHROPIC_BASE_URL",
+  "UBER_LMSTUDIO_BASE_URL",
+  "UBER_LLM_MODEL",
+  "UBER_LLM_SUMMARY_MODEL",
+  "UBER_TELEGRAM_API_URL",
+  "ANTHROPIC_API_KEY",
+  "TELEGRAM_BOT_TOKEN",
+  "TEST_CHAT_ID",
+] as const
+const snapshot = Object.fromEntries(ENVS_TO_RESTORE.map((k) => [k, process.env[k]]))
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  for (const k of ENVS_TO_RESTORE) {
+    if (snapshot[k] === undefined) delete process.env[k]
+    else process.env[k] = snapshot[k]
+  }
+})
+
+const mockFetch = (responseBody: unknown, status = 200) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(responseBody),
+  })
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+const callResearchQuery = (layer: Layer.Layer<LlmService>) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const llm = yield* LlmService
+      return yield* llm.researchQuery({
+        slug: "x",
+        title: "x",
+        topics: [],
+        question: "what?",
+        profileName: "Test",
+        contextPages: [],
+      })
+    }).pipe(Effect.provide(layer)),
+  )
+
+describe("buildLlmLayer", () => {
+  it("local-kernel routes through GCTRL_KERNEL_URL", async () => {
+    process.env.GCTRL_KERNEL_URL = "http://kernel.fixture"
+    process.env.UBER_LLM_MODEL = "claude-opus-4-7"
+    const fetchMock = mockFetch({
+      content: [{ type: "text", text: "Some answer." }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+      model: "claude-opus-4-7",
+    })
+    const layer = buildLlmLayer("local-kernel").pipe(Layer.provide(EnvSecretsLive))
+    await callResearchQuery(layer)
+    expect(fetchMock.mock.calls[0][0]).toBe("http://kernel.fixture/api/llm/messages")
+  })
+
+  it("local-direct + claude-* model routes to AnthropicLlm", async () => {
+    process.env.UBER_ANTHROPIC_BASE_URL = "https://anthropic.fixture"
+    process.env.UBER_LLM_MODEL = "claude-opus-4-7"
+    process.env.ANTHROPIC_API_KEY = "sk-ant-fixture"
+    const fetchMock = mockFetch({
+      content: [{ type: "text", text: "Direct anthropic answer." }],
+      usage: { input_tokens: 5, output_tokens: 10 },
+      model: "claude-opus-4-7",
+    })
+    const layer = buildLlmLayer("local-direct").pipe(Layer.provide(EnvSecretsLive))
+    await callResearchQuery(layer)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://anthropic.fixture/v1/messages")
+    expect((init as { headers: Record<string, string> }).headers["x-api-key"]).toBe(
+      "sk-ant-fixture",
+    )
+  })
+
+  it("local-direct + non-claude model routes to LMStudioLlm", async () => {
+    process.env.UBER_LMSTUDIO_BASE_URL = "http://lmstudio.fixture:1234"
+    process.env.UBER_LLM_MODEL = "google/gemma-4-31b"
+    const fetchMock = mockFetch({
+      choices: [{ message: { role: "assistant", content: "Local answer." } }],
+      usage: { prompt_tokens: 5, completion_tokens: 10 },
+      model: "google/gemma-4-31b",
+    })
+    const layer = buildLlmLayer("local-direct").pipe(Layer.provide(EnvSecretsLive))
+    await callResearchQuery(layer)
+    expect(fetchMock.mock.calls[0][0]).toBe("http://lmstudio.fixture:1234/v1/chat/completions")
+  })
+
+  it("cloud-only routes to AnthropicLlm (operator may rebase via UBER_ANTHROPIC_BASE_URL)", async () => {
+    process.env.UBER_ANTHROPIC_BASE_URL =
+      "https://gateway.ai.cloudflare.com/v1/acct/gw/anthropic"
+    process.env.UBER_LLM_MODEL = "claude-opus-4-7"
+    process.env.ANTHROPIC_API_KEY = "sk-ant-cloud"
+    const fetchMock = mockFetch({
+      content: [{ type: "text", text: "Gateway answer." }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+      model: "claude-opus-4-7",
+    })
+    const layer = buildLlmLayer("cloud-only").pipe(Layer.provide(EnvSecretsLive))
+    await callResearchQuery(layer)
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://gateway.ai.cloudflare.com/v1/acct/gw/anthropic/v1/messages",
+    )
+  })
+
+  it("explicit model arg overrides UBER_LLM_MODEL", async () => {
+    process.env.UBER_LMSTUDIO_BASE_URL = "http://lmstudio.fixture"
+    process.env.UBER_LLM_MODEL = "claude-opus-4-7"
+    const fetchMock = mockFetch({
+      choices: [{ message: { role: "assistant", content: "ok" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+      model: "google/gemma-4-31b",
+    })
+    // Override the env hint with an explicit non-claude model arg → LMStudio path
+    const layer = buildLlmLayer("local-direct", "google/gemma-4-31b").pipe(
+      Layer.provide(EnvSecretsLive),
+    )
+    await callResearchQuery(layer)
+    expect(fetchMock.mock.calls[0][0]).toBe("http://lmstudio.fixture/v1/chat/completions")
+  })
+})
+
+describe("buildDelivererLayer", () => {
+  it("local-kernel routes Telegram through kernel /api/telegram/send", async () => {
+    process.env.GCTRL_KERNEL_URL = "http://kernel.fixture"
+    process.env.TEST_CHAT_ID = "1"
+    const fetchMock = mockFetch({ ok: true, message_id: 1 })
+    const layer = buildDelivererLayer("local-kernel").pipe(Layer.provide(EnvSecretsLive))
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(fetchMock.mock.calls[0][0]).toBe("http://kernel.fixture/api/telegram/send")
+  })
+
+  it("local-direct routes Telegram directly to api.telegram.org", async () => {
+    process.env.UBER_TELEGRAM_API_URL = "https://telegram.fixture"
+    process.env.TELEGRAM_BOT_TOKEN = "9:tok"
+    process.env.TEST_CHAT_ID = "1"
+    const fetchMock = mockFetch({ ok: true, result: { message_id: 1 } })
+    const layer = buildDelivererLayer("local-direct").pipe(Layer.provide(EnvSecretsLive))
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const d = yield* DelivererService
+        return yield* d.send({
+          channel: "telegram_primary",
+          driver: "telegram",
+          targetRef: "tg:chat:env:TEST_CHAT_ID",
+          silent: false,
+          content: "hi",
+          briefDate: "2026-04-22",
+        })
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(fetchMock.mock.calls[0][0]).toBe("https://telegram.fixture/bot9:tok/sendMessage")
+  })
+})
+
+describe("buildModeLayer composition", () => {
+  it("composes both LlmService + DelivererService", () => {
+    const layer = buildModeLayer("local-direct")
+    // Smoke: composing succeeds — type checks already enforce R=SecretsService.
+    expect(layer).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Slice 4 of the uebermensch eject plan (**PR-B**). Stacks on #154.

Replaces hardcoded `KernelLlmLive` / `HttpDelivererLive` references in the six command modules with `buildLlmLayer(mode)` / `buildDelivererLayer(mode)`, making the resolved `Mode` (`UBER_MODE` env, default `local-kernel`) finally **load-bearing**.

Until this PR, the `--mode` flag was a tag-along — every command still wired the kernel adapters by hand regardless of mode.

## Mode → adapter mapping

| Mode | LLM | Deliverer | Notes |
|---|---|---|---|
| `local-kernel` | `KernelLlm` | `HttpDeliverer` | Kernel daemon proxies LLM + messaging; secrets injected kernel-side. Default. |
| `local-direct` | `AnthropicLlm` _or_ `LMStudioLlm` | `DirectDeliverer` | No daemon. LLM provider picked by `UBER_LLM_MODEL` prefix: `claude-*` → Anthropic, else → LMStudio. |
| `cloud-only` | `AnthropicLlm` | `DirectDeliverer` | Worker / hosted target. Operator routes through Cloudflare AI Gateway by setting `UBER_ANTHROPIC_BASE_URL`. |

```mermaid
flowchart LR
  E[UBER_MODE env] --> RM[resolveMode]
  RM --> BLL[buildLlmLayer]
  RM --> BDL[buildDelivererLayer]
  BLL -.local-kernel.-> KL[KernelLlmLive]
  BLL -.local-direct + claude-*.-> AL[AnthropicLlmLive]
  BLL -.local-direct + non-claude.-> ML[LMStudioLlmLive]
  BLL -.cloud-only.-> AL
  BDL -.local-kernel.-> HD[HttpDelivererLive]
  BDL -.local-direct/cloud-only.-> DD[DirectDelivererLive]
  AL & DD --> SS[SecretsService]
```

## Updated commands

`brief.ts`, `report.ts`, `run-daily.ts`, `ingest.ts` (3 sites), `prompts.ts`, `send.ts`. Each picks up `EnvSecretsLive` at the bottom of its layer stack so the direct adapters can resolve API keys / bot tokens via `SecretsService`.

Behavior in the default `local-kernel` mode is **unchanged** — the new layer factory still returns `KernelLlmLive` / `HttpDelivererLive` for that mode. The only delta visible in tests is that every command now provides `EnvSecretsLive`, which was already provided in the deliverer-touching commands (`report`, `run-daily`, `send`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — **280 passing** (was 272, +8 new)
- [x] `pnpm exec biome lint shell/*/src/ apps/*/src/` — 0 errors (34 pre-existing warnings unchanged)
- [x] `tests/build-mode-layer.test.ts` (8): all four mode×provider combos hit the right URL with the right headers — local-kernel through `GCTRL_KERNEL_URL`, local-direct claude-* to `api.anthropic.com`, local-direct non-claude to LMStudio, cloud-only through AI Gateway, explicit model arg overriding the env hint, plus deliverer routing for telegram local-kernel vs local-direct.
- [ ] Manual smoke: `UBER_MODE=local-direct ANTHROPIC_API_KEY=… uber brief` against fixture vault.
- [ ] Manual smoke: `UBER_MODE=local-direct UBER_LLM_MODEL=google/gemma-4-31b uber brief` against a running LM Studio.

## Eject sequence

- [x] PR-A foundation — #145 (merged)
- [x] PR-B slice 7a — wire VaultSecretGuard into write path — #147 (CI green, awaiting merge)
- [x] PR-B slice 2 — direct LLM adapters — #153 (CI green)
- [x] PR-B slice 3 — direct deliverer adapter — #154 (CI in flight)
- [x] **PR-B slice 4** — buildModeLayer factory + wire through commands — **this PR**
- [ ] PR-B slice 5 — remove kernel `uber_*` tables + routes
- [ ] PR-B slice 6 — `gctrl-app.toml` install protocol
- [ ] PR-C — `R2VaultWriter` + repo carve to `OpenHackersClub/uebermensch`
