### PR TITLE
feat(uebermensch): rate-limit-aware report pipeline + opus-4.7/1M support

### DIFF
--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -389,17 +389,20 @@ const fetchKernel = (
     return raw;
   });
 
-// Bounded retry loop for `rate_limited` LlmErrors only. Honors
-// `retryAfterMs` from the upstream when present and otherwise falls
-// back to exponential backoff capped at MAX_MS. Other LlmError kinds
-// propagate immediately so a 503 / invalid request surfaces fast.
+// Bounded retry loop for transient LlmErrors. Two kinds qualify:
+//   - `rate_limited` (HTTP 429): honors `retryAfterMs` when present,
+//     otherwise exponential backoff capped at MAX_MS.
+//   - `unavailable`  (HTTP 502/503 + connection failures): exponential
+//     backoff only — upstream doesn't supply a hint.
+// `invalid` (4xx other than 429) propagates immediately so a malformed
+// request surfaces fast.
 //
 // Knobs (env, all optional):
 //   UBER_LLM_RATE_LIMIT_RETRIES  attempts after the first failure (default 4)
 //   UBER_LLM_RATE_LIMIT_BASE_MS  base delay for exponential backoff (default 2000)
 //   UBER_LLM_RATE_LIMIT_MAX_MS   ceiling delay (default 60000)
-// Setting RETRIES=0 disables retry entirely — the typed `LlmError` with
-// kind=rate_limited surfaces directly to the caller (used by tests).
+// Setting RETRIES=0 disables retry entirely — the typed `LlmError`
+// surfaces directly to the caller (used by tests).
 const envInt = (key: string, fallback: number, min = 0): number => {
   const raw = process.env[key];
   if (raw === undefined || raw === null) return fallback;
@@ -419,6 +422,9 @@ const rateLimitConfig = (): RateLimitConfig => ({
   maxMs: envInt("UBER_LLM_RATE_LIMIT_MAX_MS", 60_000, 1),
 });
 
+const isTransientKind = (kind: LlmError["kind"]): boolean =>
+  kind === "rate_limited" || kind === "unavailable";
+
 const withRateLimitRetry = <A>(
   eff: Effect.Effect<A, LlmError>,
 ): Effect.Effect<A, LlmError> => {
@@ -426,11 +432,16 @@ const withRateLimitRetry = <A>(
   const loop = (attempt: number): Effect.Effect<A, LlmError> =>
     eff.pipe(
       Effect.catchTag("LlmError", (e) => {
-        if (e.kind !== "rate_limited" || attempt >= cfg.maxRetries) {
+        if (!isTransientKind(e.kind) || attempt >= cfg.maxRetries) {
           return Effect.fail(e);
         }
         const expBackoff = Math.min(cfg.baseMs * 2 ** attempt, cfg.maxMs);
-        const delayMs = e.retryAfterMs ?? expBackoff;
+        // 429 supplies retryAfterMs; 5xx does not — fall back to
+        // exponential. Cap the hint at MAX_MS too so a buggy upstream
+        // can't stall a run.
+        const hint = e.retryAfterMs;
+        const delayMs =
+          hint !== undefined ? Math.min(hint, cfg.maxMs) : expBackoff;
         return Effect.sleep(Duration.millis(delayMs)).pipe(
           Effect.andThen(loop(attempt + 1)),
         );

--- a/apps/uebermensch/src/adapters/KernelLlm.ts
+++ b/apps/uebermensch/src/adapters/KernelLlm.ts
@@ -1,5 +1,5 @@
 import { Agent } from "undici";
-import { Effect, Layer } from "effect";
+import { Duration, Effect, Layer } from "effect";
 import { LlmError } from "../errors.js";
 
 // Constrained decoding under `response_format: json_schema` can run for many
@@ -93,13 +93,51 @@ const effortFromEnv = (): Effort => {
 // - "extended" → `{ type: "enabled", budget_tokens: N }` — explicit budget
 type ThinkingMode = "off" | "adaptive" | "extended";
 
+type OutputEffort = "low" | "medium" | "high";
+
 type EffortConfig = {
   readonly maxTokens: number;
   readonly thinking: ThinkingMode;
   readonly thinkingBudgetTokens: number;
+  // Opus 4.7 rejects `thinking.type: "enabled"` and instead controls effort
+  // via top-level `output_config.effort`. When set, callers emit it in the
+  // request body alongside `thinking: { type: "adaptive" }`.
+  readonly outputEffort?: OutputEffort;
 };
 
-const effortConfigFor = (effort: Effort): EffortConfig => {
+// Models in the 4.7+ family use the new effort-control semantics:
+// `thinking.type: "adaptive"` + `output_config.effort`. Older 4.x families
+// (4.5/4.6) still accept `thinking.type: "enabled"` with a budget. Bump
+// the regex when 4.8 lands.
+const isOpus47Family = (model: string): boolean =>
+  /^claude-opus-4-(7|8|9)\b/.test(stripContextSuffix(model));
+
+const effortConfigFor = (effort: Effort, model?: string): EffortConfig => {
+  if (model && isOpus47Family(model)) {
+    switch (effort) {
+      case "low":
+        return {
+          maxTokens: 4000,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "low",
+        };
+      case "high":
+        return {
+          maxTokens: 32000,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "high",
+        };
+      default:
+        return {
+          maxTokens: DEFAULT_MAX_TOKENS,
+          thinking: "adaptive",
+          thinkingBudgetTokens: 0,
+          outputEffort: "medium",
+        };
+    }
+  }
   switch (effort) {
     case "low":
       // Tight cap, no thinking. Single-pass, fast, cheap.
@@ -130,9 +168,60 @@ const summaryModelFor = (): string =>
 // Anthropic-shaped models go through /api/llm/messages. Everything else
 // (`@cf/...` Workers AI, locally-served OpenAI-compat backends like
 // LM Studio / Ollama) goes through /api/llm/completions.
-const isAnthropicModel = (model: string): boolean => model.startsWith("claude-");
+const isAnthropicModel = (model: string): boolean =>
+  stripContextSuffix(model).startsWith("claude-");
 // Back-compat alias — older callers/tests still import this name.
 const isWorkersAiModel = (model: string): boolean => !isAnthropicModel(model);
+
+// Anthropic's 1M context window is enabled per-request via the
+// `anthropic-beta: context-1m-2025-08-07` header. Operators opt in by
+// suffixing the model id (e.g. `claude-opus-4-7[1m]`) or by setting
+// `UBER_LLM_CONTEXT_1M=1`. Any non-Anthropic model ignores the suffix.
+const CONTEXT_1M_BETA = "context-1m-2025-08-07";
+
+const stripContextSuffix = (model: string): string =>
+  model.replace(/\[1m\]$/i, "");
+
+const is1MContextRequested = (model: string): boolean => {
+  if (/\[1m\]$/i.test(model)) return true;
+  const env = process.env.UBER_LLM_CONTEXT_1M?.toLowerCase().trim();
+  return env === "1" || env === "true" || env === "yes";
+};
+
+// Per-model concurrency defaults for the report pipeline. Anthropic
+// rate-limits by tokens/minute per (org, model). Tier 1 opus-4.7 is the
+// tightest at 30k input TPM, so a single ~30k-token deep-dive prompt
+// already saturates a minute — concurrency=1 + paced retries is the only
+// way to make a clean run. Higher tiers can override with
+// UBER_REPORT_CONCURRENCY.
+const defaultConcurrencyForModel = (model: string | undefined): number => {
+  if (!model) return 2;
+  const m = stripContextSuffix(model);
+  if (isOpus47Family(m)) return 1;
+  if (/^claude-opus-4-/.test(m)) return 2;
+  if (/^claude-sonnet-4-/.test(m)) return 4;
+  if (/^claude-haiku-4-/.test(m)) return 6;
+  return 2;
+};
+
+// Parse `Retry-After` header (RFC 7231: delta-seconds OR HTTP-date).
+// Anthropic sends seconds; bare numbers are clamped to a sane ceiling so
+// a buggy upstream can't stall a run for an hour. Returns ms or null.
+const parseRetryAfter = (raw: string | null | undefined): number | null => {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const asNum = Number.parseFloat(trimmed);
+  if (Number.isFinite(asNum) && asNum >= 0) {
+    return Math.min(asNum, 120) * 1000;
+  }
+  const t = Date.parse(trimmed);
+  if (Number.isFinite(t)) {
+    const delta = t - Date.now();
+    return delta > 0 ? Math.min(delta, 120_000) : 0;
+  }
+  return null;
+};
 
 const kernelBase = (): string =>
   (process.env.GCTRL_KERNEL_URL ?? "http://127.0.0.1:4318").replace(/\/+$/, "");
@@ -179,8 +268,11 @@ type NormalizedResponse = {
   readonly model: string;
 };
 
-const llmErr = (kind: LlmError["kind"], message: string): LlmError =>
-  new LlmError({ kind, message });
+const llmErr = (
+  kind: LlmError["kind"],
+  message: string,
+  retryAfterMs?: number,
+): LlmError => new LlmError({ kind, message, retryAfterMs });
 
 const classifyKernelStatus = (status: number): LlmError["kind"] => {
   if (status === 503) return "unavailable";
@@ -229,9 +321,12 @@ const tokensCost = (
 // POST a JSON body to `${kernelBase()}${path}` and return the raw response
 // text. Connection-level failures (ECONNREFUSED etc.) become a "kernel daemon
 // not reachable" hint; non-2xx responses become a classified LlmError.
+// `extraHeaders` lets callers forward request-shaping headers like
+// `anthropic-beta` (the kernel's /api/llm/messages re-emits them upstream).
 const fetchKernel = (
   path: string,
   body: unknown,
+  extraHeaders: Record<string, string> = {},
 ): Effect.Effect<string, LlmError> =>
   Effect.gen(function* () {
     const res = yield* Effect.tryPromise({
@@ -242,6 +337,7 @@ const fetchKernel = (
             "content-type": "application/json",
             "x-session-id": sessionIdFor(),
             "x-service-name": SERVICE_NAME,
+            ...extraHeaders,
           },
           body: JSON.stringify(body),
           // Non-standard undici option — silently ignored if a test replaces
@@ -262,44 +358,121 @@ const fetchKernel = (
         llmErr("unavailable", `kernel ${path} body read failed: ${String(e)}`),
     });
     if (!res.ok) {
+      const kind = classifyKernelStatus(res.status);
+      let retryAfterMs: number | undefined;
+      if (kind === "rate_limited") {
+        // Headers may be unavailable on test mocks — guard the lookup.
+        const headerGet = (k: string): string | null => {
+          try {
+            return res.headers?.get?.(k) ?? null;
+          } catch {
+            return null;
+          }
+        };
+        const ra =
+          parseRetryAfter(headerGet("retry-after")) ??
+          // Anthropic also sends `anthropic-ratelimit-input-tokens-reset`
+          // as an ISO-8601 timestamp. Honor it as a fallback so paced
+          // retries don't hammer the upstream early.
+          parseRetryAfter(headerGet("anthropic-ratelimit-input-tokens-reset")) ??
+          parseRetryAfter(headerGet("anthropic-ratelimit-tokens-reset"));
+        if (ra !== null) retryAfterMs = ra;
+      }
       return yield* Effect.fail(
         llmErr(
-          classifyKernelStatus(res.status),
+          kind,
           `kernel ${path} HTTP ${res.status}: ${raw.slice(0, 500)}`,
+          retryAfterMs,
         ),
       );
     }
     return raw;
   });
 
-const thinkingBody = (
-  thinking: ThinkingMode,
-  budgetTokens: number,
-): Record<string, unknown> => {
-  if (thinking === "off") return {};
-  if (thinking === "extended") {
-    return { thinking: { type: "enabled", budget_tokens: budgetTokens } };
+// Bounded retry loop for `rate_limited` LlmErrors only. Honors
+// `retryAfterMs` from the upstream when present and otherwise falls
+// back to exponential backoff capped at MAX_MS. Other LlmError kinds
+// propagate immediately so a 503 / invalid request surfaces fast.
+//
+// Knobs (env, all optional):
+//   UBER_LLM_RATE_LIMIT_RETRIES  attempts after the first failure (default 4)
+//   UBER_LLM_RATE_LIMIT_BASE_MS  base delay for exponential backoff (default 2000)
+//   UBER_LLM_RATE_LIMIT_MAX_MS   ceiling delay (default 60000)
+// Setting RETRIES=0 disables retry entirely — the typed `LlmError` with
+// kind=rate_limited surfaces directly to the caller (used by tests).
+const envInt = (key: string, fallback: number, min = 0): number => {
+  const raw = process.env[key];
+  if (raw === undefined || raw === null) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= min ? n : fallback;
+};
+
+type RateLimitConfig = {
+  readonly maxRetries: number;
+  readonly baseMs: number;
+  readonly maxMs: number;
+};
+
+const rateLimitConfig = (): RateLimitConfig => ({
+  maxRetries: envInt("UBER_LLM_RATE_LIMIT_RETRIES", 4),
+  baseMs: envInt("UBER_LLM_RATE_LIMIT_BASE_MS", 2_000, 1),
+  maxMs: envInt("UBER_LLM_RATE_LIMIT_MAX_MS", 60_000, 1),
+});
+
+const withRateLimitRetry = <A>(
+  eff: Effect.Effect<A, LlmError>,
+): Effect.Effect<A, LlmError> => {
+  const cfg = rateLimitConfig();
+  const loop = (attempt: number): Effect.Effect<A, LlmError> =>
+    eff.pipe(
+      Effect.catchTag("LlmError", (e) => {
+        if (e.kind !== "rate_limited" || attempt >= cfg.maxRetries) {
+          return Effect.fail(e);
+        }
+        const expBackoff = Math.min(cfg.baseMs * 2 ** attempt, cfg.maxMs);
+        const delayMs = e.retryAfterMs ?? expBackoff;
+        return Effect.sleep(Duration.millis(delayMs)).pipe(
+          Effect.andThen(loop(attempt + 1)),
+        );
+      }),
+    );
+  return loop(0);
+};
+
+const effortBody = (cfg: EffortConfig): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  if (cfg.thinking === "extended") {
+    out.thinking = { type: "enabled", budget_tokens: cfg.thinkingBudgetTokens };
+  } else if (cfg.thinking === "adaptive") {
+    out.thinking = { type: "adaptive" };
   }
-  return { thinking: { type: "adaptive" } };
+  // `output_config.effort` is opus-4.7+ only; older models 400 on it,
+  // which is why we gate it through `EffortConfig.outputEffort` (set
+  // exclusively by the opus-4.7 branch of `effortConfigFor`).
+  if (cfg.outputEffort) {
+    out.output_config = { effort: cfg.outputEffort };
+  }
+  return out;
 };
 
 const postAnthropic = (
   model: string,
   system: string,
   userPrompt: string,
-  maxTokens: number,
-  thinking: ThinkingMode,
-  thinkingBudgetTokens: number,
+  cfg: EffortConfig,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
   Effect.gen(function* () {
+    const wireModel = stripContextSuffix(model);
     const body: Record<string, unknown> = {
-      model,
-      max_tokens: maxTokens,
+      model: wireModel,
+      max_tokens: cfg.maxTokens,
       system,
       messages: [{ role: "user", content: userPrompt }],
-      ...thinkingBody(thinking, thinkingBudgetTokens),
+      ...effortBody(cfg),
     };
-    const raw = yield* fetchKernel("/api/llm/messages", body);
+    const headers: Record<string, string> = {};
+    if (is1MContextRequested(model)) headers["anthropic-beta"] = CONTEXT_1M_BETA;
+    const raw = yield* fetchKernel("/api/llm/messages", body, headers);
     const parsed = yield* Effect.try({
       try: () =>
         (raw.length > 0 ? (JSON.parse(raw) as AnthropicResponse) : ({} as AnthropicResponse)),
@@ -319,7 +492,7 @@ const postAnthropic = (
       text: textBlock.text,
       inputTokens: parsed.usage?.input_tokens ?? 0,
       outputTokens: parsed.usage?.output_tokens ?? 0,
-      model: parsed.model ?? model,
+      model: parsed.model ?? wireModel,
     };
   });
 
@@ -376,14 +549,14 @@ const postLlm = (
   model: string,
   system: string,
   userPrompt: string,
-  maxTokens: number,
-  thinking: ThinkingMode,
-  thinkingBudgetTokens: number,
+  cfg: EffortConfig,
   jsonFormat: JsonResponseFormat | null,
 ): Effect.Effect<NormalizedResponse, LlmError> =>
-  isWorkersAiModel(model)
-    ? postWorkersAi(model, system, userPrompt, maxTokens, jsonFormat)
-    : postAnthropic(model, system, userPrompt, maxTokens, thinking, thinkingBudgetTokens);
+  withRateLimitRetry(
+    isWorkersAiModel(model)
+      ? postWorkersAi(model, system, userPrompt, cfg.maxTokens, jsonFormat)
+      : postAnthropic(model, system, userPrompt, cfg),
+  );
 
 // USD cost for a normalized LLM response. Workers AI / local models
 // always cost $0. Anthropic models look up rates by model id so Opus 4.7
@@ -410,14 +583,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildUserPrompt(req);
       const promptHash = sha256(`${SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
+      const eff = effortConfigFor(effortFromEnv(), model);
       const res = yield* postLlm(
         model,
         SYSTEM_PROMPT,
         userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
+        eff,
         briefJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(res.text, LlmOutputSchema, "kernel /api/llm/messages");
@@ -445,14 +616,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildSubtopicUserPrompt(req);
       const promptHash = sha256(`${SUBTOPIC_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
+      const eff = effortConfigFor(effortFromEnv(), model);
       const res = yield* postLlm(
         model,
         SUBTOPIC_SYSTEM_PROMPT,
         userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
+        eff,
         subtopicJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
@@ -487,14 +656,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildInterestReportUserPrompt(req);
       const promptHash = sha256(`${REPORT_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
+      const eff = effortConfigFor(effortFromEnv(), model);
       const res = yield* postLlm(
         model,
         REPORT_SYSTEM_PROMPT,
         userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
+        eff,
         interestReportJsonFormat(),
       );
       const decoded = yield* decodeLlmJson(
@@ -528,14 +695,12 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       const model = modelFor();
       const userPrompt = buildResearchQueryUserPrompt(req);
       const promptHash = sha256(`${RESEARCH_SYSTEM_PROMPT}\n---\n${userPrompt}`);
-      const eff = effortConfigFor(effortFromEnv());
+      const eff = effortConfigFor(effortFromEnv(), model);
       const res = yield* postLlm(
         model,
         RESEARCH_SYSTEM_PROMPT,
         userPrompt,
-        eff.maxTokens,
-        eff.thinking,
-        eff.thinkingBudgetTokens,
+        eff,
         null,
       );
       const answerMd = res.text.trim();
@@ -556,13 +721,16 @@ export const KernelLlmLive = Layer.succeed(LlmService, {
       // Summary lane is always low-effort: short, cheap, no thinking. Not
       // operator-tunable — bumping summarization to "high" would 10x the
       // ingest spend with negligible quality lift.
+      const summaryCfg: EffortConfig = {
+        maxTokens: SUMMARY_MAX_TOKENS,
+        thinking: "off",
+        thinkingBudgetTokens: 0,
+      };
       const res = yield* postLlm(
         summaryModelFor(),
         SUMMARY_SYSTEM_PROMPT,
         userPrompt,
-        SUMMARY_MAX_TOKENS,
-        "off",
-        0,
+        summaryCfg,
         null,
       );
       const insightsMd = normalizeInsights(res.text);
@@ -616,4 +784,11 @@ export const _internal = {
   isWorkersAiModel,
   effortFromEnv,
   effortConfigFor,
+  effortBody,
+  isOpus47Family,
+  is1MContextRequested,
+  stripContextSuffix,
+  parseRetryAfter,
+  defaultConcurrencyForModel,
+  CONTEXT_1M_BETA,
 };

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -8,7 +8,7 @@ import { _internal as KernelLlmInternal, KernelLlmLive } from "../adapters/Kerne
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
-import { DeliveryError } from "../errors.js"
+import { DeliveryError, LlmError } from "../errors.js"
 import { selectCandidates, type CandidateRef } from "../lib/candidates.js"
 import { isChatChannel, resolveChannels } from "../lib/channels.js"
 import { publicBaseUrl, publicReportUrl, requiresR2Sync, resolveVaultDir } from "../lib/env.js"
@@ -343,7 +343,14 @@ export const report = Command.make(
           readonly proposeCostUsd: number
           readonly response: InterestReportResponse
         }
-        const responses: ReadonlyArray<DeepResponse> = yield* Effect.all(
+        // Per-interest pipeline wrapped in Effect.either so a single
+        // transient failure (rate-limit-after-retries, gateway 502, etc.)
+        // doesn't abort the whole batch — every other interest still runs.
+        // Failed interests are reported in the run summary and skipped
+        // when rendering.
+        const perInterest: ReadonlyArray<
+          Either.Either<DeepResponse, LlmError>
+        > = yield* Effect.all(
           interestInputs.map((ii) =>
             Effect.gen(function* () {
               yield* Console.log(`  → ${ii.slug}: proposing subtopic ...`)
@@ -411,10 +418,30 @@ export const report = Command.make(
                 proposeCostUsd: propose.costUsd,
                 response,
               }
-            }),
+            }).pipe(Effect.either),
           ),
           { concurrency },
         )
+
+        const responses: ReadonlyArray<DeepResponse> = []
+        const failures: Array<{ slug: string; error: LlmError }> = []
+        for (let i = 0; i < perInterest.length; i += 1) {
+          const result = perInterest[i]!
+          const slug = interestInputs[i]!.slug
+          if (Either.isLeft(result)) {
+            failures.push({ slug, error: result.left })
+            yield* Console.log(
+              `  ✗ ${slug}: ${result.left.kind ?? "error"} — ${result.left.message}`,
+            )
+          } else {
+            ;(responses as DeepResponse[]).push(result.right)
+          }
+        }
+        if (failures.length > 0) {
+          yield* Console.log(
+            `  ${failures.length}/${interestInputs.length} interest(s) failed: ${failures.map((f) => f.slug).join(", ")}`,
+          )
+        }
 
         // Render per-interest reports; drop empty ones (insight-only).
         type Written = {

--- a/apps/uebermensch/src/commands/report.ts
+++ b/apps/uebermensch/src/commands/report.ts
@@ -4,7 +4,7 @@ import { EnvSecretsLive } from "../adapters/EnvSecrets.js"
 import { FileSystemProfileLive } from "../adapters/FileSystemProfile.js"
 import { FileSystemVaultLive } from "../adapters/FileSystemVault.js"
 import { HttpDelivererLive } from "../adapters/HttpDeliverer.js"
-import { KernelLlmLive } from "../adapters/KernelLlm.js"
+import { _internal as KernelLlmInternal, KernelLlmLive } from "../adapters/KernelLlm.js"
 import { R2SyncConfigFromEnv, R2SyncLive } from "../adapters/R2Sync.js"
 import { StrictRendererLive } from "../adapters/StrictRenderer.js"
 import { StubLlmLive } from "../adapters/StubLlm.js"
@@ -56,21 +56,37 @@ const maxItemsOpt = Options.integer("max-items-per-interest").pipe(
   Options.withDefault(5),
 )
 
-// Default to 2: hosted gateways tolerate 3+, but local OpenAI-compat backends
-// (LM Studio, Ollama) often serialize requests and drop in-flight forwards
-// when more than ~2 land at once. Bump via UBER_REPORT_CONCURRENCY for cloud.
-const envConcurrency = (): number => {
+// Sentinel for "operator did not pass --concurrency"; the model-aware
+// default kicks in once we know which model is active. Negative because
+// `Options.integer` allows 0 and any positive int as legitimate values.
+const CONCURRENCY_UNSET = -1
+
+const envConcurrency = (): number | null => {
   const raw = process.env.UBER_REPORT_CONCURRENCY
-  if (!raw) return 2
+  if (!raw) return null
   const n = Number.parseInt(raw, 10)
-  return Number.isFinite(n) && n > 0 ? n : 2
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+// Resolve the concurrency to use given the operator's flags + active model.
+// Precedence: explicit `--concurrency` > `UBER_REPORT_CONCURRENCY` > per-model
+// default (opus-4.7 → 1 to live within Anthropic tier-1 30k input TPM;
+// opus-4.x → 2; sonnet → 4; haiku/local → 6/2).
+const resolveConcurrency = (
+  cliValue: number,
+  activeModel: string | undefined,
+): number => {
+  if (cliValue !== CONCURRENCY_UNSET) return cliValue
+  const fromEnv = envConcurrency()
+  if (fromEnv !== null) return fromEnv
+  return KernelLlmInternal.defaultConcurrencyForModel(activeModel)
 }
 
 const concurrencyOpt = Options.integer("concurrency").pipe(
   Options.withDescription(
-    "Concurrent LLM calls across interests (default 2, overridable via UBER_REPORT_CONCURRENCY)",
+    "Concurrent LLM calls across interests. Defaults to a model-aware value (opus-4.7 → 1, opus-4.x → 2, sonnet → 4, haiku/local → 6/2). Override with UBER_REPORT_CONCURRENCY or this flag.",
   ),
-  Options.withDefault(envConcurrency()),
+  Options.withDefault(CONCURRENCY_UNSET),
 )
 
 const dryRunOpt = Options.boolean("dry-run").pipe(
@@ -194,7 +210,7 @@ export const report = Command.make(
     sinceDaysOpt: sinceDays,
     dateOpt: dateOptVal,
     maxItemsOpt: maxItems,
-    concurrencyOpt: concurrency,
+    concurrencyOpt: concurrencyCli,
     dryRunOpt: dryRun,
     sendOpt: doSend,
     syncOpt: doSyncOpt,
@@ -219,14 +235,14 @@ export const report = Command.make(
           process.env.UBER_LLM_EFFORT = e
         },
       })
-      const activeModel =
-        Option.getOrUndefined(modelOverride) ??
-        process.env.UBER_LLM_MODEL ??
-        "(default)"
+      const activeModelRaw =
+        Option.getOrUndefined(modelOverride) ?? process.env.UBER_LLM_MODEL
+      const activeModel = activeModelRaw ?? "(default)"
       const activeEffort =
         Option.getOrUndefined(effortOverride) ??
         process.env.UBER_LLM_EFFORT ??
         "medium"
+      const concurrency = resolveConcurrency(concurrencyCli, activeModelRaw)
       const anchor = Option.getOrElse(dateOptVal, today)
       const anchorDate = new Date(`${anchor}T00:00:00Z`)
       const { label: periodLabel } = isoWeekLabel(anchorDate)

--- a/apps/uebermensch/src/errors.ts
+++ b/apps/uebermensch/src/errors.ts
@@ -41,6 +41,10 @@ export class LlmError extends Schema.TaggedError<LlmError>()("LlmError", {
   kind: Schema.optional(
     Schema.Literal("unavailable", "rate_limited", "budget_exceeded", "invalid"),
   ),
+  // Hint from the upstream `Retry-After` header (or Anthropic's
+  // `anthropic-ratelimit-*-reset`) for `rate_limited` failures. Schedule
+  // wrappers honor this before falling back to exponential backoff.
+  retryAfterMs: Schema.optional(Schema.Number),
 }) {}
 
 export class CitationError extends Schema.TaggedError<CitationError>()("CitationError", {

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -93,12 +93,18 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
   const prevModel = process.env.UBER_LLM_MODEL
   const prevSummaryModel = process.env.UBER_LLM_SUMMARY_MODEL
 
+  // Default to retries=0 across this suite so failure-shape assertions
+  // observe the typed error directly. Tests that exercise retry behavior
+  // (transient 502, 429 then 200) override this env in their setup.
+  const prevRetries = process.env.UBER_LLM_RATE_LIMIT_RETRIES
+
   beforeEach(() => {
     process.env.GCTRL_KERNEL_URL = "http://kernel.test"
     // Pin to claude-* models so these tests exercise the Anthropic /messages
     // path. The live defaults are now LM Studio (OpenAI-compat /completions).
     process.env.UBER_LLM_MODEL = TEST_ANTHROPIC_MODEL
     process.env.UBER_LLM_SUMMARY_MODEL = TEST_ANTHROPIC_SUMMARY_MODEL
+    process.env.UBER_LLM_RATE_LIMIT_RETRIES = "0"
   })
 
   afterEach(() => {
@@ -108,6 +114,8 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     else process.env.UBER_LLM_MODEL = prevModel
     if (prevSummaryModel === undefined) delete process.env.UBER_LLM_SUMMARY_MODEL
     else process.env.UBER_LLM_SUMMARY_MODEL = prevSummaryModel
+    if (prevRetries === undefined) delete process.env.UBER_LLM_RATE_LIMIT_RETRIES
+    else process.env.UBER_LLM_RATE_LIMIT_RETRIES = prevRetries
   })
 
   it("POSTs to kernel /api/llm/messages and decodes items", async () => {
@@ -247,6 +255,88 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     } finally {
       if (prevModel === undefined) delete process.env.UBER_LLM_MODEL
       else process.env.UBER_LLM_MODEL = prevModel
+    }
+  })
+
+  it("transient unavailable 502 retries with exponential backoff then succeeds", async () => {
+    const prevRetries = process.env.UBER_LLM_RATE_LIMIT_RETRIES
+    const prevBase = process.env.UBER_LLM_RATE_LIMIT_BASE_MS
+    process.env.UBER_LLM_RATE_LIMIT_RETRIES = "3"
+    process.env.UBER_LLM_RATE_LIMIT_BASE_MS = "1"
+    try {
+      const failResponse = {
+        ok: false,
+        status: 502,
+        text: async () => "ai gateway request failed",
+      }
+      const okResponse = {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify(anthropicJson({
+            items: [],
+            topicsCovered: [],
+            thesesCovered: [],
+          })),
+      }
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(failResponse)
+        .mockResolvedValue(okResponse)
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      const res = await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: [],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      expect(res.items).toEqual([])
+      expect(fetchMock.mock.calls.length).toBe(2)
+    } finally {
+      if (prevRetries === undefined) delete process.env.UBER_LLM_RATE_LIMIT_RETRIES
+      else process.env.UBER_LLM_RATE_LIMIT_RETRIES = prevRetries
+      if (prevBase === undefined) delete process.env.UBER_LLM_RATE_LIMIT_BASE_MS
+      else process.env.UBER_LLM_RATE_LIMIT_BASE_MS = prevBase
+    }
+  })
+
+  it("invalid 400 surfaces immediately without retrying", async () => {
+    const prevRetries = process.env.UBER_LLM_RATE_LIMIT_RETRIES
+    process.env.UBER_LLM_RATE_LIMIT_RETRIES = "3"
+    try {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => "bad request",
+      })
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: [],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(fetchMock).toHaveBeenCalledOnce() // no retry on `invalid`
+    } finally {
+      if (prevRetries === undefined) delete process.env.UBER_LLM_RATE_LIMIT_RETRIES
+      else process.env.UBER_LLM_RATE_LIMIT_RETRIES = prevRetries
     }
   })
 

--- a/apps/uebermensch/tests/kernel-llm.test.ts
+++ b/apps/uebermensch/tests/kernel-llm.test.ts
@@ -1,11 +1,25 @@
-import { Effect, Exit } from "effect"
+import { Cause, Effect, Exit, Option } from "effect"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { KernelLlmLive, _internal } from "../src/adapters/KernelLlm.js"
 import type { CandidateRef } from "../src/lib/candidates.js"
 import { LlmService } from "../src/services/LlmService.js"
 import type { WikiPage } from "../src/services/VaultService.js"
 
-const { extractJson, buildUserPrompt, kernelBase, normalizeInsights, effortFromEnv, effortConfigFor } = _internal
+const {
+  extractJson,
+  buildUserPrompt,
+  kernelBase,
+  normalizeInsights,
+  effortFromEnv,
+  effortConfigFor,
+  effortBody,
+  isOpus47Family,
+  is1MContextRequested,
+  stripContextSuffix,
+  parseRetryAfter,
+  defaultConcurrencyForModel,
+  CONTEXT_1M_BETA,
+} = _internal
 
 // The Anthropic-routed tests in this file pin UBER_LLM_MODEL /
 // UBER_LLM_SUMMARY_MODEL to claude-* via beforeEach so they keep exercising
@@ -152,6 +166,200 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     expect(body.system).toContain("uebermensch-curator")
     expect(body.messages[0].role).toBe("user")
     expect(body.messages[0].content).toContain("cand-0000")
+  })
+
+  it("opus-4.7 high effort wires adaptive thinking + output_config.effort instead of enabled+budget", async () => {
+    const prevEffort = process.env.UBER_LLM_EFFORT
+    process.env.UBER_LLM_EFFORT = "high"
+    try {
+      const payload = anthropicJson({
+        items: [],
+        topicsCovered: [],
+        thesesCovered: [],
+      })
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(payload),
+      })
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: ["alpha"],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+
+      const [, init] = fetchMock.mock.calls[0]!
+      const body = JSON.parse((init as { body: string }).body)
+      expect(body.thinking).toEqual({ type: "adaptive" })
+      expect(body.output_config).toEqual({ effort: "high" })
+      // Opus 4.7 rejected `thinking.type=enabled` → make sure we don't send it.
+      expect(body.thinking?.type).not.toBe("enabled")
+    } finally {
+      if (prevEffort === undefined) delete process.env.UBER_LLM_EFFORT
+      else process.env.UBER_LLM_EFFORT = prevEffort
+    }
+  })
+
+  it("model id with [1m] suffix strips the suffix on the wire and sets anthropic-beta", async () => {
+    const prevModel = process.env.UBER_LLM_MODEL
+    process.env.UBER_LLM_MODEL = "claude-opus-4-7[1m]"
+    try {
+      const payload = anthropicJson(
+        { items: [], topicsCovered: [], thesesCovered: [] },
+        { input_tokens: 0, output_tokens: 0 },
+      )
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(payload),
+      })
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: [],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+
+      const [, init] = fetchMock.mock.calls[0]!
+      const body = JSON.parse((init as { body: string }).body)
+      expect(body.model).toBe("claude-opus-4-7") // suffix stripped
+      const headers = (init as { headers: Record<string, string> }).headers
+      expect(headers["anthropic-beta"]).toBe("context-1m-2025-08-07")
+    } finally {
+      if (prevModel === undefined) delete process.env.UBER_LLM_MODEL
+      else process.env.UBER_LLM_MODEL = prevModel
+    }
+  })
+
+  it("rate_limited 429 retries with small delay then succeeds", async () => {
+    const prevRetries = process.env.UBER_LLM_RATE_LIMIT_RETRIES
+    const prevBase = process.env.UBER_LLM_RATE_LIMIT_BASE_MS
+    process.env.UBER_LLM_RATE_LIMIT_RETRIES = "3"
+    process.env.UBER_LLM_RATE_LIMIT_BASE_MS = "1"
+    try {
+      const headerMap = new Map<string, string>([["retry-after", "0"]])
+      const failResponse = {
+        ok: false,
+        status: 429,
+        text: async () =>
+          JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "tokens per minute exceeded" },
+          }),
+        headers: { get: (k: string) => headerMap.get(k.toLowerCase()) ?? null },
+      }
+      const okResponse = {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify(anthropicJson({
+            items: [],
+            topicsCovered: [],
+            thesesCovered: [],
+          })),
+      }
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(failResponse)
+        .mockResolvedValueOnce(failResponse)
+        .mockResolvedValue(okResponse)
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      const res = await Effect.runPromise(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: [],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      expect(res.items).toEqual([])
+      // Two failures + one success.
+      expect(fetchMock.mock.calls.length).toBe(3)
+    } finally {
+      if (prevRetries === undefined) delete process.env.UBER_LLM_RATE_LIMIT_RETRIES
+      else process.env.UBER_LLM_RATE_LIMIT_RETRIES = prevRetries
+      if (prevBase === undefined) delete process.env.UBER_LLM_RATE_LIMIT_BASE_MS
+      else process.env.UBER_LLM_RATE_LIMIT_BASE_MS = prevBase
+    }
+  })
+
+  it("429 with Retry-After produces a typed rate_limited LlmError carrying retryAfterMs", async () => {
+    const prevRetries = process.env.UBER_LLM_RATE_LIMIT_RETRIES
+    // Disable retries so we observe the first failure directly. The retry
+    // path is exercised separately via Schedule.recurs unit tests.
+    process.env.UBER_LLM_RATE_LIMIT_RETRIES = "0"
+    try {
+      const headerMap = new Map<string, string>([["retry-after", "7"]])
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        text: async () =>
+          JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "tokens per minute exceeded" },
+          }),
+        headers: { get: (k: string) => headerMap.get(k.toLowerCase()) ?? null },
+      })
+      globalThis.fetch = fetchMock as unknown as typeof fetch
+
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          const llm = yield* LlmService
+          return yield* llm.generateBrief({
+            date: "2026-04-22",
+            profileName: "Test",
+            topics: [],
+            thesesSlugs: [],
+            candidates: [],
+            maxItems: 1,
+          })
+        }).pipe(Effect.provide(KernelLlmLive)),
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(fetchMock).toHaveBeenCalledOnce()
+      if (Exit.isFailure(exit)) {
+        const failure = exit.cause
+        const text = String(failure)
+        expect(text).toContain("HTTP 429")
+        // The LlmError should carry kind=rate_limited and retryAfterMs=7000.
+        // We pull it out via Cause to assert the typed payload.
+        const failOpt = Cause.failureOption(failure)
+        expect(Option.isSome(failOpt)).toBe(true)
+        if (Option.isSome(failOpt)) {
+          const e = failOpt.value
+          expect(e.kind).toBe("rate_limited")
+          expect(e.retryAfterMs).toBe(7_000)
+        }
+      }
+    } finally {
+      if (prevRetries === undefined) delete process.env.UBER_LLM_RATE_LIMIT_RETRIES
+      else process.env.UBER_LLM_RATE_LIMIT_RETRIES = prevRetries
+    }
   })
 
   it("fails with unavailable when kernel returns 503", async () => {
@@ -585,6 +793,117 @@ describe("KernelLlm generateBrief (kernel-routed)", () => {
     it("invalid UBER_LLM_EFFORT falls back to medium", () => {
       process.env.UBER_LLM_EFFORT = "ludicrous"
       expect(effortFromEnv()).toBe("medium")
+    })
+
+    it("opus-4.7 high effort uses adaptive thinking + output_config.effort=high (not enabled+budget)", () => {
+      process.env.UBER_LLM_EFFORT = "high"
+      const cfg = effortConfigFor(effortFromEnv(), "claude-opus-4-7")
+      expect(cfg.maxTokens).toBe(32000)
+      expect(cfg.thinking).toBe("adaptive")
+      expect(cfg.outputEffort).toBe("high")
+      const body = effortBody(cfg)
+      expect(body.thinking).toEqual({ type: "adaptive" })
+      expect(body.output_config).toEqual({ effort: "high" })
+    })
+
+    it("opus-4.7 medium effort still emits output_config.effort", () => {
+      delete process.env.UBER_LLM_EFFORT
+      const cfg = effortConfigFor(effortFromEnv(), "claude-opus-4-7")
+      expect(cfg.thinking).toBe("adaptive")
+      expect(cfg.outputEffort).toBe("medium")
+    })
+
+    it("opus-4.6 high effort keeps the legacy enabled+budget shape", () => {
+      process.env.UBER_LLM_EFFORT = "high"
+      const cfg = effortConfigFor(effortFromEnv(), "claude-opus-4-6")
+      expect(cfg.thinking).toBe("extended")
+      expect(cfg.thinkingBudgetTokens).toBeGreaterThan(0)
+      expect(cfg.outputEffort).toBeUndefined()
+      const body = effortBody(cfg)
+      expect(body.thinking).toEqual({ type: "enabled", budget_tokens: 16000 })
+      expect(body.output_config).toBeUndefined()
+    })
+
+    it("opus-4.7 with [1m] suffix is still routed through the 4.7 effort path", () => {
+      process.env.UBER_LLM_EFFORT = "high"
+      const cfg = effortConfigFor(effortFromEnv(), "claude-opus-4-7[1m]")
+      expect(cfg.thinking).toBe("adaptive")
+      expect(cfg.outputEffort).toBe("high")
+    })
+  })
+
+  describe("model id helpers", () => {
+    it("isOpus47Family matches 4.7 with or without context suffix and rejects older opus", () => {
+      expect(isOpus47Family("claude-opus-4-7")).toBe(true)
+      expect(isOpus47Family("claude-opus-4-7-20260101")).toBe(true)
+      expect(isOpus47Family("claude-opus-4-7[1m]")).toBe(true)
+      expect(isOpus47Family("claude-opus-4-6")).toBe(false)
+      expect(isOpus47Family("claude-sonnet-4-6")).toBe(false)
+    })
+
+    it("stripContextSuffix removes the [1m] suffix only", () => {
+      expect(stripContextSuffix("claude-opus-4-7[1m]")).toBe("claude-opus-4-7")
+      expect(stripContextSuffix("claude-opus-4-7")).toBe("claude-opus-4-7")
+      expect(stripContextSuffix("@cf/google/gemma-4-31b")).toBe("@cf/google/gemma-4-31b")
+    })
+
+    it("is1MContextRequested honors the [1m] suffix and UBER_LLM_CONTEXT_1M env", () => {
+      const prev = process.env.UBER_LLM_CONTEXT_1M
+      try {
+        delete process.env.UBER_LLM_CONTEXT_1M
+        expect(is1MContextRequested("claude-opus-4-7")).toBe(false)
+        expect(is1MContextRequested("claude-opus-4-7[1m]")).toBe(true)
+        process.env.UBER_LLM_CONTEXT_1M = "1"
+        expect(is1MContextRequested("claude-opus-4-7")).toBe(true)
+        process.env.UBER_LLM_CONTEXT_1M = "yes"
+        expect(is1MContextRequested("claude-opus-4-7")).toBe(true)
+        process.env.UBER_LLM_CONTEXT_1M = "0"
+        expect(is1MContextRequested("claude-opus-4-7")).toBe(false)
+      } finally {
+        if (prev === undefined) delete process.env.UBER_LLM_CONTEXT_1M
+        else process.env.UBER_LLM_CONTEXT_1M = prev
+      }
+    })
+
+    it("CONTEXT_1M_BETA matches the documented beta slug", () => {
+      expect(CONTEXT_1M_BETA).toBe("context-1m-2025-08-07")
+    })
+
+    it("defaultConcurrencyForModel picks tight values for opus-4.7 and looser for sonnet/haiku", () => {
+      expect(defaultConcurrencyForModel(undefined)).toBe(2)
+      expect(defaultConcurrencyForModel("claude-opus-4-7")).toBe(1)
+      expect(defaultConcurrencyForModel("claude-opus-4-7[1m]")).toBe(1)
+      expect(defaultConcurrencyForModel("claude-opus-4-6")).toBe(2)
+      expect(defaultConcurrencyForModel("claude-sonnet-4-6")).toBe(4)
+      expect(defaultConcurrencyForModel("claude-haiku-4-5")).toBe(6)
+      expect(defaultConcurrencyForModel("@cf/google/gemma-4-31b")).toBe(2)
+    })
+  })
+
+  describe("parseRetryAfter", () => {
+    it("parses delta-seconds and clamps absurd values", () => {
+      expect(parseRetryAfter("5")).toBe(5000)
+      expect(parseRetryAfter("0.5")).toBe(500)
+      expect(parseRetryAfter("3600")).toBe(120_000) // clamped
+      expect(parseRetryAfter("0")).toBe(0)
+    })
+
+    it("parses HTTP-date and returns positive ms-from-now", () => {
+      const future = new Date(Date.now() + 7000).toUTCString()
+      const ms = parseRetryAfter(future)
+      expect(ms).not.toBeNull()
+      // Allow generous slop for execution time between Date.now() reads.
+      expect(ms!).toBeGreaterThan(2000)
+      expect(ms!).toBeLessThanOrEqual(120_000)
+    })
+
+    it("returns 0 for past HTTP-date and null for garbage", () => {
+      const past = new Date(Date.now() - 5000).toUTCString()
+      expect(parseRetryAfter(past)).toBe(0)
+      expect(parseRetryAfter("nope")).toBeNull()
+      expect(parseRetryAfter(null)).toBeNull()
+      expect(parseRetryAfter(undefined)).toBeNull()
+      expect(parseRetryAfter("")).toBeNull()
     })
   })
 })

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -4167,6 +4167,7 @@ async fn discord_send(
 
 async fn llm_messages(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     let Ok(account_id) = std::env::var("CLOUDFLARE_ACCOUNT_ID") else {
@@ -4206,9 +4207,34 @@ async fn llm_messages(
     if let Some(t) = gateway_token {
         req = req.header("cf-aig-authorization", format!("Bearer {t}"));
     }
+    // Forward request-shaping Anthropic headers from the client. `anthropic-beta`
+    // is the opt-in switch for features like the 1M context window
+    // (`context-1m-2025-08-07`); without forwarding, callers cannot control
+    // them through the kernel and would have to bypass driver-llm.
+    if let Some(beta) = headers.get("anthropic-beta").and_then(|v| v.to_str().ok()) {
+        req = req.header("anthropic-beta", beta);
+    }
     match req.json(&body).send().await {
         Ok(resp) => {
             let status = resp.status();
+            // Capture rate-limit headers before consuming the body so the
+            // client can pace retries against the upstream's hint instead of
+            // blind exponential backoff.
+            let rl_headers: Vec<(String, String)> = [
+                "retry-after",
+                "anthropic-ratelimit-input-tokens-reset",
+                "anthropic-ratelimit-output-tokens-reset",
+                "anthropic-ratelimit-tokens-reset",
+                "anthropic-ratelimit-requests-reset",
+            ]
+            .iter()
+            .filter_map(|name| {
+                resp.headers()
+                    .get(*name)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| ((*name).to_string(), s.to_string()))
+            })
+            .collect();
             let text = resp.text().await.unwrap_or_default();
             if status.is_success() {
                 match serde_json::from_str::<serde_json::Value>(&text) {
@@ -4216,7 +4242,16 @@ async fn llm_messages(
                     Err(_) => (StatusCode::BAD_GATEWAY, text).into_response(),
                 }
             } else {
-                (messaging_upstream_status(status), text).into_response()
+                let mut out_headers = HeaderMap::new();
+                for (name, value) in &rl_headers {
+                    if let (Ok(hn), Ok(hv)) = (
+                        axum::http::HeaderName::from_bytes(name.as_bytes()),
+                        axum::http::HeaderValue::from_str(value),
+                    ) {
+                        out_headers.insert(hn, hv);
+                    }
+                }
+                (messaging_upstream_status(status), out_headers, text).into_response()
             }
         }
         Err(e) => (


### PR DESCRIPTION
## Summary

The previous opus-4.7 report run produced **0 reports**: every interest hit the org's tier-1 30k input-TPM ceiling on the first call, all `LlmError`s were swallowed, and the CLI exited 0. A second issue surfaced once retries were in: a single transient Cloudflare AI Gateway 502 killed the whole batch because `Effect.all` is fail-fast.

This PR makes uebermensch's report pipeline rate-limit and 5xx resilient, fixes opus-4.7 / 1M-context wiring, and isolates per-interest failures. End-to-end run with `--model 'claude-opus-4-7[1m]' --effort high` after the changes: **11 of 12 LLM-eligible interests wrote reports; cost $9.42**.

## How it works

### `KernelLlm.ts`

- `effortConfigFor(effort, model)` branches on the **opus-4.7 family**: emits `thinking: {type: "adaptive"}` + `output_config.effort: <tier>` instead of the legacy `enabled+budget_tokens` shape (which 4.7 rejects with HTTP 400). Older 4.x families keep the existing shape unchanged.
- **1M context**: model id `[1m]` suffix (or `UBER_LLM_CONTEXT_1M=1`) strips the suffix on the wire and adds the `anthropic-beta: context-1m-2025-08-07` request header.
- **Bounded retry loop** for transient `LlmError`s (`rate_limited` and `unavailable`):
  - `rate_limited`: honors upstream `Retry-After` and `anthropic-ratelimit-*-reset` headers when present, otherwise exponential backoff capped at MAX_MS.
  - `unavailable` (502/503/ECONNREFUSED): exponential backoff only.
  - `invalid` (other 4xx) propagates immediately so malformed requests surface fast.
  - Tunable: `UBER_LLM_RATE_LIMIT_{RETRIES,BASE_MS,MAX_MS}`. `RETRIES=0` disables (used by tests to assert typed error shape directly).
- `LlmError.retryAfterMs` carries the parsed delay across the typed error channel.
- `defaultConcurrencyForModel`: opus-4.7 → 1 (Anthropic tier-1 30k TPM allows ~one big prompt per minute); opus-4.x → 2; sonnet → 4; haiku → 6; else → 2.

### `commands/report.ts`

- `--concurrency` now defaults to `defaultConcurrencyForModel(activeModel)`. Explicit flag and `UBER_REPORT_CONCURRENCY` still win.
- Each per-interest pipeline wrapped in `Effect.either` so a single failed interest is logged + skipped instead of aborting the rest. The run summary lists which interests failed.

### `kernel/crates/gctrl-otel/src/receiver.rs`

- `llm_messages` forwards client `anthropic-beta` header upstream (without it, 1M context cannot be enabled through the kernel).
- On non-success, propagates `retry-after` and `anthropic-ratelimit-*-reset` headers back to the client so the Effect retry loop has a real hint.

## Effect-TS notes

- All retry control flow uses `Effect.catchTag` + recursive `Effect.gen` (no `._tag` access, no `try/catch` around `runPromise`).
- Per-interest fault isolation uses `Effect.either` to lift `LlmError` into the success channel; aggregation iterates with `Either.isLeft`.
- `LlmError` extended via `Schema.optional(Schema.Number)` for `retryAfterMs` — schema-tagged, serializable, pattern-matchable.

## Test plan

- [x] `pnpm test` — 270 pass (was 252)
  - new: opus-4.7 effort body shape (high → adaptive + output_config.effort)
  - new: opus-4.6 still emits enabled+budget (regression guard)
  - new: `[1m]` suffix stripped on wire + anthropic-beta header set
  - new: 429 with Retry-After produces typed `LlmError` with `kind=rate_limited`, `retryAfterMs=7000`
  - new: 429 retries with small base delay then succeeds (schedule wiring)
  - new: 502 retries with backoff then succeeds (`unavailable` is transient)
  - new: 400 surfaces immediately without retrying (`invalid` is terminal)
  - new: parseRetryAfter (delta-seconds, HTTP-date, garbage)
  - new: defaultConcurrencyForModel (opus-4.7=1, sonnet=4, haiku=6, else=2)
- [x] `pnpm run typecheck` — clean
- [x] `cargo check -p gctrl-otel` — clean
- [x] `cargo test -p gctrl-otel --test net_routes` — existing `llm_messages_fails_closed_without_gateway_config` still passes
- [x] **End-to-end run**: `uber report --model 'claude-opus-4-7[1m]' --effort high --max-items-per-interest 3` against the live kernel → 11 reports written, $9.42 total, no rate-limit aborts; previous failure interest (`sg-property`) succeeded.

## Out of scope / follow-ups

- `ai-compute-capex` failed at **render time** (not LLM time) on a `CitationError: unresolved wikilink` — the model cited a source slug that wasn't in the vault. Renderer-side concern, not addressed here.
- `unavailable` retry covers Cloudflare AI Gateway transients but doesn't yet expose a circuit breaker for sustained outages.
- Token-aware concurrency (estimating prompt size and pacing under TPM) would let opus-4.7 run at >1 concurrency. Out of scope for this PR; current opus-4.7 default of 1 is the simple correct answer at tier 1.
