### PR TITLE
docs(specs): app ↔ kernel decoupling — zero duplication invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ The `vault/specs/` directory is the single source of truth for cross-cutting des
 | `vault/specs/architecture/` | System structure | Unix layers (Kernel/Shell/Apps), hexagonal layout, data flow, OS layer guide (`os.md`). Subdirs: `kernel/` (orchestrator, scheduler, browser), `shell/` (CLI). App-specific architecture lives under `apps/{app}/specs/`. See `vault/specs/architecture/README.md` for index. MUST NOT dictate specific implementation patterns. |
 | `vault/specs/principles.md` | Design invariants | Design principles, architectural invariants, crate ownership rules, Effect-TS invariants, testing invariants, git workflow. The "constitution" — rules that MUST NOT be violated. |
 | `vault/specs/architecture/domain-model.md` | Types & schemas | Domain types, traits, storage schema (all SQL DDL), Effect-TS schemas, entity relationships. The "data dictionary." |
+| `vault/specs/architecture/app-decoupling.md` | App ↔ kernel contract | Zero-duplication rule, port-based capability declarations, ejection (rebinding, not rewriting), worked uebermensch example, reviewer boundary tests. |
 | `vault/specs/gctrl/` | gctrl's own workflow | gctrl's PRD and WORKFLOW files. See "gctrl Kernel Workflow" section below. |
 
 ### Kernel Architecture — Orchestration & Dispatch
@@ -125,11 +126,12 @@ Detailed programming patterns, code examples, and how-to guides live under `vaul
 3. **App tables are namespaced** — `board_*`, `eval_*`, `inbox_*`, `capacity_*`. (§ Architectural Invariants #3)
 4. **Kernel makes no assumptions about apps; shell mediates all kernel access.** (§ Architectural Invariants #4–5)
 5. **External tools go through kernel drivers (LKMs)** that implement kernel interface traits (`TrackerPort`, `ObservabilityExportPort`, `KnowledgeSourcePort`). Shell + apps MUST NOT hold secrets or call external APIs directly. (§ Design Principles #7; § os.md "Drivers")
-6. **Effect-TS hygiene** — no `._tag` access, no bare `new Error` in Effect contexts, no `as any` on external JSON, no `export *` barrels, no dynamic `require` inside Effect generators, no untyped `catchAll`, no mutable module state. Reviewer sweep: `rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts`. (§ Effect-TS Invariants #1–8; `implementation/{apps,shell}/style.md`)
-7. **TDD is default** — failing test first, then implementation. Storage tests use `:memory:` DuckDB; HTTP tests use `axum::test::oneshot`; shell tests use mock `KernelClient`. (§ Testing Invariants #1–11)
-8. **Every new public function MUST have a test.** (§ Testing Invariants #4)
-9. **Git workflow** — feature branches only, no `--admin` merges, no force-push to main, no rebase of main. (§ Git Workflow #1–2; CLAUDE.md)
-10. **Apps live under `apps/{app-name}/`** with `PRD.md` and `WORKFLOW.md`. (§ Specs Table of Contents below)
+6. **App ↔ kernel zero duplication.** Apps declare capability *requirements* (ports); the kernel provides capability *implementations* (drivers). An app MUST NOT ship in-app code that duplicates a kernel-provided capability — no second LLM transport when `driver-llm` exists, no second deliverer when `driver-telegram`/`driver-discord` exist, no app-specific kernel SQL tables when the vault + watcher already index app data. Ejection is **rebinding** the default Layer to a user-supplied implementation, not rewriting the app. (`principles.md` § App ↔ Kernel Decoupling; full spec: `architecture/app-decoupling.md`)
+7. **Effect-TS hygiene** — no `._tag` access, no bare `new Error` in Effect contexts, no `as any` on external JSON, no `export *` barrels, no dynamic `require` inside Effect generators, no untyped `catchAll`, no mutable module state. Reviewer sweep: `rg -n 'new Error\(|Effect\.fail\(new Error|as any|: any\b|^export \*|require\(|\._tag\b' shell apps --type ts`. (§ Effect-TS Invariants #1–8; `implementation/{apps,shell}/style.md`)
+8. **TDD is default** — failing test first, then implementation. Storage tests use `:memory:` DuckDB; HTTP tests use `axum::test::oneshot`; shell tests use mock `KernelClient`. (§ Testing Invariants #1–11)
+9. **Every new public function MUST have a test.** (§ Testing Invariants #4)
+10. **Git workflow** — feature branches only, no `--admin` merges, no force-push to main, no rebase of main. (§ Git Workflow #1–2; CLAUDE.md)
+11. **Apps live under `apps/{app-name}/`** with `PRD.md` and `WORKFLOW.md`. (§ Specs Table of Contents below)
 
 ## Agent Conventions
 

--- a/vault/specs/architecture/README.md
+++ b/vault/specs/architecture/README.md
@@ -29,6 +29,7 @@ See `vault/specs/principles.md` for the full Unix philosophy mapping and design 
 vault/specs/architecture/
 ├── README.md          ← this file — system overview, Unix philosophy, data flow
 ├── os.md              ← layer guide: kernel, shell, apps, utilities, external apps
+├── app-decoupling.md  ← app ↔ kernel contract: zero duplication, port-based capabilities, ejection model
 ├── domain-model.md    ← domain types, storage schema (DDL), Effect-TS schemas
 │
 ├── kernel/            ← kernel primitives and extensions (Tasks + Sessions only)
@@ -52,6 +53,7 @@ vault/specs/architecture/
 | This file | System layers, Unix philosophy, internal code architecture, data flow |
 | [domain-model.md](domain-model.md) | Domain types, traits, storage schema (DDL), Effect-TS schemas |
 | [os.md](os.md) | Unix layers in depth — kernel, shell, applications, utilities, drivers (loadable kernel modules), and how to extend each |
+| [app-decoupling.md](app-decoupling.md) | App ↔ kernel contract — zero-duplication rule, capability ports, ejection as rebinding (not rewriting), reviewer boundary tests |
 | [kernel/orchestrator.md](kernel/orchestrator.md) | Orchestrator kernel primitive — Task claim states, dispatch eligibility, retry/backoff, concurrency control |
 | [kernel/scheduler.md](kernel/scheduler.md) | Scheduler kernel primitive — Task lifecycle, interface trait, platform implementations |
 | [kernel/harness.md](kernel/harness.md) | `AgentHarness` port — which agent program runs (`claude-code`, `codex`, `opencode`, …) |

--- a/vault/specs/architecture/app-decoupling.md
+++ b/vault/specs/architecture/app-decoupling.md
@@ -1,0 +1,119 @@
+---
+title: App ↔ Kernel Decoupling — Zero Duplication, Host-Swappable Apps
+status: foundational
+---
+
+# App ↔ Kernel Decoupling
+
+This spec captures the contract between gctrl applications and the gctrl kernel, and what it means to "eject" an app so it can run on a different host.
+
+> **Invariant:** Apps declare *capability requirements*. The kernel provides *capability implementations*. The two MUST NOT duplicate the same capability.
+
+## The Mental Model
+
+gctrl is an OS. Applications are programs that run on it.
+
+| Term | Meaning |
+|---|---|
+| **Capability** | A named, kernel-provided service an app can depend on (LLM relay, deliverer, vault storage, scheduler, secrets, OTel capture, etc.) |
+| **Capability requirement** | A port (interface) an app declares it needs. Lives in the app. |
+| **Capability implementation** | A driver / kernel module that fulfills the port. Lives in the kernel, OR is supplied by another host at install time. |
+| **App** | Application + featureset requirements. Owns its business logic and its vault namespace; depends on capabilities. |
+| **Eject** | Make the app installable on a non-gctrl host. NOT "re-implement everything kernel does". |
+
+**Default fulfillment:** When an app is installed on a gctrl-equipped host, the kernel fulfills every capability the app declares. Nothing else needs to be wired.
+
+**Alternate fulfillment:** When an app is installed on a host without gctrl, the operator (often with LLM assistance — Claude Code, opencode, aider — that's the "user role to use LLM to configure the app") wires the declared capabilities to whatever the host provides: opinionated CLIs, vendor SDKs, in-process implementations, or nothing at all (the feature is then disabled).
+
+## The Zero-Duplication Rule
+
+> **An app MUST NOT ship in-app code that duplicates a capability the kernel already provides.**
+
+If `driver-llm` already routes Anthropic and OpenAI-compat traffic, the app does NOT contain its own `AnthropicLlm.ts` adapter. If `driver-telegram` already POSTs to the Bot API, the app does NOT contain its own `TelegramDeliverer.ts`.
+
+What the app contains:
+- The **port** (`LlmService`, `DelivererService`).
+- The **business logic** that calls through the port (`brief`, `report`, `send`, `sinkin`).
+- The **default Layer wiring** that binds the port to the kernel implementation (`KernelLlmLive`, `HttpDelivererLive`).
+
+What the app MUST NOT contain:
+- A second adapter that talks directly to Anthropic / Telegram / Discord / R2 / etc. when the kernel already has a driver for that target.
+
+**Why:** Two implementations drift. Drift creates bugs that only show up in one mode. Caching, secret injection, OTel capture, rate limiting, cost attribution all live in the kernel — re-implementing the transport in the app silently regresses every one of those concerns.
+
+## The Application's Three Pieces
+
+```mermaid
+flowchart LR
+  subgraph App["App package"]
+    Logic[Business logic]
+    Ports[Capability ports — interfaces]
+    Defaults[Default Layer = port → kernel]
+  end
+  Logic --> Ports
+  Defaults -. binds .-> Ports
+  Defaults -. on gctrl host .-> Kernel[(gctrl kernel — driver-llm, driver-deliverer, driver-vault, …)]
+```
+
+1. **Business logic** — the why-this-app-exists code. Calls through ports only.
+2. **Capability ports** — Effect-TS `Context.Tag`s declaring what the app needs (e.g. `LlmService`, `DelivererService`, `VaultWriterPort`, `SecretsService`).
+3. **Default Layer** — a `Layer.mergeAll(...)` that binds each port to its kernel-fulfilled adapter. This Layer is the *default*, used unless the user explicitly overrides.
+
+## Ejection — What Actually Changes
+
+Ejecting an app to another host changes ONE thing: the Layer that fulfills the ports. Everything else stays put.
+
+| Surface | On gctrl host (default) | On another host (ejected) |
+|---|---|---|
+| Business logic | unchanged | unchanged |
+| Ports | unchanged | unchanged |
+| Default Layer | wires to kernel | replaced by user-supplied Layer |
+| App-specific data | lives in the app vault | lives in the app vault |
+| Secrets | resolved by kernel `driver-secrets` | resolved by host-supplied SecretsService impl |
+
+The eject is **not** a rewrite. It is a **rebinding**.
+
+### How the rebinding happens
+
+The app exposes an extension point that loads a user-supplied Layer at startup. Suggested mechanisms (any one is sufficient):
+
+- **`UBER_CUSTOM_LAYER` env var** — points to a JS module exporting a `Layer` that satisfies the app's port surface. Loaded with dynamic import at startup. (Reference design — not yet implemented.)
+- **`gctrl-app.toml` capability declarations** — the app's manifest lists the capabilities it requires; the host's installer wires them. (Implementation specced in [implementation/app-install-protocol.md] — to be written.)
+
+The app MUST NOT bundle a hard-coded "alternate" Layer for `local-direct` or `cloud-only` modes that simply re-implements kernel drivers. That defeats the point.
+
+## What This Means for Vault & Storage
+
+Apps MUST NOT depend on kernel SQL tables for app-specific data. The vault is the source of truth.
+
+- App-specific schemas in the kernel's DuckDB (`app_*` tables) are a **smell** — they coupled the kernel to the app and forced a new kernel migration whenever the app's data shape changed.
+- The replacement: the app owns its vault namespace (`apps/{app}/vault/...`); the kernel watches the filesystem and indexes mtime + content_hash; queryability comes from the kernel's generic vault index, not from per-app tables.
+- This makes the app trivially portable: zip the vault, hand it to another host, the app keeps working as soon as the ports are bound.
+
+## Worked Example — Uebermensch
+
+| Capability | Default (kernel) | Ejected option (user wires) | What does NOT live in the app |
+|---|---|---|---|
+| LLM curator + summary lanes | `driver-llm` via `KernelLlm` Layer | Anthropic SDK, OpenAI SDK, local LM Studio call, anything that satisfies `LlmService` | A second LLM transport in `apps/uebermensch/src/adapters/` |
+| Telegram delivery | `driver-telegram` via `HttpDeliverer` | direct fetch against `api.telegram.org/bot{token}/sendMessage`, or a different chat platform entirely | A second deliverer transport in the app |
+| Discord delivery | `driver-discord` via `HttpDeliverer` | direct fetch against the webhook URL, or a different platform | A second deliverer transport in the app |
+| Vault filesystem write | `FileSystemVault` (filesystem direct) + watcher | R2VaultWriter, S3, Notion API, anything that satisfies `VaultWriterPort` | An R2 transport in the app *if* an `driver-r2-vault` is the right home for it |
+| Secrets read | `driver-secrets` (kernel — TBD) / `EnvSecrets` transitional | local keychain, 1Password CLI, env vars, Worker bindings | Anything provider-specific |
+| Scheduling | kernel `scheduler` | host cron, launchd, Worker cron, GitHub Actions | An in-app scheduler |
+| OTel session correlation | kernel telemetry | host OTel collector, or none (lose telemetry) | An app-side span exporter |
+
+## Boundary Tests for Reviewers
+
+When reviewing an app PR, ask:
+
+1. **"Does the kernel already do this?"** If yes, the app MUST NOT add its own implementation. Use the kernel driver via the existing port.
+2. **"Is this app code calling an external API directly?"** If yes, it should be calling a kernel route that wraps a driver. Direct external calls bypass caching, OTel, and secret injection.
+3. **"Is the app declaring a new app-specific kernel table?"** If yes, push back hard — vault file + watcher index is almost always the right shape.
+4. **"Is there a second 'mode' that swaps in app-bundled adapters?"** If yes, those adapters are duplicating the kernel. Either delete them or move them to the kernel as drivers (with proper interface traits).
+5. **"Does ejecting the app require touching its source?"** If yes, the port surface is wrong. Ejection should be configuration / Layer wiring at install time, not a fork.
+
+## Related
+
+- [`../principles.md`](../principles.md) § App ↔ Kernel Decoupling
+- [`os.md`](os.md) § 3 Applications, § 5 Drivers
+- [`apps/adr-runtime-compute-decoupling.md`](apps/adr-runtime-compute-decoupling.md) — sibling concern (compute substrate vs harness)

--- a/vault/specs/architecture/os.md
+++ b/vault/specs/architecture/os.md
@@ -277,10 +277,12 @@ Applications are larger, stateful programs that orchestrate kernel primitives th
 
 ### Application rules
 
-1. **Table namespacing**: All tables MUST use `{app}_*` prefixes (`board_issues`, `eval_scores`)
+1. **Table namespacing**: All tables MUST use `{app}_*` prefixes (`board_issues`, `eval_scores`). Note: new apps SHOULD prefer the vault (filesystem + content-hash index) over per-app kernel tables — see the [App ↔ Kernel Decoupling](app-decoupling.md) spec.
 2. **Kernel access via shell**: Applications access kernel primitives through CLI or HTTP API — not by importing kernel crates directly (except Rust apps compiled into the binary)
 3. **Cross-app isolation**: Apps MUST NOT join across each other's tables. Cross-app data flows through kernel-level events
 4. **Optional by default**: Every application MUST be independently disableable. A developer using gctrl only for telemetry MUST NOT see board commands
+5. **Capability requirements, not implementations**: An app declares the capabilities it needs via *ports*; the kernel (or, on a non-gctrl host, user-supplied wiring) fulfills them. Apps MUST NOT bundle in-app re-implementations of capabilities the kernel already provides (e.g. an in-app Anthropic adapter when `driver-llm` already exists). See [app-decoupling.md](app-decoupling.md) for the full contract and the zero-duplication rule.
+6. **Ejection is rebinding, not rewriting**: Installing an app on another host swaps the default Layer that binds ports to kernel adapters; business logic and the vault MUST NOT change. There is no "local-direct" or "cloud-only" mode shipped inside the app that re-implements kernel drivers.
 
 ### Extending with a new application
 

--- a/vault/specs/principles.md
+++ b/vault/specs/principles.md
@@ -52,6 +52,17 @@ These apply the Unix philosophy to gctrl's specific architecture.
 4. **Kernel MUST NOT make assumptions about applications.** It captures telemetry, stores data, enforces safety, and provides primitives. What you do with that — through the shell — is the application and utility layer's job.
 5. **Shell MUST mediate all external access to the kernel.** Agents and applications MUST interact with kernel primitives through CLI commands or HTTP API, never by importing kernel crates directly (except Rust apps compiled into the binary).
 
+## App ↔ Kernel Decoupling
+
+> Full spec: [architecture/app-decoupling.md](architecture/app-decoupling.md). The invariants below are non-negotiable.
+
+1. **Apps declare capability requirements; the kernel provides capability implementations.** Apps own their *ports* (e.g. `LlmService`, `DelivererService`, `VaultWriterPort`, `SecretsService`) and their business logic. The kernel — or, on a non-gctrl host, a user-supplied wiring — fulfills those ports through drivers / kernel modules.
+2. **Zero duplication by default.** An app MUST NOT ship in-app code that duplicates a capability the kernel already provides. If `driver-llm` routes Anthropic traffic, the app does NOT add its own `AnthropicLlm` adapter. If `driver-telegram` POSTs to the Bot API, the app does NOT add its own `TelegramDeliverer`. Two implementations drift; caching, OTel capture, secret injection, and rate limiting all live in the kernel — re-implementing the transport in the app silently regresses every one of those concerns.
+3. **The default Layer binds ports to the kernel.** Every app ships a default `Layer.mergeAll(...)` that wires each port to its kernel-fulfilled adapter (`KernelLlmLive`, `HttpDelivererLive`, `FileSystemVaultLive`, etc.). On a gctrl host, this is the only wiring needed.
+4. **Ejection is rebinding, not rewriting.** Installing an app on a non-gctrl host swaps the default Layer for a user-supplied Layer that satisfies the same port surface. The business logic, the ports, and the vault MUST NOT change. The app MUST NOT bundle hard-coded "alternate modes" (`local-direct`, `cloud-only`) that simply re-implement kernel drivers in app code.
+5. **Apps MUST NOT depend on app-specific kernel SQL tables.** The vault is the source of truth for app-owned data. The kernel watches the filesystem and indexes mtime + content_hash via a generic vault index — apps MUST NOT request per-app schemas in the kernel's DuckDB. (Application tables that DO exist in the kernel are deprecated; new apps MUST NOT add more.)
+6. **Ejection MUST NOT require touching app source.** A user installing the app on another host configures the binding (env var pointing to a Layer module, `gctrl-app.toml` capability mapping, etc.) — they do not edit app code. If the port surface forces source changes to swap implementations, the port surface is wrong.
+
 ## Crate Ownership
 
 When modifying code, respect crate boundaries:


### PR DESCRIPTION
## Summary

Captures a foundational principle that was previously implicit and led to a wrong-direction implementation in the uebermensch eject sequence (PRs #153, #154 — closing those next).

> **Apps declare capability requirements (ports). The kernel provides capability implementations (drivers). Zero duplication by default.**
>
> Ejection is **rebinding** the default Layer to a user-supplied implementation, **not rewriting** the app or bundling alternate "modes" that re-implement kernel drivers.

## What lands

| File | Change |
|---|---|
| `vault/specs/architecture/app-decoupling.md` | **New.** Full spec — mental model, zero-duplication rule, the app's three pieces (business logic / ports / default Layer), what changes on ejection, vault-as-source-of-truth, worked uebermensch table, reviewer boundary tests |
| `vault/specs/principles.md` | New "App ↔ Kernel Decoupling" section with 6 non-negotiable invariants below the existing Architectural Invariants |
| `vault/specs/architecture/os.md` | Application rules add #5 (capability requirements not implementations) and #6 (ejection is rebinding); both point to the new spec |
| `vault/specs/architecture/README.md` | Indexes `app-decoupling.md` |
| `AGENTS.md` | Quick-reference invariant #6 (app ↔ kernel zero duplication); table-of-contents entry for the new spec |

## How it works

```mermaid
flowchart LR
  subgraph App[App package]
    Logic[Business logic]
    Ports[Capability ports — interfaces]
    Defaults[Default Layer = port → kernel]
  end
  Logic --> Ports
  Defaults -. binds .-> Ports
  Defaults -. on gctrl host .-> Kernel[(gctrl kernel — driver-llm, driver-deliverer, driver-vault, …)]
  Defaults -. on another host .-> User[user-supplied Layer]
```

The default Layer binds ports to kernel adapters; ejection swaps that Layer for a user-supplied one. Business logic, ports, and the vault are unchanged.

## Why now

PR #145 (port + adapter foundation) shipped the right port surface (`SecretsService`, `VaultWriterPort`, `ModeConfig`, `LlmService`, `DelivererService`) — but lacked an explicit "what the app MUST NOT do" rule. The follow-up slices then implemented `AnthropicLlm`, `LMStudioLlm`, and `DirectDeliverer` adapters *inside the uebermensch app* (PRs #153, #154), duplicating `driver-llm`, `driver-telegram`, and `driver-discord`. This spec makes that wrong direction unambiguous so future apps don't repeat the mistake.

## Aftermath

After this lands:
- PRs #153, #154 close (in-app transports duplicate kernel drivers — see invariant #2).
- A small replacement PR keeps just the salvage that makes `KernelLlm` / `HttpDeliverer` simpler (the `makeLlmServiceShape` factory, `lib/llm-shared.ts`, `lib/deliverer-shared.ts`).
- PR #156 (buildModeLayer) gets reshaped to support `kernel` (default) + `custom` (user-supplied Layer) instead of enumerating `local-direct` / `cloud-only` modes that re-implement kernel work in the app.
- PR #157 (drop kernel `uber_*` tables) stays — directly aligned with invariant #5 (no app-specific kernel SQL tables).

## Test plan

- [x] Markdown lint clean (no broken links inside the new spec; cross-refs to `principles.md`, `os.md`, sibling apps/ ADRs verified)
- [x] `principles.md` line count delta = +6 lines under "Architectural Invariants" + new "App ↔ Kernel Decoupling" section (diff stat verified)
- [x] No code changes — pure documentation
- [ ] Reviewer sanity check: does invariant #2 ("zero duplication") match how you'd describe the app/kernel relationship to a new contributor?
