### PR TITLE
feat(kernel): app install storage — gctrl_app_installs + gctrl_app_bindings

### DIFF
--- a/kernel/crates/gctrl-storage/src/sqlite_store.rs
+++ b/kernel/crates/gctrl-storage/src/sqlite_store.rs
@@ -13,10 +13,10 @@ use gctrl_core::{
     memory::{MemoryEntry, MemoryEntryId, MemoryFilter, MemoryStats, MemoryType},
     AcceptanceCheck, AcceptanceCheckRow, AcceptanceKind, AcceptanceRollup, AcceptanceStatus,
     AppBinding, AppInstall, GctlError, InboxAction, InboxActionFilter, InboxMessage,
-    InboxMessageFilter, InboxThread, PersonaDefinition, PersonaReviewRule, Result, Schedule,
-    ScheduleFilter, ScheduleHealth, ScheduleRun, ScheduleRunFilter, ScheduleRunUpdate,
-    SchedulesHealthCounts, SchedulesRunsCounts, SchedulesSummary, OrchTask, UberBrief,
-    UberSinkinSession, VaultMount, VaultMountKind,
+    InboxMessageFilter, InboxThread, OrchTask, PersonaDefinition, PersonaReviewRule, Result,
+    Schedule, ScheduleFilter, ScheduleHealth, ScheduleRun, ScheduleRunFilter, ScheduleRunUpdate,
+    SchedulesHealthCounts, SchedulesRunsCounts, SchedulesSummary, UberBrief, UberSinkinSession,
+    VaultMount, VaultMountKind,
 };
 use rusqlite::{params, Connection};
 


### PR DESCRIPTION
## Summary

PR-α.2 of the install-protocol implementation (spec: #161). **Stacks on #166** (PR-α.1: capability registry + manifest parser).

Adds the persistence layer for `gctrl app install` records. PR-α.3 mounts HTTP routes + a shell subcommand on top of these CRUD methods.

## What lands

### `gctrl-core::app_install` (new module)

| Type | Role |
|---|---|
| `AppInstall` | One row per installed app: `name`, `version`, `source_ref`, `manifest_sha`, `installed_at`, `reloaded_at` |
| `AppBinding` | One row per (install, capability): `install_name`, `capability`, `driver_id`, `required`, `resolved_at` |

`driver_id` is the resolved kernel driver from `crate::capabilities::REGISTRY`, captured at install time. If the kernel registry later swaps a default driver, existing installs keep their old binding until `gctrl app reload` re-resolves — no silent rewrites.

### `gctrl-storage::sqlite_store` — schema

```sql
CREATE TABLE IF NOT EXISTS gctrl_app_installs (
    name           TEXT PRIMARY KEY,
    version        TEXT NOT NULL,
    source_ref     TEXT NOT NULL,
    manifest_sha   TEXT NOT NULL,
    installed_at   TEXT NOT NULL,
    reloaded_at    TEXT
);

CREATE TABLE IF NOT EXISTS gctrl_app_bindings (
    install_name   TEXT NOT NULL REFERENCES gctrl_app_installs(name) ON DELETE CASCADE,
    capability     TEXT NOT NULL,
    driver_id      TEXT NOT NULL,
    required       INTEGER NOT NULL,
    resolved_at    TEXT NOT NULL,
    PRIMARY KEY (install_name, capability)
);

CREATE INDEX IF NOT EXISTS idx_gctrl_app_bindings_install
    ON gctrl_app_bindings(install_name);
```

### CRUD methods

| Method | Behavior |
|---|---|
| `upsert_app_install` | Insert / reload. `ON CONFLICT(name) DO UPDATE` touches everything except `installed_at`, so the original install timestamp is preserved across reloads (analytics gets a true first-install time). |
| `get_app_install` | Returns `Option<AppInstall>`; missing → `None`. |
| `list_app_installs` | Alphabetical by `name` for stable listings. |
| `delete_app_install` | Removes install record. Defensive cascade — drops bindings explicitly before installs even when `PRAGMA foreign_keys` is off (SQLite default). |
| `replace_app_bindings` | Single-transaction replace-all so reload is atomic. The manifest is the source of truth for the capability set; we drop existing rows and insert the new set. |
| `list_app_bindings` | Required-first (`required DESC`), then alphabetical by `capability`, so `gctrl app status` output is deterministic. |

## Why `replace_app_bindings` rather than per-row upsert

`gctrl app reload` re-applies the full manifest. If a capability is removed from `[requires]` between versions, the corresponding binding row needs to disappear. Per-row upsert can't express "this capability is gone now" without an extra delete step that races with the inserts. Single-tx replace-all is simpler and correct.

## Test plan

- [x] `cargo build --workspace` clean (`RUSTFLAGS=-D warnings`)
- [x] `cargo test --workspace` — **570 passing** (8 new in `gctrl-storage`, 0 regressions)
- [x] **`app_install_upsert_and_get`** — basic round-trip
- [x] **`app_install_upsert_preserves_installed_at_on_reload`** — reload doesn't churn the install timestamp
- [x] **`app_install_list_alphabetical`** — listing order
- [x] **`app_install_delete_cascades_bindings`** — both rows gone after `delete_app_install`
- [x] **`app_bindings_replace_overwrites_full_set`** — old bindings dropped, retained ones get new driver_id, new ones inserted
- [x] **`app_bindings_list_orders_required_then_alphabetical`** — verifies the four-cap example produces `[llm, vault.write, browser.cdp, gcal]`
- [x] **`app_bindings_required_flag_round_trips`** — bool ↔ SQLite int
- [x] **`app_bindings_for_unknown_install_is_empty`** — list returns empty vec, not error

## Stack

- #166 — **PR-α.1** registry + parser
- **This PR** — **PR-α.2** storage tables + CRUD ← *you are here*
- Next — **PR-α.3** `/api/app/{install,status,reload,uninstall}` HTTP routes + `gctrl app install` shell subcommand

## Out of scope (deferred)

- **HTTP routes** — PR-α.3.
- **Vault-mount registration** — install handler will call the existing `create_vault_mount` API (already in `SqliteStore`); not part of this CRUD layer.
- **Schedule registration** — install handler will call existing `create_schedule`.
- **Project-key collision check** — install handler logic in PR-α.3 (queries `gctrl_vault_mounts` before registering).
