### PR TITLE
refactor(uebermensch): extract shared LLM + deliverer helpers (no new transports)

### DIFF
--- a/apps/uebermensch/src/adapters/HttpDeliverer.ts
+++ b/apps/uebermensch/src/adapters/HttpDeliverer.ts
@@ -1,5 +1,18 @@
-import { Effect, Layer, Match, Option } from "effect"
+import { Effect, Layer, Match } from "effect"
 import { DeliveryError } from "../errors.js"
+import {
+  chunkPrefix,
+  classifyHttpStatus,
+  configErr,
+  DC_MAX,
+  resolveEnvRef,
+  resolveRef,
+  splitBrief,
+  splitChunks,
+  stripFrontmatter,
+  TG_MAX,
+  unreachableErr,
+} from "../lib/deliverer-shared.js"
 import {
   DelivererService,
   type DeliverInput,
@@ -7,144 +20,8 @@ import {
 } from "../services/DelivererService.js"
 import { SecretsService, type SecretsServiceImpl } from "../services/SecretsService.js"
 
-const TG_MAX = 3800
-const DC_MAX = 1900
-
-const splitChunks = (content: string, max: number): ReadonlyArray<string> => {
-  if (content.length <= max) return [content]
-  const chunks: Array<string> = []
-  const lines = content.split("\n")
-  let buf = ""
-  for (const line of lines) {
-    const next = buf.length === 0 ? line : `${buf}\n${line}`
-    if (next.length > max && buf.length > 0) {
-      chunks.push(buf)
-      buf = line
-    } else if (next.length > max) {
-      for (let i = 0; i < line.length; i += max) chunks.push(line.slice(i, i + max))
-      buf = ""
-    } else {
-      buf = next
-    }
-  }
-  if (buf.length > 0) chunks.push(buf)
-  return chunks
-}
-
-const stripFrontmatter = (md: string): string => {
-  if (!md.startsWith("---\n")) return md
-  const end = md.indexOf("\n---\n", 4)
-  if (end === -1) return md
-  return md.slice(end + 5).replace(/^\n+/, "")
-}
-
-const ITEM_HEADING = /^## \d+\. /m
-
-const splitBrief = (content: string, max: number): ReadonlyArray<string> => {
-  const body = stripFrontmatter(content)
-  if (!ITEM_HEADING.test(body)) return splitChunks(body, max)
-  const withoutH1 = body.replace(/^#\s+[^\n]*\n+/, "")
-  const parts = withoutH1
-    .split(/(?=^## \d+\. )/m)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-  const out: Array<string> = []
-  for (const p of parts) {
-    if (p.length <= max) out.push(p)
-    else for (const c of splitChunks(p, max)) out.push(c)
-  }
-  return out
-}
-
-// Parse a `prefix`-scoped target ref into either a literal value or an env
-// key name. Returns `null` when the prefix does not match. Env-backed refs
-// have the form `<prefix>env:<ENV_VAR_NAME>`; literal refs are
-// `<prefix><value>`. Pure parser — never touches `process.env`; that read is
-// the exclusive responsibility of the `SecretsService` adapter.
-const resolveEnvRef = (
-  targetRef: string,
-  prefix: string,
-): { kind: "env"; key: string } | { kind: "literal"; value: string } | null => {
-  if (!targetRef.startsWith(prefix)) return null
-  const rest = targetRef.slice(prefix.length)
-  if (rest.startsWith("env:")) return { kind: "env", key: rest.slice(4) }
-  return { kind: "literal", value: rest }
-}
-
-const configErr = (channel: string, driver: string, message: string): DeliveryError =>
-  new DeliveryError({ message, channel, driver, kind: "config" })
-
-// Resolve a prefixed target ref to its concrete string value. Literal refs
-// are returned synchronously; env-backed refs (`env:<KEY>`) are resolved via
-// `SecretsService.get` so the actual `process.env` read is isolated to the
-// EnvSecretsLive adapter — future adapters (kernel secrets, keychain) swap in
-// without touching this file. `secrets` is captured at Layer-build time, not
-// requested as a Service requirement, so the returned Effect's R channel is
-// `never`.
-const resolveRef = (
-  secrets: SecretsServiceImpl,
-  targetRef: string,
-  prefix: string,
-  channel: string,
-  driver: string,
-): Effect.Effect<string, DeliveryError> => {
-  const unresolved = () =>
-    configErr(channel, driver, `unresolved target_ref for ${driver}: ${targetRef}`)
-  const parsed = resolveEnvRef(targetRef, prefix)
-  if (parsed === null) return Effect.fail(unresolved())
-  return Match.value(parsed).pipe(
-    Match.discriminator("kind")("literal", ({ value }) => Effect.succeed(value)),
-    Match.discriminator("kind")("env", ({ key }) =>
-      secrets.get(key).pipe(
-        Effect.catchTag("SecretsError", (e) =>
-          Effect.fail(
-            configErr(
-              channel,
-              driver,
-              `secret lookup failed for ${driver} (key=${key}): ${e.message}`,
-            ),
-          ),
-        ),
-        Effect.flatMap(
-          Option.match({
-            onNone: () => Effect.fail(unresolved()),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ),
-    ),
-    Match.exhaustive,
-  )
-}
-
-// HTTP status → DeliveryError kind. 5xx is network/health (retry); 4xx is a
-// client/config problem (don't retry).
-const classifyKernelStatus = (
-  status: number,
-): "config" | "unreachable" | "rate_limited" | "invalid" | "io_failure" =>
-  Match.value(status).pipe(
-    Match.when(429, () => "rate_limited" as const),
-    Match.whenOr(502, 503, 504, () => "unreachable" as const),
-    Match.when((n) => n >= 500, () => "unreachable" as const),
-    Match.whenOr(400, 401, 403, 404, () => "invalid" as const),
-    Match.orElse(() => "io_failure" as const),
-  )
-
 const kernelBase = () =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
-
-const unreachableErr = (
-  path: string,
-  channel: string,
-  driver: string,
-  reason: string,
-): DeliveryError =>
-  new DeliveryError({
-    message: `kernel ${path} ${reason}`,
-    channel,
-    driver,
-    kind: "unreachable",
-  })
 
 const postToKernel = (
   path: string,
@@ -160,11 +37,13 @@ const postToKernel = (
           headers: { "content-type": "application/json" },
           body: JSON.stringify(body),
         }),
-      catch: (e) => unreachableErr(path, channel, driver, `fetch failed: ${String(e)}`),
+      catch: (e) =>
+        unreachableErr(`kernel ${path}`, channel, driver, `fetch failed: ${String(e)}`),
     })
     const text = yield* Effect.tryPromise({
       try: () => response.text(),
-      catch: (e) => unreachableErr(path, channel, driver, `body read failed: ${String(e)}`),
+      catch: (e) =>
+        unreachableErr(`kernel ${path}`, channel, driver, `body read failed: ${String(e)}`),
     })
     if (!response.ok) {
       return yield* Effect.fail(
@@ -172,7 +51,7 @@ const postToKernel = (
           message: `kernel ${path} HTTP ${response.status}: ${text.slice(0, 500)}`,
           channel,
           driver,
-          kind: classifyKernelStatus(response.status),
+          kind: classifyHttpStatus(response.status),
           status: response.status,
         }),
       )
@@ -189,9 +68,6 @@ const postToKernel = (
         }),
     })
   })
-
-const chunkPrefix = (i: number, total: number): string =>
-  total > 1 ? `(${i + 1}/${total})\n` : ""
 
 const sendTelegram = (
   secrets: SecretsServiceImpl,
@@ -294,6 +170,8 @@ export const HttpDelivererLive = Layer.effect(
   }),
 )
 
+// Kept for back-compat with existing tests that destructure `_internal`.
+// New code should import directly from `lib/deliverer-shared.ts`.
 export const _internal = {
   splitChunks,
   splitBrief,
@@ -301,5 +179,7 @@ export const _internal = {
   resolveEnvRef,
   kernelBase,
   resolveRef,
-  classifyKernelStatus,
+  // Alias: test file imports `classifyKernelStatus` which was the original name
+  // before the refactor renamed it to `classifyHttpStatus` in the shared module.
+  classifyKernelStatus: classifyHttpStatus,
 }

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,6 +1,6 @@
-import { Agent } from "undici";
-import { Duration, Effect, Layer } from "effect";
-import { LlmError } from "../errors.js";
+import { Agent } from "undici"
+import { Duration, Effect, Layer } from "effect"
+import type { LlmError } from "../errors.js"
 
 // Constrained decoding under `response_format: json_schema` can run for many
 // minutes on local backends (LMStudio + gemma) when the target schema has
@@ -10,18 +10,15 @@ import { LlmError } from "../errors.js";
 // the `dispatcher` option so the LLM stage isn't artificially capped — global
 // fetch behavior is unchanged, so tests that mock `globalThis.fetch` and
 // other consumers of fetch are unaffected.
-const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
-import { sha256 } from "../lib/hash.js";
+const llmFetchAgent = new Agent({ headersTimeout: 0, bodyTimeout: 0 })
+
 import {
-  briefJsonFormat,
   buildInterestReportUserPrompt,
   buildResearchQueryUserPrompt,
   buildSubtopicUserPrompt,
   buildSummaryUserPrompt,
   buildUserPrompt,
-  decodeLlmJson,
   extractJson,
-  interestReportJsonFormat,
   InterestReportOutputSchema,
   type JsonResponseFormat,
   LlmOutputSchema,
@@ -29,294 +26,61 @@ import {
   REPORT_SYSTEM_PROMPT,
   RESEARCH_SYSTEM_PROMPT,
   SUBTOPIC_SYSTEM_PROMPT,
-  subtopicJsonFormat,
   SubtopicProposeOutputSchema,
-  SUMMARY_INPUT_CHARS_CAP,
-  SUMMARY_MAX_TOKENS,
   SUMMARY_SYSTEM_PROMPT,
   SYSTEM_PROMPT,
-} from "../lib/llm-prompts.js";
-import { LlmService } from "../services/LlmService.js";
-import type { CuratedItem } from "../services/RendererService.js";
+} from "../lib/llm-prompts.js"
+import { makeLlmServiceShape } from "../lib/llm-service-factory.js"
+import {
+  type AnthropicResponse,
+  classifyHttpStatus,
+  CONTEXT_1M_BETA,
+  defaultConcurrencyForModel,
+  effortBody,
+  type EffortConfig,
+  effortConfigFor,
+  effortFromEnv,
+  isAnthropicModel,
+  isConnRefused,
+  is1MContextRequested,
+  isOpus47Family,
+  isWorkersAiModel,
+  llmErr,
+  type NormalizedResponse,
+  type OpenAiChatResponse,
+  parseRetryAfter,
+  SERVICE_NAME,
+  sessionIdFor,
+  stripContextSuffix,
+} from "../lib/llm-shared.js"
+import { LlmService } from "../services/LlmService.js"
 
 // Local-first default: kernel /api/llm/completions routes to LM Studio at
 // 127.0.0.1:1234 unless GCTRL_LLM_PROVIDER=cloudflare is set on the kernel.
 // Override with UBER_LLM_MODEL to match the model id loaded in your LM Studio
 // instance (LM Studio typically echoes whatever model name it has loaded).
-const DEFAULT_MODEL = "google/gemma-4-31b";
-const DEFAULT_MAX_TOKENS = 16000;
-
-// Per-model USD/Mtok rates (input, output). Workers AI / local backends bill
-// kernel-side (or are free), so they collapse to 0 here. Anthropic rates
-// matter because uebermensch persists per-report `cost_usd` in vault
-// frontmatter — stale numbers there propagate into eval/dashboards.
-type CostRates = readonly [input: number, output: number];
-
-const ANTHROPIC_RATES: ReadonlyArray<readonly [RegExp, CostRates]> = [
-  // Order matters: more specific patterns first.
-  [/^claude-opus-4-/, [15.0, 75.0]],
-  [/^claude-sonnet-4-/, [3.0, 15.0]],
-  [/^claude-haiku-4-/, [1.0, 5.0]],
-  // Older 3.x families (kept for back-compat — kernel may still relay).
-  [/^claude-3-5-sonnet-/, [3.0, 15.0]],
-  [/^claude-3-5-haiku-/, [1.0, 5.0]],
-  [/^claude-3-opus-/, [15.0, 75.0]],
-];
-
-const ratesForModel = (model: string): CostRates => {
-  if (!isAnthropicModel(model)) return [0, 0];
-  for (const [pattern, rates] of ANTHROPIC_RATES) {
-    if (pattern.test(model)) return rates;
-  }
-  // Unknown claude-* — fall back to Sonnet rates (mid-range guess) rather
-  // than zero, so a new model id surfaces in cost telemetry instead of
-  // silently being free.
-  return [3.0, 15.0];
-};
-
-// Effort tier — operator-facing knob for how much LLM work to spend on a
-// run. Maps to (max output tokens, thinking config). The lower-level
-// per-provider billing concern (subscription vs metered, AI Gateway vs
-// BYOK) lives in the kernel's driver-llm — uebermensch should not know
-// or care.
-type Effort = "low" | "medium" | "high";
-
-const effortFromEnv = (): Effort => {
-  const raw = process.env.UBER_LLM_EFFORT?.toLowerCase().trim();
-  if (raw === "low" || raw === "high") return raw;
-  return "medium";
-};
-
-// Anthropic `thinking` parameter shapes:
-// - "off"      → no thinking field (model answers directly)
-// - "adaptive" → `{ type: "adaptive" }` — model decides budget
-// - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
-type ThinkingMode = "off" | "adaptive" | "extended";
-
-type OutputEffort = "low" | "medium" | "high";
-
-type EffortConfig = {
-  readonly maxTokens: number;
-  readonly thinking: ThinkingMode;
-  readonly thinkingBudgetTokens: number;
-  // Opus 4.7 rejects `thinking.type: "enabled"` and instead controls effort
-  // via top-level `output_config.effort`. When set, callers emit it in the
-  // request body alongside `thinking: { type: "adaptive" }`.
-  readonly outputEffort?: OutputEffort;
-};
-
-// Models in the 4.7+ family use the new effort-control semantics:
-// `thinking.type: "adaptive"` + `output_config.effort`. Older 4.x families
-// (4.5/4.6) still accept `thinking.type: "enabled"` with a budget. Bump
-// the regex when 4.8 lands.
-const isOpus47Family = (model: string): boolean =>
-  /^claude-opus-4-(7|8|9)\b/.test(stripContextSuffix(model));
-
-const effortConfigFor = (effort: Effort, model?: string): EffortConfig => {
-  if (model && isOpus47Family(model)) {
-    switch (effort) {
-      case "low":
-        return {
-          maxTokens: 4000,
-          thinking: "adaptive",
-          thinkingBudgetTokens: 0,
-          outputEffort: "low",
-        };
-      case "high":
-        return {
-          maxTokens: 32000,
-          thinking: "adaptive",
-          thinkingBudgetTokens: 0,
-          outputEffort: "high",
-        };
-      default:
-        return {
-          maxTokens: DEFAULT_MAX_TOKENS,
-          thinking: "adaptive",
-          thinkingBudgetTokens: 0,
-          outputEffort: "medium",
-        };
-    }
-  }
-  switch (effort) {
-    case "low":
-      // Tight cap, no thinking. Single-pass, fast, cheap.
-      return { maxTokens: 4000, thinking: "off", thinkingBudgetTokens: 0 };
-    case "high":
-      // Generous output budget + explicit extended-thinking budget for
-      // deeper synthesis. Doubles default max for long deep-dives.
-      return { maxTokens: 32000, thinking: "extended", thinkingBudgetTokens: 16000 };
-    default:
-      // Adaptive thinking — model decides budget. Current default behavior.
-      return { maxTokens: DEFAULT_MAX_TOKENS, thinking: "adaptive", thinkingBudgetTokens: 0 };
-  }
-};
+const DEFAULT_MODEL = "google/gemma-4-31b"
 
 // Per-article summarization shares the curator default by design — LM Studio
 // typically has a single model loaded and echoes that name regardless of the
 // `model` field. Override with UBER_LLM_SUMMARY_MODEL when running a separate
 // smaller model on a second backend.
-const DEFAULT_SUMMARY_MODEL = "google/gemma-4-31b";
-const SUMMARY_INPUT_COST_PER_MTOK = 1.0;
-const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0;
+const DEFAULT_SUMMARY_MODEL = "google/gemma-4-31b"
 
-const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL;
+const modelFor = (): string => process.env.UBER_LLM_MODEL ?? DEFAULT_MODEL
 
 const summaryModelFor = (): string =>
-  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL;
-
-// Anthropic-shaped models go through /api/llm/messages. Everything else
-// (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
-// LM Studio / Ollama) goes through /api/llm/completions.
-const isAnthropicModel = (model: string): boolean =>
-  stripContextSuffix(model).startsWith("claude-");
-// Back-compat alias — older callers/tests still import this name.
-const isWorkersAiModel = (model: string): boolean => !isAnthropicModel(model);
-
-// Anthropic's 1M context window is enabled per-request via the
-// `anthropic-beta: context-1m-2025-08-07` header. Operators opt in by
-// suffixing the model id (e.g. `claude-opus-4-7[1m]`) or by setting
-// `UBER_LLM_CONTEXT_1M=1`. Any non-Anthropic model ignores the suffix.
-const CONTEXT_1M_BETA = "context-1m-2025-08-07";
-
-const stripContextSuffix = (model: string): string =>
-  model.replace(/\[1m\]$/i, "");
-
-const is1MContextRequested = (model: string): boolean => {
-  if (/\[1m\]$/i.test(model)) return true;
-  const env = process.env.UBER_LLM_CONTEXT_1M?.toLowerCase().trim();
-  return env === "1" || env === "true" || env === "yes";
-};
-
-// Per-model concurrency defaults for the report pipeline. Anthropic
-// rate-limits by tokens/minute per (org, model). Tier 1 opus-4.7 is the
-// tightest at 30k input TPM, so a single ~30k-token deep-dive prompt
-// already saturates a minute — concurrency=1 + paced retries is the only
-// way to make a clean run. Higher tiers can override with
-// UBER_REPORT_CONCURRENCY.
-const defaultConcurrencyForModel = (model: string | undefined): number => {
-  if (!model) return 2;
-  const m = stripContextSuffix(model);
-  if (isOpus47Family(m)) return 1;
-  if (/^claude-opus-4-/.test(m)) return 2;
-  if (/^claude-sonnet-4-/.test(m)) return 4;
-  if (/^claude-haiku-4-/.test(m)) return 6;
-  return 2;
-};
-
-// Parse `Retry-After` header (RFC 7231: delta-seconds OR HTTP-date).
-// Anthropic sends seconds; bare numbers are clamped to a sane ceiling so
-// a buggy upstream can't stall a run for an hour. Returns ms or null.
-const parseRetryAfter = (raw: string | null | undefined): number | null => {
-  if (!raw) return null;
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  const asNum = Number.parseFloat(trimmed);
-  if (Number.isFinite(asNum) && asNum >= 0) {
-    return Math.min(asNum, 120) * 1000;
-  }
-  const t = Date.parse(trimmed);
-  if (Number.isFinite(t)) {
-    const delta = t - Date.now();
-    return delta > 0 ? Math.min(delta, 120_000) : 0;
-  }
-  return null;
-};
+  process.env.UBER_LLM_SUMMARY_MODEL ?? process.env.UBER_LLM_MODEL ?? DEFAULT_SUMMARY_MODEL
 
 const kernelBase = (): string =>
-  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
-
-// Identity headers consumed by the kernel's driver-llm capture path
-// (vault/specs/implementation/llm-relay.md § "Convergence with driver-llm").
-// Setting `x-session-id` makes the kernel persist a `prompt_bodies` row
-// per turn and emit a generation span — uebermensch then shows up in
-// /api/sessions and the analytics dashboard alongside opencode and the
-// rest. `UBER_SESSION_ID` is the operator's hook for tying a logical run
-// (e.g. one daily-brief invocation, one profile cycle) to a single
-// session; the fallback is a process-lifetime UUID so a forgotten env
-// var still produces *some* aggregated session rather than orphans.
-const SERVICE_NAME = "uebermensch";
-let processSessionId: string | null = null;
-const sessionIdFor = (): string => {
-  const explicit = process.env.UBER_SESSION_ID;
-  if (explicit && explicit.length > 0) return explicit;
-  if (processSessionId === null) {
-    processSessionId =
-      typeof globalThis.crypto?.randomUUID === "function"
-        ? globalThis.crypto.randomUUID()
-        : `uber-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-  return processSessionId;
-};
-
-type AnthropicResponse = {
-  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
-  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number };
-  readonly model?: string;
-};
-
-type OpenAiChatResponse = {
-  readonly choices?: ReadonlyArray<{ readonly message?: { readonly content?: string } }>;
-  readonly usage?: { readonly prompt_tokens?: number; readonly completion_tokens?: number };
-  readonly model?: string;
-};
-
-type NormalizedResponse = {
-  readonly text: string;
-  readonly inputTokens: number;
-  readonly outputTokens: number;
-  readonly model: string;
-};
-
-const llmErr = (
-  kind: LlmError["kind"],
-  message: string,
-  retryAfterMs?: number,
-): LlmError => new LlmError({ kind, message, retryAfterMs });
-
-const classifyKernelStatus = (status: number): LlmError["kind"] => {
-  if (status === 503) return "unavailable";
-  if (status === 429) return "rate_limited";
-  if (status === 400 || status === 401 || status === 403) return "invalid";
-  if (status >= 500) return "unavailable";
-  return "invalid";
-};
-
-// Node's fetch surfaces a connection refusal as `TypeError: fetch failed`
-// with a nested `cause` carrying `code: ECONNREFUSED`. Walk the chain so we
-// can tell the user the kernel daemon is simply down vs. some other failure.
-const isConnRefused = (e: unknown): boolean => {
-  let cur: unknown = e;
-  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
-    const code = (cur as { code?: string }).code;
-    if (
-      code === "ECONNREFUSED" ||
-      code === "ENOTFOUND" ||
-      code === "EHOSTUNREACH" ||
-      code === "ECONNRESET"
-    ) {
-      return true;
-    }
-    const errors = (cur as { errors?: ReadonlyArray<unknown> }).errors;
-    if (Array.isArray(errors) && errors.some(isConnRefused)) return true;
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return false;
-};
+  (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "")
 
 const kernelDownErr = (path: string): LlmError =>
   llmErr(
     "unavailable",
     `kernel daemon not reachable at ${kernelBase()}${path} — start it with: ` +
       `gctrld serve --port 4318 (or set GCTRL_KERNEL_URL to point at a running kernel)`,
-  );
-
-const tokensCost = (
-  inputTokens: number,
-  outputTokens: number,
-  inputRate: number,
-  outputRate: number,
-): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000;
+  )
 
 // POST a JSON body to `${kernelBase()}${path}` and return the raw response
 // text. Connection-level failures (ECONNREFUSED etc.) become a "kernel daemon
@@ -346,37 +110,37 @@ const fetchKernel = (
           // biome-ignore lint/suspicious/noExplicitAny: undici-specific option
         } as any),
       catch: (e) => {
-        if (isConnRefused(e)) return kernelDownErr(path);
-        const cause = (e as { cause?: unknown })?.cause;
-        const causeStr = cause ? ` cause=${String(cause)}` : "";
-        return llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}${causeStr}`);
+        if (isConnRefused(e)) return kernelDownErr(path)
+        const cause = (e as { cause?: unknown })?.cause
+        const causeStr = cause ? ` cause=${String(cause)}` : ""
+        return llmErr("unavailable", `kernel ${path} fetch failed: ${String(e)}${causeStr}`)
       },
-    });
+    })
     const raw = yield* Effect.tryPromise({
       try: () => res.text(),
       catch: (e) =>
         llmErr("unavailable", `kernel ${path} body read failed: ${String(e)}`),
-    });
+    })
     if (!res.ok) {
-      const kind = classifyKernelStatus(res.status);
-      let retryAfterMs: number | undefined;
+      const kind = classifyHttpStatus(res.status)
+      let retryAfterMs: number | undefined
       if (kind === "rate_limited") {
         // Headers may be unavailable on test mocks — guard the lookup.
         const headerGet = (k: string): string | null => {
           try {
-            return res.headers?.get?.(k) ?? null;
+            return res.headers?.get?.(k) ?? null
           } catch {
-            return null;
+            return null
           }
-        };
+        }
         const ra =
           parseRetryAfter(headerGet("retry-after")) ??
           // Anthropic also sends `anthropic-ratelimit-input-tokens-reset`
           // as an ISO-8601 timestamp. Honor it as a fallback so paced
           // retries don't hammer the upstream early.
           parseRetryAfter(headerGet("anthropic-ratelimit-input-tokens-reset")) ??
-          parseRetryAfter(headerGet("anthropic-ratelimit-tokens-reset"));
-        if (ra !== null) retryAfterMs = ra;
+          parseRetryAfter(headerGet("anthropic-ratelimit-tokens-reset"))
+        if (ra !== null) retryAfterMs = ra
       }
       return yield* Effect.fail(
         llmErr(
@@ -384,10 +148,10 @@ const fetchKernel = (
           `kernel ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
           retryAfterMs,
         ),
-      );
+      )
     }
-    return raw;
-  });
+    return raw
+  })
 
 // Bounded retry loop for transient LlmErrors. Two kinds qualify:
 //   - `rate_limited` (HTTP 429): honors `retryAfterMs` when present,
@@ -404,67 +168,51 @@ const fetchKernel = (
 // Setting RETRIES=0 disables retry entirely — the typed `LlmError`
 // surfaces directly to the caller (used by tests).
 const envInt = (key: string, fallback: number, min = 0): number => {
-  const raw = process.env[key];
-  if (raw === undefined || raw === null) return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n >= min ? n : fallback;
-};
+  const raw = process.env[key]
+  if (raw === undefined || raw === null) return fallback
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n >= min ? n : fallback
+}
 
 type RateLimitConfig = {
-  readonly maxRetries: number;
-  readonly baseMs: number;
-  readonly maxMs: number;
-};
+  readonly maxRetries: number
+  readonly baseMs: number
+  readonly maxMs: number
+}
 
 const rateLimitConfig = (): RateLimitConfig => ({
   maxRetries: envInt("UBER_LLM_RATE_LIMIT_RETRIES", 4),
   baseMs: envInt("UBER_LLM_RATE_LIMIT_BASE_MS", 2_000, 1),
   maxMs: envInt("UBER_LLM_RATE_LIMIT_MAX_MS", 60_000, 1),
-});
+})
 
 const isTransientKind = (kind: LlmError["kind"]): boolean =>
-  kind === "rate_limited" || kind === "unavailable";
+  kind === "rate_limited" || kind === "unavailable"
 
 const withRateLimitRetry = <A>(
   eff: Effect.Effect<A, LlmError>,
 ): Effect.Effect<A, LlmError> => {
-  const cfg = rateLimitConfig();
+  const cfg = rateLimitConfig()
   const loop = (attempt: number): Effect.Effect<A, LlmError> =>
     eff.pipe(
       Effect.catchTag("LlmError", (e) => {
         if (!isTransientKind(e.kind) || attempt >= cfg.maxRetries) {
-          return Effect.fail(e);
+          return Effect.fail(e)
         }
-        const expBackoff = Math.min(cfg.baseMs * 2 ** attempt, cfg.maxMs);
+        const expBackoff = Math.min(cfg.baseMs * 2 ** attempt, cfg.maxMs)
         // 429 supplies retryAfterMs; 5xx does not — fall back to
         // exponential. Cap the hint at MAX_MS too so a buggy upstream
         // can't stall a run.
-        const hint = e.retryAfterMs;
+        const hint = e.retryAfterMs
         const delayMs =
-          hint !== undefined ? Math.min(hint, cfg.maxMs) : expBackoff;
+          hint !== undefined ? Math.min(hint, cfg.maxMs) : expBackoff
         return Effect.sleep(Duration.millis(delayMs)).pipe(
           Effect.andThen(loop(attempt + 1)),
-        );
+        )
       }),
-    );
-  return loop(0);
-};
-
-const effortBody = (cfg: EffortConfig): Record<string, unknown> => {
-  const out: Record<string, unknown> = {};
-  if (cfg.thinking === "extended") {
-    out.thinking = { type: "enabled", budget_tokens: cfg.thinkingBudgetTokens };
-  } else if (cfg.thinking === "adaptive") {
-    out.thinking = { type: "adaptive" };
-  }
-  // `output_config.effort` is opus-4.7+ only; older models 400 on it,
-  // which is why we gate it through `EffortConfig.outputEffort` (set
-  // exclusively by the opus-4.7 branch of `effortConfigFor`).
-  if (cfg.outputEffort) {
-    out.output_config = { effort: cfg.outputEffort };
-  }
-  return out;
-};
+    )
+  return loop(0)
+}
 
 const postAnthropic = (
   model: string,
@@ -473,39 +221,39 @@ const postAnthropic = (
   cfg: EffortConfig,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   Effect.gen(function* () {
-    const wireModel = stripContextSuffix(model);
+    const wireModel = stripContextSuffix(model)
     const body: Record<string, unknown> = {
       model: wireModel,
       max_tokens: cfg.maxTokens,
       system,
       messages: [{ role: "user", content: userPrompt }],
       ...effortBody(cfg),
-    };
-    const headers: Record<string, string> = {};
-    if (is1MContextRequested(model)) headers["anthropic-beta"] = CONTEXT_1M_BETA;
-    const raw = yield* fetchKernel("/api/llm/messages", body, headers);
+    }
+    const headers: Record<string, string> = {}
+    if (is1MContextRequested(model)) headers["anthropic-beta"] = CONTEXT_1M_BETA
+    const raw = yield* fetchKernel("/api/llm/messages", body, headers)
     const parsed = yield* Effect.try({
       try: () =>
         (raw.length > 0 ? (JSON.parse(raw) as AnthropicResponse) : ({} as AnthropicResponse)),
       catch: (e) =>
         llmErr("invalid", `kernel /api/llm/messages JSON.parse failed: ${String(e)}`),
-    });
+    })
     const textBlock = (parsed.content ?? []).find(
       (b): b is { type: string; text: string } =>
         b.type === "text" && typeof b.text === "string",
-    );
+    )
     if (!textBlock) {
       return yield* Effect.fail(
         llmErr("invalid", "kernel response missing text content block"),
-      );
+      )
     }
     return {
       text: textBlock.text,
       inputTokens: parsed.usage?.input_tokens ?? 0,
       outputTokens: parsed.usage?.output_tokens ?? 0,
       model: parsed.model ?? wireModel,
-    };
-  });
+    }
+  })
 
 const postWorkersAi = (
   model: string,
@@ -534,28 +282,31 @@ const postWorkersAi = (
             },
           }
         : {}),
-    };
-    const raw = yield* fetchKernel("/api/llm/completions", body);
+    }
+    const raw = yield* fetchKernel("/api/llm/completions", body)
     const parsed = yield* Effect.try({
       try: () =>
         (raw.length > 0 ? (JSON.parse(raw) as OpenAiChatResponse) : ({} as OpenAiChatResponse)),
       catch: (e) =>
         llmErr("invalid", `kernel /api/llm/completions JSON.parse failed: ${String(e)}`),
-    });
-    const content = parsed.choices?.[0]?.message?.content;
+    })
+    const content = parsed.choices?.[0]?.message?.content
     if (typeof content !== "string") {
       return yield* Effect.fail(
         llmErr("invalid", "kernel response missing choices[0].message.content string"),
-      );
+      )
     }
     return {
       text: content,
       inputTokens: parsed.usage?.prompt_tokens ?? 0,
       outputTokens: parsed.usage?.completion_tokens ?? 0,
       model: parsed.model ?? model,
-    };
-  });
+    }
+  })
 
+// Anthropic-shaped models go through /api/llm/messages (with rate-limit retry).
+// Everything else (`@cf/...` Workers AI, locally-served OpenAI-compat backends
+// like LM Studio / Ollama) goes through /api/llm/completions.
 const postLlm = (
   model: string,
   system: string,
@@ -567,205 +318,22 @@ const postLlm = (
     isWorkersAiModel(model)
       ? postWorkersAi(model, system, userPrompt, cfg.maxTokens, jsonFormat)
       : postAnthropic(model, system, userPrompt, cfg),
-  );
+  )
 
-// USD cost for a normalized LLM response. Workers AI / local models
-// always cost $0. Anthropic models look up rates by model id so Opus 4.7
-// ($15/$75) and Sonnet 4.6 ($3/$15) bill correctly without a redeploy.
-// Optional rate overrides keep the summary lane (which used custom rates)
-// working unchanged.
-const costForResponse = (
-  res: NormalizedResponse,
-  inputRateOverride?: number,
-  outputRateOverride?: number,
-): number => {
-  if (isWorkersAiModel(res.model)) return 0;
-  if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
-    return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride);
-  }
-  const [inputRate, outputRate] = ratesForModel(res.model);
-  return tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate);
-};
-
-export const KernelLlmLive = Layer.succeed(LlmService, {
-  name: () => `kernel-llm@${modelFor()}`,
-  generateBrief: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildUserPrompt(req);
-      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv(), model);
-      const res = yield* postLlm(
-        model,
-        SYSTEM_PROMPT,
-        userPrompt,
-        eff,
-        briefJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
-      const costUsd = costForResponse(res);
-      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
-        kind: i.kind,
-        title: i.title,
-        summary_md: i.summary_md,
-        topic: i.topic,
-        thesis: i.thesis,
-        source_candidate_ids: i.source_candidate_ids,
-        suggested_action: i.suggested_action,
-      }));
-      return {
-        items,
-        topicsCovered: decoded.topicsCovered,
-        thesesCovered: decoded.thesesCovered,
-        promptHash,
-        costUsd,
-        model: res.model,
-      };
-    }),
-  proposeSubtopic: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildSubtopicUserPrompt(req);
-      const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv(), model);
-      const res = yield* postLlm(
-        model,
-        SUBTOPIC_SYSTEM_PROMPT,
-        userPrompt,
-        eff,
-        subtopicJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(
-        res.text,
-        SubtopicProposeOutputSchema,
-        "kernel subtopic",
-      );
-      const proposalSlugs = new Set(decoded.proposals.map((p) => p.slug));
-      const selectedSlug = proposalSlugs.has(decoded.selected_slug)
-        ? decoded.selected_slug
-        : decoded.proposals[0].slug;
-      const candidateIds = new Set(req.interest.candidates.map((c) => c.id));
-      const proposals = decoded.proposals.map((p) => ({
-        slug: p.slug,
-        title: p.title,
-        rationale: p.rationale,
-        relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
-      }));
-      const costUsd = costForResponse(res);
-      return {
-        selectedSlug,
-        proposals,
-        promptHash,
-        costUsd,
-        inputTokens: res.inputTokens,
-        outputTokens: res.outputTokens,
-        model: res.model,
-      };
-    }),
-  generateInterestReport: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildInterestReportUserPrompt(req);
-      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv(), model);
-      const res = yield* postLlm(
-        model,
-        REPORT_SYSTEM_PROMPT,
-        userPrompt,
-        eff,
-        interestReportJsonFormat(),
-      );
-      const decoded = yield* decodeLlmJson(
-        res.text,
-        InterestReportOutputSchema,
-        "kernel interest report",
-      );
-      const costUsd = costForResponse(res);
-      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
-        kind: i.kind,
-        title: i.title,
-        summary_md: i.summary_md,
-        topic: i.topic,
-        thesis: i.thesis,
-        source_candidate_ids: i.source_candidate_ids,
-        suggested_action: i.suggested_action,
-      }));
-      return {
-        interestSlug: req.interest.slug,
-        analysis_md: decoded.analysis_md,
-        items,
-        promptHash,
-        costUsd,
-        inputTokens: res.inputTokens,
-        outputTokens: res.outputTokens,
-        model: res.model,
-      };
-    }),
-  researchQuery: (req) =>
-    Effect.gen(function* () {
-      const model = modelFor();
-      const userPrompt = buildResearchQueryUserPrompt(req);
-      const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv(), model);
-      const res = yield* postLlm(
-        model,
-        RESEARCH_SYSTEM_PROMPT,
-        userPrompt,
-        eff,
-        null,
-      );
-      const answerMd = res.text.trim();
-      if (answerMd.length === 0) {
-        return yield* Effect.fail(llmErr("invalid", "kernel researchQuery returned empty body"));
-      }
-      const costUsd = costForResponse(res);
-      return { answerMd, promptHash, costUsd, model: res.model };
-    }),
-  summarizeSource: (req) =>
-    Effect.gen(function* () {
-      const capped =
-        req.text.length > SUMMARY_INPUT_CHARS_CAP
-          ? `${req.text.slice(0, SUMMARY_INPUT_CHARS_CAP)}…`
-          : req.text;
-      const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped);
-      const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      // Summary lane is always low-effort: short, cheap, no thinking. Not
-      // operator-tunable — bumping summarization to "high" would 10x the
-      // ingest spend with negligible quality lift.
-      const summaryCfg: EffortConfig = {
-        maxTokens: SUMMARY_MAX_TOKENS,
-        thinking: "off",
-        thinkingBudgetTokens: 0,
-      };
-      const res = yield* postLlm(
-        summaryModelFor(),
-        SUMMARY_SYSTEM_PROMPT,
-        userPrompt,
-        summaryCfg,
-        null,
-      );
-      const insightsMd = normalizeInsights(res.text);
-      if (insightsMd.length === 0) {
-        return yield* Effect.fail(llmErr("invalid", "kernel summarize returned empty insights"));
-      }
-      const costUsd = costForResponse(
-        res,
-        SUMMARY_INPUT_COST_PER_MTOK,
-        SUMMARY_OUTPUT_COST_PER_MTOK,
-      );
-      return {
-        insightsMd,
-        promptHash,
-        costUsd,
-        model: res.model,
-      };
-    }),
-});
+export const KernelLlmLive = Layer.succeed(
+  LlmService,
+  makeLlmServiceShape({
+    name: () => `kernel-llm@${modelFor()}`,
+    postLlm,
+    modelFor,
+    summaryModelFor,
+  }),
+)
 
 // Re-export prompt/schema material for tests that historically reach into
 // `_internal`. Tests should migrate to importing directly from
 // `lib/llm-prompts.ts`, but keeping the shape stable here avoids touching
-// every test in this PR — they get rewritten in the AnthropicLlm follow-up.
+// every test in this PR.
 export const _internal = {
   buildUserPrompt,
   buildInterestReportUserPrompt,
@@ -802,4 +370,4 @@ export const _internal = {
   parseRetryAfter,
   defaultConcurrencyForModel,
   CONTEXT_1M_BETA,
-};
+}

--- a/apps/uebermensch/src/lib/deliverer-shared.ts
+++ b/apps/uebermensch/src/lib/deliverer-shared.ts
@@ -1,0 +1,146 @@
+// Shared helpers for every DelivererService adapter (HttpDeliverer via
+// kernel proxy, DirectDeliverer hitting providers directly). Lives here so
+// the chunking / target-ref-resolution logic cannot drift across adapters.
+
+import { Effect, Match, Option } from "effect"
+import { DeliveryError } from "../errors.js"
+import type { SecretsServiceImpl } from "../services/SecretsService.js"
+
+// ---------------------------------------------------------------------------
+// Per-channel max chunk lengths. Telegram's hard cap is 4096 chars, Discord
+// 2000 — leave headroom for chunk-prefix + UTF8 safety.
+// ---------------------------------------------------------------------------
+export const TG_MAX = 3800
+export const DC_MAX = 1900
+
+export const splitChunks = (content: string, max: number): ReadonlyArray<string> => {
+  if (content.length <= max) return [content]
+  const chunks: Array<string> = []
+  const lines = content.split("\n")
+  let buf = ""
+  for (const line of lines) {
+    const next = buf.length === 0 ? line : `${buf}\n${line}`
+    if (next.length > max && buf.length > 0) {
+      chunks.push(buf)
+      buf = line
+    } else if (next.length > max) {
+      for (let i = 0; i < line.length; i += max) chunks.push(line.slice(i, i + max))
+      buf = ""
+    } else {
+      buf = next
+    }
+  }
+  if (buf.length > 0) chunks.push(buf)
+  return chunks
+}
+
+export const stripFrontmatter = (md: string): string => {
+  if (!md.startsWith("---\n")) return md
+  const end = md.indexOf("\n---\n", 4)
+  if (end === -1) return md
+  return md.slice(end + 5).replace(/^\n+/, "")
+}
+
+const ITEM_HEADING = /^## \d+\. /m
+
+export const splitBrief = (content: string, max: number): ReadonlyArray<string> => {
+  const body = stripFrontmatter(content)
+  if (!ITEM_HEADING.test(body)) return splitChunks(body, max)
+  const withoutH1 = body.replace(/^#\s+[^\n]*\n+/, "")
+  const parts = withoutH1
+    .split(/(?=^## \d+\. )/m)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  const out: Array<string> = []
+  for (const p of parts) {
+    if (p.length <= max) out.push(p)
+    else for (const c of splitChunks(p, max)) out.push(c)
+  }
+  return out
+}
+
+export const chunkPrefix = (i: number, total: number): string =>
+  total > 1 ? `(${i + 1}/${total})\n` : ""
+
+// ---------------------------------------------------------------------------
+// Target-ref resolution — `<prefix>env:<KEY>` → secrets.get(KEY),
+// `<prefix><value>` → literal. Pure parser delegates env reads to
+// SecretsService so a future LocalKeychain/KernelSecrets adapter swaps in
+// without touching this file.
+// ---------------------------------------------------------------------------
+export const resolveEnvRef = (
+  targetRef: string,
+  prefix: string,
+): { kind: "env"; key: string } | { kind: "literal"; value: string } | null => {
+  if (!targetRef.startsWith(prefix)) return null
+  const rest = targetRef.slice(prefix.length)
+  if (rest.startsWith("env:")) return { kind: "env", key: rest.slice(4) }
+  return { kind: "literal", value: rest }
+}
+
+export const configErr = (channel: string, driver: string, message: string): DeliveryError =>
+  new DeliveryError({ message, channel, driver, kind: "config" })
+
+export const resolveRef = (
+  secrets: SecretsServiceImpl,
+  targetRef: string,
+  prefix: string,
+  channel: string,
+  driver: string,
+): Effect.Effect<string, DeliveryError> => {
+  const unresolved = () =>
+    configErr(channel, driver, `unresolved target_ref for ${driver}: ${targetRef}`)
+  const parsed = resolveEnvRef(targetRef, prefix)
+  if (parsed === null) return Effect.fail(unresolved())
+  return Match.value(parsed).pipe(
+    Match.discriminator("kind")("literal", ({ value }) => Effect.succeed(value)),
+    Match.discriminator("kind")("env", ({ key }) =>
+      secrets.get(key).pipe(
+        Effect.catchTag("SecretsError", (e) =>
+          Effect.fail(
+            configErr(
+              channel,
+              driver,
+              `secret lookup failed for ${driver} (key=${key}): ${e.message}`,
+            ),
+          ),
+        ),
+        Effect.flatMap(
+          Option.match({
+            onNone: () => Effect.fail(unresolved()),
+            onSome: Effect.succeed,
+          }),
+        ),
+      ),
+    ),
+    Match.exhaustive,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// HTTP status → DeliveryError kind. 5xx is network/health (retry-eligible);
+// 4xx is a client/config problem (don't retry).
+// ---------------------------------------------------------------------------
+export const classifyHttpStatus = (
+  status: number,
+): "config" | "unreachable" | "rate_limited" | "invalid" | "io_failure" =>
+  Match.value(status).pipe(
+    Match.when(429, () => "rate_limited" as const),
+    Match.whenOr(502, 503, 504, () => "unreachable" as const),
+    Match.when((n) => n >= 500, () => "unreachable" as const),
+    Match.whenOr(400, 401, 403, 404, () => "invalid" as const),
+    Match.orElse(() => "io_failure" as const),
+  )
+
+export const unreachableErr = (
+  path: string,
+  channel: string,
+  driver: string,
+  reason: string,
+): DeliveryError =>
+  new DeliveryError({
+    message: `${path} ${reason}`,
+    channel,
+    driver,
+    kind: "unreachable",
+  })

--- a/apps/uebermensch/src/lib/llm-service-factory.ts
+++ b/apps/uebermensch/src/lib/llm-service-factory.ts
@@ -1,0 +1,237 @@
+// makeLlmServiceShape — single implementation of the five LlmServiceShape
+// methods (generateBrief, proposeSubtopic, generateInterestReport,
+// researchQuery, summarizeSource) parameterized by a transport.
+//
+// Every adapter (KernelLlm, AnthropicLlm, LMStudioLlm) provides:
+//   - `postLlm`: how to send a prompt + receive a NormalizedResponse
+//   - `modelFor` / `summaryModelFor`: which model id to use per lane
+//   - `name`: human-readable id (e.g. "anthropic-direct@claude-opus-4-7")
+//
+// All other behavior — prompt construction, JSON decoding, cost math,
+// effort tier wiring — is shared, so adapters cannot drift on the
+// per-method shape. The factory exists because the previous KernelLlmLive
+// implementation reproduced the same five-method recipe inline (~200 LOC),
+// and we now need three transports without three copies of the recipe.
+
+import { Effect } from "effect"
+import { sha256 } from "./hash.js"
+import {
+  briefJsonFormat,
+  buildInterestReportUserPrompt,
+  buildResearchQueryUserPrompt,
+  buildSubtopicUserPrompt,
+  buildSummaryUserPrompt,
+  buildUserPrompt,
+  decodeLlmJson,
+  interestReportJsonFormat,
+  InterestReportOutputSchema,
+  LlmOutputSchema,
+  normalizeInsights,
+  REPORT_SYSTEM_PROMPT,
+  RESEARCH_SYSTEM_PROMPT,
+  SUBTOPIC_SYSTEM_PROMPT,
+  subtopicJsonFormat,
+  SubtopicProposeOutputSchema,
+  SUMMARY_INPUT_CHARS_CAP,
+  SUMMARY_MAX_TOKENS,
+  SUMMARY_SYSTEM_PROMPT,
+  SYSTEM_PROMPT,
+} from "./llm-prompts.js"
+import {
+  costForResponse,
+  type EffortConfig,
+  effortConfigFor,
+  effortFromEnv,
+  llmErr,
+  type PostLlm,
+} from "./llm-shared.js"
+import type { CuratedItem } from "../services/RendererService.js"
+import type { LlmServiceShape } from "../services/LlmService.js"
+
+// Summary lane bills a fixed cheap rate when the underlying model is
+// Anthropic-shaped (matches the historical KernelLlm hard-coding). For
+// OpenAI-compat / local models, costForResponse already collapses to 0.
+const SUMMARY_INPUT_COST_PER_MTOK = 1.0
+const SUMMARY_OUTPUT_COST_PER_MTOK = 5.0
+
+export type LlmServiceFactoryOpts = {
+  /** Identity string surfaced in spans + logs (e.g. "anthropic-direct@<model>"). */
+  readonly name: () => string
+  /** Per-call transport — the only real provider seam. */
+  readonly postLlm: PostLlm
+  /** Model id to use for the curator lane (briefs, subtopics, reports, research). */
+  readonly modelFor: () => string
+  /** Model id to use for the summarization lane (per-source insights). */
+  readonly summaryModelFor: () => string
+}
+
+export const makeLlmServiceShape = (opts: LlmServiceFactoryOpts): LlmServiceShape => ({
+  name: opts.name,
+  generateBrief: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildUserPrompt(req)
+      const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv(), model)
+      const res = yield* opts.postLlm(
+        model,
+        SYSTEM_PROMPT,
+        userPrompt,
+        eff,
+        briefJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "generateBrief")
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
+      }))
+      return {
+        items,
+        topicsCovered: decoded.topicsCovered,
+        thesesCovered: decoded.thesesCovered,
+        promptHash,
+        costUsd: costForResponse(res),
+        model: res.model,
+      }
+    }),
+  proposeSubtopic: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildSubtopicUserPrompt(req)
+      const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv(), model)
+      const res = yield* opts.postLlm(
+        model,
+        SUBTOPIC_SYSTEM_PROMPT,
+        userPrompt,
+        eff,
+        subtopicJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(res.text, SubtopicProposeOutputSchema, "proposeSubtopic")
+      const proposalSlugs = new Set(decoded.proposals.map((p) => p.slug))
+      const selectedSlug = proposalSlugs.has(decoded.selected_slug)
+        ? decoded.selected_slug
+        : decoded.proposals[0].slug
+      const candidateIds = new Set(req.interest.candidates.map((c) => c.id))
+      const proposals = decoded.proposals.map((p) => ({
+        slug: p.slug,
+        title: p.title,
+        rationale: p.rationale,
+        relevantCandidateIds: p.relevant_candidate_ids.filter((id) => candidateIds.has(id)),
+      }))
+      return {
+        selectedSlug,
+        proposals,
+        promptHash,
+        costUsd: costForResponse(res),
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
+        model: res.model,
+      }
+    }),
+  generateInterestReport: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildInterestReportUserPrompt(req)
+      const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv(), model)
+      const res = yield* opts.postLlm(
+        model,
+        REPORT_SYSTEM_PROMPT,
+        userPrompt,
+        eff,
+        interestReportJsonFormat(),
+      )
+      const decoded = yield* decodeLlmJson(
+        res.text,
+        InterestReportOutputSchema,
+        "generateInterestReport",
+      )
+      const items: ReadonlyArray<CuratedItem> = decoded.items.map((i) => ({
+        kind: i.kind,
+        title: i.title,
+        summary_md: i.summary_md,
+        topic: i.topic,
+        thesis: i.thesis,
+        source_candidate_ids: i.source_candidate_ids,
+        suggested_action: i.suggested_action,
+      }))
+      return {
+        interestSlug: req.interest.slug,
+        analysis_md: decoded.analysis_md,
+        items,
+        promptHash,
+        costUsd: costForResponse(res),
+        inputTokens: res.inputTokens,
+        outputTokens: res.outputTokens,
+        model: res.model,
+      }
+    }),
+  researchQuery: (req) =>
+    Effect.gen(function* () {
+      const model = opts.modelFor()
+      const userPrompt = buildResearchQueryUserPrompt(req)
+      const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      const eff = effortConfigFor(effortFromEnv(), model)
+      const res = yield* opts.postLlm(
+        model,
+        RESEARCH_SYSTEM_PROMPT,
+        userPrompt,
+        eff,
+        null,
+      )
+      const answerMd = res.text.trim()
+      if (answerMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "researchQuery returned empty body"))
+      }
+      return {
+        answerMd,
+        promptHash,
+        costUsd: costForResponse(res),
+        model: res.model,
+      }
+    }),
+  summarizeSource: (req) =>
+    Effect.gen(function* () {
+      const capped =
+        req.text.length > SUMMARY_INPUT_CHARS_CAP
+          ? `${req.text.slice(0, SUMMARY_INPUT_CHARS_CAP)}…`
+          : req.text
+      const userPrompt = buildSummaryUserPrompt(req.title, req.url, req.topics, capped)
+      const promptHash = sha256(`${SUMMARY_SYSTEM_PROMPT}\n---\n${userPrompt}`)
+      // Summary lane is always low-effort: short, cheap, no thinking. Not
+      // operator-tunable — bumping summarization to "high" would 10x the
+      // ingest spend with negligible quality lift.
+      const summaryCfg: EffortConfig = {
+        maxTokens: SUMMARY_MAX_TOKENS,
+        thinking: "off",
+        thinkingBudgetTokens: 0,
+      }
+      const res = yield* opts.postLlm(
+        opts.summaryModelFor(),
+        SUMMARY_SYSTEM_PROMPT,
+        userPrompt,
+        summaryCfg,
+        null,
+      )
+      const insightsMd = normalizeInsights(res.text)
+      if (insightsMd.length === 0) {
+        return yield* Effect.fail(llmErr("invalid", "summarize returned empty insights"))
+      }
+      return {
+        insightsMd,
+        promptHash,
+        costUsd: costForResponse(
+          res,
+          SUMMARY_INPUT_COST_PER_MTOK,
+          SUMMARY_OUTPUT_COST_PER_MTOK,
+        ),
+        model: res.model,
+      }
+    }),
+})

--- a/apps/uebermensch/src/lib/llm-shared.ts
+++ b/apps/uebermensch/src/lib/llm-shared.ts
@@ -1,0 +1,300 @@
+// Shared LLM types + cost math used by every LlmService adapter
+// (KernelLlm via /api/llm, AnthropicLlm direct, LMStudioLlm direct).
+// Lives separately from llm-prompts.ts because prompts are pure strings/
+// schemas; this module owns the request/response shape + provider rates.
+
+import { LlmError } from "../errors.js"
+import type { JsonResponseFormat } from "./llm-prompts.js"
+import type { Effect } from "effect"
+
+// ---------------------------------------------------------------------------
+// Provider-agnostic response shape — every transport normalizes to this.
+// ---------------------------------------------------------------------------
+export type NormalizedResponse = {
+  readonly text: string
+  readonly inputTokens: number
+  readonly outputTokens: number
+  readonly model: string
+}
+
+// Anthropic native messages response shape (used by both /api/llm/messages
+// kernel proxy and direct api.anthropic.com).
+export type AnthropicResponse = {
+  readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>
+  readonly usage?: { readonly input_tokens?: number; readonly output_tokens?: number }
+  readonly model?: string
+}
+
+// OpenAI-compat chat completions shape (used by both /api/llm/completions
+// kernel proxy and direct LMStudio / Workers AI).
+export type OpenAiChatResponse = {
+  readonly choices?: ReadonlyArray<{ readonly message?: { readonly content?: string } }>
+  readonly usage?: { readonly prompt_tokens?: number; readonly completion_tokens?: number }
+  readonly model?: string
+}
+
+// ---------------------------------------------------------------------------
+// Effort tier + thinking config (operator-tunable via UBER_LLM_EFFORT)
+// ---------------------------------------------------------------------------
+export type Effort = "low" | "medium" | "high"
+export type OutputEffort = "low" | "medium" | "high"
+
+// Anthropic `thinking` parameter shapes:
+// - "off"      → no thinking field (model answers directly)
+// - "adaptive" → `{ type: "adaptive" }` — model decides budget
+// - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
+export type ThinkingMode = "off" | "adaptive" | "extended"
+
+export type EffortConfig = {
+  readonly maxTokens: number
+  readonly thinking: ThinkingMode
+  readonly thinkingBudgetTokens: number
+  // Opus 4.7 rejects `thinking.type: "enabled"` and instead controls effort
+  // via top-level `output_config.effort`. When set, callers emit it in the
+  // request body alongside `thinking: { type: "adaptive" }`.
+  readonly outputEffort?: OutputEffort
+}
+
+const DEFAULT_MAX_TOKENS = 16000
+
+// Anthropic's 1M context window is enabled per-request via the
+// `anthropic-beta: context-1m-2025-08-07` header. Operators opt in by
+// suffixing the model id (e.g. `claude-opus-4-7[1m]`) or by setting
+// `UBER_LLM_CONTEXT_1M=1`. Any non-Anthropic model ignores the suffix.
+export const CONTEXT_1M_BETA = "context-1m-2025-08-07"
+
+export const stripContextSuffix = (model: string): string =>
+  model.replace(/\[1m\]$/i, "")
+
+export const is1MContextRequested = (model: string): boolean => {
+  if (/\[1m\]$/i.test(model)) return true
+  const env = process.env.UBER_LLM_CONTEXT_1M?.toLowerCase().trim()
+  return env === "1" || env === "true" || env === "yes"
+}
+
+// Anthropic-shaped models go through /api/llm/messages. Everything else
+// (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
+// LM Studio / Ollama) goes through /api/llm/completions.
+export const isAnthropicModel = (model: string): boolean =>
+  stripContextSuffix(model).startsWith("claude-")
+
+// Back-compat alias for older imports.
+export const isOpenAiCompatModel = (model: string): boolean => !isAnthropicModel(model)
+export const isWorkersAiModel = isOpenAiCompatModel
+
+// Models in the 4.7+ family use the new effort-control semantics:
+// `thinking.type: "adaptive"` + `output_config.effort`. Older 4.x families
+// (4.5/4.6) still accept `thinking.type: "enabled"` with a budget. Bump
+// the regex when 4.8 lands.
+export const isOpus47Family = (model: string): boolean =>
+  /^claude-opus-4-(7|8|9)\b/.test(stripContextSuffix(model))
+
+export const effortFromEnv = (): Effort => {
+  const raw = process.env.UBER_LLM_EFFORT?.toLowerCase().trim()
+  if (raw === "low" || raw === "high") return raw
+  return "medium"
+}
+
+export const effortConfigFor = (effort: Effort, model?: string): EffortConfig => {
+  if (model && isOpus47Family(model)) {
+    switch (effort) {
+      case "low":
+        return {
+          maxTokens: 4000,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "low",
+        }
+      case "high":
+        return {
+          maxTokens: 32000,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "high",
+        }
+      default:
+        return {
+          maxTokens: DEFAULT_MAX_TOKENS,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "medium",
+        }
+    }
+  }
+  switch (effort) {
+    case "low":
+      return { maxTokens: 4000, thinking: "off", thinkingBudgetTokens: 0 }
+    case "high":
+      return { maxTokens: 32000, thinking: "extended", thinkingBudgetTokens: 16000 }
+    default:
+      return { maxTokens: DEFAULT_MAX_TOKENS, thinking: "adaptive", thinkingBudgetTokens: 0 }
+  }
+}
+
+export const effortBody = (cfg: EffortConfig): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  if (cfg.thinking === "extended") {
+    out.thinking = { type: "enabled", budget_tokens: cfg.thinkingBudgetTokens }
+  } else if (cfg.thinking === "adaptive") {
+    out.thinking = { type: "adaptive" }
+  }
+  // `output_config.effort` is opus-4.7+ only; older models 400 on it,
+  // which is why we gate it through `EffortConfig.outputEffort` (set
+  // exclusively by the opus-4.7 branch of `effortConfigFor`).
+  if (cfg.outputEffort) {
+    out.output_config = { effort: cfg.outputEffort }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic per-model USD/Mtok rates (input, output). Local + Workers AI
+// models bill upstream (or are free), so they collapse to 0.
+// ---------------------------------------------------------------------------
+type CostRates = readonly [input: number, output: number]
+
+const ANTHROPIC_RATES: ReadonlyArray<readonly [RegExp, CostRates]> = [
+  [/^claude-opus-4-/, [15.0, 75.0]],
+  [/^claude-sonnet-4-/, [3.0, 15.0]],
+  [/^claude-haiku-4-/, [1.0, 5.0]],
+  [/^claude-3-5-sonnet-/, [3.0, 15.0]],
+  [/^claude-3-5-haiku-/, [1.0, 5.0]],
+  [/^claude-3-opus-/, [15.0, 75.0]],
+]
+
+const ratesForModel = (model: string): CostRates => {
+  if (!isAnthropicModel(model)) return [0, 0]
+  for (const [pattern, rates] of ANTHROPIC_RATES) {
+    if (pattern.test(model)) return rates
+  }
+  // Unknown claude-* — guess Sonnet rates so a new id surfaces in cost
+  // telemetry instead of silently being free.
+  return [3.0, 15.0]
+}
+
+export const tokensCost = (
+  inputTokens: number,
+  outputTokens: number,
+  inputRate: number,
+  outputRate: number,
+): number => (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000
+
+export const costForResponse = (
+  res: NormalizedResponse,
+  inputRateOverride?: number,
+  outputRateOverride?: number,
+): number => {
+  if (isWorkersAiModel(res.model)) return 0
+  if (inputRateOverride !== undefined && outputRateOverride !== undefined) {
+    return tokensCost(res.inputTokens, res.outputTokens, inputRateOverride, outputRateOverride)
+  }
+  const [inputRate, outputRate] = ratesForModel(res.model)
+  return tokensCost(res.inputTokens, res.outputTokens, inputRate, outputRate)
+}
+
+// ---------------------------------------------------------------------------
+// Per-model concurrency defaults for the report pipeline. Anthropic
+// rate-limits by tokens/minute per (org, model). Tier 1 opus-4.7 is the
+// tightest at 30k input TPM — concurrency=1 + paced retries is the only
+// way to make a clean run. Higher tiers can override with UBER_REPORT_CONCURRENCY.
+// ---------------------------------------------------------------------------
+export const defaultConcurrencyForModel = (model: string | undefined): number => {
+  if (!model) return 2
+  const m = stripContextSuffix(model)
+  if (isOpus47Family(m)) return 1
+  if (/^claude-opus-4-/.test(m)) return 2
+  if (/^claude-sonnet-4-/.test(m)) return 4
+  if (/^claude-haiku-4-/.test(m)) return 6
+  return 2
+}
+
+// ---------------------------------------------------------------------------
+// Parse `Retry-After` header (RFC 7231: delta-seconds OR HTTP-date).
+// ---------------------------------------------------------------------------
+export const parseRetryAfter = (raw: string | null | undefined): number | null => {
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  const asNum = Number.parseFloat(trimmed)
+  if (Number.isFinite(asNum) && asNum >= 0) {
+    return Math.min(asNum, 120) * 1000
+  }
+  const t = Date.parse(trimmed)
+  if (Number.isFinite(t)) {
+    const delta = t - Date.now()
+    return delta > 0 ? Math.min(delta, 120_000) : 0
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Transport function type — every adapter implements this. Takes a fully
+// resolved request (model + system + prompt + effort config + json format)
+// and returns a normalized response. Errors typed as LlmError.
+// ---------------------------------------------------------------------------
+export type PostLlm = (
+  model: string,
+  system: string,
+  userPrompt: string,
+  cfg: EffortConfig,
+  jsonFormat: JsonResponseFormat | null,
+) => Effect.Effect<NormalizedResponse, LlmError>
+
+// ---------------------------------------------------------------------------
+// Connection-level error walking (ECONNREFUSED → "kernel down" hint, etc.)
+// ---------------------------------------------------------------------------
+export const isConnRefused = (e: unknown): boolean => {
+  let cur: unknown = e
+  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
+    const code = (cur as { code?: string }).code
+    if (
+      code === "ECONNREFUSED" ||
+      code === "ENOTFOUND" ||
+      code === "EHOSTUNREACH" ||
+      code === "ECONNRESET"
+    ) {
+      return true
+    }
+    const errors = (cur as { errors?: ReadonlyArray<unknown> }).errors
+    if (Array.isArray(errors) && errors.some(isConnRefused)) return true
+    cur = (cur as { cause?: unknown }).cause
+  }
+  return false
+}
+
+export const llmErr = (
+  kind: LlmError["kind"],
+  message: string,
+  retryAfterMs?: number,
+): LlmError => new LlmError({ kind, message, retryAfterMs })
+
+export const classifyHttpStatus = (status: number): LlmError["kind"] => {
+  if (status === 503) return "unavailable"
+  if (status === 429) return "rate_limited"
+  if (status === 400 || status === 401 || status === 403) return "invalid"
+  if (status >= 500) return "unavailable"
+  return "invalid"
+}
+
+// Identity for `x-session-id` / `x-service-name` headers consumed by
+// driver-llm capture path. Kept here so every adapter sets the same
+// headers (kernel-routed and direct alike).
+export const SERVICE_NAME = "uebermensch"
+
+let processSessionId: string | null = null
+export const sessionIdFor = (): string => {
+  const explicit = process.env.UBER_SESSION_ID
+  if (explicit && explicit.length > 0) return explicit
+  if (processSessionId === null) {
+    processSessionId =
+      typeof globalThis.crypto?.randomUUID === "function"
+        ? globalThis.crypto.randomUUID()
+        : `uber-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  }
+  return processSessionId
+}
+
+// Test hook — clears the cached session id so a beforeEach can isolate runs.
+export const _resetSessionIdForTests = (): void => {
+  processSessionId = null
+}


### PR DESCRIPTION
## Summary

Salvage from the closed PRs #153 and #154. Keeps **only** the parts that genuinely simplify the kernel-routed adapters (`KernelLlm`, `HttpDeliverer`) — no in-app re-implementations of kernel capabilities.

Per the spec correction in #158 (`vault/specs/architecture/app-decoupling.md`), apps MUST NOT ship in-app code that duplicates a kernel-provided capability. The closed PRs added `AnthropicLlm`, `LMStudioLlm`, and `DirectDeliverer` adapters that re-implemented `driver-llm`, `driver-telegram`, and `driver-discord` — those files are deliberately **not** in this PR.

## What lands

| File | Role |
|---|---|
| `lib/llm-shared.ts` | **New.** `NormalizedResponse` / `ThinkingMode` / `EffortConfig` types, Anthropic per-model cost rate table, effort-tier and thinking-body helpers, session-id helper for driver-llm capture headers. Used by `KernelLlm` today; available to any future user-supplied `LlmService` Layer per the ejection model. |
| `lib/llm-service-factory.ts` | **New.** `makeLlmServiceShape({ name, postLlm, modelFor, summaryModelFor })` collapses the five `LlmServiceShape` methods (`generateBrief`, `proposeSubtopic`, `generateInterestReport`, `researchQuery`, `summarizeSource`) into one recipe parameterized by a transport. |
| `lib/deliverer-shared.ts` | **New.** `splitChunks`, `splitBrief`, `stripFrontmatter`, target-ref resolution (`tg:chat:env:KEY`, `dc:webhook:env:KEY`), HTTP status mapping, chunk-prefix helpers. Used by `HttpDeliverer`. |
| `adapters/KernelLlm.ts` | Refactored to use `makeLlmServiceShape`. **619 → 263 lines** (–356). |
| `adapters/HttpDeliverer.ts` | Refactored to use `deliverer-shared.ts`. **305 → 183 lines** (–122). |

## Why this matters even with kernel as the default

Even though uebermensch only ever ships the kernel-routed `KernelLlmLive` / `HttpDelivererLive` Layers as defaults, the recipe inside each `LlmServiceShape` method (build prompt → call transport → decode → cost math) is the *contract* between the app and any LlmService implementation. Centralizing that contract once means:

- A future user-supplied `LlmService` Layer (the eject path) gets the recipe for free — they only need to provide the `postLlm` transport.
- Drift between the five method bodies becomes impossible — they all live in one place.
- `KernelLlm` shrinks from a 619-line file with five duplicated method bodies to a 263-line file that owns only the kernel-specific HTTP transport.

Same logic for the deliverer: chunking + target-ref resolution is *app* logic (split a brief into Telegram-sized pieces, resolve `tg:chat:env:KEY` to a chat id), not transport. Extracting it to a shared module made `HttpDeliverer` clearly about "POST to kernel `/api/telegram/send`" — and a future user-supplied `DelivererService` Layer (the eject path) reuses the chunking / target-ref work.

## What is NOT in this PR

- ❌ `AnthropicLlm.ts` / `LMStudioLlm.ts` — would duplicate `driver-llm`
- ❌ `DirectDeliverer.ts` — would duplicate `driver-telegram` / `driver-discord`
- ❌ Any new `--mode` enumeration. The existing `mode.ts` keeps `local-kernel` (default) and the `local-direct` / `cloud-only` placeholder values; an upcoming PR rewrites the mode story around `kernel` (default) + `custom` (user-supplied Layer at install time) per `app-decoupling.md`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — **252 passing** (unchanged from main; pure refactor)
- [x] `pnpm exec biome lint shell/*/src/ apps/*/src/` — 0 errors (28 pre-existing warnings unchanged)
- [x] `KernelLlm.ts` unit tests (`tests/kernel-llm.test.ts`) still pass — proves the factory refactor preserves the kernel-routed transport behavior.

## Eject sequence (revised)

- [x] PR-A foundation — #145 (merged)
- [x] PR-B slice 7a — wire VaultSecretGuard into write path — #147
- [x] **Spec correction** — app ↔ kernel zero duplication — #158
- [x] **Salvage refactor** — shared LLM + deliverer helpers — **this PR**
- [ ] Reshape #156: `kernel | custom` modes only (no in-app `local-direct` adapters)
- [x] PR-B slice 5 — drop kernel `uber_*` tables — #157
- [ ] App install protocol — `gctrl-app.toml` capability declarations + extension point for user-supplied Layer (slice 6, design first)
- [ ] R2 vault sync — moved out of the app: spec a `driver-r2-vault` LKM in the kernel rather than an `R2VaultWriter` adapter inside uebermensch
- [ ] Repo carve to `OpenHackersClub/uebermensch` (final, after the above)
