### PR TITLE
feat(kernel): app capability registry + gctrl-app.toml manifest parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,9 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
+ "toml",
  "uuid",
 ]
 
@@ -3705,7 +3707,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -4400,6 +4402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +4978,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,12 +5009,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
@@ -4995,6 +5041,12 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5760,6 +5812,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/kernel/crates/gctrl-core/Cargo.toml
+++ b/kernel/crates/gctrl-core/Cargo.toml
@@ -7,7 +7,11 @@ edition.workspace = true
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-core/src/app_manifest.rs
+++ b/kernel/crates/gctrl-core/src/app_manifest.rs
@@ -1,0 +1,692 @@
+//! `gctrl-app.toml` parser + validator.
+//!
+//! Reads an app's manifest into a typed `AppManifest`, validates that every
+//! declared capability id exists in the kernel registry (`crate::capabilities`),
+//! and enforces the project-key rules from
+//! `vault/specs/architecture/app-install-protocol.md` § Schema rules.
+//!
+//! Pure data — no I/O beyond `std::fs::read_to_string`. The install machinery
+//! (PR-α.2 / PR-α.3) takes the validated manifest and persists it.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+use thiserror::Error;
+
+use crate::capabilities;
+
+// ───────────────────────── Manifest types ─────────────────────────
+
+/// Parsed `gctrl-app.toml`. Field shapes mirror the spec example in
+/// `vault/specs/architecture/app-install-protocol.md`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppManifest {
+    pub app: AppMeta,
+    pub entrypoint: Entrypoint,
+
+    /// Required capabilities (manifest table `[requires.<id>]`). The
+    /// installer rejects the manifest if any id is unknown to the registry.
+    /// Stored as an ordered map so manifest order is preserved for
+    /// deterministic installer output.
+    #[serde(default, rename = "requires")]
+    pub requires: BTreeMap<String, CapabilitySpec>,
+
+    /// Optional capabilities (`[optional.<id>]`). Same validation; the app's
+    /// code MUST gracefully degrade when one is unavailable on this host.
+    #[serde(default, rename = "optional")]
+    pub optional: BTreeMap<String, CapabilitySpec>,
+
+    /// Vault project keys this app claims under the kernel-owned vault root
+    /// (per PR #163). At install time, each is registered into
+    /// `gctrl_vault_mounts` with the app as owner.
+    #[serde(default, rename = "vault-projects")]
+    pub vault_projects: Vec<VaultProject>,
+
+    /// Cron schedules the kernel registers on the app's behalf.
+    #[serde(default)]
+    pub schedule: Vec<Schedule>,
+
+    /// Secrets the app reads via `SecretsService.get`. Informational — the
+    /// kernel uses this for the onboarding wizard's UX, not for enforcement.
+    #[serde(default, rename = "secrets")]
+    pub secrets: Vec<SecretDecl>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppMeta {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Entrypoint {
+    pub bin: String,
+    pub command: String,
+    pub runtime: String,
+}
+
+/// `[requires.llm]` body. Today only `description` is meaningful; future
+/// versions may add per-capability config (e.g. effort tier defaults).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CapabilitySpec {
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VaultProject {
+    /// Uppercase, globally unique within the kernel's vault root.
+    pub key: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Schedule {
+    pub name: String,
+    pub cron: String,
+    /// One of `"exec"` | `"http"`. Mirrors the kernel scheduler's `target_kind`.
+    pub target: String,
+    /// For `target = "exec"`: command argv. For `target = "http"`: URL parts
+    /// arrive in additional fields not modeled here yet.
+    #[serde(default)]
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecretDecl {
+    pub key: String,
+    /// One of `"string"` | `"url"` | `"token"` — UX hint only.
+    pub kind: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+// ───────────────────────── Errors ─────────────────────────
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ManifestError {
+    #[error("toml parse failed: {0}")]
+    Parse(String),
+
+    #[error("io error reading manifest at {path}: {cause}")]
+    Io { path: String, cause: String },
+
+    #[error("unknown capability id `{id}` in [{section}.] — not in kernel capability registry")]
+    UnknownCapability { id: String, section: String },
+
+    #[error("capability id `{id}` declared in both [requires.] and [optional.]")]
+    DuplicateCapability { id: String },
+
+    #[error("project key `{key}` is not uppercase / kebab+digits — must match /^[A-Z][A-Z0-9-]*$/")]
+    InvalidProjectKey { key: String },
+
+    #[error("project key `{key}` declared more than once")]
+    DuplicateProjectKey { key: String },
+
+    #[error("schedule name `{name}` declared more than once")]
+    DuplicateSchedule { name: String },
+
+    #[error("secret key `{key}` declared more than once")]
+    DuplicateSecret { key: String },
+
+    #[error("[app] name `{name}` is not kebab-case (/^[a-z][a-z0-9-]*[a-z0-9]$/)")]
+    InvalidAppName { name: String },
+
+    #[error("[entrypoint] runtime `{runtime}` is not one of: node | bun | deno | binary")]
+    InvalidRuntime { runtime: String },
+
+    #[error("schedule `{name}` target `{target}` is not one of: exec | http")]
+    InvalidScheduleTarget { name: String, target: String },
+
+    #[error("secret `{key}` kind `{kind}` is not one of: string | url | token")]
+    InvalidSecretKind { key: String, kind: String },
+}
+
+// ───────────────────────── API ─────────────────────────
+
+impl AppManifest {
+    /// Load + validate a manifest from disk.
+    pub fn load(path: &Path) -> Result<Self, ManifestError> {
+        let text = std::fs::read_to_string(path).map_err(|e| ManifestError::Io {
+            path: path.display().to_string(),
+            cause: e.to_string(),
+        })?;
+        Self::parse(&text)
+    }
+
+    /// Parse + validate from an in-memory string. Used by tests + the future
+    /// `/api/app/install` route which may receive manifest text inline.
+    pub fn parse(text: &str) -> Result<Self, ManifestError> {
+        // Two-phase parse:
+        // 1. Pull `requires` / `optional` out as raw TOML tables and flatten
+        //    nested keys (`[requires.deliverer.telegram]` → `"deliverer.telegram"`).
+        //    TOML's nested-table syntax is the natural way to write dotted ids
+        //    without quoting; we rebuild the flat capability id post-parse.
+        // 2. Strongly-type the rest.
+        let mut root: toml::Table =
+            toml::from_str(text).map_err(|e| ManifestError::Parse(e.to_string()))?;
+
+        let requires = take_capability_section(&mut root, "requires")?;
+        let optional = take_capability_section(&mut root, "optional")?;
+
+        // Re-serialize the remainder so serde can deserialize the typed shape
+        // for app / entrypoint / vault-projects / schedule / secrets.
+        let remainder = toml::to_string(&root).map_err(|e| ManifestError::Parse(e.to_string()))?;
+
+        #[derive(Deserialize)]
+        struct Skeleton {
+            app: AppMeta,
+            entrypoint: Entrypoint,
+            #[serde(default, rename = "vault-projects")]
+            vault_projects: Vec<VaultProject>,
+            #[serde(default)]
+            schedule: Vec<Schedule>,
+            #[serde(default)]
+            secrets: Vec<SecretDecl>,
+        }
+        let skel: Skeleton =
+            toml::from_str(&remainder).map_err(|e| ManifestError::Parse(e.to_string()))?;
+
+        let manifest = AppManifest {
+            app: skel.app,
+            entrypoint: skel.entrypoint,
+            requires,
+            optional,
+            vault_projects: skel.vault_projects,
+            schedule: skel.schedule,
+            secrets: skel.secrets,
+        };
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Run every cross-field validation rule. Idempotent.
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        validate_app_name(&self.app.name)?;
+        validate_runtime(&self.entrypoint.runtime)?;
+
+        for id in self.requires.keys() {
+            if capabilities::lookup(id).is_none() {
+                return Err(ManifestError::UnknownCapability {
+                    id: id.clone(),
+                    section: "requires".into(),
+                });
+            }
+        }
+        for id in self.optional.keys() {
+            if capabilities::lookup(id).is_none() {
+                return Err(ManifestError::UnknownCapability {
+                    id: id.clone(),
+                    section: "optional".into(),
+                });
+            }
+            if self.requires.contains_key(id) {
+                return Err(ManifestError::DuplicateCapability { id: id.clone() });
+            }
+        }
+
+        let mut seen_keys = HashSet::new();
+        for vp in &self.vault_projects {
+            validate_project_key(&vp.key)?;
+            if !seen_keys.insert(vp.key.clone()) {
+                return Err(ManifestError::DuplicateProjectKey { key: vp.key.clone() });
+            }
+        }
+
+        let mut seen_schedules = HashSet::new();
+        for s in &self.schedule {
+            if !seen_schedules.insert(s.name.clone()) {
+                return Err(ManifestError::DuplicateSchedule { name: s.name.clone() });
+            }
+            if s.target != "exec" && s.target != "http" {
+                return Err(ManifestError::InvalidScheduleTarget {
+                    name: s.name.clone(),
+                    target: s.target.clone(),
+                });
+            }
+        }
+
+        let mut seen_secrets = HashSet::new();
+        for sec in &self.secrets {
+            if !seen_secrets.insert(sec.key.clone()) {
+                return Err(ManifestError::DuplicateSecret { key: sec.key.clone() });
+            }
+            if !matches!(sec.kind.as_str(), "string" | "url" | "token") {
+                return Err(ManifestError::InvalidSecretKind {
+                    key: sec.key.clone(),
+                    kind: sec.kind.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// All capability ids the manifest declares (required + optional), in
+    /// stable order — required first (alphabetical), then optional.
+    pub fn all_capabilities(&self) -> impl Iterator<Item = (&str, bool)> {
+        self.requires
+            .keys()
+            .map(|id| (id.as_str(), true))
+            .chain(self.optional.keys().map(|id| (id.as_str(), false)))
+    }
+}
+
+/// Walk a TOML table tree under `[requires]` / `[optional]` and flatten dotted
+/// nested tables into a flat `BTreeMap<String, CapabilitySpec>` keyed by the
+/// dotted path. A "leaf" is a table whose values are all scalars / arrays /
+/// inline tables — i.e. the body of a `[requires.deliverer.telegram]` block.
+fn take_capability_section(
+    root: &mut toml::Table,
+    section: &'static str,
+) -> Result<BTreeMap<String, CapabilitySpec>, ManifestError> {
+    let raw = match root.remove(section) {
+        Some(toml::Value::Table(t)) => t,
+        Some(_) => {
+            return Err(ManifestError::Parse(format!(
+                "[{section}] must be a table"
+            )))
+        }
+        None => return Ok(BTreeMap::new()),
+    };
+    let mut out = BTreeMap::new();
+    flatten_capability_table(&raw, String::new(), &mut out, section)?;
+    Ok(out)
+}
+
+fn flatten_capability_table(
+    table: &toml::Table,
+    prefix: String,
+    out: &mut BTreeMap<String, CapabilitySpec>,
+    section: &'static str,
+) -> Result<(), ManifestError> {
+    // A table is a "capability spec leaf" iff every value is a scalar,
+    // array, or inline-table that doesn't itself look like another nested
+    // capability (no further sub-tables of strings). The simple rule we use:
+    // if any value is itself a `Table`, this node is *not* a leaf — we
+    // recurse. Otherwise we treat the whole thing as the CapabilitySpec body.
+    let has_subtable = table.values().any(|v| matches!(v, toml::Value::Table(_)));
+
+    if !has_subtable {
+        // Leaf: deserialize the body as CapabilitySpec.
+        if prefix.is_empty() {
+            // Empty prefix means [requires] itself was a leaf with no
+            // children — that's a manifest with no capabilities, which is
+            // legal but yields no entries.
+            return Ok(());
+        }
+        let spec_value = toml::Value::Table(table.clone());
+        let spec: CapabilitySpec = spec_value
+            .try_into()
+            .map_err(|e: toml::de::Error| ManifestError::Parse(format!(
+                "[{section}.{prefix}] body invalid: {e}"
+            )))?;
+        out.insert(prefix, spec);
+        return Ok(());
+    }
+
+    for (key, value) in table.iter() {
+        match value {
+            toml::Value::Table(sub) => {
+                let next_prefix = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                flatten_capability_table(sub, next_prefix, out, section)?;
+            }
+            // Mixed: sibling scalar fields at this level mean THIS node has
+            // both children and CapabilitySpec-shape data — disallowed (would
+            // mean both "deliverer is itself a capability" and "deliverer.X
+            // is a capability").
+            other => {
+                return Err(ManifestError::Parse(format!(
+                    "[{section}.{prefix}] mixes a sub-capability with a sibling \
+                     scalar `{key} = {other}` — pick one shape"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_app_name(name: &str) -> Result<(), ManifestError> {
+    let invalid = || ManifestError::InvalidAppName {
+        name: name.to_string(),
+    };
+    if name.is_empty() {
+        return Err(invalid());
+    }
+    let bytes = name.as_bytes();
+    if !bytes[0].is_ascii_lowercase() {
+        return Err(invalid());
+    }
+    let last = bytes[bytes.len() - 1];
+    if !(last.is_ascii_lowercase() || last.is_ascii_digit()) {
+        return Err(invalid());
+    }
+    for &b in bytes {
+        let c = b as char;
+        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+            return Err(invalid());
+        }
+    }
+    Ok(())
+}
+
+fn validate_runtime(runtime: &str) -> Result<(), ManifestError> {
+    if matches!(runtime, "node" | "bun" | "deno" | "binary") {
+        Ok(())
+    } else {
+        Err(ManifestError::InvalidRuntime {
+            runtime: runtime.to_string(),
+        })
+    }
+}
+
+fn validate_project_key(key: &str) -> Result<(), ManifestError> {
+    let bad = || ManifestError::InvalidProjectKey { key: key.to_string() };
+    if key.is_empty() {
+        return Err(bad());
+    }
+    let bytes = key.as_bytes();
+    if !bytes[0].is_ascii_uppercase() {
+        return Err(bad());
+    }
+    for &b in bytes {
+        let c = b as char;
+        if !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-') {
+            return Err(bad());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_manifest() -> &'static str {
+        r#"
+[app]
+name = "uebermensch"
+version = "0.2.0"
+
+[entrypoint]
+bin = "dist/main.js"
+command = "uber"
+runtime = "node"
+"#
+    }
+
+    fn full_uebermensch_manifest() -> &'static str {
+        r#"
+[app]
+name = "uebermensch"
+version = "0.2.0"
+description = "Personal Chief of Staff for investors."
+homepage = "https://github.com/OpenHackersClub/uebermensch"
+license = "MIT"
+
+[entrypoint]
+bin = "dist/main.js"
+command = "uber"
+runtime = "node"
+
+[requires.llm]
+description = "Curator + summary lanes."
+
+[requires.deliverer.telegram]
+[requires.deliverer.discord]
+[requires.vault.write]
+[requires.vault.sync]
+[requires.secrets]
+
+[optional.gcal]
+description = "Calendar event apply for timeboxes."
+
+[optional."search.brave"]
+[optional."browser.cdp"]
+
+[[vault-projects]]
+key = "UBER"
+description = "Uebermensch namespace"
+
+[[schedule]]
+name = "uber-daily-brief"
+cron = "0 8 * * *"
+target = "exec"
+command = ["uber", "run-daily"]
+
+[[schedule]]
+name = "uber-weekly-report"
+cron = "0 9 * * 1"
+target = "exec"
+command = ["uber", "report", "--send"]
+
+[[secrets]]
+key = "ANTHROPIC_API_KEY"
+kind = "token"
+required = false
+description = "Anthropic API key."
+
+[[secrets]]
+key = "TELEGRAM_BOT_TOKEN"
+kind = "token"
+"#
+    }
+
+    #[test]
+    fn parses_minimal_manifest() {
+        let m = AppManifest::parse(minimal_manifest()).expect("parse");
+        assert_eq!(m.app.name, "uebermensch");
+        assert_eq!(m.app.version, "0.2.0");
+        assert_eq!(m.entrypoint.runtime, "node");
+        assert!(m.requires.is_empty());
+        assert!(m.optional.is_empty());
+        assert!(m.vault_projects.is_empty());
+        assert!(m.schedule.is_empty());
+        assert!(m.secrets.is_empty());
+    }
+
+    #[test]
+    fn parses_full_uebermensch_manifest() {
+        let m = AppManifest::parse(full_uebermensch_manifest()).expect("parse");
+        assert_eq!(m.app.name, "uebermensch");
+        // Required: llm, deliverer.telegram, deliverer.discord, vault.write, vault.sync, secrets
+        assert_eq!(m.requires.len(), 6);
+        assert!(m.requires.contains_key("llm"));
+        assert!(m.requires.contains_key("deliverer.telegram"));
+        // Optional: gcal, search.brave, browser.cdp
+        assert_eq!(m.optional.len(), 3);
+        assert!(m.optional.contains_key("gcal"));
+        assert!(m.optional.contains_key("search.brave"));
+        assert_eq!(m.vault_projects.len(), 1);
+        assert_eq!(m.vault_projects[0].key, "UBER");
+        assert_eq!(m.schedule.len(), 2);
+        assert_eq!(m.secrets.len(), 2);
+    }
+
+    #[test]
+    fn unknown_capability_in_requires_rejected() {
+        let manifest = format!(
+            "{}\n[requires.vault.frobnicate]\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::UnknownCapability { ref id, .. } if id == "vault.frobnicate"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_capability_in_optional_rejected() {
+        let manifest = format!(
+            "{}\n[optional.search.frobnicate]\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::UnknownCapability { ref section, .. } if section == "optional"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn capability_in_both_requires_and_optional_rejected() {
+        let manifest = format!(
+            "{}\n[requires.llm]\n[optional.llm]\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::DuplicateCapability { ref id } if id == "llm"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn lowercase_project_key_rejected() {
+        let manifest = format!(
+            "{}\n[[vault-projects]]\nkey = \"uber\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::InvalidProjectKey { ref key } if key == "uber"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn project_key_with_underscore_rejected() {
+        let manifest = format!(
+            "{}\n[[vault-projects]]\nkey = \"UBER_NOTES\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidProjectKey { .. }));
+    }
+
+    #[test]
+    fn duplicate_project_keys_rejected() {
+        let manifest = format!(
+            "{}\n[[vault-projects]]\nkey = \"UBER\"\n[[vault-projects]]\nkey = \"UBER\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::DuplicateProjectKey { .. }));
+    }
+
+    #[test]
+    fn invalid_app_name_rejected() {
+        for bad_name in ["UeberMensch", "ueber_mensch", "1uber", "uber-", "ueber!", ""] {
+            let manifest = format!(
+                "[app]\nname = \"{bad_name}\"\nversion = \"0.1.0\"\n\n\
+                [entrypoint]\nbin = \"x\"\ncommand = \"x\"\nruntime = \"node\"\n"
+            );
+            let err = AppManifest::parse(&manifest).unwrap_err();
+            assert!(
+                matches!(err, ManifestError::InvalidAppName { .. } | ManifestError::Parse(_)),
+                "name={bad_name:?} got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_runtime_rejected() {
+        let manifest = "[app]\nname = \"x\"\nversion = \"0.1.0\"\n\n\
+                        [entrypoint]\nbin = \"x\"\ncommand = \"x\"\nruntime = \"python\"\n";
+        let err = AppManifest::parse(manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidRuntime { .. }));
+    }
+
+    #[test]
+    fn duplicate_schedule_name_rejected() {
+        let manifest = format!(
+            "{}\n\
+            [[schedule]]\nname = \"foo\"\ncron = \"* * * * *\"\ntarget = \"exec\"\n\
+            [[schedule]]\nname = \"foo\"\ncron = \"0 0 * * *\"\ntarget = \"exec\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::DuplicateSchedule { .. }));
+    }
+
+    #[test]
+    fn invalid_schedule_target_rejected() {
+        let manifest = format!(
+            "{}\n[[schedule]]\nname = \"foo\"\ncron = \"* * * * *\"\ntarget = \"smtp\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidScheduleTarget { .. }));
+    }
+
+    #[test]
+    fn invalid_secret_kind_rejected() {
+        let manifest = format!(
+            "{}\n[[secrets]]\nkey = \"X\"\nkind = \"binary\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidSecretKind { .. }));
+    }
+
+    #[test]
+    fn duplicate_secret_key_rejected() {
+        let manifest = format!(
+            "{}\n[[secrets]]\nkey = \"X\"\nkind = \"token\"\n[[secrets]]\nkey = \"X\"\nkind = \"token\"\n",
+            minimal_manifest()
+        );
+        let err = AppManifest::parse(&manifest).unwrap_err();
+        assert!(matches!(err, ManifestError::DuplicateSecret { .. }));
+    }
+
+    #[test]
+    fn malformed_toml_rejected() {
+        let err = AppManifest::parse("this is not toml [[[").unwrap_err();
+        assert!(matches!(err, ManifestError::Parse(_)));
+    }
+
+    #[test]
+    fn all_capabilities_iterates_required_then_optional() {
+        let m = AppManifest::parse(full_uebermensch_manifest()).unwrap();
+        let caps: Vec<(&str, bool)> = m.all_capabilities().collect();
+        // First 6 are required (BTreeMap → alphabetical); last 3 are optional.
+        let required_count = caps.iter().filter(|(_, req)| *req).count();
+        let optional_count = caps.iter().filter(|(_, req)| !*req).count();
+        assert_eq!(required_count, 6);
+        assert_eq!(optional_count, 3);
+        let first_required_idx = caps.iter().position(|(_, req)| *req).unwrap();
+        let first_optional_idx = caps.iter().position(|(_, req)| !*req).unwrap();
+        assert!(first_required_idx < first_optional_idx);
+    }
+
+    #[test]
+    fn load_from_disk_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gctrl-app.toml");
+        std::fs::write(&path, full_uebermensch_manifest()).unwrap();
+        let m = AppManifest::load(&path).expect("load");
+        assert_eq!(m.app.name, "uebermensch");
+    }
+
+    #[test]
+    fn load_from_disk_missing_file_returns_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.toml");
+        let err = AppManifest::load(&path).unwrap_err();
+        assert!(matches!(err, ManifestError::Io { .. }));
+    }
+}

--- a/kernel/crates/gctrl-core/src/capabilities.rs
+++ b/kernel/crates/gctrl-core/src/capabilities.rs
@@ -1,0 +1,193 @@
+//! Capability registry — the kernel-published list of capabilities apps may
+//! declare in their `gctrl-app.toml` manifests.
+//!
+//! Apps reference *capability ids* (e.g. `"llm"`, `"deliverer.telegram"`),
+//! NOT driver names. The registry pins one default driver per capability id,
+//! plus the HTTP route prefix the kernel mounts. The kernel can swap a
+//! default driver implementation without manifest churn — the contract is
+//! the capability, not the implementation.
+//!
+//! See `vault/specs/architecture/app-install-protocol.md` § Capability
+//! Registry for the full contract.
+
+/// One row in the capability registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityRegistration {
+    /// Capability id used in manifests, e.g. `"llm"` or `"deliverer.telegram"`.
+    /// Dotted-path. Kebab-case within each segment.
+    pub id: &'static str,
+
+    /// The kernel driver / module that fulfills this capability today.
+    /// Apps never reference this directly — it shows up in `gctrl_app_bindings`
+    /// rows (`driver_id` column) so operators can see what backs each capability.
+    pub default_driver: &'static str,
+
+    /// HTTP route prefix the kernel mounts for this capability. Apps' default
+    /// Layer wires its port to this prefix.
+    pub route_prefix: &'static str,
+
+    /// One-sentence operator-facing description.
+    pub description: &'static str,
+}
+
+/// Static registry of capabilities the kernel knows how to fulfill.
+///
+/// Order is **stable** — installers and `/api/app/capabilities` responses
+/// emit entries in this order so external tooling can rely on a consistent
+/// listing.
+///
+/// Adding a new capability requires a kernel update — manifests cannot
+/// extend the registry. Removing a capability is a breaking change for
+/// any installed app declaring it.
+pub const REGISTRY: &[CapabilityRegistration] = &[
+    CapabilityRegistration {
+        id: "llm",
+        default_driver: "driver-llm",
+        route_prefix: "/api/llm",
+        description: "LLM relay — Anthropic /v1/messages and OpenAI-compat \
+                      /v1/chat/completions, with caching + cost capture.",
+    },
+    CapabilityRegistration {
+        id: "deliverer.telegram",
+        default_driver: "driver-telegram",
+        route_prefix: "/api/telegram",
+        description: "Telegram Bot API delivery — POST /api/telegram/send.",
+    },
+    CapabilityRegistration {
+        id: "deliverer.discord",
+        default_driver: "driver-discord",
+        route_prefix: "/api/discord",
+        description: "Discord webhook delivery — POST /api/discord/send.",
+    },
+    CapabilityRegistration {
+        id: "vault.write",
+        default_driver: "kernel-vault-fs",
+        route_prefix: "/api/vault",
+        description: "Atomic markdown writes against the kernel-owned vault \
+                      root + content-hash watcher index.",
+    },
+    CapabilityRegistration {
+        id: "vault.sync",
+        default_driver: "gctrl-sync.vault",
+        route_prefix: "/api/sync/vault",
+        description: "Per-project-key sync to R2 (push/pull) backed by the \
+                      kernel's R2Client.",
+    },
+    CapabilityRegistration {
+        id: "secrets",
+        default_driver: "driver-secrets",
+        route_prefix: "/api/secrets",
+        description: "Read-only secret resolution — apps call \
+                      SecretsService.get; the kernel materializes values from \
+                      its backing store (env / keychain / cloud bindings).",
+    },
+    CapabilityRegistration {
+        id: "scheduler",
+        default_driver: "kernel-scheduler",
+        route_prefix: "/api/schedules",
+        description: "Cron-style task scheduling (registered via [[schedule]] \
+                      in the manifest).",
+    },
+    CapabilityRegistration {
+        id: "gcal",
+        default_driver: "driver-gcal",
+        route_prefix: "/api/gcal",
+        description: "Google Calendar event read/apply — used by uebermensch \
+                      timeboxes.",
+    },
+    CapabilityRegistration {
+        id: "search.brave",
+        default_driver: "driver-brave",
+        route_prefix: "/api/search",
+        description: "Brave Search API — web/news/images.",
+    },
+    CapabilityRegistration {
+        id: "browser.cdp",
+        default_driver: "driver-browser",
+        route_prefix: "/api/browser",
+        description: "Headless Chromium via Chrome DevTools Protocol — for \
+                      paywall-fallback article extraction.",
+    },
+];
+
+/// Look up a capability by id. Returns `None` if the id is not in the
+/// registry — the install protocol uses this for manifest validation.
+pub fn lookup(id: &str) -> Option<&'static CapabilityRegistration> {
+    REGISTRY.iter().find(|c| c.id == id)
+}
+
+/// All known capability ids, in registry order.
+pub fn known_ids() -> impl Iterator<Item = &'static str> {
+    REGISTRY.iter().map(|c| c.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_has_every_documented_capability() {
+        // The manifest example in app-install-protocol.md declares these caps;
+        // the kernel registry MUST know all of them or the example install
+        // would fail.
+        for id in [
+            "llm",
+            "deliverer.telegram",
+            "deliverer.discord",
+            "vault.write",
+            "vault.sync",
+            "secrets",
+            "gcal",
+            "search.brave",
+            "browser.cdp",
+        ] {
+            assert!(lookup(id).is_some(), "missing capability id: {id}");
+        }
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for cap in REGISTRY {
+            assert!(
+                seen.insert(cap.id),
+                "duplicate capability id: {}",
+                cap.id
+            );
+        }
+    }
+
+    #[test]
+    fn ids_are_kebab_dotted() {
+        for cap in REGISTRY {
+            for segment in cap.id.split('.') {
+                assert!(!segment.is_empty(), "empty segment in id: {}", cap.id);
+                assert!(
+                    segment.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                    "non-kebab-case segment `{segment}` in id: {}",
+                    cap.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn route_prefixes_start_with_slash() {
+        for cap in REGISTRY {
+            assert!(cap.route_prefix.starts_with('/'), "{} route_prefix missing leading /", cap.id);
+        }
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(lookup("vault.frobnicate").is_none());
+        assert!(lookup("").is_none());
+    }
+
+    #[test]
+    fn known_ids_iterator_matches_registry_order() {
+        let ids: Vec<&'static str> = known_ids().collect();
+        let direct: Vec<&'static str> = REGISTRY.iter().map(|c| c.id).collect();
+        assert_eq!(ids, direct);
+    }
+}

--- a/kernel/crates/gctrl-core/src/lib.rs
+++ b/kernel/crates/gctrl-core/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod acceptance;
+pub mod app_manifest;
+pub mod capabilities;
 pub mod config;
 pub mod context;
 pub mod error;


### PR DESCRIPTION
## Summary

PR-α.1 of the install-protocol implementation (spec: #161). Adds the kernel's published capability registry and the typed parser + validator for `gctrl-app.toml`. **No HTTP, no storage** — pure Rust types that subsequent PRs build on.

## What lands

### `gctrl-core::capabilities` — the registry

10-entry static `REGISTRY` pinning each capability id → default driver → HTTP route prefix → operator-facing description. Covers every capability the spec example declares:

| Capability id | Default driver | Route prefix |
|---|---|---|
| `llm` | `driver-llm` | `/api/llm` |
| `deliverer.telegram` | `driver-telegram` | `/api/telegram` |
| `deliverer.discord` | `driver-discord` | `/api/discord` |
| `vault.write` | `kernel-vault-fs` | `/api/vault` |
| `vault.sync` | `gctrl-sync.vault` | `/api/sync/vault` |
| `secrets` | `driver-secrets` | `/api/secrets` |
| `scheduler` | `kernel-scheduler` | `/api/schedules` |
| `gcal` | `driver-gcal` | `/api/gcal` |
| `search.brave` | `driver-brave` | `/api/search` |
| `browser.cdp` | `driver-browser` | `/api/browser` |

Helpers: `lookup(id)` for manifest validation, `known_ids()` for enumeration. Order is stable so external tooling can rely on a consistent listing.

### `gctrl-core::app_manifest` — typed parser

```rust
let manifest = AppManifest::parse(toml_text)?;
// or
let manifest = AppManifest::load(Path::new("apps/uebermensch/gctrl-app.toml"))?;
```

Strongly-typed structs: `AppManifest`, `AppMeta`, `Entrypoint`, `CapabilitySpec`, `VaultProject`, `Schedule`, `SecretDecl`.

**Two-phase parse** so manifests can use natural TOML nested-table syntax for dotted capability ids:

```toml
[requires.deliverer.telegram]   # parses to id "deliverer.telegram"
[requires.vault.sync]            # parses to id "vault.sync"
```

The parser pulls `[requires.*]` / `[optional.*]` out as raw TOML tables, walks the tree, and flattens nested tables into flat dotted ids. No quoting required in real-world manifests.

### Validation rules enforced (per `app-install-protocol.md` § Schema rules)

| Rule | Error variant |
|---|---|
| Every capability id resolves in the kernel registry | `UnknownCapability` |
| No capability appears in both [requires] and [optional] | `DuplicateCapability` |
| Project keys are uppercase + kebab+digits | `InvalidProjectKey` |
| Project keys are unique within a manifest | `DuplicateProjectKey` |
| Schedule names are unique | `DuplicateSchedule` |
| Secret keys are unique | `DuplicateSecret` |
| App name is kebab-case (`/^[a-z][a-z0-9-]*[a-z0-9]$/`) | `InvalidAppName` |
| Runtime is one of node / bun / deno / binary | `InvalidRuntime` |
| Schedule target is exec / http | `InvalidScheduleTarget` |
| Secret kind is string / url / token | `InvalidSecretKind` |

`ManifestError` is a `thiserror`-tagged enum so install-time rejections surface with precise rule + offending value.

## Test plan

- [x] `cargo build --workspace` clean (`RUSTFLAGS=-D warnings`)
- [x] `cargo test --workspace` — **562 passing** (30 new in `gctrl-core`, 0 regressions)
- [x] `cargo clippy -p gctrl-core --all-targets` — 0 warnings on the new files (10 pre-existing warnings on unrelated code unchanged)
- [x] Parses the full uebermensch-shaped manifest from the spec example end-to-end
- [x] Rejects every documented invalid case (unknown cap, duplicate cap, bad project key, bad app name, bad runtime, bad target, bad secret kind, malformed TOML)
- [x] Round-trips through disk via `AppManifest::load` (uses `tempfile::TempDir`)

## Why this is a discrete PR

The capability registry + manifest parser are pure-data and testable in isolation. Splitting them out:

- Lets the spec discussion (#161) settle before storage commits.
- Gives reviewers a focused diff (parser + tests, ~700 LOC excluding tests).
- Unblocks parallel work on PR-α.2 (storage tables) and PR-α.3 (HTTP + shell) once this lands.

## Stack

- This PR: **PR-α.1** — registry + parser ← *you are here*
- Next: **PR-α.2** — `gctrl_app_installs` + `gctrl_app_bindings` storage tables + CRUD methods on `SqliteStore`
- Next: **PR-α.3** — `/api/app/{install,status,reload,uninstall}` HTTP routes + `gctrl app install` shell subcommand
- Then: kernel `gctrl-sync` vault extension + watcher generalization
- Then: uebermensch migration (manifest, vault relocation, `R2Sync.ts` replacement, `lib/mode.ts` deletion)
- Then: repo carve to `OpenHackersClub/uebermensch`

Targets `main` directly. Stacks under #157, #159, #161 (no overlap with any of them — pure additions to `gctrl-core`).
