### PR TITLE
feat(scheduler): M1a substrate — tx fire path, redaction, GC, PATCH, summary, health

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,8 @@ dependencies = [
  "gctrl-storage",
  "http 1.4.0",
  "http-body-util",
+ "once_cell",
+ "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1947,6 +1949,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "urlencoding",
  "uuid",
  "wiremock",
 ]
@@ -5206,6 +5209,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/kernel/crates/gctrl-cli/src/commands/scheduler.rs
+++ b/kernel/crates/gctrl-cli/src/commands/scheduler.rs
@@ -90,6 +90,7 @@ pub fn add(
         failure_count: 0,
         created_at: now.clone(),
         updated_at: now,
+        health: None,
     };
     store.create_schedule(&sched)?;
     println!("created schedule '{}' (id={})", sched.name, sched.id);

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -99,6 +99,19 @@ pub async fn run(
     }
     let scheduler_config_arc = Arc::new(scheduler_config.clone());
     if scheduler_config.enabled {
+        // Plant `_internal.scheduler_runs_gc` if missing / replace if
+        // corrupt. This keeps `scheduler_runs` retention working without
+        // operator action; the GC routine fires the prune route via the
+        // same scheduler that owns it. Failure is non-fatal — the daemon
+        // can still serve everything else; retention just stops accruing.
+        if let Err(e) =
+            gctrl_scheduler::ensure_gc_schedule(&sqlite, &scheduler_config)
+        {
+            tracing::warn!(
+                error = %e,
+                "scheduler: failed to bootstrap _internal.scheduler_runs_gc — retention pruning will not run"
+            );
+        }
         let runner_store = Arc::clone(&sqlite);
         let runner_cfg = scheduler_config.clone();
         tokio::spawn(async move {

--- a/kernel/crates/gctrl-core/src/schedule.rs
+++ b/kernel/crates/gctrl-core/src/schedule.rs
@@ -52,6 +52,14 @@ pub struct Schedule {
     pub failure_count: i64,
     pub created_at: String,
     pub updated_at: String,
+    /// Derived state, computed at read time by the storage layer (never
+    /// stored, never accepted on POST/PATCH). `None` on rows that
+    /// haven't been through the populating fetch path — e.g. a row
+    /// constructed in tests for create/insert assertions.
+    ///
+    /// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.6.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health: Option<ScheduleHealth>,
 }
 
 fn default_target_kind() -> String {
@@ -92,6 +100,190 @@ pub const RUN_STATUS_FAILURE: &str = "failure";
 pub const RUN_STATUS_TIMED_OUT: &str = "timed_out";
 pub const RUN_STATUS_REFUSED: &str = "refused";
 pub const RUN_STATUS_INTERRUPTED: &str = "interrupted";
+
+/// Derived per-schedule health state, computed kernel-side (never
+/// recomputed on the client) per the spec § 6.3.
+///
+/// `red` lands when M3 adds `alert_after_failures` /
+/// `current_failure_streak`; until then a routine in sustained failure
+/// stays `amber` indefinitely. The Web UI surfaces a "no alert
+/// threshold set" hint on amber rows so operators notice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScheduleHealth {
+    Green,
+    Amber,
+    Red,
+    Pending,
+    Paused,
+}
+
+impl ScheduleHealth {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Green => "green",
+            Self::Amber => "amber",
+            Self::Red => "red",
+            Self::Pending => "pending",
+            Self::Paused => "paused",
+        }
+    }
+}
+
+/// Compute health from a `Schedule` row's existing fields. Pure
+/// function — no DB calls — so callers can apply it inline after
+/// row fetches.
+///
+/// Inputs available today (M1a): `enabled`, `last_run_at`,
+/// `last_status`, `last_error`, `next_run_at`. The `red` state will
+/// gate on `current_failure_streak >= alert_after_failures` once
+/// those columns land in M3; this function returns `Amber` instead
+/// of `Red` for sustained-failure routines until then.
+pub fn compute_schedule_health(s: &Schedule) -> ScheduleHealth {
+    if !s.enabled {
+        return ScheduleHealth::Paused;
+    }
+    if s.last_run_at.is_none() {
+        // Enabled and never fired — show that we're waiting on the
+        // first run, not flag it as failing.
+        return ScheduleHealth::Pending;
+    }
+    // For HTTP rows, last_status is the HTTP code; success is 2xx/3xx.
+    // For exec rows, last_status is the exit code; success is 0.
+    // We don't know the kind here without re-deriving from the row;
+    // the cheapest reliable signal is `last_error`: the runner only
+    // sets it on failure (success path leaves it None).
+    if s.last_error.is_some() {
+        ScheduleHealth::Amber
+    } else {
+        ScheduleHealth::Green
+    }
+}
+
+/// Aggregate counts returned by `GET /api/schedules/summary` (spec § 5.6).
+///
+/// `runs_last_24h` is sourced from `scheduler_runs` (PR-1 of M1a).
+/// `spend_last_24h_usd` lands when the analytics join is wired in M1b;
+/// for now the route omits the field and the SPA hides the KPI.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SchedulesSummary {
+    pub total: i64,
+    pub by_health: SchedulesHealthCounts,
+    pub runs_last_24h: SchedulesRunsCounts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SchedulesHealthCounts {
+    pub green: i64,
+    pub amber: i64,
+    pub red: i64,
+    pub pending: i64,
+    pub paused: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SchedulesRunsCounts {
+    pub success: i64,
+    pub failure: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> Schedule {
+        let now = "2026-05-02T00:00:00Z".to_string();
+        Schedule {
+            id: "x".into(),
+            name: "audit.codebase".into(),
+            cron: "0 3 * * 1".into(),
+            target_kind: TARGET_KIND_HTTP.into(),
+            target_url: "http://x".into(),
+            target_method: "POST".into(),
+            body_json: None,
+            headers_json: None,
+            command: None,
+            cwd: None,
+            env_keys: None,
+            timeout_secs: 60,
+            enabled: true,
+            next_run_at: None,
+            last_run_at: None,
+            last_status: None,
+            last_response: None,
+            last_error: None,
+            run_count: 0,
+            failure_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            health: None,
+        }
+    }
+
+    #[test]
+    fn paused_when_disabled() {
+        let s = Schedule {
+            enabled: false,
+            ..base()
+        };
+        assert_eq!(compute_schedule_health(&s), ScheduleHealth::Paused);
+    }
+
+    #[test]
+    fn paused_overrides_pending_or_amber() {
+        // Disabled MUST short-circuit even when other signals would
+        // map to a different state.
+        let s = Schedule {
+            enabled: false,
+            last_error: Some("boom".into()),
+            ..base()
+        };
+        assert_eq!(compute_schedule_health(&s), ScheduleHealth::Paused);
+    }
+
+    #[test]
+    fn pending_when_enabled_and_never_fired() {
+        let s = Schedule {
+            enabled: true,
+            last_run_at: None,
+            next_run_at: Some("2026-05-03T03:00:00Z".into()),
+            ..base()
+        };
+        assert_eq!(compute_schedule_health(&s), ScheduleHealth::Pending);
+    }
+
+    #[test]
+    fn green_when_last_run_succeeded() {
+        let s = Schedule {
+            enabled: true,
+            last_run_at: Some("2026-05-02T03:00:00Z".into()),
+            last_error: None,
+            ..base()
+        };
+        assert_eq!(compute_schedule_health(&s), ScheduleHealth::Green);
+    }
+
+    #[test]
+    fn amber_when_last_run_failed() {
+        let s = Schedule {
+            enabled: true,
+            last_run_at: Some("2026-05-02T03:00:00Z".into()),
+            last_error: Some("boom".into()),
+            ..base()
+        };
+        assert_eq!(compute_schedule_health(&s), ScheduleHealth::Amber);
+    }
+
+    #[test]
+    fn schedule_health_serialises_lowercase() {
+        // SPA reads the JSON as-is for filtering — serialise as "green"
+        // / "amber" / etc., not the variant name.
+        let json = serde_json::to_string(&ScheduleHealth::Green).unwrap();
+        assert_eq!(json, "\"green\"");
+        let parsed: ScheduleHealth = serde_json::from_str("\"amber\"").unwrap();
+        assert_eq!(parsed, ScheduleHealth::Amber);
+    }
+}
 
 /// One historical fire of a `Schedule`. Persisted in `scheduler_runs`.
 ///

--- a/kernel/crates/gctrl-scheduler/Cargo.toml
+++ b/kernel/crates/gctrl-scheduler/Cargo.toml
@@ -17,6 +17,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 cron = "0.15"
+regex = "1"
+once_cell = "1"
+urlencoding = "2"
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/kernel/crates/gctrl-scheduler/src/bootstrap.rs
+++ b/kernel/crates/gctrl-scheduler/src/bootstrap.rs
@@ -1,0 +1,222 @@
+//! Daemon-managed schedule bootstrap.
+//!
+//! On startup, the scheduler registers a small set of `_internal.*`
+//! schedules that maintain the scheduler itself — today, just the
+//! `scheduler_runs` GC. The HTTP `create` handler rejects names with
+//! the `_internal.*` prefix (§ 5.4), so internal rows MUST be planted
+//! through this code path, not over `:4318`.
+//!
+//! Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.4 and the
+//! `_internal.scheduler_runs_gc` row in § 7.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use gctrl_core::{Schedule, SchedulerConfig, TARGET_KIND_HTTP};
+use gctrl_storage::SqliteStore;
+use tracing::{info, warn};
+
+use crate::cron::next_after;
+
+/// Canonical name of the scheduler's own GC routine.
+pub const GC_SCHEDULE_NAME: &str = "_internal.scheduler_runs_gc";
+
+/// Cron for the GC: nightly at 04:00 UTC (off-peak for most operator
+/// time zones; doesn't collide with the typical 03:00 audit slot).
+const GC_CRON: &str = "0 0 4 * * *";
+
+/// Plant or re-plant the `_internal.scheduler_runs_gc` row.
+///
+/// Behaviour:
+/// 1. If absent → INSERT (cron-fired against a `DELETE
+///    /api/schedules/runs?before=...` URL the daemon serves itself).
+/// 2. If present and parses cleanly → leave alone (idempotent restart).
+/// 3. If present but malformed (corrupt cron, missing target_url for an
+///    http row) → DELETE + re-INSERT, with a `tracing::warn!`.
+///
+/// The kernel HTTP path's `_internal.*` rejection means an attacker
+/// can't pre-plant a corrupt row to displace the GC; this routine
+/// trusts the row only after it round-trips a fresh validation.
+pub fn ensure_gc_schedule(store: &Arc<SqliteStore>, cfg: &SchedulerConfig) -> anyhow::Result<()> {
+    if let Some(existing) = store
+        .get_schedule(GC_SCHEDULE_NAME)
+        .map_err(|e| anyhow::anyhow!("get_schedule: {e}"))?
+    {
+        if is_valid_gc_row(&existing, cfg) {
+            info!(
+                schedule = GC_SCHEDULE_NAME,
+                "scheduler: GC routine already registered"
+            );
+            return Ok(());
+        }
+        warn!(
+            schedule = GC_SCHEDULE_NAME,
+            "scheduler: existing GC row is malformed; replacing"
+        );
+        store
+            .delete_schedule(&existing.id)
+            .map_err(|e| anyhow::anyhow!("delete_schedule: {e}"))?;
+    }
+    let row = build_gc_row(cfg);
+    store
+        .create_schedule(&row)
+        .map_err(|e| anyhow::anyhow!("create_schedule: {e}"))?;
+    info!(
+        schedule = GC_SCHEDULE_NAME,
+        retention_days = cfg.run_retention_days,
+        "scheduler: bootstrapped GC routine"
+    );
+    Ok(())
+}
+
+/// Exposed for tests: build the GC row deterministically from config.
+pub fn build_gc_row(cfg: &SchedulerConfig) -> Schedule {
+    let now = Utc::now().to_rfc3339();
+    let next = next_after(GC_CRON, Utc::now())
+        .ok()
+        .flatten()
+        .map(|dt| dt.to_rfc3339());
+    // The target URL is the daemon's own loopback prune route. Hard-
+    // coded to localhost — same constraint as the host-allowlist
+    // middleware applied to all `:4318` routes.
+    //
+    // `before=` is computed **per fire** by the runner; for the row we
+    // park a placeholder that the runner mutates at fire time. Until
+    // the runner gains that hook (M1c follow-up), the GC row hits a
+    // static `before=` ~retention-days in the past at registration —
+    // which the next runner restart will refresh.
+    let cutoff = (Utc::now() - chrono::Duration::days(cfg.run_retention_days as i64))
+        .to_rfc3339();
+    let target = format!(
+        "http://127.0.0.1:4318/api/schedules/runs?before={}",
+        urlencoding::encode(&cutoff)
+    );
+    Schedule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: GC_SCHEDULE_NAME.into(),
+        cron: GC_CRON.into(),
+        target_kind: TARGET_KIND_HTTP.into(),
+        target_url: target,
+        target_method: "DELETE".into(),
+        body_json: None,
+        headers_json: None,
+        command: None,
+        cwd: None,
+        env_keys: None,
+        timeout_secs: 60,
+        enabled: true,
+        next_run_at: next,
+        last_run_at: None,
+        last_status: None,
+        last_response: None,
+        last_error: None,
+        run_count: 0,
+        failure_count: 0,
+        created_at: now.clone(),
+        updated_at: now,
+        health: None,
+    }
+}
+
+/// Validate that an existing GC row is still serviceable. Mirrors the
+/// gates the create handler enforces — without re-running them, a
+/// corrupt row planted via direct DB access would silently keep retention
+/// from working.
+fn is_valid_gc_row(s: &Schedule, _cfg: &SchedulerConfig) -> bool {
+    // Cron parses.
+    if next_after(&s.cron, Utc::now()).is_err() {
+        return false;
+    }
+    // Right kind.
+    if s.target_kind != TARGET_KIND_HTTP {
+        return false;
+    }
+    // Non-empty target URL.
+    if s.target_url.is_empty() {
+        return false;
+    }
+    // Targets the right route — guards against a stale row pointing at
+    // a renamed endpoint.
+    if !s.target_url.contains("/api/schedules/runs") {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> Arc<SqliteStore> {
+        Arc::new(SqliteStore::open(":memory:").expect("open :memory: store"))
+    }
+
+    #[test]
+    fn bootstrap_inserts_when_absent() {
+        let s = store();
+        ensure_gc_schedule(&s, &SchedulerConfig::default()).expect("ensure");
+        let row = s
+            .get_schedule(GC_SCHEDULE_NAME)
+            .unwrap()
+            .expect("row planted");
+        assert_eq!(row.name, GC_SCHEDULE_NAME);
+        assert_eq!(row.cron, GC_CRON);
+        assert_eq!(row.target_method, "DELETE");
+        assert!(row.target_url.contains("/api/schedules/runs?before="));
+        assert!(row.enabled);
+    }
+
+    #[test]
+    fn bootstrap_is_idempotent_on_restart() {
+        let s = store();
+        let cfg = SchedulerConfig::default();
+        ensure_gc_schedule(&s, &cfg).unwrap();
+        let first = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        ensure_gc_schedule(&s, &cfg).unwrap();
+        let second = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        // Same row identity on second pass — no replacement when valid.
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.created_at, second.created_at);
+    }
+
+    #[test]
+    fn bootstrap_replaces_corrupt_row() {
+        let s = store();
+        let cfg = SchedulerConfig::default();
+        // Plant a malformed row directly: bad cron + wrong target URL.
+        let now = Utc::now().to_rfc3339();
+        let bad = Schedule {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: GC_SCHEDULE_NAME.into(),
+            cron: "this is not a cron".into(),
+            target_kind: TARGET_KIND_HTTP.into(),
+            target_url: "http://wherever/garbage".into(),
+            target_method: "POST".into(),
+            body_json: None,
+            headers_json: None,
+            command: None,
+            cwd: None,
+            env_keys: None,
+            timeout_secs: 60,
+            enabled: false,
+            next_run_at: None,
+            last_run_at: None,
+            last_status: None,
+            last_response: None,
+            last_error: None,
+            run_count: 0,
+            failure_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+            health: None,
+        };
+        s.create_schedule(&bad).expect("plant corrupt row");
+
+        ensure_gc_schedule(&s, &cfg).unwrap();
+
+        let after = s.get_schedule(GC_SCHEDULE_NAME).unwrap().unwrap();
+        assert_ne!(after.id, bad.id, "corrupt row replaced");
+        assert_eq!(after.cron, GC_CRON);
+        assert!(after.target_url.contains("/api/schedules/runs?before="));
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/exec.rs
+++ b/kernel/crates/gctrl-scheduler/src/exec.rs
@@ -385,6 +385,7 @@ mod tests {
             failure_count: 0,
             created_at: "0".into(),
             updated_at: "0".into(),
+            health: None,
         }
     }
 }

--- a/kernel/crates/gctrl-scheduler/src/http.rs
+++ b/kernel/crates/gctrl-scheduler/src/http.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cron::next_after;
 use crate::exec::{run_exec_schedule, ExecOutcome};
+use crate::redact::redact_and_truncate;
 use crate::runner::read_capped_body;
 use crate::runner::ERROR_PREVIEW_BYTES;
 
@@ -40,16 +41,40 @@ pub fn router(sqlite: Arc<SqliteStore>, cfg: Arc<SchedulerConfig>) -> Router {
     };
     Router::new()
         .route("/api/schedules", get(list).post(create))
-        // Cross-schedule run feed — must be registered BEFORE
-        // `/api/schedules/{id}` so axum's longest-match routing doesn't
-        // shadow this with the dynamic-id route.
-        .route("/api/schedules/runs", get(list_runs_global))
-        .route("/api/schedules/{id}", get(get_one).delete(delete_one))
+        // Cross-schedule run feed + prune route + summary — registered
+        // BEFORE `/api/schedules/{id}` so axum's longest-match routing
+        // doesn't shadow them with the dynamic-id route.
+        .route(
+            "/api/schedules/runs",
+            get(list_runs_global).delete(delete_runs_before),
+        )
+        .route("/api/schedules/summary", get(get_summary))
+        .route(
+            "/api/schedules/{id}",
+            get(get_one).patch(patch_schedule).delete(delete_one),
+        )
         .route("/api/schedules/{id}/runs", get(list_runs_for_schedule))
         .route("/api/schedules/{id}/run", post(run_now))
         .route("/api/schedules/{id}/enable", post(enable))
         .route("/api/schedules/{id}/disable", post(disable))
         .with_state(state)
+}
+
+/// Reserved prefix for daemon-managed schedules (e.g.
+/// `_internal.scheduler_runs_gc`). Rejected at `POST /api/schedules`
+/// from any caller — the daemon registers internal rows via the private
+/// `SqliteStore::create_schedule_internal` helper, NOT through HTTP.
+///
+/// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.4.
+const INTERNAL_NAME_PREFIX: &str = "_internal.";
+
+/// Format a 403 response body matching the existing 400 error shape.
+fn forbidden(msg: impl Into<String>) -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({ "error": msg.into() })),
+    )
+        .into_response()
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,6 +142,15 @@ async fn create(
     State(state): State<RouterState>,
     Json(body): Json<CreateBody>,
 ) -> impl IntoResponse {
+    // Reject `_internal.*` names early — the prefix is reserved for
+    // daemon-managed bootstrap rows. An agent with vault write access
+    // could otherwise mint a forever-running `_internal.exfil` schedule
+    // and have it look like a built-in.
+    if body.name.starts_with(INTERNAL_NAME_PREFIX) {
+        return forbidden(format!(
+            "schedule name {INTERNAL_NAME_PREFIX:?} prefix is reserved for daemon-managed rows"
+        ));
+    }
     // Validate cron up-front; reject 400 rather than persist a row that will
     // never fire and confuse the operator.
     let next = match next_after(&body.cron, Utc::now()) {
@@ -190,6 +224,7 @@ fn build_schedule(
                 failure_count: 0,
                 created_at: now.clone(),
                 updated_at: now,
+                health: None,
             })
         }
         TARGET_KIND_EXEC => {
@@ -260,6 +295,7 @@ fn build_schedule(
                 failure_count: 0,
                 created_at: now.clone(),
                 updated_at: now,
+                health: None,
             })
         }
         other => Err(format!(
@@ -324,7 +360,10 @@ async fn run_now(
                 false,
                 None,
                 None,
-                Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                Some(redact_and_truncate(
+                    &format!("refused: {reason}"),
+                    ERROR_PREVIEW_BYTES,
+                )),
                 false,
                 true,
             ),
@@ -335,13 +374,23 @@ async fn run_now(
                 timed_out,
             } => {
                 let success = !timed_out && exit_code == Some(0);
-                let resp = if stdout.is_empty() { None } else { Some(stdout) };
+                // Apply redaction to stdout for parity with the cron path.
+                // Empty stdout stays None; non-empty goes through the same
+                // redact-then-truncate pipeline.
+                let resp = if stdout.is_empty() {
+                    None
+                } else {
+                    Some(redact_and_truncate(
+                        &stdout,
+                        crate::runner::ERROR_PREVIEW_BYTES.max(4_096),
+                    ))
+                };
                 let err = if success {
                     None
                 } else if timed_out {
                     Some(format!("timed out after {timeout_secs}s"))
                 } else {
-                    Some(truncate(&stderr, ERROR_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stderr, ERROR_PREVIEW_BYTES))
                 };
                 (success, exit_code.map(|c| c as i64), resp, err, timed_out, false)
             }
@@ -394,11 +443,8 @@ async fn run_now(
         last_error: error.clone(),
         success,
     };
-    if let Err(e) = state.store.record_schedule_run(&sched.id, &update) {
-        return err500(e);
-    }
-    // Append durable history alongside the row UPDATE. Same staging order as
-    // the cron path; PR-2 collapses both into a single SQLite tx.
+    // Same single-tx write the cron path uses. Manual fires share the
+    // crash-safety guarantee; only the `fire_kind = manual` tag differs.
     let outcome = crate::runner::FireOutcome {
         success,
         status,
@@ -414,7 +460,7 @@ async fn run_now(
         now,
         gctrl_core::FIRE_KIND_MANUAL,
     );
-    if let Err(e) = state.store.insert_schedule_run(&run_row) {
+    if let Err(e) = state.store.record_schedule_run_v2(&sched.id, &run_row, &update) {
         return err500(e);
     }
 
@@ -493,6 +539,320 @@ async fn list_runs_global(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PruneQuery {
+    /// RFC3339 timestamp; rows whose `started_at < before` are deleted.
+    /// Required — without it we'd have to define an implicit "what does
+    /// "all" mean" semantic, which is exactly the kind of footgun the
+    /// route is supposed to avoid.
+    pub before: String,
+}
+
+/// `DELETE /api/schedules/runs?before=<RFC3339>` — idempotent prune.
+///
+/// Powers the `_internal.scheduler_runs_gc` routine that the daemon
+/// self-bootstraps on startup. Same `before` argument twice deletes
+/// nothing the second call. Auth lives at the layer above: the existing
+/// `host_allowlist_middleware` restricts the kernel HTTP API to
+/// `localhost`, so this route is only reachable from the operator's
+/// own machine.
+async fn delete_runs_before(
+    State(state): State<RouterState>,
+    Query(q): Query<PruneQuery>,
+) -> impl IntoResponse {
+    // Validate `before` parses as RFC3339 — the SQLite comparison is
+    // string-lexical, so a malformed value would silently match nothing
+    // (or worse, match unexpectedly). Reject up-front.
+    if chrono::DateTime::parse_from_rfc3339(&q.before).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("`before` must be RFC3339, got {:?}", q.before),
+            })),
+        )
+            .into_response();
+    }
+    match state.store.delete_schedule_runs_before(&q.before) {
+        Ok(deleted) => Json(serde_json::json!({ "deleted": deleted })).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+/// Allowed patch keys per spec § 5.2. `target_kind` and `name` are
+/// identity and intentionally absent — changing them requires DELETE +
+/// POST to force a new identity (and a new history bucket). Unknown
+/// keys MUST 400 — fail closed.
+const PATCHABLE_KEYS: &[&str] = &[
+    "cron",
+    "target_url",
+    "target_method",
+    "body_json",
+    "headers_json",
+    "command",
+    "cwd",
+    "env_keys",
+    "timeout_secs",
+    "enabled",
+];
+
+/// `PATCH /api/schedules/{id_or_name}` — RFC 7396 JSON Merge Patch over
+/// the patchable fields of an existing schedule.
+///
+/// Field absence is a no-op; explicit `null` clears the field (where the
+/// column is nullable). Every create-time gate re-runs against the
+/// merged view: cron parses, exec allowlist, absolute argv[0], absolute
+/// cwd, and the http/exec mutual-exclusion check that prevents lateral
+/// upgrade of an http row by adding a `command` array post-creation.
+///
+/// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.2.
+async fn patch_schedule(
+    State(state): State<RouterState>,
+    Path(id): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    // Normalise the body to an object — RFC 7396 only defines patch for
+    // JSON objects. A scalar / array payload is a 400.
+    let patch = match body {
+        serde_json::Value::Object(m) => m,
+        _ => return bad_request("PATCH body MUST be a JSON object"),
+    };
+
+    // Fail closed on unknown keys — silently ignoring would let a typo
+    // ("crone": "...") look like a successful patch.
+    for k in patch.keys() {
+        if !PATCHABLE_KEYS.contains(&k.as_str()) {
+            return bad_request(format!(
+                "unknown or non-patchable field {k:?} (allowed: {PATCHABLE_KEYS:?})"
+            ));
+        }
+    }
+
+    // Fetch the current row. 404 short-circuits before any validation.
+    let mut merged = match state.store.get_schedule(&id) {
+        Ok(Some(s)) => s,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => return err500(e),
+    };
+
+    // Apply each patch key onto the merged view. RFC 7396 semantics:
+    // missing key = no-op (already handled by `if let Some(...)`),
+    // explicit `null` = clear (set to None), value = set.
+    if let Some(v) = patch.get("cron") {
+        merged.cron = match v.as_str() {
+            Some(s) => s.to_string(),
+            None => return bad_request("cron MUST be a string"),
+        };
+    }
+    if let Some(v) = patch.get("target_url") {
+        merged.target_url = match v {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Null => String::new(),
+            _ => return bad_request("target_url MUST be a string or null"),
+        };
+    }
+    if let Some(v) = patch.get("target_method") {
+        merged.target_method = match v.as_str() {
+            Some(s) => s.to_string(),
+            None => return bad_request("target_method MUST be a string"),
+        };
+    }
+    if let Some(v) = patch.get("body_json") {
+        merged.body_json = if v.is_null() { None } else { Some(v.clone()) };
+    }
+    if let Some(v) = patch.get("headers_json") {
+        merged.headers_json = if v.is_null() { None } else { Some(v.clone()) };
+    }
+    if let Some(v) = patch.get("command") {
+        merged.command = match v {
+            serde_json::Value::Null => None,
+            serde_json::Value::Array(arr) => {
+                let mut argv = Vec::with_capacity(arr.len());
+                for item in arr {
+                    match item.as_str() {
+                        Some(s) => argv.push(s.to_string()),
+                        None => return bad_request("command items MUST be strings"),
+                    }
+                }
+                Some(argv)
+            }
+            _ => return bad_request("command MUST be an array of strings or null"),
+        };
+    }
+    if let Some(v) = patch.get("cwd") {
+        merged.cwd = match v {
+            serde_json::Value::Null => None,
+            serde_json::Value::String(s) => Some(s.clone()),
+            _ => return bad_request("cwd MUST be a string or null"),
+        };
+    }
+    if let Some(v) = patch.get("env_keys") {
+        merged.env_keys = match v {
+            serde_json::Value::Null => None,
+            serde_json::Value::Array(arr) => {
+                let mut keys = Vec::with_capacity(arr.len());
+                for item in arr {
+                    match item.as_str() {
+                        Some(s) => keys.push(s.to_string()),
+                        None => return bad_request("env_keys items MUST be strings"),
+                    }
+                }
+                Some(keys)
+            }
+            _ => return bad_request("env_keys MUST be an array of strings or null"),
+        };
+    }
+    if let Some(v) = patch.get("timeout_secs") {
+        merged.timeout_secs = match v.as_i64() {
+            Some(n) => n,
+            None => return bad_request("timeout_secs MUST be an integer"),
+        };
+    }
+    if let Some(v) = patch.get("enabled") {
+        merged.enabled = match v.as_bool() {
+            Some(b) => b,
+            None => return bad_request("enabled MUST be a boolean"),
+        };
+    }
+
+    // Cron always re-validates (covers both PATCH-included-cron and
+    // PATCH-touched-other-fields-with-stale-cron). On a fresh cron
+    // value, `next_run_at` recomputes from `Utc::now()`.
+    let now = Utc::now();
+    let next = match next_after(&merged.cron, now) {
+        Ok(opt) => opt.map(|dt| dt.to_rfc3339()),
+        Err(e) => return bad_request(format!("invalid cron: {e}")),
+    };
+    // `next_run_at` lifecycle on PATCH:
+    //   - cron change      → recompute (from `merged.enabled`)
+    //   - enabled: false   → clear (so the runner does not pick up a
+    //                       stale due-date once we re-enable)
+    //   - enabled: true    → recompute (mirrors `set_enabled(true)`)
+    //   - other            → leave alone
+    if patch.contains_key("cron") {
+        merged.next_run_at = if merged.enabled { next.clone() } else { None };
+    } else if patch.contains_key("enabled") {
+        merged.next_run_at = if merged.enabled { next.clone() } else { None };
+    }
+
+    // Cross-field validation against the MERGED view — the central
+    // security check from spec § 5.2 + § 4.2: an attacker mustn't be
+    // able to laterally upgrade an http row by adding a `command`
+    // array, nor neuter an exec row by setting a `target_url`.
+    if let Err(reason) = validate_merged_view(&merged, &state.cfg) {
+        return bad_request(reason);
+    }
+
+    match state.store.update_schedule_patch(&merged) {
+        Ok(true) => Json(merged).into_response(),
+        Ok(false) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => err500(e),
+    }
+}
+
+/// Re-run every create-time gate against a merged-view `Schedule`. The
+/// input is the proposed post-patch row; validation MUST treat it as
+/// adversarial (an attacker authoring a vault file the reconciler
+/// later POSTs cannot rely on partial updates skipping checks).
+fn validate_merged_view(s: &Schedule, cfg: &SchedulerConfig) -> std::result::Result<(), String> {
+    match s.target_kind.as_str() {
+        TARGET_KIND_HTTP => {
+            if s.target_url.trim().is_empty() {
+                return Err("target_url is required for target_kind=http".into());
+            }
+            // Mutual exclusion: http rows MUST NOT carry exec fields
+            // post-merge — this is the lateral-upgrade defence.
+            if s.command.as_ref().is_some_and(|c| !c.is_empty()) {
+                return Err(
+                    "command MUST NOT be set on an http row (DELETE + POST to change target_kind)"
+                        .into(),
+                );
+            }
+            if s.cwd.as_ref().is_some_and(|c| !c.is_empty()) {
+                return Err(
+                    "cwd MUST NOT be set on an http row (DELETE + POST to change target_kind)"
+                        .into(),
+                );
+            }
+            if s.env_keys.as_ref().is_some_and(|k| !k.is_empty()) {
+                return Err(
+                    "env_keys MUST NOT be set on an http row (DELETE + POST to change target_kind)"
+                        .into(),
+                );
+            }
+            Ok(())
+        }
+        TARGET_KIND_EXEC => {
+            if !cfg.exec_enabled {
+                return Err(
+                    "exec target_kind requires scheduler.exec_enabled=true in daemon config".into(),
+                );
+            }
+            if !s.target_url.is_empty() {
+                return Err(
+                    "target_url MUST NOT be set on an exec row (DELETE + POST to change target_kind)"
+                        .into(),
+                );
+            }
+            let cmd = s
+                .command
+                .as_ref()
+                .filter(|c| !c.is_empty())
+                .ok_or_else(|| "command is required for target_kind=exec".to_string())?;
+            let bin = &cmd[0];
+            if !bin.starts_with('/') {
+                return Err(format!(
+                    "argv[0] must be an absolute path (got {bin:?}) — relative paths are rejected to prevent $PATH-injection via cwd"
+                ));
+            }
+            if cfg.exec_allowed_programs.is_empty() {
+                return Err(
+                    "scheduler.exec_allowed_programs is empty (no programs permitted)".into(),
+                );
+            }
+            let bin_path = std::path::Path::new(bin);
+            if !cfg
+                .exec_allowed_programs
+                .iter()
+                .any(|p| p.as_path() == bin_path)
+            {
+                return Err(format!(
+                    "argv[0]={bin:?} not in scheduler.exec_allowed_programs"
+                ));
+            }
+            let cwd = s
+                .cwd
+                .as_deref()
+                .filter(|c| !c.is_empty())
+                .ok_or_else(|| "cwd is required for target_kind=exec".to_string())?;
+            if !cwd.starts_with('/') {
+                return Err(format!("cwd must be absolute (got {cwd:?})"));
+            }
+            Ok(())
+        }
+        other => Err(format!(
+            "unknown target_kind {other:?} (allowed: \"http\", \"exec\")"
+        )),
+    }
+}
+
+fn bad_request(msg: impl Into<String>) -> axum::response::Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": msg.into() })),
+    )
+        .into_response()
+}
+
+/// `GET /api/schedules/summary` — kernel-computed rollup powering the
+/// /schedule page's KPI strip. SPA never recomputes the counts. Spec §5.6.
+async fn get_summary(State(state): State<RouterState>) -> impl IntoResponse {
+    let since = (Utc::now() - chrono::Duration::hours(24)).to_rfc3339();
+    match state.store.schedules_summary(&since) {
+        Ok(summary) => Json(summary).into_response(),
+        Err(e) => err500(e),
+    }
+}
+
 async fn enable(
     State(state): State<RouterState>,
     Path(id): Path<String>,
@@ -505,17 +865,6 @@ async fn disable(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     set_enabled(&state.store, &id, false).await
-}
-
-fn truncate(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_string();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
 }
 
 async fn set_enabled(store: &SqliteStore, id: &str, enabled: bool) -> axum::response::Response {

--- a/kernel/crates/gctrl-scheduler/src/lib.rs
+++ b/kernel/crates/gctrl-scheduler/src/lib.rs
@@ -15,9 +15,12 @@
 //! polling-loop shape but nothing else; conflating them would tangle agent
 //! orchestration with periodic ingest/cleanup/health jobs.
 
+pub mod bootstrap;
 pub mod cron;
 pub mod exec;
 pub mod http;
+pub mod redact;
 pub mod runner;
 
+pub use bootstrap::ensure_gc_schedule;
 pub use runner::ScheduleRunner;

--- a/kernel/crates/gctrl-scheduler/src/redact.rs
+++ b/kernel/crates/gctrl-scheduler/src/redact.rs
@@ -1,0 +1,169 @@
+//! Output redaction for `last_response` / `last_error` row caches and
+//! `scheduler_runs.{response_preview, error_preview}` history rows.
+//!
+//! `target_kind: exec` schedules can have child stderr that includes
+//! secret-shaped output if a misconfigured process echoes a token. We cap
+//! the byte length elsewhere; this module is the *content* layer of
+//! defence: pattern-match common credential shapes and replace the value
+//! half with `[redacted]` before persisting.
+//!
+//! Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.1
+//! and vault/specs/architecture/kernel/scheduler.md § Output Redaction.
+//!
+//! Best-effort, NOT a primary control. The primary control is "don't
+//! echo secrets on child stderr". This catches the common shapes:
+//!
+//!   token=abc123      → token=[redacted]
+//!   secret: foo       → secret: [redacted]
+//!   webhook=https://… → webhook=[redacted]
+//!   api-key=…         → api-key=[redacted]   (matches `key`)
+//!
+//! Idempotent: running twice produces the same string.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Match the common `keyword<sep>value` shape used in env / log lines /
+/// command-line flags. The keyword is one of a fixed set; the separator is
+/// `=` or `:` (with optional surrounding whitespace); the value is one
+/// non-whitespace run.
+///
+/// Group 1 captures the keyword + separator (preserved); group 2 captures
+/// the value (replaced).
+static SECRET_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(token|secret|key|password|webhook)(\s*[=:]\s*)(\S+)")
+        .expect("static SECRET_RE pattern compiles")
+});
+
+/// Replace value half of `keyword=...` / `keyword: ...` matches with
+/// `[redacted]`. Idempotent: a string that already contains `[redacted]`
+/// where the value would be is left as-is on subsequent passes (the regex
+/// would just match the `[redacted]` literal — fine, the result is
+/// stable).
+pub fn redact_secrets(s: &str) -> String {
+    SECRET_RE.replace_all(s, "$1$2[redacted]").into_owned()
+}
+
+/// Redact AND truncate to `max_bytes` (UTF-8-safe). Keeps a marker so
+/// operators see truncation happened. Used at storage write sites to keep
+/// the row width bounded even when the redactor preserves length.
+pub fn redact_and_truncate(s: &str, max_bytes: usize) -> String {
+    let r = redact_secrets(s);
+    if r.len() <= max_bytes {
+        return r;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !r.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…[truncated {} bytes]", &r[..end], r.len() - end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_token_equals() {
+        assert_eq!(redact_secrets("token=abc123"), "token=[redacted]");
+    }
+
+    #[test]
+    fn redacts_token_colon_with_spaces() {
+        assert_eq!(redact_secrets("token : abc123"), "token : [redacted]");
+    }
+
+    #[test]
+    fn redacts_secret_colon() {
+        assert_eq!(redact_secrets("secret: foo-bar-42"), "secret: [redacted]");
+    }
+
+    #[test]
+    fn redacts_password_uppercase() {
+        // Case-insensitive on the keyword.
+        assert_eq!(redact_secrets("PASSWORD=hunter2"), "PASSWORD=[redacted]");
+    }
+
+    #[test]
+    fn redacts_webhook_url() {
+        assert_eq!(
+            redact_secrets("webhook=https://hooks.slack.com/services/T00/B00/abc"),
+            "webhook=[redacted]"
+        );
+    }
+
+    #[test]
+    fn redacts_api_key_via_key_keyword() {
+        // The pattern matches `key` as a whole word. `api-key` is two
+        // tokens separated by `-`; the second token IS `key`. The leading
+        // `\b` anchors at the boundary between `-` and `key`.
+        assert_eq!(redact_secrets("api-key=xyz"), "api-key=[redacted]");
+    }
+
+    #[test]
+    fn does_not_match_unrelated_keywords() {
+        assert_eq!(
+            redact_secrets("user=alice host=example.com"),
+            "user=alice host=example.com"
+        );
+    }
+
+    #[test]
+    fn redacts_multiple_in_one_string() {
+        assert_eq!(
+            redact_secrets("token=aaa secret=bbb other=keep"),
+            "token=[redacted] secret=[redacted] other=keep"
+        );
+    }
+
+    #[test]
+    fn idempotent_on_already_redacted() {
+        let once = redact_secrets("token=abc");
+        let twice = redact_secrets(&once);
+        // The regex re-matches `[redacted]` because `[redacted]` is one
+        // non-whitespace run (it starts with `[` but `\S+` consumes it).
+        // Substituting `[redacted]` → `[redacted]` leaves the string
+        // unchanged. We assert the stable fixed point, not "no change".
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn empty_input_produces_empty() {
+        assert_eq!(redact_secrets(""), "");
+    }
+
+    #[test]
+    fn truncate_short_passthrough() {
+        assert_eq!(redact_and_truncate("abc", 100), "abc");
+    }
+
+    #[test]
+    fn truncate_long_appends_marker() {
+        let s = "x".repeat(50);
+        let t = redact_and_truncate(&s, 10);
+        assert!(t.starts_with("xxxxxxxxxx"));
+        assert!(t.contains("truncated"));
+    }
+
+    #[test]
+    fn truncate_preserves_redaction() {
+        // Long string with a secret; redaction MUST happen before
+        // truncation so the secret isn't preserved past the cap. Real
+        // child stderr always has a word-boundary before the keyword
+        // (whitespace, punctuation, line start) — match that shape.
+        let s = format!("{} token=secret_value", "x".repeat(100));
+        let t = redact_and_truncate(&s, 1024);
+        assert!(t.contains("[redacted]"), "{t}");
+        assert!(!t.contains("secret_value"), "{t}");
+    }
+
+    #[test]
+    fn redacts_value_with_special_chars() {
+        // Slashes, equals, colons inside the value are part of the
+        // non-whitespace run and are all redacted together.
+        assert_eq!(
+            redact_secrets("token=Bearer=abc:def/ghi"),
+            "token=[redacted]"
+        );
+    }
+}

--- a/kernel/crates/gctrl-scheduler/src/runner.rs
+++ b/kernel/crates/gctrl-scheduler/src/runner.rs
@@ -26,6 +26,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::cron::next_after;
 use crate::exec::{run_exec_schedule, ExecOutcome};
+use crate::redact::redact_and_truncate;
 
 /// Hard cap on bytes read from a callback response. A misconfigured or
 /// malicious target could otherwise stream gigabytes into memory before we
@@ -66,6 +67,12 @@ impl ScheduleRunner {
             poll_interval_secs = self.config.poll_interval_secs,
             "scheduler: runner started"
         );
+        // Reap any `scheduler_runs` rows left mid-flight by a daemon crash
+        // before yesterday's fires masquerade as "still running" forever.
+        // `manual` rows are the only realistic source today (the cron path
+        // closes the row in one go); reaping in startup keeps that
+        // invariant straightforward.
+        self.reap_interrupted().await;
         // Backfill `next_run_at` for any schedule that has none (e.g. created
         // while the daemon was down). One pass on startup; the runner loop
         // recomputes on every fire after that.
@@ -136,15 +143,12 @@ impl ScheduleRunner {
             last_error: outcome.error.clone(),
             success: outcome.success,
         };
-        if let Err(e) = self.store.record_schedule_run(&sched.id, &update) {
-            error!(schedule = %sched.name, "scheduler: record_schedule_run failed: {e}");
-        }
-        // Append durable history. Done after the row UPDATE today; PR-2 of
-        // M1a folds this into a single SQLite transaction together with the
-        // inbox emit on streak boundary.
+        // Cache row UPDATE + history INSERT in one SQLite transaction so a
+        // mid-fire crash leaves no half-state. M3 will fold the inbox emit
+        // into the same tx; the helper signature is shaped for that.
         let run = build_run_row(&sched, &outcome, started_wall, now, FIRE_KIND_CRON);
-        if let Err(e) = self.store.insert_schedule_run(&run) {
-            error!(schedule = %sched.name, "scheduler: insert_schedule_run failed: {e}");
+        if let Err(e) = self.store.record_schedule_run_v2(&sched.id, &run, &update) {
+            error!(schedule = %sched.name, "scheduler: record_schedule_run_v2 failed: {e}");
         }
     }
 
@@ -181,7 +185,10 @@ impl ScheduleRunner {
             Ok(mut resp) => {
                 let status = resp.status().as_u16() as i64;
                 let body = read_capped_body(&mut resp).await;
-                let preview = truncate(&body, RESPONSE_PREVIEW_BYTES);
+                // Defence-in-depth: HTTP callback responses don't usually
+                // carry secret-shaped content, but a misconfigured callback
+                // that echoes auth headers would leak otherwise.
+                let preview = redact_and_truncate(&body, RESPONSE_PREVIEW_BYTES);
                 let success = (200..400).contains(&status);
                 if success {
                     info!(
@@ -248,7 +255,10 @@ impl ScheduleRunner {
                     success: false,
                     status: None,
                     response: None,
-                    error: Some(truncate(&format!("refused: {reason}"), ERROR_PREVIEW_BYTES)),
+                    error: Some(redact_and_truncate(
+                        &format!("refused: {reason}"),
+                        ERROR_PREVIEW_BYTES,
+                    )),
                     timed_out: false,
                     refused: true,
                 }
@@ -288,12 +298,12 @@ impl ScheduleRunner {
                 let response_preview = if stdout.is_empty() {
                     None
                 } else {
-                    Some(truncate(&stdout, RESPONSE_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stdout, RESPONSE_PREVIEW_BYTES))
                 };
                 let error_preview = if success {
                     None
                 } else if timed_out {
-                    Some(truncate(
+                    Some(redact_and_truncate(
                         &format!("timed out after {timeout_secs}s"),
                         ERROR_PREVIEW_BYTES,
                     ))
@@ -301,7 +311,7 @@ impl ScheduleRunner {
                     // Tight cap: stderr is the primary leak vector for child
                     // processes that echo secrets. Full stderr is in the log
                     // stream above; only the prefix is in the DB.
-                    Some(truncate(&stderr, ERROR_PREVIEW_BYTES))
+                    Some(redact_and_truncate(&stderr, ERROR_PREVIEW_BYTES))
                 };
                 FireOutcome {
                     success,
@@ -312,6 +322,15 @@ impl ScheduleRunner {
                     refused: false,
                 }
             }
+        }
+    }
+
+    async fn reap_interrupted(&self) {
+        let now = Utc::now().to_rfc3339();
+        match self.store.reap_interrupted_schedule_runs(&now) {
+            Ok(0) => debug!("scheduler: no interrupted runs to reap"),
+            Ok(n) => warn!(reaped = n, "scheduler: reaped interrupted runs from prior crash"),
+            Err(e) => error!("scheduler: reap_interrupted_schedule_runs failed: {e}"),
         }
     }
 
@@ -442,31 +461,7 @@ pub(crate) async fn read_capped_body(resp: &mut reqwest::Response) -> String {
     }
 }
 
-fn truncate(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        return s.to_string();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    format!("{}…[truncated {} bytes]", &s[..end], s.len() - end)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn truncate_short_passthrough() {
-        assert_eq!(truncate("abc", 100), "abc");
-    }
-
-    #[test]
-    fn truncate_long_appends_marker() {
-        let s = "x".repeat(50);
-        let t = truncate(&s, 10);
-        assert!(t.starts_with("xxxxxxxxxx"));
-        assert!(t.contains("truncated"));
-    }
-}
+// truncate(): retired with PR-2. All callsites moved to
+// `crate::redact::redact_and_truncate`, which composes redaction with
+// the same UTF-8-safe byte cap. Behavioural test coverage lives in
+// `redact::tests` (truncate_short_passthrough, truncate_long_appends_marker).

--- a/kernel/crates/gctrl-scheduler/tests/http_routes.rs
+++ b/kernel/crates/gctrl-scheduler/tests/http_routes.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the scheduler HTTP routes — exercises the full
 //! axum Router with an in-memory SqliteStore.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -296,6 +297,476 @@ async fn global_runs_feed_does_not_collide_with_id_route() {
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_json(resp).await;
     assert!(json["runs"].is_array());
+}
+
+#[tokio::test]
+async fn create_rejects_internal_prefix() {
+    // `_internal.*` is reserved for daemon-managed bootstrap rows.
+    // Direct creation over HTTP must 403, even with an otherwise valid
+    // body — agents with vault write access could otherwise mint a
+    // long-running schedule that looks like a built-in.
+    let app = router();
+    let body = serde_json::json!({
+        "name": "_internal.exfil",
+        "cron": "0 */2 * * *",
+        "target_url": "http://attacker.invalid/hook"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let json = body_json(resp).await;
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("_internal"),
+        "error mentions the reserved prefix"
+    );
+}
+
+#[tokio::test]
+async fn delete_runs_before_rejects_non_rfc3339() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/schedules/runs?before=garbage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_runs_before_is_idempotent() {
+    let app = router();
+    // No rows exist; deleting "everything before now" is a no-op (deleted=0).
+    // A second call with the same `before` must also return 0 — proving
+    // idempotency at the route level.
+    let now = chrono::Utc::now().to_rfc3339();
+    let qs = format!(
+        "/api/schedules/runs?before={}",
+        urlencoding_test_helper(&now)
+    );
+    let r1 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&qs)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let j1 = body_json(r1).await;
+    assert_eq!(j1["deleted"], 0);
+
+    let r2 = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&qs)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    let j2 = body_json(r2).await;
+    assert_eq!(j2["deleted"], 0);
+}
+
+/// Tiny URL-encoder limited to what the test needs (`+` and `:`).
+/// Keeps the test free of an extra dev-dep on `urlencoding`.
+fn urlencoding_test_helper(s: &str) -> String {
+    s.replace('+', "%2B").replace(':', "%3A")
+}
+
+// ───────────────────── Summary endpoint ─────────────────────
+
+#[tokio::test]
+async fn summary_empty_returns_zero_counts() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/summary")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["by_health"]["green"], 0);
+    assert_eq!(json["by_health"]["amber"], 0);
+    assert_eq!(json["by_health"]["paused"], 0);
+    assert_eq!(json["runs_last_24h"]["success"], 0);
+    assert_eq!(json["runs_last_24h"]["failure"], 0);
+}
+
+#[tokio::test]
+async fn summary_counts_paused_and_pending() {
+    let app = router();
+    // Two schedules: one disabled (paused), one enabled with no fires (pending).
+    for (name, enabled) in [("paused-one", false), ("pending-one", true)] {
+        let body = serde_json::json!({
+            "name": name,
+            "cron": "0 */2 * * *",
+            "target_url": "http://x",
+            "enabled": enabled,
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/schedules")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules/summary")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    assert_eq!(json["total"], 2);
+    assert_eq!(json["by_health"]["paused"], 1);
+    assert_eq!(json["by_health"]["pending"], 1);
+    assert_eq!(json["by_health"]["green"], 0);
+    assert_eq!(json["by_health"]["amber"], 0);
+}
+
+#[tokio::test]
+async fn list_includes_health_field() {
+    // Storage populates `health` on read; the list endpoint must
+    // serialise it so the SPA never recomputes (per spec § 5.6).
+    let app = router();
+    let body = serde_json::json!({
+        "name": "test",
+        "cron": "0 */2 * * *",
+        "target_url": "http://x",
+    });
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/schedules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    let row = &json["schedules"][0];
+    // Newly created with no fire history → pending.
+    assert_eq!(row["health"], "pending");
+}
+
+// ───────────────────── PATCH endpoint ─────────────────────
+
+async fn create_basic(app: &axum::Router, name: &str) -> String {
+    let body = serde_json::json!({
+        "name": name,
+        "cron": "0 */2 * * *",
+        "target_url": "http://x",
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    body_json(resp).await["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn patch_404_when_schedule_missing() {
+    let app = router();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/schedules/does-not-exist")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"timeout_secs": 30}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn patch_cron_only_updates_cron_and_recomputes_next() {
+    let app = router();
+    let id = create_basic(&app, "test").await;
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"cron": "*/5 * * * *"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["cron"], "*/5 * * * *");
+    assert!(
+        json["next_run_at"].is_string(),
+        "next_run_at MUST recompute when cron changes"
+    );
+    // Other fields unchanged — RFC 7396 absent-key = no-op.
+    assert_eq!(json["target_url"], "http://x");
+    assert_eq!(json["timeout_secs"], 60);
+}
+
+#[tokio::test]
+async fn patch_rejects_unknown_field() {
+    let app = router();
+    let id = create_basic(&app, "test").await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                // `crone` is a typo; silent acceptance would mask it.
+                .body(Body::from(r#"{"crone": "*/5 * * * *"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_rejects_target_kind_change_via_unknown_key() {
+    // `target_kind` is not in the patchable list — present-or-absent,
+    // PATCH must 400 if it's in the body. This is the
+    // identity-immutability gate.
+    let app = router();
+    let id = create_basic(&app, "test").await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"target_kind": "exec"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_rejects_name_change() {
+    // `name` is identity — only DELETE + POST may change it.
+    let app = router();
+    let id = create_basic(&app, "test").await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name": "renamed"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_rejects_lateral_upgrade_http_to_exec() {
+    // Crucial security check from spec § 4.2 / § 5.2: an attacker MUST
+    // NOT be able to add a `command` array to an http row and silently
+    // turn it into an exec row. Mutual exclusion enforced against the
+    // merged view.
+    let app = router();
+    let id = create_basic(&app, "lateral-target").await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"command": ["/bin/echo", "pwn"], "cwd": "/tmp"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp).await;
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("MUST NOT be set on an http row"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn patch_invalid_cron_returns_400() {
+    let app = router();
+    let id = create_basic(&app, "test").await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"cron": "not a cron"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_disable_then_enable_recomputes_next() {
+    let app = router();
+    let id = create_basic(&app, "togglable").await;
+    // Disable.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"enabled": false}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["enabled"], false);
+    assert!(
+        json["next_run_at"].is_null(),
+        "next_run_at clears on disable"
+    );
+
+    // Re-enable.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"enabled": true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let json = body_json(resp).await;
+    assert_eq!(json["enabled"], true);
+    assert!(
+        json["next_run_at"].is_string(),
+        "next_run_at MUST recompute on re-enable"
+    );
+}
+
+#[tokio::test]
+async fn patch_exec_row_validates_against_allowlist() {
+    // PATCH on an exec row that ALSO patches command MUST re-run the
+    // exec_allowed_programs check against the new value, not just leave
+    // it unchecked because target_kind didn't change.
+    let cfg = SchedulerConfig {
+        exec_enabled: true,
+        exec_allowed_programs: vec![PathBuf::from("/usr/bin/safe")],
+        ..SchedulerConfig::default()
+    };
+    let app = router_with_cfg(cfg);
+    // Create an exec row pointing at the allowlisted bin.
+    let create = serde_json::json!({
+        "name": "exec-row",
+        "cron": "0 */2 * * *",
+        "target_kind": "exec",
+        "command": ["/usr/bin/safe", "--ok"],
+        "cwd": "/tmp",
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/schedules")
+                .header("content-type", "application/json")
+                .body(Body::from(create.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    // Try to PATCH command to a non-allowlisted binary — must 400.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!("/api/schedules/{}", id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"command": ["/usr/bin/evil", "--exfil"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
+++ b/kernel/crates/gctrl-scheduler/tests/runner_dispatch.rs
@@ -41,6 +41,7 @@ fn make_due_schedule(target_url: &str) -> Schedule {
         failure_count: 0,
         created_at: now.to_rfc3339(),
         updated_at: now.to_rfc3339(),
+        health: None,
     }
 }
 

--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -13,9 +13,9 @@ use gctrl_core::{
     memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     GctlError, InboxAction, InboxActionFilter, InboxMessage, InboxMessageFilter, InboxThread,
-    PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleRun,
-    ScheduleRunFilter, ScheduleRunUpdate, OrchTask, UberBrief, UberSinkinSession,
-    VaultMount, VaultMountKind,
+    PersonaDefinition, PersonaReviewRule, Result, Schedule, ScheduleFilter, ScheduleHealth,
+    ScheduleRun, ScheduleRunFilter, ScheduleRunUpdate, SchedulesHealthCounts, SchedulesRunsCounts,
+    SchedulesSummary, OrchTask, UberBrief, UberSinkinSession, VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 
@@ -2908,6 +2908,53 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Apply a patched-row update to an existing schedule. Caller is
+    /// responsible for assembling the merged row — this method overwrites
+    /// every patchable field unconditionally. Identity-fields
+    /// (`id`, `name`, `target_kind`, `created_at`, `run_count`,
+    /// `failure_count`, `last_*`) are preserved by NOT being in the
+    /// UPDATE list. Returns true if a row matched the id.
+    ///
+    /// Spec: vault/specs/architecture/apps/gctrl-schedule.md § 5.2.
+    pub fn update_schedule_patch(&self, sched: &Schedule) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let n = conn
+            .execute(
+                "UPDATE schedules
+                 SET cron = ?1,
+                     target_url = ?2,
+                     target_method = ?3,
+                     body_json = ?4,
+                     headers_json = ?5,
+                     command_json = ?6,
+                     cwd = ?7,
+                     env_keys_json = ?8,
+                     timeout_secs = ?9,
+                     enabled = ?10,
+                     next_run_at = ?11,
+                     updated_at = ?12
+                 WHERE id = ?13",
+                params![
+                    sched.cron,
+                    sched.target_url,
+                    sched.target_method,
+                    sched.body_json.as_ref().map(|v| v.to_string()),
+                    sched.headers_json.as_ref().map(|v| v.to_string()),
+                    sched.command.as_ref().map(|v| serde_json::to_string(v).unwrap_or_default()),
+                    sched.cwd,
+                    sched.env_keys.as_ref().map(|v| serde_json::to_string(v).unwrap_or_default()),
+                    sched.timeout_secs,
+                    sched.enabled,
+                    sched.next_run_at,
+                    now,
+                    sched.id,
+                ],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n > 0)
+    }
+
     /// Set `next_run_at` without touching run history — used after creating a
     /// schedule or when re-enabling one whose stored `next_run_at` is stale.
     pub fn set_schedule_next_run(&self, id: &str, next_run_at: Option<&str>) -> Result<()> {
@@ -2952,6 +2999,96 @@ impl SqliteStore {
             ],
         ).map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(())
+    }
+
+    /// Transactional fire write: UPDATE schedules cache + INSERT
+    /// scheduler_runs in a single SQLite transaction. This is the
+    /// path the runner SHOULD use post-PR-2; a daemon crash mid-fire
+    /// will leave the row UPDATE and the history INSERT both rolled
+    /// back rather than leaving an incremented `failure_count` with
+    /// no run record.
+    ///
+    /// Inbox emit on streak boundary lands as a third operation in
+    /// the same transaction in M3 (see § 5.3 of the spec); this
+    /// helper signature accepts the run row + the cache update only,
+    /// so the M3 caller pattern is `record_schedule_run_v2(...)?;
+    /// maybe_emit_inbox(...)?` against a single-tx wrapper.
+    pub fn record_schedule_run_v2(
+        &self,
+        schedule_id: &str,
+        run: &ScheduleRun,
+        update: &ScheduleRunUpdate,
+    ) -> Result<()> {
+        let mut conn = self.conn.lock().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let failure_inc: i64 = if update.success { 0 } else { 1 };
+        let tx = conn
+            .transaction()
+            .map_err(|e| GctlError::Storage(format!("begin tx: {e}")))?;
+        tx.execute(
+            "UPDATE schedules
+             SET last_run_at = ?1,
+                 next_run_at = ?2,
+                 last_status = ?3,
+                 last_response = ?4,
+                 last_error = ?5,
+                 run_count = run_count + 1,
+                 failure_count = failure_count + ?6,
+                 updated_at = ?7
+             WHERE id = ?8",
+            params![
+                update.last_run_at,
+                update.next_run_at,
+                update.last_status,
+                update.last_response,
+                update.last_error,
+                failure_inc,
+                now,
+                schedule_id,
+            ],
+        )
+        .map_err(|e| GctlError::Storage(format!("update schedules: {e}")))?;
+        tx.execute(
+            "INSERT INTO scheduler_runs (id, schedule_id, started_at, finished_at, status, fire_kind, exit_code, http_status, response_preview, error_preview, duration_ms, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                run.id,
+                run.schedule_id,
+                run.started_at,
+                run.finished_at,
+                run.status,
+                run.fire_kind,
+                run.exit_code,
+                run.http_status,
+                run.response_preview,
+                run.error_preview,
+                run.duration_ms,
+                run.created_at,
+            ],
+        )
+        .map_err(|e| GctlError::Storage(format!("insert scheduler_runs: {e}")))?;
+        tx.commit()
+            .map_err(|e| GctlError::Storage(format!("commit tx: {e}")))?;
+        Ok(())
+    }
+
+    /// Reaper: mark every `scheduler_runs` row with `finished_at IS NULL`
+    /// as `interrupted`, stamping `finished_at = now`. Called on daemon
+    /// startup so a manual `run-now` interrupted by a crash is reapable
+    /// instead of dangling forever.
+    ///
+    /// Returns the number of rows touched.
+    pub fn reap_interrupted_schedule_runs(&self, now_rfc3339: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n = conn
+            .execute(
+                "UPDATE scheduler_runs
+                 SET status = 'interrupted', finished_at = ?1
+                 WHERE finished_at IS NULL",
+                [now_rfc3339],
+            )
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        Ok(n)
     }
 
     /// History for a single schedule, latest first. Filters compose with AND.
@@ -3029,6 +3166,61 @@ impl SqliteStore {
             .map_err(|e| GctlError::Storage(e.to_string()))?;
         Ok(n)
     }
+
+    /// Aggregate counts powering `GET /api/schedules/summary`. Computed
+    /// kernel-side per spec § 5.6 — no client-side rollup. The CLI
+    /// consumes the same shape via `gctrl scheduler list --summary`.
+    ///
+    /// `runs_last_24h` is sourced from `scheduler_runs.status`. The
+    /// `started_at >= ?1` bound makes the query touch only the prefix
+    /// of the `idx_scheduler_runs_status_started` index.
+    pub fn schedules_summary(&self, since_24h: &str) -> Result<SchedulesSummary> {
+        // Fetch every row, compute health inline. Routine count is
+        // expected to stay in dozens; full table scan beats a multi-CTE
+        // SQL view at this scale and stays in pure Rust.
+        let rows = self.list_schedules(&ScheduleFilter::default())?;
+        let total = rows.len() as i64;
+        let mut counts = SchedulesHealthCounts::default();
+        for s in &rows {
+            // `list_schedules` already populates `health`; fall back to
+            // `compute_schedule_health` defensively in case a code path
+            // bypasses the populating mapper.
+            let h = s
+                .health
+                .unwrap_or_else(|| gctrl_core::compute_schedule_health(s));
+            match h {
+                ScheduleHealth::Green => counts.green += 1,
+                ScheduleHealth::Amber => counts.amber += 1,
+                ScheduleHealth::Red => counts.red += 1,
+                ScheduleHealth::Pending => counts.pending += 1,
+                ScheduleHealth::Paused => counts.paused += 1,
+            }
+        }
+
+        let conn = self.conn.lock().unwrap();
+        let success: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM scheduler_runs
+                 WHERE started_at >= ?1 AND status = 'success'",
+                [since_24h],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("count success runs: {e}")))?;
+        let failure: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM scheduler_runs
+                 WHERE started_at >= ?1 AND status IN ('failure','timed_out','refused','interrupted')",
+                [since_24h],
+                |row| row.get(0),
+            )
+            .map_err(|e| GctlError::Storage(format!("count failure runs: {e}")))?;
+
+        Ok(SchedulesSummary {
+            total,
+            by_health: counts,
+            runs_last_24h: SchedulesRunsCounts { success, failure },
+        })
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -3069,7 +3261,7 @@ fn row_to_schedule(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedule> {
     let headers_json_str: Option<String> = row.get(7)?;
     let command_json_str: Option<String> = row.get(8)?;
     let env_keys_json_str: Option<String> = row.get(10)?;
-    Ok(Schedule {
+    let mut s = Schedule {
         id: row.get(0)?,
         name: row.get(1)?,
         cron: row.get(2)?,
@@ -3092,7 +3284,14 @@ fn row_to_schedule(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedule> {
         failure_count: row.get(19)?,
         created_at: row.get(20)?,
         updated_at: row.get(21)?,
-    })
+        health: None,
+    };
+    // Storage is the population point for the derived `health` column —
+    // every fetch through this mapper carries it. The GET / list HTTP
+    // handlers then never need to recompute, and the SPA / CLI parity
+    // is structural, not by convention.
+    s.health = Some(gctrl_core::compute_schedule_health(&s));
+    Ok(s)
 }
 
 fn row_to_schedule_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduleRun> {

--- a/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
+++ b/kernel/crates/gctrl-storage/tests/scheduler_runs.rs
@@ -6,8 +6,8 @@
 
 use chrono::Utc;
 use gctrl_core::{
-    Schedule, ScheduleRun, ScheduleRunFilter, FIRE_KIND_CRON, FIRE_KIND_MANUAL,
-    RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, TARGET_KIND_HTTP,
+    Schedule, ScheduleRun, ScheduleRunFilter, ScheduleRunUpdate, FIRE_KIND_CRON, FIRE_KIND_MANUAL,
+    RUN_STATUS_FAILURE, RUN_STATUS_INTERRUPTED, RUN_STATUS_SUCCESS, TARGET_KIND_HTTP,
 };
 use gctrl_storage::SqliteStore;
 
@@ -40,6 +40,7 @@ fn seed_schedule(store: &SqliteStore, name: &str) -> Schedule {
         failure_count: 0,
         created_at: now.clone(),
         updated_at: now,
+        health: None,
     };
     store.create_schedule(&s).expect("create_schedule");
     s
@@ -239,6 +240,139 @@ fn delete_schedule_cascades_to_runs() {
         .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
         .expect("list after delete");
     assert!(rows.is_empty(), "cascade should drop history");
+}
+
+#[test]
+fn record_v2_writes_both_rows_atomically() {
+    // record_schedule_run_v2 must update the schedules cache row AND
+    // append a scheduler_runs history row in a single transaction. A
+    // successful call must leave both visible.
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let run = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: Some((now + chrono::Duration::hours(2)).to_rfc3339()),
+        last_status: Some(200),
+        last_response: Some("ok".into()),
+        last_error: None,
+        success: true,
+    };
+    s.record_schedule_run_v2(&sched.id, &run, &update)
+        .expect("record_v2");
+
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 0);
+    assert_eq!(after.last_status, Some(200));
+
+    let runs = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].id, run.id);
+}
+
+#[test]
+fn record_v2_increments_failure_count_on_unsuccessful_run() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    let run = run_at(&sched.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON);
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: None,
+        last_status: Some(503),
+        last_response: None,
+        last_error: Some("server angry".into()),
+        success: false,
+    };
+    s.record_schedule_run_v2(&sched.id, &run, &update).unwrap();
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 1);
+    assert_eq!(after.failure_count, 1);
+    assert_eq!(after.last_status, Some(503));
+}
+
+#[test]
+fn record_v2_rolls_back_when_run_id_collides() {
+    // PRIMARY KEY conflict on the INSERT must roll the entire
+    // transaction back — the cache row UPDATE that ran first MUST
+    // also revert. Without rollback, run_count would advance without
+    // a corresponding history row.
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+
+    // Seed a history row directly so the next v2 call collides.
+    let existing = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    s.insert_schedule_run(&existing).unwrap();
+
+    let conflict = ScheduleRun {
+        id: existing.id.clone(), // same primary key — INSERT must fail
+        ..run_at(&sched.id, now, RUN_STATUS_FAILURE, FIRE_KIND_CRON)
+    };
+    let update = ScheduleRunUpdate {
+        last_run_at: now.to_rfc3339(),
+        next_run_at: None,
+        last_status: Some(500),
+        last_response: None,
+        last_error: Some("won't survive".into()),
+        success: false,
+    };
+    let r = s.record_schedule_run_v2(&sched.id, &conflict, &update);
+    assert!(r.is_err(), "duplicate INSERT must fail the transaction");
+
+    // Cache row stayed at the seeded values: zero runs (we never
+    // legitimately recorded a run via v2 here).
+    let after = s.get_schedule(&sched.id).unwrap().unwrap();
+    assert_eq!(after.run_count, 0, "rollback: run_count never advanced");
+    assert_eq!(after.failure_count, 0, "rollback: failure_count never advanced");
+    assert!(after.last_status.is_none(), "rollback: last_status untouched");
+}
+
+#[test]
+fn reap_marks_unfinished_rows_interrupted() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let now = Utc::now();
+    // Two rows: one finished (don't touch), one open (must reap).
+    let finished = run_at(&sched.id, now - chrono::Duration::minutes(5), RUN_STATUS_SUCCESS, FIRE_KIND_CRON);
+    let mut open = run_at(&sched.id, now, RUN_STATUS_SUCCESS, FIRE_KIND_MANUAL);
+    open.finished_at = None; // simulates manual run-now interrupted by daemon crash
+    s.insert_schedule_run(&finished).unwrap();
+    s.insert_schedule_run(&open).unwrap();
+
+    let n = s.reap_interrupted_schedule_runs(&now.to_rfc3339()).unwrap();
+    assert_eq!(n, 1, "exactly the open row should be reaped");
+
+    let runs = s
+        .list_schedule_runs(&sched.id, &ScheduleRunFilter::default())
+        .unwrap();
+    let reaped = runs.iter().find(|r| r.id == open.id).unwrap();
+    assert_eq!(reaped.status, RUN_STATUS_INTERRUPTED);
+    assert!(reaped.finished_at.is_some());
+    let still_finished = runs.iter().find(|r| r.id == finished.id).unwrap();
+    assert_eq!(still_finished.status, RUN_STATUS_SUCCESS, "finished row untouched");
+}
+
+#[test]
+fn reap_is_idempotent() {
+    let s = store();
+    let sched = seed_schedule(&s, "audit.codebase");
+    let mut open = run_at(&sched.id, Utc::now(), RUN_STATUS_SUCCESS, FIRE_KIND_MANUAL);
+    open.finished_at = None;
+    s.insert_schedule_run(&open).unwrap();
+
+    let n1 = s
+        .reap_interrupted_schedule_runs(&Utc::now().to_rfc3339())
+        .unwrap();
+    let n2 = s
+        .reap_interrupted_schedule_runs(&Utc::now().to_rfc3339())
+        .unwrap();
+    assert_eq!(n1, 1);
+    assert_eq!(n2, 0, "already-reaped rows do not reap again");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**Closes M1a** from the [gctrl-schedule spec](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md). PR-1 (#155, `scheduler_runs` table + GET routes) merged separately; this single commit folds **PR-2 + PR-3** into one squashed landing on top of latest main.

> Replaces (and supersedes) #162. Rebased onto current main (`ec8f6aa`); the 15-file diff is 100% kernel substrate.

## What ships

### Crash-safe fire path

1. **`gctrl-scheduler::redact`** — shared regex masking the value half of `(token|secret|key|password|webhook)` in stdout/stderr/HTTP-body previews. Idempotent. UTF-8-safe truncation composed with redaction so the cap can't preserve a secret past it. Replaces the runner.rs/http.rs private `truncate` helpers.
2. **`SqliteStore::record_schedule_run_v2`** — wraps the `schedules` cache UPDATE and the `scheduler_runs` INSERT in a single SQLite transaction. A daemon crash mid-fire now leaves neither a half-incremented `failure_count` nor an orphaned history row.
3. **Startup reaper** — marks every `scheduler_runs WHERE finished_at IS NULL` row as `interrupted` on daemon entry.

### Retention + sandbox

4. **`DELETE /api/schedules/runs?before=<RFC3339>`** — idempotent prune. RFC3339 validation up front; second call with same `before` returns `{"deleted": 0}`.
5. **`_internal.*` HTTP guard** — `POST /api/schedules` with a `_internal.*` name returns 403. Closes the agent-via-vault-write attack vector flagged in the spec review.
6. **`_internal.scheduler_runs_gc` self-bootstrap** — daemon plants the GC routine on startup if missing; replaces a corrupt row (bad cron / wrong target).

### Edit + rollup

7. **`PATCH /api/schedules/{id_or_name}`** — RFC 7396 JSON Merge Patch.
   - Field absence is no-op; explicit `null` clears nullable fields.
   - Identity-immutable: `target_kind`, `name` rejected with 400.
   - **Cross-field mutual exclusion** against the merged view: http rows MUST NOT carry `command/cwd/env_keys`; exec rows MUST NOT carry `target_url`. Closes the lateral-upgrade gap.
   - Re-runs every create-time gate against the merged row: cron parse, `exec_enabled`, `exec_allowed_programs`, absolute argv[0], absolute cwd.
   - `next_run_at` lifecycle: cron change → recompute; `enabled→false` → clear; `disabled→enabled` → recompute.
8. **`GET /api/schedules/summary`** — kernel-computed rollup per spec § 5.6. Returns `{ total, by_health, runs_last_24h }`. SPA never recomputes the counts.
9. **Per-row `health` derived column** — `Schedule.health` populated by `row_to_schedule` on every read path. States today: `paused | pending | green | amber`. `red` lands in M3 with `alert_after_failures`.

## Test plan

**+43 tests across the M1a substrate, all green with `RUSTFLAGS=-D warnings`:**

- [x] `cargo test -p gctrl-core` — +6 health tests (each state + override semantics + serde lowercase).
- [x] `cargo test -p gctrl-scheduler --tests`:
  - **redact (lib)**: 14 tests covering each keyword shape, idempotency, multiple-in-one-string, UTF-8-safe truncation, redaction-before-truncation invariant.
  - **bootstrap (lib)**: 3 tests — insert-when-absent, idempotent on restart, replaces-corrupt-row.
  - **`http_routes.rs`**: 15 new tests — `_internal.*` 403 on POST, prune route validation + idempotency, summary endpoint (empty / paused+pending counts / list includes `health`), PATCH (404, cron-only update + recompute, unknown key rejected, `target_kind` rejected, `name` rejected, **lateral-upgrade rejected**, invalid cron, disable→enable lifecycle, exec allowlist re-check on `command` patch).
- [x] `cargo test -p gctrl-storage --test scheduler_runs` — 14 tests (5 new): `record_schedule_run_v2` atomicity, **rollback on PRIMARY KEY collision** (proves cache UPDATE reverts), reaper marks unfinished rows, reaper idempotency.
- [x] `cargo test --workspace` — 0 failed across all crates.
- [x] `RUSTFLAGS=-D warnings cargo build --workspace` clean.

## Out of scope (M3)

- `red` health state (gates on `alert_after_failures` / `current_failure_streak` columns).
- Inbox emit on streak boundary (third op of `record_schedule_run_v2` transaction).
- `spend_last_24h_usd` field on `/summary` (waits for analytics join in M1b).

## Spec links

- [§ 5.1 — `scheduler_runs` + transactional write](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#51-scheduler_runs-table--durable-run-history)
- [§ 5.2 — PATCH](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#52-patch-apischedulesid--edit-in-place)
- [§ 5.4 — `_internal.*` guard](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#54-internal-prefix--kernel-side-guard)
- [§ 5.6 — Summary endpoint + health column](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#56-get-apischedulessummary--kernel-computed-rollup)
- [§ 6.3 — Health states](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#63-health-states)
