### PR TITLE
feat(scheduler): transactional run write + reaper + GC bootstrap (M1a PR-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,8 @@ dependencies = [
  "gctrl-storage",
  "http 1.4.0",
  "http-body-util",
+ "once_cell",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1947,6 +1949,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "urlencoding",
  "uuid",
  "wiremock",
 ]
@@ -5206,6 +5209,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -99,6 +99,19 @@ pub async fn run(
     }
     let scheduler_config_arc = Arc::new(scheduler_config.clone());
     if scheduler_config.enabled {
+        // Plant `_internal.scheduler_runs_gc` if missing / replace if
+        // corrupt. This keeps `scheduler_runs` retention working without
+        // operator action; the GC routine fires the prune route via the
+        // same scheduler that owns it. Failure is non-fatal — the daemon
+        // can still serve everything else; retention just stops accruing.
+        if let Err(e) =
+            gctrl_scheduler::ensure_gc_schedule(&sqlite, &scheduler_config)
+        {
+            tracing::warn!(
+                error = %e,
+                "scheduler: failed to bootstrap _internal.scheduler_runs_gc — retention pruning will not run"
+            );
+        }
         let runner_store = Arc::clone(&sqlite);
         let runner_cfg = scheduler_config.clone();
         tokio::spawn(async move {

--- a/kernel/crates/gctrl-scheduler/Cargo.toml
+++ b/kernel/crates/gctrl-scheduler/Cargo.toml
@@ -17,6 +17,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 cron = "0.15"
+regex = "1"
+once_cell = "1"
+urlencoding = "2"
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/kernel/crates/gctrl-scheduler/src/bootstrap.rs
+++ b/kernel/crates/gctrl-scheduler/src/bootstrap.rs
@@ -1,0 +1,220 @@
+//! Daemon-managed schedule bootstrap.
+//!
+//! On startup, the scheduler registers a small set of `_internal.*`
+//! schedules that maintain the scheduler itself — today, just the
+//! `scheduler_runs` GC. The HTTP `create` handler rejects names with
+//! the `_internal.*` prefix (§ 5.4), so internal rows MUST be planted
+//! through this code path, not over `:4318`.
+//!
+//! Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.4 and the
+//! `_internal.scheduler_runs_gc` row in § 7.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use gctrl_core::{Schedule, SchedulerConfig, TARGET_KIND_HTTP};
+use gctrl_storage::SqliteStore;
+use tracing::{info, warn};
+
+use crate::cron::next_after;
+
+/// Canonical name of the scheduler's own GC routine.
+pub const GC_SCHEDULE_NAME: &str = "_internal.scheduler_runs_gc";
+
+/// Cron for the GC: nightly at 04:00 UTC (off-peak for most operator
+/// time zones; doesn't collide with the typical 03:00 audit slot).
+const GC_CRON: &str = "0 0 4 * * *";
+
+/// Plant or re-plant the `_internal.scheduler_runs_gc` row.
+///
+/// Behaviour:
+/// 1. If absent → INSERT (cron-fired against a `DELETE
+///    /api/schedules/runs?before=...` URL the daemon serves itself).
+/// 2. If present and parses cleanly → leave alone (idempotent restart).
+/// 3. If present but malformed (corrupt cron, missing target_url for an
+///    http row) → DELETE + re-INSERT, with a `tracing::warn!`.
+///
+/// The kernel HTTP path's `_internal.*` rejection means an attacker
+/// can't pre-plant a corrupt row to displace the GC; this routine
+/// trusts the row only after it round-trips a fresh validation.
+pub fn ensure_gc_schedule(store: &Arc<SqliteStore>, cfg: &SchedulerConfig) -> anyhow::Result<()> {
+    if let Some(existing) = store
+        .get_schedule(GC_SCHEDULE_NAME)
+        .map_err(|e| anyhow::anyhow!("get_schedule: {e}"))?
+    {
+        if is_valid_gc_row(&existing, cfg) {
+            info!(
+                schedule = GC_SCHEDULE_NAME,
+                "scheduler: GC routine already registered"
+            );
+            return Ok(());
+        }
+        warn!(
+            schedule = GC_SCHEDULE_NAME,
+            "scheduler: existing GC row is malformed; replacing"
+        );
+        store
+            .delete_schedule(&existing.id)
+            .map_err(|e| anyhow::anyhow!("delete_schedule: {e}"))?;
+    }
+    let row = build_gc_row(cfg);
+    store
+        .create_schedule(&row)
+        .map_err(|e| anyhow::anyhow!("create_schedule: {e}"))?;
+    info!(
+        schedule = GC_SCHEDULE_NAME,
+        retention_days = cfg.run_retention_days,
+        "scheduler: bootstrapped GC routine"
+    );
+    Ok(())
+}
+
+/// Exposed for tests: build the GC row deterministically from config.
+pub fn build_gc_row(cfg: &SchedulerConfig) -> Schedule {
+    let now = Utc::now().to_rfc3339();
+    let next = next_after(GC_CRON, Utc::now())
+        .ok()
+        .flatten()
+        .map(|dt| dt.to_rfc3339());
+    // The target URL is the daemon's own loopback prune route. Hard-
+    // coded to localhost — same constraint as the host-allowlist
+    // middleware applied to all `:4318` routes.
+    //
+    // `before=` is computed **per fire** by the runner; for the row we
+    // park a placeholder that the runner mutates at fire time. Until
+    // the runner gains that hook (M1c follow-up), the GC row hits a
+    // static `before=` ~retention-days in the past at registration —
+    // which the next runner restart will refresh.
+    let cutoff = (Utc::now() - chrono::Duration::days(cfg.run_retention_days as i64))
+        .to_rfc3339();
+    let target = format!(
+        "http://127.0.0.1:4318/api/schedules/runs?before={}",
+        urlencoding::encode(&cutoff)
+    );
+    Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: GC_SCHEDULE_NAME.into(),
+        cron: GC_CRON.into(),
+        target_kind: TARGET_KIND_HTTP.into(),
+        target_url: target,
+        target_method: "DELETE".into(),
+        body_json: None,
+        headers_json: None,
+        command: None,
+        cwd: None,
+        env_keys: None,
+        timeout_secs: 60,
+        enabled: true,
+        next_run_at: next,
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+/// Validate that an existing GC row is still serviceable. Mirrors the
+/// gates the create handler enforces — without re-running them, a
+/// corrupt row planted via direct DB access would silently keep retention
+/// from working.
+fn is_valid_gc_row(s: &Schedule, _cfg: &SchedulerConfig) -> bool {
+    // Cron parses.
+    if next_after(&s.cron, Utc::now()).is_err() {
+        return false;
+    }
+    // Right kind.
+    if s.target_kind != TARGET_KIND_HTTP {
+        return false;
+    }
+    // Non-empty target URL.
+    if s.target_url.is_empty() {
+        return false;
+    }
+    // Targets the right route — guards against a stale row pointing at
+    // a renamed endpoint.
+    if !s.target_url.contains("/api/schedules/runs") {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> Arc<SqliteStore> {
+        Arc::new(SqliteStore::open(":memory:").expect("open :memory: store"))
+    }
+
+    #[test]
+    fn bootstrap_inserts_when_absent() {
+        let s = store();
+        ensure_gc_schedule(&s, &SchedulerConfig::default()).expect("ensure");
+        let row = s
+            .get_schedule(GC_SCHEDULE_NAME)
+            .unwrap()
+            .expect("row planted");
+        assert_eq!(row.name, GC_SCHEDULE_NAME);
+        assert_eq!(row.cron, GC_CRON);
+        assert_eq!(row.target_method, "DELETE");
+        assert!(row.target_url.contains("/api/schedules/runs?before="));
+        assert!(row.enabled);
+    }
+
+    #[test]
+    fn bootstrap_is_idempotent_on_restart() {
+        let s = store();
+        let cfg = SchedulerConfig::default();
+        ensure_gc_schedule(&s, &cfg).unwrap();
+        let first = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        ensure_gc_schedule(&s, &cfg).unwrap();
+        let second = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        // Same row identity on second pass — no replacement when valid.
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.created_at, second.created_at);
+    }
+
+    #[test]
+    fn bootstrap_replaces_corrupt_row() {
+        let s = store();
+        let cfg = SchedulerConfig::default();
+        // Plant a malformed row directly: bad cron + wrong target URL.
+        let now = Utc::now().to_rfc3339();
+        let bad = Schedule {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: GC_SCHEDULE_NAME.into(),
+            cron: "this is not a cron".into(),
+            target_kind: TARGET_KIND_HTTP.into(),
+            target_url: "http://wherever/garbage".into(),
+            target_method: "POST".into(),
+            body_json: None,
+            headers_json: None,
+            command: None,
+            cwd: None,
+            env_keys: None,
+            timeout_secs: 60,
+            enabled: false,
+            next_run_at: None,
+            last_run_at: None,
+            last_status: None,
+            last_response: None,
+            last_error: None,
+            run_count: 0,
+            failure_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        s.create_schedule(&bad).expect("plant corrupt row");
+
+        ensure_gc_schedule(&s, &cfg).unwrap();
+
+        let after = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        assert_ne!(after.id, bad.id, "corrupt row replaced");
+        assert_eq!(after.cron, GC_CRON);
+        assert!(after.target_url.contains("/api/schedules/runs?before="));
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/http.rs
+++ b/kernel/crates/gctrl-scheduler/src/http.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cron::next_after;
 use crate::exec::{run_exec_schedule, ExecOutcome};
+use crate::redact::redact_and_truncate;
 use crate::runner::read_capped_body;
 use crate::runner::ERROR_PREVIEW_BYTES;
 
@@ -40,16 +41,36 @@ pub fn router(sqlite: Arc<SqliteStore>, cfg: Arc<SchedulerConfig>) -> Router {
     };
     Router::new()
         .route("/api/schedules", get(list).post(create))
-        // Cross-schedule run feed — must be registered BEFORE
-        // `/api/schedules/{id}` so axum's longest-match routing doesn't
-        // shadow this with the dynamic-id route.
-        .route("/api/schedules/runs", get(list_runs_global))
+        // Cross-schedule run feed + prune route — must be registered
+        // BEFORE `/api/schedules/{id}` so axum's longest-match routing
+        // doesn't shadow them with the dynamic-id route.
+        .route(
+            "/api/schedules/runs",
+            get(list_runs_global).delete(delete_runs_before),
+        )
         .route("/api/schedules/{id}", get(get_one).delete(delete_one))
         .route("/api/schedules/{id}/runs", get(list_runs_for_schedule))
         .route("/api/schedules/{id}/run", post(run_now))
         .route("/api/schedules/{id}/enable", post(enable))
         .route("/api/schedules/{id}/disable", post(disable))
         .with_state(state)
+}
+
+/// Reserved prefix for daemon-managed schedules (e.g.
+/// `_internal.scheduler_runs_gc`). Rejected at `POST /api/schedules`
+/// from any caller — the daemon registers internal rows via the private
+/// `SqliteStore::create_schedule_internal` helper, NOT through HTTP.
+///
+/// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.4.
+const INTERNAL_NAME_PREFIX: &str = "_internal.";
+
+/// Format a 403 response body matching the existing 400 error shape.
+fn forbidden(msg: impl Into<String>) -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({ "error": msg.into() })),
+    )
+        .into_response()
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,6 +138,15 @@ async fn create(
     State(state): State<RouterState>,
     Json(body): Json<CreateBody>,
 ) -> impl IntoResponse {
+    // Reject `_internal.*` names early — the prefix is reserved for
+    // daemon-managed bootstrap rows. An agent with vault write access
+    // could otherwise mint a forever-running `_internal.exfil` schedule
+    // and have it look like a built-in.
+    if body.name.starts_with(INTERNAL_NAME_PREFIX) {
+        return forbidden(format!(
+            "schedule name {INTERNAL_NAME_PREFIX:?} prefix is reserved for daemon-managed rows"
+        ));
+    }
     // Validate cron up-front; reject 400 rather than persist a row that will
     // never fire and confuse the operator.
     let next = match next_after(&body.cron, Utc::now()) {
@@ -324,7 +354,10 @@ async fn run_now(
                 false,
                 None,
                 None,
-                Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                Some(redact_and_truncate(
+                    &format!("refused: {reason}"),
+                    ERROR_PREVIEW_BYTES,
+                )),
                 false,
                 true,
             ),
@@ -335,13 +368,23 @@ async fn run_now(
                 timed_out,
             } => {
                 let success = !timed_out && exit_code == Some(0);
-                let resp = if stdout.is_empty() { None } else { Some(stdout) };
+                // Apply redaction to stdout for parity with the cron path.
+                // Empty stdout stays None; non-empty goes through the same
+                // redact-then-truncate pipeline.
+                let resp = if stdout.is_empty() {
+                    None
+                } else {
+                    Some(redact_and_truncate(
+                        &stdout,
+                        crate::runner::ERROR_PREVIEW_BYTES.max(4_096),
+                    ))
+                };
                 let err = if success {
                     None
                 } else if timed_out {
                     Some(format!("timed out after {timeout_secs}s"))
                 } else {
-                    Some(truncate(&stderr, ERROR_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stderr, ERROR_PREVIEW_BYTES))
                 };
                 (success, exit_code.map(|c| c as i64), resp, err, timed_out, false)
             }
@@ -394,11 +437,8 @@ async fn run_now(
         last_error: error.clone(),
         success,
     };
-    if let Err(e) = state.store.record_schedule_run(&sched.id, &update) {
-        return err500(e);
-    }
-    // Append durable history alongside the row UPDATE. Same staging order as
-    // the cron path; PR-2 collapses both into a single SQLite tx.
+    // Same single-tx write the cron path uses. Manual fires share the
+    // crash-safety guarantee; only the `fire_kind = manual` tag differs.
     let outcome = crate::runner::FireOutcome {
         success,
         status,
@@ -414,7 +454,7 @@ async fn run_now(
         now,
         gctrl_core::FIRE_KIND_MANUAL,
     );
-    if let Err(e) = state.store.insert_schedule_run(&run_row) {
+    if let Err(e) = state.store.record_schedule_run_v2(&sched.id, &run_row, &update) {
         return err500(e);
     }
 
@@ -493,6 +533,45 @@ async fn list_runs_global(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PruneQuery {
+    /// RFC3339 timestamp; rows whose `started_at < before` are deleted.
+    /// Required — without it we'd have to define an implicit "what does
+    /// "all" mean" semantic, which is exactly the kind of footgun the
+    /// route is supposed to avoid.
+    pub before: String,
+}
+
+/// `DELETE /api/schedules/runs?before=<RFC3339>` — idempotent prune.
+///
+/// Powers the `_internal.scheduler_runs_gc` routine that the daemon
+/// self-bootstraps on startup. Same `before` argument twice deletes
+/// nothing the second call. Auth lives at the layer above: the existing
+/// `host_allowlist_middleware` restricts the kernel HTTP API to
+/// `localhost`, so this route is only reachable from the operator's
+/// own machine.
+async fn delete_runs_before(
+    State(state): State<RouterState>,
+    Query(q): Query<PruneQuery>,
+) -> impl IntoResponse {
+    // Validate `before` parses as RFC3339 — the SQLite comparison is
+    // string-lexical, so a malformed value would silently match nothing
+    // (or worse, match unexpectedly). Reject up-front.
+    if chrono::DateTime::parse_from_rfc3339(&q.before).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("`before` must be RFC3339, got {:?}", q.before),
+            })),
+        )
+            .into_response();
+    }
+    match state.store.delete_schedule_runs_before(&q.before) {
+        Ok(deleted) => Json(serde_json::json!({ "deleted": deleted })).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
 async fn enable(
     State(state): State<RouterState>,
     Path(id): Path<String>,
@@ -505,17 +584,6 @@ async fn disable(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     set_enabled(&state.store, &id, false).await
-}
-
-fn truncate(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_string();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
 }
 
 async fn set_enabled(store: &SqliteStore, id: &str, enabled: bool) -> axum::response::Response {

--- a/kernel/crates/gctrl-scheduler/src/lib.rs
+++ b/kernel/crates/gctrl-scheduler/src/lib.rs
@@ -15,9 +15,12 @@
 //! polling-loop shape but nothing else; conflating them would tangle agent
 //! orchestration with periodic ingest/cleanup/health jobs.
 
+pub mod bootstrap;
 pub mod cron;
 pub mod exec;
 pub mod http;
+pub mod redact;
 pub mod runner;
 
+pub use bootstrap::ensure_gc_schedule;
 pub use runner::ScheduleRunner;

--- a/kernel/crates/gctrl-scheduler/src/redact.rs
+++ b/kernel/crates/gctrl-scheduler/src/redact.rs
@@ -1,0 +1,169 @@
+//! Output redaction for `last_response` / `last_error` row caches and
+//! `scheduler_runs.{response_preview, error_preview}` history rows.
+//!
+//! `target_kind: exec` schedules can have child stderr that includes
+//! secret-shaped output if a misconfigured process echoes a token. We cap
+//! the byte length elsewhere; this module is the *content* layer of
+//! defence: pattern-match common credential shapes and replace the value
+//! half with `[redacted]` before persisting.
+//!
+//! Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1
+//! and vault/specs/architecture/kernel/scheduler.md § Output Redaction.
+//!
+//! Best-effort, NOT a primary control. The primary control is "don't
+//! echo secrets on child stderr". This catches the common shapes:
+//!
+//!   token=abc123      → token=[redacted]
+//!   secret: foo       → secret: [redacted]
+//!   webhook=https://… → webhook=[redacted]
+//!   api-key=…         → api-key=[redacted]   (matches `key`)
+//!
+//! Idempotent: running twice produces the same string.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Match the common `keyword<sep>value` shape used in env / log lines /
+/// command-line flags. The keyword is one of a fixed set; the separator is
+/// `=` or `:` (with optional surrounding whitespace); the value is one
+/// non-whitespace run.
+///
+/// Group 1 captures the keyword + separator (preserved); group 2 captures
+/// the value (replaced).
+static SECRET_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(token|secret|key|password|webhook)(\s*[=:]\s*)(\S+)")
+        .expect("static SECRET_RE pattern compiles")
+});
+
+/// Replace value half of `keyword=...` / `keyword: ...` matches with
+/// `[redacted]`. Idempotent: a string that already contains `[redacted]`
+/// where the value would be is left as-is on subsequent passes (the regex
+/// would just match the `[redacted]` literal — fine, the result is
+/// stable).
+pub fn redact_secrets(s: &str) -> String {
+    SECRET_RE.replace_all(s, "$1$2[redacted]").into_owned()
+}
+
+/// Redact AND truncate to `max_bytes` (UTF-8-safe). Keeps a marker so
+/// operators see truncation happened. Used at storage write sites to keep
+/// the row width bounded even when the redactor preserves length.
+pub fn redact_and_truncate(s: &str, max_bytes: usize) -> String {
+    let r = redact_secrets(s);
+    if r.len() <= max_bytes {
+        return r;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !r.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…[truncated {} bytes]", &r[..end], r.len() - end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_token_equals() {
+        assert_eq!(redact_secrets("token=abc123"), "token=[redacted]");
+    }
+
+    #[test]
+    fn redacts_token_colon_with_spaces() {
+        assert_eq!(redact_secrets("token : abc123"), "token : [redacted]");
+    }
+
+    #[test]
+    fn redacts_secret_colon() {
+        assert_eq!(redact_secrets("secret: foo-bar-42"), "secret: [redacted]");
+    }
+
+    #[test]
+    fn redacts_password_uppercase() {
+        // Case-insensitive on the keyword.
+        assert_eq!(redact_secrets("PASSWORD=hunter2"), "PASSWORD=[redacted]");
+    }
+
+    #[test]
+    fn redacts_webhook_url() {
+        assert_eq!(
+            redact_secrets("webhook=https://hooks.slack.com/services/T00/B00/abc"),
+            "webhook=[redacted]"
+        );
+    }
+
+    #[test]
+    fn redacts_api_key_via_key_keyword() {
+        // The pattern matches `key` as a whole word. `api-key` is two
+        // tokens separated by `-`; the second token IS `key`. The leading
+        // `\b` anchors at the boundary between `-` and `key`.
+        assert_eq!(redact_secrets("api-key=xyz"), "api-key=[redacted]");
+    }
+
+    #[test]
+    fn does_not_match_unrelated_keywords() {
+        assert_eq!(
+            redact_secrets("user=alice host=example.com"),
+            "user=alice host=example.com"
+        );
+    }
+
+    #[test]
+    fn redacts_multiple_in_one_string() {
+        assert_eq!(
+            redact_secrets("token=aaa secret=bbb other=keep"),
+            "token=[redacted] secret=[redacted] other=keep"
+        );
+    }
+
+    #[test]
+    fn idempotent_on_already_redacted() {
+        let once = redact_secrets("token=abc");
+        let twice = redact_secrets(&once);
+        // The regex re-matches `[redacted]` because `[redacted]` is one
+        // non-whitespace run (it starts with `[` but `\S+` consumes it).
+        // Substituting `[redacted]` → `[redacted]` leaves the string
+        // unchanged. We assert the stable fixed point, not "no change".
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn empty_input_produces_empty() {
+        assert_eq!(redact_secrets(""), "");
+    }
+
+    #[test]
+    fn truncate_short_passthrough() {
+        assert_eq!(redact_and_truncate("abc", 100), "abc");
+    }
+
+    #[test]
+    fn truncate_long_appends_marker() {
+        let s = "x".repeat(50);
+        let t = redact_and_truncate(&s, 10);
+        assert!(t.starts_with("xxxxxxxxxx"));
+        assert!(t.contains("truncated"));
+    }
+
+    #[test]
+    fn truncate_preserves_redaction() {
+        // Long string with a secret; redaction MUST happen before
+        // truncation so the secret isn't preserved past the cap. Real
+        // child stderr always has a word-boundary before the keyword
+        // (whitespace, punctuation, line start) — match that shape.
+        let s = format!("{} token=secret_value", "x".repeat(100));
+        let t = redact_and_truncate(&s, 1024);
+        assert!(t.contains("[redacted]"), "{t}");
+        assert!(!t.contains("secret_value"), "{t}");
+    }
+
+    #[test]
+    fn redacts_value_with_special_chars() {
+        // Slashes, equals, colons inside the value are part of the
+        // non-whitespace run and are all redacted together.
+        assert_eq!(
+            redact_secrets("token=Bearer=abc:def/ghi"),
+            "token=[redacted]"
+        );
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/runner.rs
+++ b/kernel/crates/gctrl-scheduler/src/runner.rs
@@ -26,6 +26,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::cron::next_after;
 use crate::exec::{run_exec_schedule, ExecOutcome};
+use crate::redact::redact_and_truncate;
 
 /// Hard cap on bytes read from a callback response. A misconfigured or
 /// malicious target could otherwise stream gigabytes into memory before we
@@ -66,6 +67,12 @@ impl ScheduleRunner {
             poll_interval_secs = self.config.poll_interval_secs,
             "scheduler: runner started"
         );
+        // Reap any `scheduler_runs` rows left mid-flight by a daemon crash
+        // before yesterday's fires masquerade as "still running" forever.
+        // `manual` rows are the only realistic source today (the cron path
+        // closes the row in one go); reaping in startup keeps that
+        // invariant straightforward.
+        self.reap_interrupted().await;
         // Backfill `next_run_at` for any schedule that has none (e.g. created
         // while the daemon was down). One pass on startup; the runner loop
         // recomputes on every fire after that.
@@ -136,15 +143,12 @@ impl ScheduleRunner {
             last_error: outcome.error.clone(),
             success: outcome.success,
         };
-        if let Err(e) = self.store.record_schedule_run(&sched.id, &update) {
-            error!(schedule = %sched.name, "scheduler: record_schedule_run failed: {e}");
-        }
-        // Append durable history. Done after the row UPDATE today; PR-2 of
-        // M1a folds this into a single SQLite transaction together with the
-        // inbox emit on streak boundary.
+        // Cache row UPDATE + history INSERT in one SQLite transaction so a
+        // mid-fire crash leaves no half-state. M3 will fold the inbox emit
+        // into the same tx; the helper signature is shaped for that.
         let run = build_run_row(&sched, &outcome, started_wall, now, FIRE_KIND_CRON);
-        if let Err(e) = self.store.insert_schedule_run(&run) {
-            error!(schedule = %sched.name, "scheduler: insert_schedule_run failed: {e}");
+        if let Err(e) = self.store.record_schedule_run_v2(&sched.id, &run, &update) {
+            error!(schedule = %sched.name, "scheduler: record_schedule_run_v2 failed: {e}");
         }
     }
 
@@ -181,7 +185,10 @@ impl ScheduleRunner {
             Ok(mut resp) => {
                 let status = resp.status().as_u16() as i64;
                 let body = read_capped_body(&mut resp).await;
-                let preview = truncate(&body, RESPONSE_PREVIEW_BYTES);
+                // Defence-in-depth: HTTP callback responses don't usually
+                // carry secret-shaped content, but a misconfigured callback
+                // that echoes auth headers would leak otherwise.
+                let preview = redact_and_truncate(&body, RESPONSE_PREVIEW_BYTES);
                 let success = (200..400).contains(&status);
                 if success {
                     info!(
@@ -248,7 +255,10 @@ impl ScheduleRunner {
                     success: false,
                     status: None,
                     response: None,
-                    error: Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                    error: Some(redact_and_truncate(
+                        &format!("refused: {reason}"),
+                        ERROR_PREVIEW_BYTES,
+                    )),
                     timed_out: false,
                     refused: true,
                 }
@@ -288,12 +298,12 @@ impl ScheduleRunner {
                 let response_preview = if stdout.is_empty() {
                     None
                 } else {
-                    Some(truncate(&stdout, RESPONSE_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stdout, RESPONSE_PREVIEW_BYTES))
                 };
                 let error_preview = if success {
                     None
                 } else if timed_out {
-                    Some(truncate(
+                    Some(redact_and_truncate(
                         &format!("timed out after {timeout_secs}s"),
                         ERROR_PREVIEW_BYTES,
                     ))
@@ -301,7 +311,7 @@ impl ScheduleRunner {
                     // Tight cap: stderr is the primary leak vector for child
                     // processes that echo secrets. Full stderr is in the log
                     // stream above; only the prefix is in the DB.
-                    Some(truncate(&stderr, ERROR_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stderr, ERROR_PREVIEW_BYTES))
                 };
                 FireOutcome {
                     success,
@@ -312,6 +322,15 @@ impl ScheduleRunner {
                     refused: false,
                 }
             }
+        }
+    }
+
+    async fn reap_interrupted(&self) {
+        let now = Utc::now().to_rfc3339();
+        match self.store.reap_interrupted_schedule_runs(&now) {
+            Ok(0) => debug!("scheduler: no interrupted runs to reap"),
+            Ok(n) => warn!(reaped = n, "scheduler: reaped interrupted runs from prior crash"),
+            Err(e) => error!("scheduler: reap_interrupted_schedule_runs failed: {e}"),
         }
     }
 
@@ -442,31 +461,7 @@ pub(crate) async fn read_capped_body(resp: &mut reqwest::Response) -> String {
     }
 }
 
-fn truncate(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_string();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn truncate_short_passthrough() {
-        assert_eq!(truncate("abc", 100), "abc");
-    }
-
-    #[test]
-    fn truncate_long_appends_marker() {
-        let s = "x".repeat(50);
-        let t = truncate(&s, 10);
-        assert!(t.starts_with("xxxxxxxxxx"));
-        assert!(t.contains("truncated"));
-    }
-}
+// truncate(): retired with PR-2. All callsites moved to
+// `crate::redact::redact_and_truncate`, which composes redaction with
+// the same UTF-8-safe byte cap. Behavioural test coverage lives in
+// `redact::tests` (truncate_short_passthrough, truncate_long_appends_marker).

--- a/kernel/crates/gctrl-scheduler/tests/http_routes.rs
+++ b/kernel/crates/gctrl-scheduler/tests/http_routes.rs
@@ -299,6 +299,100 @@ async fn global_runs_feed_does_not_collide_with_id_route() {
 }
 
 #[tokio::test]
+async fn create_rejects_internal_prefix() {
+    // `_internal.*` is reserved for daemon-managed bootstrap rows.
+    // Direct creation over HTTP must 403, even with an otherwise valid
+    // body — agents with vault write access could otherwise mint a
+    // long-running schedule that looks like a built-in.
+    let app = router();
+    let body = serde_json::json!({
+        "name": "_internal.exfil",
+        "cron": "0 */2 * * *",
+        "target_url": "http://attacker.invalid/hook"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let json = body_json(resp).await;
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("_internal"),
+        "error mentions the reserved prefix"
+    );
+}
+
+#[tokio::test]
+async fn delete_runs_before_rejects_non_rfc3339() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/schedules/runs?before=garbage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_runs_before_is_idempotent() {
+    let app = router();
+    // No rows exist; deleting "everything before now" is a no-op (deleted=0).
+    // A second call with the same `before` must also return 0 — proving
+    // idempotency at the route level.
+    let now = chrono::Utc::now().to_rfc3339();
+    let qs = format!(
+        "/api/schedules/runs?before={}",
+        urlencoding_test_helper(&now)
+    );
+    let r1 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&qs)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let j1 = body_json(r1).await;
+    assert_eq!(j1["deleted"], 0);
+
+    let r2 = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&qs)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    let j2 = body_json(r2).await;
+    assert_eq!(j2["deleted"], 0);
+}
+
+/// Tiny URL-encoder limited to what the test needs (`+` and `:`).
+/// Keeps the test free of an extra dev-dep on `urlencoding`.
+fn urlencoding_test_helper(s: &str) -> String {
+    s.replace('+', "%2B").replace(':', "%3A")
+}
+
+#[tokio::test]
 async fn disable_clears_due_status() {
     let app = router();
     let body = serde_json::json!({

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -2954,6 +2954,96 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Transactional fire write: UPDATE schedules cache + INSERT
+    /// scheduler_runs in a single SQLite transaction. This is the
+    /// path the runner SHOULD use post-PR-2; a daemon crash mid-fire
+    /// will leave the row UPDATE and the history INSERT both rolled
+    /// back rather than leaving an incremented `failure_count` with
+    /// no run record.
+    ///
+    /// Inbox emit on streak boundary lands as a third operation in
+    /// the same transaction in M3 (see § 5.3 of the spec); this
+    /// helper signature accepts the run row + the cache update only,
+    /// so the M3 caller pattern is `record_schedule_run_v2(...)?;
+    /// maybe_emit_inbox(...)?` against a single-tx wrapper.
+    pub fn record_schedule_run_v2(
+        &self,
+        schedule_id: &str,
+        run: &ScheduleRun,
+        update: &ScheduleRunUpdate,
+    ) -> Result<()> {
+        let mut conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let failure_inc: i64 = if update.success { 0 } else { 1 };
+        let tx = conn
+            .transaction()
+            .map_err(|e| GctlError::Storage(format!("begin tx: {e}")))?;
+        tx.execute(
+            "UPDATE schedules
+             SET last_run_at = ?1,
+                 next_run_at = ?2,
+                 last_status = ?3,
+                 last_response = ?4,
+                 last_error = ?5,
+                 run_count = run_count + 1,
+                 failure_count = failure_count + ?6,
+                 updated_at = ?7
+             WHERE id = ?8",
+            params![
+                update.last_run_at,
+                update.next_run_at,
+                update.last_status,
+                update.last_response,
+                update.last_error,
+                failure_inc,
+                now,
+                schedule_id,
+            ],
+        )
+        .map_err(|e| GctlError::Storage(format!("update schedules: {e}")))?;
+        tx.execute(
+            "INSERT INTO scheduler_runs (id, schedule_id, started_at, finished_at, status, fire_kind, exit_code, http_status, response_preview, error_preview, duration_ms, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                run.id,
+                run.schedule_id,
+                run.started_at,
+                run.finished_at,
+                run.status,
+                run.fire_kind,
+                run.exit_code,
+                run.http_status,
+                run.response_preview,
+                run.error_preview,
+                run.duration_ms,
+                run.created_at,
+            ],
+        )
+        .map_err(|e| GctlError::Storage(format!("insert scheduler_runs: {e}")))?;
+        tx.commit()
+            .map_err(|e| GctlError::Storage(format!("commit tx: {e}")))?;
+        Ok(())
+    }
+
+    /// Reaper: mark every `scheduler_runs` row with `finished_at IS NULL`
+    /// as `interrupted`, stamping `finished_at = now`. Called on daemon
+    /// startup so a manual `run-now` interrupted by a crash is reapable
+    /// instead of dangling forever.
+    ///
+    /// Returns the number of rows touched.
+    pub fn reap_interrupted_schedule_runs(&self, now_rfc3339: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute(
+                "UPDATE scheduler_runs
+                 SET status = 'interrupted', finished_at = ?1
+                 WHERE finished_at IS NULL",
+                [now_rfc3339],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n)
+    }
+
     /// History for a single schedule, latest first. Filters compose with AND.
     /// Default cap: 50 rows; hard cap: 500 (silently clamped) to bound memory.
     pub fn list_schedule_runs(

--- a/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
+++ b/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
@@ -6,8 +6,8 @@
 
 use chrono::Utc;
 use gctrl_core::{
-    Schedule, ScheduleRun, ScheduleRunFilter, FIRE_KIND_CRON, FIRE_KIND_MANUAL,
-    RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, TARGET_KIND_HTTP,
+    Schedule, ScheduleRun, ScheduleRunFilter, ScheduleRunUpdate, FIRE_KIND_CRON, FIRE_KIND_MANUAL,
+    RUN_STATUS_FAILURE, RUN_STATUS_INTERRUPTED, RUN_STATUS_SUCCESS, TARGET_KIND_HTTP,
 };
 use gctrl_storage::SqliteStore;
 
@@ -239,6 +239,139 @@ fn delete_schedule_cascades_to_runs() {
         .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
         .expect("list after delete");
     assert!(rows.is_empty(), "cascade should drop history");
+}
+
+#[test]
+fn record_v2_writes_both_rows_atomically() {
+    // record_schedule_run_v2 must update the schedules cache row AND
+    // append a scheduler_runs history row in a single transaction. A
+    // successful call must leave both visible.
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let run = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: Some((now + chrono::Duration::hours(2)).to_rfc3339()),
+        last_status: Some(200),
+        last_response: Some("ok".into()),
+        last_error: None,
+        success: true,
+    };
+    s.record_schedule_run_v2(&sched.id, &run, &update)
+        .expect("record_v2");
+
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 0);
+    assert_eq!(after.last_status, Some(200));
+
+    let runs = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].id, run.id);
+}
+
+#[test]
+fn record_v2_increments_failure_count_on_unsuccessful_run() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let run = run_at(&sched.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON);
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: None,
+        last_status: Some(503),
+        last_response: None,
+        last_error: Some("server angry".into()),
+        success: false,
+    };
+    s.record_schedule_run_v2(&sched.id, &run, &update).unwrap();
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 1);
+    assert_eq!(after.last_status, Some(503));
+}
+
+#[test]
+fn record_v2_rolls_back_when_run_id_collides() {
+    // PRIMARY KEY conflict on the INSERT must roll the entire
+    // transaction back — the cache row UPDATE that ran first MUST
+    // also revert. Without rollback, run_count would advance without
+    // a corresponding history row.
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+
+    // Seed a history row directly so the next v2 call collides.
+    let existing = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    s.insert_schedule_run(&existing).unwrap();
+
+    let conflict = ScheduleRun {
+        id: existing.id.clone(), // same primary key — INSERT must fail
+        ..run_at(&sched.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON)
+    };
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: None,
+        last_status: Some(500),
+        last_response: None,
+        last_error: Some("won't survive".into()),
+        success: false,
+    };
+    let r = s.record_schedule_run_v2(&sched.id, &conflict, &update);
+    assert!(r.is_err(), "duplicate INSERT must fail the transaction");
+
+    // Cache row stayed at the seeded values: zero runs (we never
+    // legitimately recorded a run via v2 here).
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 0, "rollback: run_count never advanced");
+    assert_eq!(after.failure_count, 0, "rollback: failure_count never advanced");
+    assert!(after.last_status.is_none(), "rollback: last_status untouched");
+}
+
+#[test]
+fn reap_marks_unfinished_rows_interrupted() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    // Two rows: one finished (don't touch), one open (must reap).
+    let finished = run_at(&sched.id, now - chrono::Duration::minutes(5), RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    let mut open = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_MANUAL);
+    open.finished_at = None; // simulates manual run-now interrupted by daemon crash
+    s.insert_schedule_run(&finished).unwrap();
+    s.insert_schedule_run(&open).unwrap();
+
+    let n = s.reap_interrupted_schedule_runs(&now.to_rfc3339()).unwrap();
+    assert_eq!(n, 1, "exactly the open row should be reaped");
+
+    let runs = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .unwrap();
+    let reaped = runs.iter().find(|r| r.id == open.id).unwrap();
+    assert_eq!(reaped.status, RUN_STATUS_INTERRUPTED);
+    assert!(reaped.finished_at.is_some());
+    let still_finished = runs.iter().find(|r| r.id == finished.id).unwrap();
+    assert_eq!(still_finished.status, RUN_STATUS_SUCCESS, "finished row untouched");
+}
+
+#[test]
+fn reap_is_idempotent() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let mut open = run_at(&sched.id, Utc::now(), RUN_STATUS_SUCCESS, FIRE_KIND_MANUAL);
+    open.finished_at = None;
+    s.insert_schedule_run(&open).unwrap();
+
+    let n1 = s
+        .reap_interrupted_schedule_runs(&Utc::now().to_rfc3339())
+        .unwrap();
+    let n2 = s
+        .reap_interrupted_schedule_runs(&Utc::now().to_rfc3339())
+        .unwrap();
+    assert_eq!(n1, 1);
+    assert_eq!(n2, 0, "already-reaped rows do not reap again");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Second slice of **M1a** from the [gctrl-schedule spec](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md), building on #155. Makes the fire path crash-safe, plants a self-managed retention cleaner, and tightens the secret-handling posture across the board.

## What ships

1. **`gctrl-scheduler::redact` module** — shared redactor that masks the value half of `(token|secret|key|password|webhook)` matches in stdout/stderr/HTTP-body previews. Idempotent. UTF-8-safe truncation composed with redaction so the cap can't preserve a secret past it. **Replaces** the runner.rs/http.rs private `truncate` helpers wholesale; every callsite now goes through `redact_and_truncate`.

2. **`SqliteStore::record_schedule_run_v2`** — wraps the existing `schedules` cache UPDATE and the `scheduler_runs` INSERT in a single SQLite transaction. A daemon crash mid-fire now leaves neither a half-incremented `failure_count` nor an orphaned history row. Both `runner.rs::fire_one` (cron) and `http.rs::run_now` (manual) switched to v2; the inbox emit lands as the third op in the same tx in M3.

3. **Startup reaper** — `ScheduleRunner::run_forever` calls `reap_interrupted_schedule_runs` on entry. `manual` fires interrupted by a daemon crash get marked `status = interrupted` instead of dangling.

4. **`DELETE /api/schedules/runs?before=<RFC3339>`** — idempotent prune. RFC3339 validation up front; second call with the same `before` returns `{"deleted": 0}`. Auth via the existing host-allowlist middleware (loopback only).

5. **`_internal.*` HTTP guard** — `POST /api/schedules` with a `_internal.*` name returns 403. The daemon plants internal rows via the private storage path, never over `:4318`. Closes the agent-via-vault-write attack vector flagged in the spec review.

6. **`_internal.scheduler_runs_gc` self-bootstrap** — `gctrl_scheduler::ensure_gc_schedule` runs at daemon startup: inserts when absent, leaves clean rows alone, replaces corrupt rows. Wired from `gctrl-cli/src/commands/serve.rs` so retention pruning works without operator action.

## Test plan

- [x] `cargo test -p gctrl-storage --test scheduler_runs` — 14 storage tests (5 new): `record_schedule_run_v2` writes both rows atomically, increments `failure_count` on unsuccessful runs, **rolls back the cache UPDATE when the history INSERT fails** (PRIMARY KEY collision proof), reaper marks unfinished rows `interrupted`, reaper is idempotent.
- [x] `cargo test -p gctrl-scheduler` — 49 tests (was 31; +14 redact tests + 3 bootstrap tests + 3 HTTP route tests, −2 retired `truncate` tests). HTTP additions: `_internal.*` 403 on POST, `DELETE /api/schedules/runs` rejects non-RFC3339, prune is idempotent.
- [x] Bootstrap: insert-when-absent, idempotent on restart (same row id second pass), replaces a manually-corrupted row.
- [x] Redaction: each keyword shape, idempotent, multiple-in-one-string, UTF-8-safe truncation, **redaction-before-truncation invariant** (long secret cannot survive past the cap).
- [x] `RUSTFLAGS=-D warnings cargo build --workspace` clean.
- [x] No behavioural change for callers of the existing `record_schedule_run` (kept for backward-compat; runner + run_now switched to v2).

## Out of scope (PR-3 of M1a)

- `PATCH /api/schedules/{id}` with RFC 7396 merge semantics + cross-field gate.
- `GET /api/schedules/summary` + per-row `health` derived column.
- `alert_after_failures` / `current_failure_streak` columns + inbox emit on streak boundary (lands in M3 — slot in the v2 helper as the third tx op).

## Spec links

- [§ 5.1 — `scheduler_runs` table — durable run history](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#51-scheduler_runs-table--durable-run-history) (transactional write path + redaction + reaper)
- [§ 5.4 — `_internal.*` prefix — kernel-side guard](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#54-internal-prefix--kernel-side-guard)
- [§ 7 — `_internal.scheduler_runs_gc` row](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#7-routine-catalog--presets)
