### PR TITLE
feat(kernel): /api/app/* HTTP routes — install / list / get / reload / delete

### DIFF
--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -17,7 +17,7 @@ use futures_core::Stream;
 use gctrl_context::ContextManager;
 use gctrl_core::{NetConfig, SchedulerConfig, SyncConfig};
 use gctrl_storage::{DuckDbStore, SqliteStore};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::event_bus::{EventBus, ReplayResult, SessionEvent};
 use crate::span_processor::{self, OtlpExportRequest};
@@ -278,6 +278,21 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/vault/mounts/{name}", delete(vault_mounts_delete))
         .route("/api/vault/page", get(vault_page_get).post(vault_page_put))
+        // App installs — gctrl-app.toml manifest install/list/status/uninstall.
+        // Spec: vault/specs/architecture/app-install-protocol.md
+        .route(
+            "/api/app/installs",
+            get(app_installs_list).post(app_installs_create),
+        )
+        .route(
+            "/api/app/installs/{name}",
+            get(app_installs_get).delete(app_installs_delete),
+        )
+        .route(
+            "/api/app/installs/{name}/reload",
+            post(app_installs_reload),
+        )
+        .route("/api/app/capabilities", get(app_capabilities_list))
         // Uebermensch briefs index — `(date, kind)` keyed; vault file is the
         // source of truth, this is the queryable index for listing/filtering.
         .route(
@@ -4656,6 +4671,303 @@ fn resolve_within(root: &str, rel: &str) -> Result<std::path::PathBuf, String> {
 }
 
 // =============================================================================
+// App installs — `gctrl-app.toml` manifest installation.
+//
+// On POST /api/app/installs:
+//   1. Parse + validate the manifest (gctrl_core::app_manifest)
+//   2. Resolve every capability to its registered driver
+//      (gctrl_core::capabilities)
+//   3. Persist install record + bindings (gctrl_app_installs +
+//      gctrl_app_bindings)
+//   4. Register vault project keys in gctrl_vault_mounts (kind=app,
+//      app_id=install.name) — collision-checked against existing mounts
+//      owned by *different* apps.
+//
+// `manifest_text` is required in the request body — git/file-path resolution
+// is deferred. The caller (shell command, future) reads the file and POSTs
+// the text inline.
+//
+// Spec: vault/specs/architecture/app-install-protocol.md
+// =============================================================================
+
+#[derive(Deserialize)]
+struct AppInstallCreateBody {
+    /// Where the manifest came from — informational. Local path or git URL.
+    /// Stored verbatim so `gctrl app reload` can re-fetch.
+    source_ref: String,
+    /// Inline `gctrl-app.toml` text. Required in v1.
+    manifest_text: String,
+}
+
+#[derive(Serialize)]
+struct AppInstallView {
+    install: gctrl_core::AppInstall,
+    bindings: Vec<gctrl_core::AppBinding>,
+    vault_mounts: Vec<gctrl_core::VaultMount>,
+}
+
+#[derive(Serialize)]
+struct CapabilityView {
+    id: &'static str,
+    default_driver: &'static str,
+    route_prefix: &'static str,
+    description: &'static str,
+}
+
+fn manifest_sha(text: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(text.as_bytes());
+    format!("{:x}", digest)
+}
+
+fn install_app_inner(
+    state: &Arc<AppState>,
+    body: AppInstallCreateBody,
+    is_reload: bool,
+) -> Result<AppInstallView, (StatusCode, String)> {
+    let manifest = gctrl_core::app_manifest::AppManifest::parse(&body.manifest_text)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("manifest invalid: {e}")))?;
+
+    // Project-key collision check: any existing mount with the same name
+    // that belongs to a *different* app blocks the install.
+    let existing_mounts = state
+        .sqlite
+        .list_vault_mounts()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    for vp in &manifest.vault_projects {
+        if let Some(m) = existing_mounts.iter().find(|m| m.name == vp.key) {
+            if m.app_id.as_deref() != Some(manifest.app.name.as_str()) {
+                return Err((
+                    StatusCode::CONFLICT,
+                    format!(
+                        "project key `{}` is already owned by app `{}`",
+                        vp.key,
+                        m.app_id.as_deref().unwrap_or("<none>")
+                    ),
+                ));
+            }
+        }
+    }
+
+    let now = chrono::Utc::now();
+
+    // Persist install record. Reload preserves `installed_at` via the
+    // store's ON CONFLICT clause.
+    let prev_installed_at = if is_reload {
+        state
+            .sqlite
+            .get_app_install(&manifest.app.name)
+            .ok()
+            .flatten()
+            .map(|prev| prev.installed_at)
+    } else {
+        None
+    };
+    let install = gctrl_core::AppInstall {
+        name: manifest.app.name.clone(),
+        version: manifest.app.version.clone(),
+        source_ref: body.source_ref,
+        manifest_sha: manifest_sha(&body.manifest_text),
+        installed_at: prev_installed_at.unwrap_or(now),
+        reloaded_at: if is_reload { Some(now) } else { None },
+    };
+    state
+        .sqlite
+        .upsert_app_install(&install)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Persist bindings (denormalized join with the registry).
+    let mut bindings = Vec::new();
+    for (id, required) in manifest.all_capabilities() {
+        let cap = gctrl_core::capabilities::lookup(id).ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("capability `{id}` not in registry — manifest validate should have caught this"),
+            )
+        })?;
+        bindings.push(gctrl_core::AppBinding {
+            install_name: manifest.app.name.clone(),
+            capability: id.to_string(),
+            driver_id: cap.default_driver.to_string(),
+            required,
+            resolved_at: now,
+        });
+    }
+    state
+        .sqlite
+        .replace_app_bindings(&manifest.app.name, &bindings)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Register vault projects in gctrl_vault_mounts (kind=app, owned by this
+    // install). Idempotent — if a mount with this name already exists owned
+    // by *this* app, leave it alone (the collision check above already
+    // rejected mounts owned by another app).
+    for vp in &manifest.vault_projects {
+        if existing_mounts.iter().any(|m| m.name == vp.key) {
+            continue;
+        }
+        let mount = gctrl_core::VaultMount {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: vp.key.clone(),
+            // Root path is kernel-owned (resolved at daemon startup from
+            // --board-dir / GCTRL_BOARD_DIR / cwd) but gctrl_vault_mounts
+            // requires a non-null root_path. Use the project key as a
+            // relative marker; the watcher generalization (next PR) will
+            // resolve this against the kernel root.
+            root_path: vp.key.clone(),
+            kind: gctrl_core::VaultMountKind::App,
+            git_url: None,
+            app_id: Some(manifest.app.name.clone()),
+            last_commit_sha: None,
+            last_synced_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        state
+            .sqlite
+            .create_vault_mount(&mount)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+
+    let mounts = state
+        .sqlite
+        .list_vault_mounts()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .into_iter()
+        .filter(|m| m.app_id.as_deref() == Some(manifest.app.name.as_str()))
+        .collect();
+    let stored_install = state
+        .sqlite
+        .get_app_install(&manifest.app.name)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "install record vanished after upsert".to_string(),
+            )
+        })?;
+    let stored_bindings = state
+        .sqlite
+        .list_app_bindings(&manifest.app.name)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(AppInstallView {
+        install: stored_install,
+        bindings: stored_bindings,
+        vault_mounts: mounts,
+    })
+}
+
+async fn app_installs_create(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<AppInstallCreateBody>,
+) -> impl IntoResponse {
+    match install_app_inner(&state, body, false) {
+        Ok(view) => (StatusCode::CREATED, Json(view)).into_response(),
+        Err((status, msg)) => (status, msg).into_response(),
+    }
+}
+
+async fn app_installs_reload(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Json(body): Json<AppInstallCreateBody>,
+) -> impl IntoResponse {
+    // Reload = re-apply manifest. The path's `name` MUST match the manifest's
+    // `[app] name`; we error otherwise to avoid silent app-rename via reload.
+    let parsed = match gctrl_core::app_manifest::AppManifest::parse(&body.manifest_text) {
+        Ok(m) => m,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, format!("manifest invalid: {e}")).into_response();
+        }
+    };
+    if parsed.app.name != name {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "manifest [app] name `{}` does not match install `{}` — apps cannot rename via reload",
+                parsed.app.name, name
+            ),
+        )
+            .into_response();
+    }
+    match install_app_inner(&state, body, true) {
+        Ok(view) => Json(view).into_response(),
+        Err((status, msg)) => (status, msg).into_response(),
+    }
+}
+
+async fn app_installs_list(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match state.sqlite.list_app_installs() {
+        Ok(installs) => Json(installs).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn app_installs_get(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let install = match state.sqlite.get_app_install(&name) {
+        Ok(Some(i)) => i,
+        Ok(None) => return (StatusCode::NOT_FOUND, format!("no install: {name}")).into_response(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let bindings = match state.sqlite.list_app_bindings(&name) {
+        Ok(b) => b,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let mounts: Vec<_> = match state.sqlite.list_vault_mounts() {
+        Ok(m) => m
+            .into_iter()
+            .filter(|m| m.app_id.as_deref() == Some(name.as_str()))
+            .collect(),
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    Json(AppInstallView {
+        install,
+        bindings,
+        vault_mounts: mounts,
+    })
+    .into_response()
+}
+
+async fn app_installs_delete(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    // Drop install record + bindings. ALSO drop vault mount registrations
+    // owned by this app (per spec — files in the kernel vault root are NOT
+    // touched, only the `gctrl_vault_mounts` rows).
+    let mounts = match state.sqlite.list_vault_mounts() {
+        Ok(m) => m,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    for m in mounts.iter().filter(|m| m.app_id.as_deref() == Some(name.as_str())) {
+        if let Err(e) = state.sqlite.delete_vault_mount(&m.name) {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+    match state.sqlite.delete_app_install(&name) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn app_capabilities_list() -> impl IntoResponse {
+    let view: Vec<CapabilityView> = gctrl_core::capabilities::REGISTRY
+        .iter()
+        .map(|c| CapabilityView {
+            id: c.id,
+            default_driver: c.default_driver,
+            route_prefix: c.route_prefix,
+            description: c.description,
+        })
+        .collect();
+    Json(view).into_response()
+}
+
+// =============================================================================
 // Uebermensch briefs index — `(date, kind)` keyed app-namespaced table.
 // Vault markdown is the source of truth; this is the queryable metadata index.
 // =============================================================================
@@ -6061,5 +6373,270 @@ Getting User settings...
         let row = build_commit_row(&commit, |_| None);
         assert_eq!(row["author"], serde_json::json!("web-ui-user"));
         assert!(row["session_id"].is_null());
+    }
+
+    // ───────── App installs (PR-α.3) ─────────
+
+    fn test_app_dual() -> Router {
+        let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+        let sqlite = Arc::new(SqliteStore::open(":memory:").expect("sqlite open"));
+        create_router_dual(store, sqlite)
+    }
+
+    fn minimal_uber_manifest() -> &'static str {
+        r#"
+[app]
+name = "uebermensch"
+version = "0.2.0"
+
+[entrypoint]
+bin = "dist/main.js"
+command = "uber"
+runtime = "node"
+
+[requires.llm]
+[requires.deliverer.telegram]
+
+[[vault-projects]]
+key = "UBER"
+"#
+    }
+
+    async fn install_uber(app: &Router) -> http::Response<Body> {
+        let body = serde_json::json!({
+            "source_ref": "/path/to/uebermensch",
+            "manifest_text": minimal_uber_manifest(),
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/app/installs")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn capabilities_endpoint_lists_registry() {
+        let app = test_app_dual();
+        let req = Request::builder()
+            .uri("/api/app/capabilities")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let arr = json.as_array().unwrap();
+        assert!(arr.iter().any(|c| c["id"] == "llm"));
+        assert!(arr.iter().any(|c| c["id"] == "deliverer.telegram"));
+        // Order matches REGISTRY (llm is first).
+        assert_eq!(arr[0]["id"], "llm");
+    }
+
+    #[tokio::test]
+    async fn install_creates_install_record_bindings_and_mount() {
+        let app = test_app_dual();
+        let resp = install_uber(&app).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let view: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(view["install"]["name"], "uebermensch");
+        assert_eq!(view["install"]["version"], "0.2.0");
+        assert!(view["install"]["manifest_sha"].as_str().unwrap().len() == 64);
+
+        let bindings = view["bindings"].as_array().unwrap();
+        // 2 required: llm, deliverer.telegram. Required first, alphabetical.
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0]["capability"], "deliverer.telegram");
+        assert_eq!(bindings[0]["driver_id"], "driver-telegram");
+        assert_eq!(bindings[0]["required"], true);
+        assert_eq!(bindings[1]["capability"], "llm");
+        assert_eq!(bindings[1]["driver_id"], "driver-llm");
+
+        let mounts = view["vault_mounts"].as_array().unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0]["name"], "UBER");
+        assert_eq!(mounts[0]["app_id"], "uebermensch");
+        assert_eq!(mounts[0]["kind"], "app");
+    }
+
+    #[tokio::test]
+    async fn install_rejects_unknown_capability() {
+        let app = test_app_dual();
+        let body = serde_json::json!({
+            "source_ref": "/x",
+            "manifest_text": "[app]\nname = \"x\"\nversion = \"0.1.0\"\n\
+                              \n[entrypoint]\nbin = \"x\"\ncommand = \"x\"\nruntime = \"node\"\n\
+                              \n[requires.vault.frobnicate]\n",
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/app/installs")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg = String::from_utf8_lossy(&body);
+        assert!(msg.contains("vault.frobnicate"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn install_rejects_project_key_collision_owned_by_other_app() {
+        let app = test_app_dual();
+        // First install of an app that claims UBER.
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        // Different app, same project key — should 409.
+        let other = serde_json::json!({
+            "source_ref": "/x",
+            "manifest_text": "[app]\nname = \"squatter\"\nversion = \"0.1.0\"\n\
+                              \n[entrypoint]\nbin = \"x\"\ncommand = \"x\"\nruntime = \"node\"\n\
+                              \n[[vault-projects]]\nkey = \"UBER\"\n",
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/app/installs")
+            .header("content-type", "application/json")
+            .body(Body::from(other.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg = String::from_utf8_lossy(&body);
+        assert!(msg.contains("UBER"));
+        assert!(msg.contains("uebermensch"));
+    }
+
+    #[tokio::test]
+    async fn install_idempotent_for_same_app_same_keys() {
+        let app = test_app_dual();
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+        // Re-install with same content → also CREATED (upsert), still 1 mount.
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        let req = Request::builder()
+            .uri("/api/app/installs/uebermensch")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let view: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(view["vault_mounts"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_returns_installs_alphabetically() {
+        let app = test_app_dual();
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        let req = Request::builder()
+            .uri("/api/app/installs")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let installs: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(installs.as_array().unwrap().len(), 1);
+        assert_eq!(installs[0]["name"], "uebermensch");
+    }
+
+    #[tokio::test]
+    async fn get_returns_404_for_unknown_app() {
+        let app = test_app_dual();
+        let req = Request::builder()
+            .uri("/api/app/installs/nonexistent")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_drops_install_bindings_and_owned_mounts() {
+        let app = test_app_dual();
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        // Delete
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/api/app/installs/uebermensch")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        // 404 on subsequent get
+        let req = Request::builder()
+            .uri("/api/app/installs/uebermensch")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        // Mount also gone (no longer registered)
+        let req = Request::builder()
+            .uri("/api/vault/mounts")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let mounts: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(mounts.as_array().unwrap().is_empty(), "owned mount should be cleaned up");
+
+        // After delete, fresh install of *same* manifest should succeed (no
+        // stale conflicts).
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn reload_updates_version_preserves_installed_at() {
+        let app = test_app_dual();
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        let bumped = serde_json::json!({
+            "source_ref": "/path/to/uebermensch",
+            "manifest_text": minimal_uber_manifest().replace("0.2.0", "0.3.0"),
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/app/installs/uebermensch/reload")
+            .header("content-type", "application/json")
+            .body(Body::from(bumped.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let view: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(view["install"]["version"], "0.3.0");
+        assert!(view["install"]["reloaded_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn reload_rejects_app_rename() {
+        let app = test_app_dual();
+        assert_eq!(install_uber(&app).await.status(), StatusCode::CREATED);
+
+        // Reload at /uebermensch/reload but the body's [app] name is different.
+        let renamed = serde_json::json!({
+            "source_ref": "/x",
+            "manifest_text": minimal_uber_manifest().replace("uebermensch", "renamed-app"),
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/app/installs/uebermensch/reload")
+            .header("content-type", "application/json")
+            .body(Body::from(renamed.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let msg = String::from_utf8_lossy(&body);
+        assert!(msg.contains("rename"), "got: {msg}");
     }
 }


### PR DESCRIPTION
## Summary

PR-α.3 of the install-protocol implementation (spec: #161). **Stacks on #167** (storage), which stacks on #166 (registry + parser).

Wires the manifest parser (#166) and storage tables (#167) into the kernel HTTP API. After this PR, `gctrl-app.toml` is end-to-end installable from any HTTP caller (curl, future shell command, future Worker).

## Routes mounted

| Route | Verb | Behavior |
|---|---|---|
| `/api/app/installs` | POST | Body: `{ source_ref, manifest_text }`. Parse + validate, project-key collision check, persist install + bindings, register vault mounts. **201** + `AppInstallView`. |
| `/api/app/installs` | GET | Alphabetical list of `AppInstall` rows. |
| `/api/app/installs/{name}` | GET | Detail = install + bindings (required-first) + vault_mounts owned by this app. **404** if unknown. |
| `/api/app/installs/{name}/reload` | POST | Re-apply manifest. Replaces bindings (drops removed caps), updates version + manifest_sha + reloaded_at. **Preserves installed_at**. Path's name MUST match manifest's `[app] name`. |
| `/api/app/installs/{name}` | DELETE | Drops install + bindings (cascade) + vault mounts owned by this app. Files in the kernel vault root NOT touched. **204**. |
| `/api/app/capabilities` | GET | Reflects the kernel's capability registry as JSON: `[{ id, default_driver, route_prefix, description }, ...]`. Used by future `gctrl app status` and external tooling. |

### Status code mapping

| Status | When |
|---|---|
| `201 Created` | Install |
| `200 OK` | List / get / reload / capabilities |
| `204 No Content` | Delete |
| `400 Bad Request` | Manifest parse / validation / unknown capability / rename-via-reload |
| `404 Not Found` | Unknown install on get/reload/delete |
| `409 Conflict` | Project key already owned by a different app |

## Manifest install: how it actually plays out

```
$ curl -X POST http://127.0.0.1:4318/api/app/installs \
    -H 'content-type: application/json' \
    -d @- <<EOF
{
  "source_ref": "/Users/me/workspaces/ohc/gctrl/apps/uebermensch",
  "manifest_text": $(jq -Rs . < apps/uebermensch/gctrl-app.toml)
}
EOF

HTTP/1.1 201 Created
{
  "install": {
    "name": "uebermensch",
    "version": "0.2.0",
    "source_ref": "/Users/me/workspaces/ohc/gctrl/apps/uebermensch",
    "manifest_sha": "8a4b…",
    "installed_at": "2026-05-03T18:00:00Z",
    "reloaded_at": null
  },
  "bindings": [
    { "capability": "deliverer.discord", "driver_id": "driver-discord", "required": true, ... },
    { "capability": "deliverer.telegram", "driver_id": "driver-telegram", "required": true, ... },
    { "capability": "llm", "driver_id": "driver-llm", "required": true, ... },
    { "capability": "secrets", "driver_id": "driver-secrets", "required": true, ... },
    { "capability": "vault.sync", "driver_id": "gctrl-sync.vault", "required": true, ... },
    { "capability": "vault.write", "driver_id": "kernel-vault-fs", "required": true, ... },
    { "capability": "browser.cdp", "driver_id": "driver-browser", "required": false, ... },
    { "capability": "gcal", "driver_id": "driver-gcal", "required": false, ... },
    { "capability": "search.brave", "driver_id": "driver-brave", "required": false, ... }
  ],
  "vault_mounts": [
    { "name": "UBER", "kind": "app", "app_id": "uebermensch", ... }
  ]
}
```

## Test plan

- [x] `cargo build --workspace` clean (`RUSTFLAGS=-D warnings`)
- [x] `cargo test --workspace` — **580 passing** (10 new HTTP integration tests, 0 regressions)

10 new tests via `tower::ServiceExt::oneshot`:

- [x] `capabilities_endpoint_lists_registry` — registry round-trips through HTTP
- [x] `install_creates_install_record_bindings_and_mount` — end-to-end happy path; verifies bindings ordering + driver_id resolution + mount registration
- [x] `install_rejects_unknown_capability` — 400 with offending id
- [x] `install_rejects_project_key_collision_owned_by_other_app` — 409 names both keys
- [x] `install_idempotent_for_same_app_same_keys` — re-install of identical manifest doesn't duplicate the mount
- [x] `list_returns_installs_alphabetically`
- [x] `get_returns_404_for_unknown_app`
- [x] `delete_drops_install_bindings_and_owned_mounts` — confirms mount is gone; fresh install of same manifest succeeds after
- [x] `reload_updates_version_preserves_installed_at`
- [x] `reload_rejects_app_rename` — BAD_REQUEST when path / body `[app] name` disagree

## Out of scope (deferred)

- **`gctrl app install/list/status/uninstall` shell subcommands** — PR-α.4. Today, callers go directly through `curl` or `gctrl gh exec --raw POST /api/app/installs ...`.
- **Schedule registration** — installer doesn't yet register `[[schedule]]` entries into kernel `schedules`. Tracking in a follow-up; manifest parser already supports the field, so this is purely the install handler wiring.
- **Source-ref resolution** — `source_ref` is stored verbatim. Future work: support `git+https://...` refs that the installer fetches before parsing.
- **Capability availability** — install validates that capability ids exist in the *registry* but doesn't check the underlying driver is actually loaded (e.g. `driver-brave` might be feature-gated off). The kernel returns 503 at request time today.

## Stack

- #166 — **PR-α.1** registry + parser
- #167 — **PR-α.2** storage tables + CRUD
- **This PR** — **PR-α.3** HTTP routes ← *you are here*
- Next — PR-α.4 shell subcommand (`gctrl app install/list/status/uninstall`)
- After: schedule registration, kernel sync vault extension, uebermensch migration, repo carve.
