### PR TITLE
feat(mac-comm): kernel driver + desktop URL scheme + inbox Focus button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gctrl-mac-comm"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "gctrl-net"
 version = "0.1.0"
 dependencies = [
@@ -1898,6 +1912,7 @@ dependencies = [
  "gctrl-core",
  "gctrl-driver-macos",
  "gctrl-gcal",
+ "gctrl-mac-comm",
  "gctrl-net",
  "gctrl-proxy",
  "gctrl-recorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "kernel/crates/gctrl-driver-macos",
     "kernel/crates/gctrl-browser",
     "kernel/crates/gctrl-recorder",
+    "kernel/crates/gctrl-mac-comm",
 ]
 
 [workspace.package]

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   IssueEvent,
   TeamRecommendation,
   TeamRenderResult,
+  CommCapabilities,
   InboxMessage,
   InboxThread,
   InboxAction,
@@ -258,6 +259,13 @@ export const api = {
       }),
 
     stats: () => request<InboxStats>("/api/inbox/stats"),
+  },
+
+  // gctrl-mac-comm driver — focus terminal sessions, capability probe.
+  // On non-macOS the routes return 501 and `os` reflects the host platform
+  // so the UI can hide the affordance entirely.
+  comm: {
+    capabilities: () => request<CommCapabilities>("/api/comm/capabilities"),
   },
 
   // Kernel analytics + sessions — proxied by Vite dev server to :4318.

--- a/apps/gctrl-board/web/src/components/MessageDetail.tsx
+++ b/apps/gctrl-board/web/src/components/MessageDetail.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react"
-import type { InboxMessage } from "../types"
+import {
+  buildFocusCliCommand,
+  buildFocusUrl,
+  labelFor,
+  shouldShowFocus,
+} from "../lib/deeplink"
+import { useCapabilities } from "../hooks/useCapabilities"
+import type { InboxMessage, TerminalContext } from "../types"
 
 const URGENCY_DOT: Record<string, string> = {
   urgent: "#f43f5e",
@@ -32,6 +39,7 @@ interface Props {
 export function MessageDetail({ message, onAction }: Props) {
   const [acting, setActing] = useState<string | null>(null)
   const [contextOpen, setContextOpen] = useState(false)
+  const { capabilities, refresh: refreshCapabilities } = useCapabilities()
 
   const urgencyColor = URGENCY_DOT[message.urgency] ?? URGENCY_DOT.low
 
@@ -45,7 +53,21 @@ export function MessageDetail({ message, onAction }: Props) {
     }
   }
 
-  const contextEntries = message.context ? Object.entries(message.context) : []
+  const terminal: TerminalContext | undefined =
+    message.context && typeof message.context === "object"
+      ? (message.context as { terminal?: TerminalContext }).terminal
+      : undefined
+
+  const focusUrl = terminal ? buildFocusUrl(terminal) : null
+  const showFocus = shouldShowFocus(capabilities, terminal) && focusUrl !== null
+  const automationDenied =
+    capabilities?.os === "macos" && capabilities.automation_granted === false
+
+  // For the "Context" panel below, hide the `terminal` block so it isn't
+  // double-rendered (the Focus button + tooltip already surfaces it).
+  const contextEntries = message.context
+    ? Object.entries(message.context).filter(([k]) => k !== "terminal")
+    : []
 
   return (
     <div className="flex flex-col h-full animate-fade-in">
@@ -143,6 +165,15 @@ export function MessageDetail({ message, onAction }: Props) {
 
       {/* Action bar */}
       <div className="px-5 py-3 border-t border-zinc-800/50 flex items-center gap-2 shrink-0">
+        {showFocus && focusUrl && terminal && (
+          <FocusButton url={focusUrl} terminal={terminal} />
+        )}
+        {automationDenied && terminal && terminal.app !== "unknown" && (
+          <AutomationDeniedHint
+            terminal={terminal}
+            onRefresh={refreshCapabilities}
+          />
+        )}
         <ActionButton
           label="Approve"
           actionType="approve"
@@ -172,6 +203,88 @@ export function MessageDetail({ message, onAction }: Props) {
           className="bg-amber-500/10 text-amber-400 border-amber-500/25 hover:bg-amber-500/20"
         />
       </div>
+    </div>
+  )
+}
+
+// --- Focus button ---------------------------------------------------------
+//
+// Renders an anchor with the `gctrl://focus/...` href. On macOS with
+// gctrl-desktop installed, LaunchServices catches the click and forwards
+// to `/api/comm/focus` (defense-in-depth: kernel re-validates).
+//
+// If the user doesn't have gctrl-desktop, clicking does nothing visible —
+// the OS shows a "no app handles this URL" prompt. We surface a copy-to-
+// clipboard fallback in the tooltip so headless users still have a path.
+
+function FocusButton({
+  url,
+  terminal,
+}: {
+  url: string
+  terminal: TerminalContext
+}) {
+  const [copied, setCopied] = useState(false)
+  const cli = buildFocusCliCommand(terminal)
+  const tooltip = `${labelFor(terminal.app)}${terminal.cwd ? ` · ${terminal.cwd}` : ""}`
+
+  const copyCli = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!cli) return
+    try {
+      await navigator.clipboard.writeText(cli)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard may be denied (e.g. http://). Fall through silently —
+      // the user can still click the main anchor below.
+    }
+  }
+
+  return (
+    <span className="inline-flex items-stretch gap-px mr-1">
+      <a
+        href={url}
+        title={tooltip}
+        className="px-3 py-1.5 text-[13px] font-display font-medium tracking-wide border border-sky-500/25 bg-sky-500/10 text-sky-400 hover:bg-sky-500/20 transition-colors cursor-pointer no-underline"
+      >
+        FOCUS {labelFor(terminal.app).toUpperCase()}
+      </a>
+      {cli && (
+        <button
+          type="button"
+          onClick={copyCli}
+          title={copied ? "Copied!" : `Copy: ${cli}`}
+          className="px-2 py-1.5 text-[11px] font-mono border border-l-0 border-sky-500/25 bg-sky-500/5 text-sky-300/80 hover:bg-sky-500/15 transition-colors cursor-pointer"
+        >
+          {copied ? "✓" : "⧉"}
+        </button>
+      )}
+    </span>
+  )
+}
+
+function AutomationDeniedHint({
+  terminal,
+  onRefresh,
+}: {
+  terminal: TerminalContext
+  onRefresh: () => void
+}) {
+  return (
+    <div className="flex items-center gap-2 mr-2 px-2 py-1.5 text-[11px] font-mono text-amber-400/80 border border-amber-500/25 bg-amber-500/5">
+      <span>
+        Automation denied for {labelFor(terminal.app)} · grant in System
+        Settings → Privacy & Security → Automation
+      </span>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="px-1.5 py-0.5 text-[10px] tracking-wider uppercase border border-amber-500/30 hover:bg-amber-500/15 cursor-pointer"
+      >
+        Refresh
+      </button>
     </div>
   )
 }

--- a/apps/gctrl-board/web/src/hooks/useCapabilities.ts
+++ b/apps/gctrl-board/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,86 @@
+/**
+ * `useCapabilities` — fetch and cache the kernel's `/api/comm/capabilities`
+ * snapshot, with degraded-only polling.
+ *
+ * - On mount: fetch once.
+ * - If the response says `automation_granted: false`, re-fetch every 10s
+ *   until the user grants Automation in System Settings (and the response
+ *   flips to `true`). Stop polling on grant.
+ * - If `automation_granted` is granted (true) or unknown (null/undefined),
+ *   never poll. Apple Events grants are sticky once given, and the
+ *   "unknown" state shouldn't itself drive UI thrash.
+ *
+ * Manual `refresh()` is exposed for the "I just granted it" affordance —
+ * the inbox renders a tiny Refresh button next to the disabled tooltip.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { api } from "../api/client"
+import type { CommCapabilities } from "../types"
+
+const DEGRADED_POLL_MS = 10_000
+
+interface UseCapabilitiesResult {
+  capabilities: CommCapabilities | null
+  loading: boolean
+  /** Force-refetch — used by a manual "Refresh" affordance after the user
+   *  has just granted Automation. */
+  refresh: () => void
+}
+
+export function useCapabilities(): UseCapabilitiesResult {
+  const [capabilities, setCapabilities] = useState<CommCapabilities | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [tick, setTick] = useState(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const refresh = useCallback(() => setTick((t) => t + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchOnce = async () => {
+      try {
+        const caps = await api.comm.capabilities()
+        if (cancelled) return
+        setCapabilities(caps)
+      } catch {
+        // Treat fetch failure as "kernel offline" — leave caps null so the
+        // UI hides the Focus button.
+        if (!cancelled) setCapabilities(null)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void fetchOnce()
+
+    return () => {
+      cancelled = true
+    }
+  }, [tick])
+
+  useEffect(() => {
+    // Schedule the next degraded poll only if the most recent snapshot says
+    // we're degraded. Any other state (granted, unknown, null) clears the
+    // timer.
+    const degraded = capabilities?.automation_granted === false
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (degraded) {
+      timerRef.current = setTimeout(() => {
+        setTick((t) => t + 1)
+      }, DEGRADED_POLL_MS)
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [capabilities])
+
+  return { capabilities, loading, refresh }
+}

--- a/apps/gctrl-board/web/src/lib/__tests__/deeplink.test.ts
+++ b/apps/gctrl-board/web/src/lib/__tests__/deeplink.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest"
+
+import type { CommCapabilities, TerminalContext } from "../../types"
+import {
+  buildFocusCliCommand,
+  buildFocusUrl,
+  escapeAttr,
+  labelFor,
+  shouldShowFocus,
+} from "../deeplink"
+
+const VALID_ITERM2_ID = "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765"
+
+const macosCaps: CommCapabilities = {
+  os: "macos",
+  terminals: ["iterm2", "terminal"],
+  notify: false,
+  automation_granted: true,
+  captured_at: "2026-05-03T00:00:00Z",
+}
+
+const linuxCaps: CommCapabilities = {
+  os: "linux",
+  terminals: [],
+  notify: false,
+  automation_granted: null,
+  captured_at: "2026-05-03T00:00:00Z",
+}
+
+const macosCapsAutomationDenied: CommCapabilities = {
+  ...macosCaps,
+  automation_granted: false,
+}
+
+const macosCapsAutomationUnknown: CommCapabilities = {
+  ...macosCaps,
+  automation_granted: null,
+}
+
+describe("buildFocusUrl", () => {
+  it("builds the iTerm2 URL for a valid session id", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(buildFocusUrl(t)).toBe(`gctrl://focus/iterm2/${VALID_ITERM2_ID}`)
+  })
+
+  it("returns null for iTerm2 with malformed session id", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: "not-iterm-shaped" }
+    expect(buildFocusUrl(t)).toBeNull()
+  })
+
+  it("returns null for iTerm2 with shell-injection attempt", () => {
+    const t: TerminalContext = {
+      app: "iterm2",
+      session_id: 'w0t0p0:X" & do shell script "rm -rf /"',
+    }
+    expect(buildFocusUrl(t)).toBeNull()
+  })
+
+  it("returns null for iTerm2 with no session id at all", () => {
+    expect(buildFocusUrl({ app: "iterm2" })).toBeNull()
+  })
+
+  it("builds the Apple Terminal URL with window/tab indices", () => {
+    const t: TerminalContext = { app: "terminal", window_id: "1", tab_id: "3" }
+    expect(buildFocusUrl(t)).toBe("gctrl://focus/terminal/1/3")
+  })
+
+  it("returns null for Apple Terminal with non-numeric indices", () => {
+    expect(
+      buildFocusUrl({ app: "terminal", window_id: "abc", tab_id: "3" }),
+    ).toBeNull()
+    expect(buildFocusUrl({ app: "terminal", window_id: "1", tab_id: "x" })).toBeNull()
+  })
+
+  it("returns null for Apple Terminal missing tab", () => {
+    expect(buildFocusUrl({ app: "terminal", window_id: "1" })).toBeNull()
+  })
+
+  it("builds the URL for Ghostty / VS Code / Warp with generic session ids", () => {
+    expect(buildFocusUrl({ app: "ghostty", session_id: "abc-123" })).toBe(
+      "gctrl://focus/ghostty/abc-123",
+    )
+    expect(buildFocusUrl({ app: "vscode", session_id: "ws.proj_1" })).toBe(
+      "gctrl://focus/vscode/ws.proj_1",
+    )
+    expect(buildFocusUrl({ app: "warp", session_id: "warp:42" })).toBe(
+      "gctrl://focus/warp/warp:42",
+    )
+  })
+
+  it("returns null for generic targets with shell-meta in session id", () => {
+    expect(buildFocusUrl({ app: "ghostty", session_id: "abc;rm" })).toBeNull()
+    expect(buildFocusUrl({ app: "ghostty", session_id: 'a"b' })).toBeNull()
+    expect(buildFocusUrl({ app: "ghostty", session_id: "a b" })).toBeNull()
+  })
+
+  it("returns null for unknown app", () => {
+    expect(buildFocusUrl({ app: "unknown" })).toBeNull()
+  })
+
+  it("returns null for null/undefined input", () => {
+    expect(buildFocusUrl(null)).toBeNull()
+    expect(buildFocusUrl(undefined)).toBeNull()
+  })
+})
+
+describe("shouldShowFocus", () => {
+  it("renders on macOS with a known terminal and granted automation", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(shouldShowFocus(macosCaps, t)).toBe(true)
+  })
+
+  it("renders even when automation_granted is unknown (so the click can trigger the prompt)", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(shouldShowFocus(macosCapsAutomationUnknown, t)).toBe(true)
+  })
+
+  it("hides when automation explicitly denied", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(shouldShowFocus(macosCapsAutomationDenied, t)).toBe(false)
+  })
+
+  it("hides on non-macOS even with valid context", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(shouldShowFocus(linuxCaps, t)).toBe(false)
+  })
+
+  it("hides when caps are still loading (null)", () => {
+    const t: TerminalContext = { app: "iterm2", session_id: VALID_ITERM2_ID }
+    expect(shouldShowFocus(null, t)).toBe(false)
+  })
+
+  it("hides when terminal context is missing", () => {
+    expect(shouldShowFocus(macosCaps, undefined)).toBe(false)
+  })
+
+  it("hides for unknown app", () => {
+    expect(shouldShowFocus(macosCaps, { app: "unknown" })).toBe(false)
+  })
+
+  it("hides when caps don't list this terminal (e.g., ghostty not yet supported)", () => {
+    const t: TerminalContext = { app: "ghostty", session_id: "abc" }
+    expect(shouldShowFocus(macosCaps, t)).toBe(false)
+  })
+})
+
+describe("labelFor", () => {
+  it("returns human labels", () => {
+    expect(labelFor("iterm2")).toBe("iTerm2")
+    expect(labelFor("terminal")).toBe("Terminal")
+    expect(labelFor("ghostty")).toBe("Ghostty")
+    expect(labelFor("vscode")).toBe("VS Code")
+    expect(labelFor("warp")).toBe("Warp")
+    expect(labelFor("unknown")).toBe("unknown")
+  })
+})
+
+describe("escapeAttr", () => {
+  it("escapes the five HTML-attribute-dangerous characters", () => {
+    expect(escapeAttr('a"b')).toBe("a&quot;b")
+    expect(escapeAttr("a'b")).toBe("a&#39;b")
+    expect(escapeAttr("a<b")).toBe("a&lt;b")
+    expect(escapeAttr("a>b")).toBe("a&gt;b")
+    expect(escapeAttr("a&b")).toBe("a&amp;b")
+  })
+
+  it("leaves benign content alone", () => {
+    expect(escapeAttr("/Users/v/code")).toBe("/Users/v/code")
+  })
+
+  it("escapes & first so previously-escaped sequences don't double-escape weirdly", () => {
+    expect(escapeAttr("a&<b")).toBe("a&amp;&lt;b")
+  })
+})
+
+describe("buildFocusCliCommand", () => {
+  it("builds the iTerm2 form", () => {
+    expect(
+      buildFocusCliCommand({ app: "iterm2", session_id: VALID_ITERM2_ID }),
+    ).toBe(`gctrl terminal focus --target iterm2 --session ${VALID_ITERM2_ID}`)
+  })
+
+  it("builds the Apple Terminal form", () => {
+    expect(
+      buildFocusCliCommand({ app: "terminal", window_id: "1", tab_id: "3" }),
+    ).toBe("gctrl terminal focus --target terminal --window 1 --tab 3")
+  })
+
+  it("returns null when fields are missing", () => {
+    expect(buildFocusCliCommand({ app: "iterm2" })).toBeNull()
+    expect(buildFocusCliCommand({ app: "terminal", window_id: "1" })).toBeNull()
+  })
+
+  it("returns null for unknown", () => {
+    expect(buildFocusCliCommand({ app: "unknown" })).toBeNull()
+  })
+})

--- a/apps/gctrl-board/web/src/lib/deeplink.ts
+++ b/apps/gctrl-board/web/src/lib/deeplink.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure builders + predicates for the gctrl `gctrl://` deep-link surface.
+ *
+ * These are intentionally pure (no React, no fetch) so the inbox UI's
+ * Focus-button gating, the deep-link href construction, and the capability
+ * probe interpretation can all be unit-tested without DOM or network.
+ *
+ * The kernel side has its own canonical validators (`gctrl-mac-comm`) and
+ * `gctrl-desktop` does another allowlist parse on `open-url`. This file is
+ * the third independent boundary — the SPA only renders an anchor that is
+ * guaranteed to match the allowlist, so a malformed payload lands as a
+ * hidden button rather than a clickable broken URL.
+ */
+
+import type { CommCapabilities, TerminalApp, TerminalContext } from "../types"
+
+const ITERM2_SESSION_RE =
+  /^w[0-9]{1,4}t[0-9]{1,4}p[0-9]{1,4}:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const GENERIC_SESSION_RE = /^[A-Za-z0-9_:.-]{1,64}$/
+const INDEX_RE = /^[0-9]{1,4}$/
+
+/**
+ * Build the `gctrl://focus/...` URL for a captured terminal context. Returns
+ * `null` if the context lacks the fields the target needs, or if any field
+ * fails the per-target shape check.
+ *
+ * No throws; renders gate on the return value being a string.
+ */
+export function buildFocusUrl(t: TerminalContext | undefined | null): string | null {
+  if (!t || t.app === "unknown") return null
+
+  switch (t.app) {
+    case "iterm2": {
+      const sid = t.session_id
+      if (!sid || !ITERM2_SESSION_RE.test(sid)) return null
+      return `gctrl://focus/iterm2/${sid}`
+    }
+    case "terminal": {
+      const w = t.window_id
+      const tab = t.tab_id
+      if (!w || !INDEX_RE.test(w)) return null
+      if (!tab || !INDEX_RE.test(tab)) return null
+      return `gctrl://focus/terminal/${w}/${tab}`
+    }
+    case "ghostty":
+    case "vscode":
+    case "warp": {
+      const sid = t.session_id
+      if (!sid || !GENERIC_SESSION_RE.test(sid)) return null
+      return `gctrl://focus/${t.app}/${sid}`
+    }
+  }
+}
+
+/**
+ * Whether the inbox should render a Focus button at all, given the
+ * terminal-context attached to a message and the current `/api/comm/
+ * capabilities` snapshot.
+ *
+ * Independent of `buildFocusUrl` — `shouldShowFocus` answers "does the UI
+ * have any business showing the affordance"; `buildFocusUrl` answers "what
+ * URL does the click open." The button only renders when both return
+ * truthy.
+ */
+export function shouldShowFocus(
+  caps: CommCapabilities | null,
+  terminal: TerminalContext | undefined,
+): boolean {
+  if (!terminal || terminal.app === "unknown") return false
+  if (!caps) return false
+  // Hide entirely on non-macOS — the kernel routes return 501 there.
+  if (caps.os !== "macos") return false
+  // The capabilities snapshot's `terminals` is the source of truth for
+  // which adapters compile in this build.
+  if (!caps.terminals.includes(terminal.app)) return false
+  // `automation_granted` is `null | undefined` until the user grants on
+  // first prompt; we still show the button (the click triggers the prompt
+  // path) and only hide on an explicit `false`.
+  if (caps.automation_granted === false) return false
+  return true
+}
+
+/**
+ * Human-readable label for a terminal app. Keep in sync with the kernel's
+ * `TerminalApp::label()`.
+ */
+export function labelFor(app: TerminalApp): string {
+  switch (app) {
+    case "iterm2":
+      return "iTerm2"
+    case "terminal":
+      return "Terminal"
+    case "ghostty":
+      return "Ghostty"
+    case "vscode":
+      return "VS Code"
+    case "warp":
+      return "Warp"
+    case "unknown":
+      return "unknown"
+  }
+}
+
+/**
+ * HTML-escape a string so it can be safely interpolated into a DOM
+ * attribute (e.g., `title="..."`). React already escapes text-content but
+ * NOT attribute values constructed via template strings; this is the
+ * defense for cases like `<a title={`${app} · ${cwd}`}>`.
+ *
+ * The kernel intake validator already rejects most dangerous `cwd` shapes,
+ * so this is belt-and-braces.
+ */
+export function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+/**
+ * The CLI command that's a fallback for users without gctrl-desktop
+ * installed. Surfaced in the "no protocol handler" toast with a copy
+ * button.
+ */
+export function buildFocusCliCommand(t: TerminalContext): string | null {
+  if (!t || t.app === "unknown") return null
+  switch (t.app) {
+    case "iterm2":
+    case "ghostty":
+    case "vscode":
+    case "warp":
+      if (!t.session_id) return null
+      return `gctrl terminal focus --target ${t.app} --session ${t.session_id}`
+    case "terminal":
+      if (!t.window_id || !t.tab_id) return null
+      return `gctrl terminal focus --target terminal --window ${t.window_id} --tab ${t.tab_id}`
+  }
+}

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -386,6 +386,54 @@ export interface TeamRenderResult {
 
 /* ── Inbox types ── */
 
+/**
+ * Terminal-app discriminator for `context.terminal`. Mirrors the kernel
+ * driver's `gctrl_mac_comm::TerminalApp`.
+ *
+ * `unknown` is the explicit "we couldn't identify" value — the inbox UI
+ * hides the Focus button for unknown.
+ */
+export type TerminalApp =
+  | "iterm2"
+  | "terminal"
+  | "ghostty"
+  | "vscode"
+  | "warp"
+  | "unknown"
+
+/**
+ * Captured terminal identity — present on `context.terminal` for
+ * permission_request, agent_question, and any other kind originating from
+ * a terminal-bound agent. Optional everywhere because older messages and
+ * non-terminal sources don't carry it.
+ */
+export interface TerminalContext {
+  app: TerminalApp
+  bundle_id?: string
+  session_id?: string
+  window_id?: string
+  tab_id?: string
+  tty?: string
+  pid?: number
+  ppid?: number
+  cwd?: string
+  term_program?: string
+  term_program_version?: string
+  captured_at?: string
+}
+
+/**
+ * `GET /api/comm/capabilities` response. Drives whether the Focus button
+ * renders and what tooltip / re-grant prompt to show.
+ */
+export interface CommCapabilities {
+  os: "macos" | "linux" | "windows" | "unknown" | string
+  terminals: string[]
+  notify: boolean
+  automation_granted?: boolean | null
+  captured_at: string
+}
+
 export interface InboxMessage {
   id: string
   thread_id: string
@@ -394,7 +442,7 @@ export interface InboxMessage {
   urgency: string
   title: string
   body?: string
-  context: Record<string, unknown>
+  context: Record<string, unknown> & { terminal?: TerminalContext }
   status: string
   requires_action: boolean
   payload?: Record<string, unknown>

--- a/apps/gctrl-desktop/package.json
+++ b/apps/gctrl-desktop/package.json
@@ -54,6 +54,12 @@
     ],
     "asar": true,
     "asarUnpack": ["resources/kernel/**"],
+    "protocols": [
+      {
+        "name": "gctrl",
+        "schemes": ["gctrl"]
+      }
+    ],
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
@@ -64,7 +70,14 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": false,
-      "x64ArchFiles": "Contents/Resources/kernel/*"
+      "x64ArchFiles": "Contents/Resources/kernel/*",
+      "extendInfo": {
+        "NSAppleEventsUsageDescription": "gctrl uses Apple Events to focus the terminal session that issued an agent permission request from your inbox.",
+        "NSAppleEventsUsageDescriptionTargets": {
+          "com.googlecode.iterm2": "gctrl uses Apple Events to bring the iTerm2 window that issued an agent permission request to the front.",
+          "com.apple.Terminal": "gctrl uses Apple Events to bring the Terminal.app tab that issued an agent permission request to the front."
+        }
+      }
     },
     "afterSign": "build/notarize.cjs",
     "publish": {

--- a/apps/gctrl-desktop/src/main/__tests__/url-handler.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/url-handler.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  focusBodyFor,
+  handleGctrlUrl,
+  inboxRouteFor,
+  parseGctrlUrl,
+  type UrlHandlerDeps,
+} from "../url-handler"
+
+const VALID_ITERM2_ID = "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765"
+const VALID_UUID = "11111111-2222-4333-8444-555555555555"
+
+describe("parseGctrlUrl — focus paths", () => {
+  it("accepts the canonical iTerm2 shape", () => {
+    expect(parseGctrlUrl(`gctrl://focus/iterm2/${VALID_ITERM2_ID}`)).toEqual({
+      kind: "focus-iterm2",
+      sessionId: VALID_ITERM2_ID,
+    })
+  })
+
+  it("rejects iTerm2 path with non-UUID tail", () => {
+    expect(parseGctrlUrl("gctrl://focus/iterm2/w0t0p0:not-a-uuid")).toBeNull()
+  })
+
+  it("rejects iTerm2 path missing window/tab/pane prefix", () => {
+    expect(
+      parseGctrlUrl(`gctrl://focus/iterm2/${VALID_UUID}`), // bare UUID, no w0t0p0
+    ).toBeNull()
+  })
+
+  it("rejects iTerm2 path with a quote-injection attempt in the session id", () => {
+    const evil = "gctrl://focus/iterm2/w0t0p0:X\" & do shell script \"rm -rf /\""
+    expect(parseGctrlUrl(evil)).toBeNull()
+  })
+
+  it("accepts Apple Terminal window/tab indices", () => {
+    expect(parseGctrlUrl("gctrl://focus/terminal/1/3")).toEqual({
+      kind: "focus-terminal",
+      windowId: "1",
+      tabId: "3",
+    })
+  })
+
+  it("rejects Apple Terminal path with non-numeric indices", () => {
+    expect(parseGctrlUrl("gctrl://focus/terminal/abc/3")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/terminal/1/abc")).toBeNull()
+  })
+
+  it("rejects Apple Terminal path with too many components", () => {
+    expect(parseGctrlUrl("gctrl://focus/terminal/1/3/extra")).toBeNull()
+  })
+
+  it("accepts ghostty / vscode / warp tokens", () => {
+    expect(parseGctrlUrl("gctrl://focus/ghostty/sess-abc")).toEqual({
+      kind: "focus-generic",
+      target: "ghostty",
+      token: "sess-abc",
+    })
+    expect(parseGctrlUrl("gctrl://focus/vscode/v1.workspace")).toEqual({
+      kind: "focus-generic",
+      target: "vscode",
+      token: "v1.workspace",
+    })
+    expect(parseGctrlUrl("gctrl://focus/warp/abc:123_xyz")).toEqual({
+      kind: "focus-generic",
+      target: "warp",
+      token: "abc:123_xyz",
+    })
+  })
+
+  it("rejects unknown focus targets", () => {
+    expect(parseGctrlUrl("gctrl://focus/kitty/abc")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/xterm/abc")).toBeNull()
+  })
+
+  it("rejects generic token with shell metacharacters", () => {
+    expect(parseGctrlUrl("gctrl://focus/ghostty/abc;rm")).toBeNull()
+    expect(parseGctrlUrl('gctrl://focus/ghostty/abc"def')).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/ghostty/abc def")).toBeNull()
+  })
+})
+
+describe("parseGctrlUrl — inbox paths", () => {
+  it("accepts UUIDv4 message id", () => {
+    expect(parseGctrlUrl(`gctrl://inbox/messages/${VALID_UUID}`)).toEqual({
+      kind: "inbox-message",
+      id: VALID_UUID,
+    })
+  })
+
+  it("accepts UUIDv4 thread id", () => {
+    expect(parseGctrlUrl(`gctrl://inbox/threads/${VALID_UUID}`)).toEqual({
+      kind: "inbox-thread",
+      id: VALID_UUID,
+    })
+  })
+
+  it("rejects non-UUIDv4 id (wrong version nibble)", () => {
+    // Position 14 is the version; v4 requires `4`. This one uses `5`.
+    expect(
+      parseGctrlUrl("gctrl://inbox/messages/11111111-2222-5333-8444-555555555555"),
+    ).toBeNull()
+  })
+
+  it("rejects non-UUIDv4 id (wrong variant nibble)", () => {
+    // Position 19 is the variant; must be in [89ab]. This one uses `c`.
+    expect(
+      parseGctrlUrl("gctrl://inbox/messages/11111111-2222-4333-c444-555555555555"),
+    ).toBeNull()
+  })
+
+  it("rejects path traversal attempt in id position", () => {
+    expect(parseGctrlUrl("gctrl://inbox/messages/../../etc/passwd")).toBeNull()
+    expect(parseGctrlUrl("gctrl://inbox/threads/..%2F..%2Fetc")).toBeNull()
+  })
+
+  it("rejects unknown inbox sub-resource", () => {
+    expect(parseGctrlUrl(`gctrl://inbox/actions/${VALID_UUID}`)).toBeNull()
+    expect(parseGctrlUrl(`gctrl://inbox/${VALID_UUID}`)).toBeNull()
+  })
+})
+
+describe("parseGctrlUrl — global rejections", () => {
+  it("rejects empty / non-string input", () => {
+    expect(parseGctrlUrl("")).toBeNull()
+    expect(parseGctrlUrl(undefined as unknown as string)).toBeNull()
+  })
+
+  it("rejects URLs with query strings or fragments", () => {
+    expect(parseGctrlUrl(`gctrl://focus/iterm2/${VALID_ITERM2_ID}?evil=1`)).toBeNull()
+    expect(parseGctrlUrl(`gctrl://focus/iterm2/${VALID_ITERM2_ID}#frag`)).toBeNull()
+  })
+
+  it("rejects embedded NUL / CR / LF", () => {
+    expect(parseGctrlUrl("gctrl://focus/iterm2/w0t0p0\x00:abc")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/iterm2/w0t0p0:\nUUID")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/iterm2/w0t0p0:\rUUID")).toBeNull()
+  })
+
+  it("rejects schemes other than gctrl:", () => {
+    expect(parseGctrlUrl(`http://focus/iterm2/${VALID_ITERM2_ID}`)).toBeNull()
+    expect(parseGctrlUrl(`gctrl-evil://focus/iterm2/${VALID_ITERM2_ID}`)).toBeNull()
+    // No leading slash variant
+    expect(parseGctrlUrl(`gctrl:focus/iterm2/${VALID_ITERM2_ID}`)).toBeNull()
+  })
+
+  it("rejects URLs over the length cap", () => {
+    const long = "gctrl://focus/iterm2/" + "x".repeat(600)
+    expect(parseGctrlUrl(long)).toBeNull()
+  })
+
+  it("rejects empty pathname", () => {
+    expect(parseGctrlUrl("gctrl://")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/")).toBeNull()
+    expect(parseGctrlUrl("gctrl://focus/iterm2/")).toBeNull()
+  })
+})
+
+describe("focusBodyFor / inboxRouteFor", () => {
+  it("focusBodyFor returns null for inbox URLs", () => {
+    const parsed = parseGctrlUrl(`gctrl://inbox/messages/${VALID_UUID}`)!
+    expect(focusBodyFor(parsed)).toBeNull()
+  })
+
+  it("focusBodyFor preserves shape for iTerm2", () => {
+    const parsed = parseGctrlUrl(`gctrl://focus/iterm2/${VALID_ITERM2_ID}`)!
+    expect(focusBodyFor(parsed)).toEqual({
+      target: "iterm2",
+      session_id: VALID_ITERM2_ID,
+    })
+  })
+
+  it("focusBodyFor preserves window/tab for Apple Terminal", () => {
+    const parsed = parseGctrlUrl("gctrl://focus/terminal/2/4")!
+    expect(focusBodyFor(parsed)).toEqual({
+      target: "terminal",
+      window_id: "2",
+      tab_id: "4",
+    })
+  })
+
+  it("inboxRouteFor returns null for focus URLs", () => {
+    const parsed = parseGctrlUrl(`gctrl://focus/iterm2/${VALID_ITERM2_ID}`)!
+    expect(inboxRouteFor(parsed)).toBeNull()
+  })
+
+  it("inboxRouteFor preserves the SPA route", () => {
+    const m = parseGctrlUrl(`gctrl://inbox/messages/${VALID_UUID}`)!
+    expect(inboxRouteFor(m)).toBe(`/inbox/messages/${VALID_UUID}`)
+    const t = parseGctrlUrl(`gctrl://inbox/threads/${VALID_UUID}`)!
+    expect(inboxRouteFor(t)).toBe(`/inbox/threads/${VALID_UUID}`)
+  })
+})
+
+describe("handleGctrlUrl", () => {
+  function mockDeps(overrides: Partial<UrlHandlerDeps> = {}): UrlHandlerDeps {
+    return {
+      kernelPost: vi.fn().mockResolvedValue({ ok: true, status: 200, bodyText: "{}" }),
+      bringToFront: vi.fn(),
+      navigateSpa: vi.fn(),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      ...overrides,
+    }
+  }
+
+  it("dispatches focus URLs to /api/comm/focus", async () => {
+    const deps = mockDeps()
+    const result = await handleGctrlUrl(
+      `gctrl://focus/iterm2/${VALID_ITERM2_ID}`,
+      deps,
+    )
+    expect(deps.kernelPost).toHaveBeenCalledWith("/api/comm/focus", {
+      target: "iterm2",
+      session_id: VALID_ITERM2_ID,
+    })
+    expect(result).toMatchObject({ kind: "focus-dispatched", status: 200 })
+    expect(deps.bringToFront).not.toHaveBeenCalled()
+    expect(deps.navigateSpa).not.toHaveBeenCalled()
+  })
+
+  it("routes inbox URLs into the SPA and brings window forward", async () => {
+    const deps = mockDeps()
+    const result = await handleGctrlUrl(
+      `gctrl://inbox/messages/${VALID_UUID}`,
+      deps,
+    )
+    expect(deps.bringToFront).toHaveBeenCalledOnce()
+    expect(deps.navigateSpa).toHaveBeenCalledWith(`/inbox/messages/${VALID_UUID}`)
+    expect(deps.kernelPost).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      kind: "inbox-routed",
+      route: `/inbox/messages/${VALID_UUID}`,
+    })
+  })
+
+  it("drops invalid URLs without contacting the kernel or window", async () => {
+    const deps = mockDeps()
+    const result = await handleGctrlUrl("gctrl://focus/kitty/abc", deps)
+    expect(deps.kernelPost).not.toHaveBeenCalled()
+    expect(deps.bringToFront).not.toHaveBeenCalled()
+    expect(deps.navigateSpa).not.toHaveBeenCalled()
+    expect(result).toEqual({ kind: "dropped", reason: "invalid-url" })
+  })
+
+  it("surfaces kernel-fetch errors as focus-failed", async () => {
+    const deps = mockDeps({
+      kernelPost: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    })
+    const result = await handleGctrlUrl(
+      `gctrl://focus/iterm2/${VALID_ITERM2_ID}`,
+      deps,
+    )
+    expect(result).toEqual({ kind: "focus-failed", reason: "ECONNREFUSED" })
+  })
+
+  it("does not navigate the SPA on any focus URL, even one for an inbox-shaped UUID", async () => {
+    // Defense-in-depth — the focus handler should never accidentally trip the
+    // SPA navigation, even if a URL looks UUID-shaped in the wrong slot.
+    const deps = mockDeps()
+    const result = await handleGctrlUrl("gctrl://focus/ghostty/abc", deps)
+    expect(deps.navigateSpa).not.toHaveBeenCalled()
+    expect(deps.bringToFront).not.toHaveBeenCalled()
+    expect(result.kind).toBe("focus-dispatched")
+  })
+})

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -161,7 +161,7 @@ app.on("open-url", (event, url) => {
   event.preventDefault()
   // If the BrowserWindow isn't ready yet, buffer the URL — the cold-launch
   // path fires `open-url` before any window exists.
-  if (!mainWindow || !mainWindow.webContents || mainWindow.webContents.isLoading()) {
+  if (!mainWindow?.webContents || mainWindow.webContents.isLoading()) {
     pendingUrls.push(url)
     return
   }

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -14,12 +14,18 @@ import { resolveKernelBinPath, resolveKernelDataDir } from "./paths"
 import { createScheduler } from "./scheduler"
 import { createSpawner } from "./spawner"
 import { startAutoUpdater } from "./updater"
+import { handleGctrlUrl, type UrlHandlerDeps } from "./url-handler"
 
 const KERNEL_PORT = 4318
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 let sidecar: KernelSidecar | undefined
 let mainWindow: BrowserWindow | undefined
+
+// Buffer URLs that arrive before the BrowserWindow is ready (cold-launch
+// path: `open gctrl://...` starts the app, fires `open-url`, then the
+// window is created). Drained on `did-finish-load`.
+const pendingUrls: string[] = []
 
 const createSidecar = (): KernelSidecar | undefined => {
   // Only spawn the kernel sidecar in packaged mode. In dev, contributors run
@@ -100,6 +106,12 @@ const createWindow = (): BrowserWindow => {
     return { action: "deny" }
   })
 
+  // Drain any URLs that arrived before this window existed.
+  win.webContents.on("did-finish-load", () => {
+    const urls = pendingUrls.splice(0)
+    for (const url of urls) void dispatchGctrlUrl(url)
+  })
+
   return win
 }
 
@@ -108,6 +120,53 @@ ipcMain.handle("show-in-finder", (_event, p: string) => {
   shell.showItemInFolder(p)
 })
 ipcMain.handle("app-version", () => app.getVersion())
+
+// --- gctrl:// URL scheme ----------------------------------------------------
+
+// Register `gctrl://` once on app startup (idempotent). LaunchServices then
+// routes any `gctrl://...` click — from a browser, an inbox anchor, or
+// `open(1)` — to this app via the `open-url` event.
+if (!app.isDefaultProtocolClient("gctrl")) {
+  app.setAsDefaultProtocolClient("gctrl")
+}
+
+const urlHandlerDeps = (): UrlHandlerDeps => ({
+  kernelPost: async (path, body) => {
+    const res = await fetch(`http://127.0.0.1:${KERNEL_PORT}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    return { ok: res.ok, status: res.status, bodyText: await res.text() }
+  },
+  bringToFront: () => {
+    if (!mainWindow) return
+    if (mainWindow.isMinimized()) mainWindow.restore()
+    mainWindow.show()
+    mainWindow.focus()
+  },
+  navigateSpa: (route) => {
+    // Renderer subscribes to `gctrl-navigate` via the preload bridge.
+    if (mainWindow) mainWindow.webContents.send("gctrl-navigate", route)
+  },
+  logger: console,
+})
+
+async function dispatchGctrlUrl(url: string): Promise<void> {
+  const deps = urlHandlerDeps()
+  await handleGctrlUrl(url, deps)
+}
+
+app.on("open-url", (event, url) => {
+  event.preventDefault()
+  // If the BrowserWindow isn't ready yet, buffer the URL — the cold-launch
+  // path fires `open-url` before any window exists.
+  if (!mainWindow || !mainWindow.webContents || mainWindow.webContents.isLoading()) {
+    pendingUrls.push(url)
+    return
+  }
+  void dispatchGctrlUrl(url)
+})
 
 void app.whenReady().then(() => {
   Menu.setApplicationMenu(buildAppMenu())

--- a/apps/gctrl-desktop/src/main/url-handler.ts
+++ b/apps/gctrl-desktop/src/main/url-handler.ts
@@ -62,25 +62,31 @@ export function parseGctrlUrl(raw: string): ParsedGctrlUrl | null {
   // this scheme and would only widen the parser's job.
   if (raw.includes("?") || raw.includes("#")) return null
   // Disallow embedded NUL / CR / LF — defense against terminal smuggling.
-  if (/[\x00\r\n]/.test(raw)) return null
+  if (raw.includes("\x00") || raw.includes("\r") || raw.includes("\n")) return null
 
-  let m: RegExpExecArray | null
-
-  if ((m = RE_FOCUS_ITERM2.exec(raw))) {
-    return { kind: "focus-iterm2", sessionId: m[1]! }
+  const iterm2 = RE_FOCUS_ITERM2.exec(raw)
+  if (iterm2 && iterm2[1] !== undefined) {
+    return { kind: "focus-iterm2", sessionId: iterm2[1] }
   }
-  if ((m = RE_FOCUS_TERMINAL.exec(raw))) {
-    return { kind: "focus-terminal", windowId: m[1]!, tabId: m[2]! }
+  const term = RE_FOCUS_TERMINAL.exec(raw)
+  if (term && term[1] !== undefined && term[2] !== undefined) {
+    return { kind: "focus-terminal", windowId: term[1], tabId: term[2] }
   }
-  if ((m = RE_FOCUS_GENERIC.exec(raw))) {
-    const target = m[1] as GenericFocusTarget
-    return { kind: "focus-generic", target, token: m[2]! }
+  const generic = RE_FOCUS_GENERIC.exec(raw)
+  if (generic && generic[1] !== undefined && generic[2] !== undefined) {
+    return {
+      kind: "focus-generic",
+      target: generic[1] as GenericFocusTarget,
+      token: generic[2],
+    }
   }
-  if ((m = RE_INBOX_MSG.exec(raw))) {
-    return { kind: "inbox-message", id: m[1]! }
+  const msg = RE_INBOX_MSG.exec(raw)
+  if (msg && msg[1] !== undefined) {
+    return { kind: "inbox-message", id: msg[1] }
   }
-  if ((m = RE_INBOX_THREAD.exec(raw))) {
-    return { kind: "inbox-thread", id: m[1]! }
+  const thread = RE_INBOX_THREAD.exec(raw)
+  if (thread && thread[1] !== undefined) {
+    return { kind: "inbox-thread", id: thread[1] }
   }
 
   return null

--- a/apps/gctrl-desktop/src/main/url-handler.ts
+++ b/apps/gctrl-desktop/src/main/url-handler.ts
@@ -1,0 +1,191 @@
+/**
+ * `gctrl://` URL scheme handler.
+ *
+ * macOS LaunchServices routes `gctrl://...` clicks to this app via the
+ * `open-url` event. This module is the single allowlist gate: only paths
+ * matching one of the patterns below are dispatched — every other shape is
+ * dropped with a debug log. There is no prefix-match, no fallback, no
+ * shell-out.
+ *
+ * Allowed paths (regex-matched against the raw URL, NOT after URL
+ * normalization — non-special schemes don't collapse `..`, so we anchor on
+ * the literal string):
+ *
+ *   gctrl://focus/iterm2/<w?t?p?:UUIDv4>
+ *   gctrl://focus/terminal/<window>/<tab>
+ *   gctrl://focus/(ghostty|vscode|warp)/<token>
+ *   gctrl://inbox/messages/<UUIDv4>
+ *   gctrl://inbox/threads/<UUIDv4>
+ *
+ * The handler forwards focus URLs to `POST /api/comm/focus` on the local
+ * kernel and routes inbox URLs into the in-app SPA. Both sides receive
+ * already-validated input — defense in depth with the kernel-side validator
+ * in `gctrl-mac-comm`.
+ */
+
+// --- pure parser (unit-testable; no IO) -------------------------------------
+
+/**
+ * Targets that take a single opaque session token (iTerm2 has its own
+ * stricter shape; these all share the generic allowlist).
+ */
+const GENERIC_FOCUS_TARGETS = ["ghostty", "vscode", "warp"] as const
+type GenericFocusTarget = (typeof GENERIC_FOCUS_TARGETS)[number]
+
+const RE_FOCUS_ITERM2 =
+  /^gctrl:\/\/focus\/iterm2\/(w[0-9]{1,4}t[0-9]{1,4}p[0-9]{1,4}:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/
+const RE_FOCUS_TERMINAL = /^gctrl:\/\/focus\/terminal\/([0-9]{1,4})\/([0-9]{1,4})$/
+const RE_FOCUS_GENERIC = /^gctrl:\/\/focus\/(ghostty|vscode|warp)\/([A-Za-z0-9_:.-]{1,64})$/
+// UUIDv4 (case-insensitive). Strict positions: version nibble = 4, variant
+// nibble in [89ab].
+const RE_INBOX_MSG =
+  /^gctrl:\/\/inbox\/messages\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$/
+const RE_INBOX_THREAD =
+  /^gctrl:\/\/inbox\/threads\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$/
+
+export type ParsedGctrlUrl =
+  | { kind: "focus-iterm2"; sessionId: string }
+  | { kind: "focus-terminal"; windowId: string; tabId: string }
+  | { kind: "focus-generic"; target: GenericFocusTarget; token: string }
+  | { kind: "inbox-message"; id: string }
+  | { kind: "inbox-thread"; id: string }
+
+/**
+ * Parse a `gctrl://` URL. Returns `null` for anything not in the allowlist
+ * — including unknown paths, malformed UUIDs, missing components, and any
+ * extraneous query-string or fragment.
+ */
+export function parseGctrlUrl(raw: string): ParsedGctrlUrl | null {
+  // Reject anything that isn't a plain `gctrl://...` string.
+  if (typeof raw !== "string" || raw.length > 512) return null
+  // Disallow query strings and fragments — they have no semantic meaning in
+  // this scheme and would only widen the parser's job.
+  if (raw.includes("?") || raw.includes("#")) return null
+  // Disallow embedded NUL / CR / LF — defense against terminal smuggling.
+  if (/[\x00\r\n]/.test(raw)) return null
+
+  let m: RegExpExecArray | null
+
+  if ((m = RE_FOCUS_ITERM2.exec(raw))) {
+    return { kind: "focus-iterm2", sessionId: m[1]! }
+  }
+  if ((m = RE_FOCUS_TERMINAL.exec(raw))) {
+    return { kind: "focus-terminal", windowId: m[1]!, tabId: m[2]! }
+  }
+  if ((m = RE_FOCUS_GENERIC.exec(raw))) {
+    const target = m[1] as GenericFocusTarget
+    return { kind: "focus-generic", target, token: m[2]! }
+  }
+  if ((m = RE_INBOX_MSG.exec(raw))) {
+    return { kind: "inbox-message", id: m[1]! }
+  }
+  if ((m = RE_INBOX_THREAD.exec(raw))) {
+    return { kind: "inbox-thread", id: m[1]! }
+  }
+
+  return null
+}
+
+// --- dispatch (impure; takes injected deps for testing) ---------------------
+
+/**
+ * Body shape sent to `POST /api/comm/focus`.
+ */
+export type FocusRequestBody =
+  | { target: "iterm2"; session_id: string }
+  | { target: "terminal"; window_id: string; tab_id: string }
+  | { target: GenericFocusTarget; session_id: string }
+
+/**
+ * Build the `/api/comm/focus` POST body from a parsed URL. Returns `null`
+ * for inbox URLs (which don't hit the comm endpoint).
+ */
+export function focusBodyFor(parsed: ParsedGctrlUrl): FocusRequestBody | null {
+  switch (parsed.kind) {
+    case "focus-iterm2":
+      return { target: "iterm2", session_id: parsed.sessionId }
+    case "focus-terminal":
+      return {
+        target: "terminal",
+        window_id: parsed.windowId,
+        tab_id: parsed.tabId,
+      }
+    case "focus-generic":
+      return { target: parsed.target, session_id: parsed.token }
+    case "inbox-message":
+    case "inbox-thread":
+      return null
+  }
+}
+
+/**
+ * Build the SPA route a parsed inbox URL should navigate to. Returns `null`
+ * for focus URLs.
+ */
+export function inboxRouteFor(parsed: ParsedGctrlUrl): string | null {
+  switch (parsed.kind) {
+    case "inbox-message":
+      return `/inbox/messages/${parsed.id}`
+    case "inbox-thread":
+      return `/inbox/threads/${parsed.id}`
+    case "focus-iterm2":
+    case "focus-terminal":
+    case "focus-generic":
+      return null
+  }
+}
+
+export interface UrlHandlerDeps {
+  /** POST to the kernel; receives the `/api/comm/focus` URL and JSON body. */
+  kernelPost: (path: string, body: unknown) => Promise<{ ok: boolean; status: number; bodyText: string }>
+  /** Bring the main BrowserWindow to the foreground. */
+  bringToFront: () => void
+  /** Tell the renderer to navigate to a SPA route. */
+  navigateSpa: (route: string) => void
+  /** Logger; defaults to console. */
+  logger?: { debug: (...args: unknown[]) => void; warn: (...args: unknown[]) => void }
+}
+
+/**
+ * Result codes for telemetry / tests.
+ */
+export type HandleResult =
+  | { kind: "dropped"; reason: "invalid-url" }
+  | { kind: "focus-dispatched"; status: number; body: string }
+  | { kind: "focus-failed"; reason: string }
+  | { kind: "inbox-routed"; route: string }
+
+export async function handleGctrlUrl(
+  raw: string,
+  deps: UrlHandlerDeps,
+): Promise<HandleResult> {
+  const log = deps.logger ?? console
+  const parsed = parseGctrlUrl(raw)
+  if (!parsed) {
+    log.debug("[gctrl-desktop] dropped url (not in allowlist)", { raw })
+    return { kind: "dropped", reason: "invalid-url" }
+  }
+
+  const body = focusBodyFor(parsed)
+  if (body !== null) {
+    try {
+      const res = await deps.kernelPost("/api/comm/focus", body)
+      return { kind: "focus-dispatched", status: res.status, body: res.bodyText }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      log.warn("[gctrl-desktop] kernel focus call failed", { raw, reason })
+      return { kind: "focus-failed", reason }
+    }
+  }
+
+  const route = inboxRouteFor(parsed)
+  if (route !== null) {
+    deps.bringToFront()
+    deps.navigateSpa(route)
+    return { kind: "inbox-routed", route }
+  }
+
+  // Unreachable — every parsed kind handled above. Belt-and-braces.
+  log.warn("[gctrl-desktop] parsed URL had no dispatch path", { parsed })
+  return { kind: "dropped", reason: "invalid-url" }
+}

--- a/apps/gctrl-desktop/src/preload/index.ts
+++ b/apps/gctrl-desktop/src/preload/index.ts
@@ -23,6 +23,12 @@ declare global {
       readonly openExternal: (url: string) => Promise<void>
       readonly showInFinder: (path: string) => Promise<void>
       readonly appVersion: () => Promise<string>
+      /**
+       * Subscribe to `gctrl://inbox/...` deep-link navigation events. The
+       * main process emits these when LaunchServices delivers a deep link
+       * (handled in `main/url-handler.ts`). Returns an unsubscribe fn.
+       */
+      readonly onNavigate: (cb: (route: string) => void) => () => void
     }
   }
 }
@@ -37,4 +43,13 @@ contextBridge.exposeInMainWorld("desktop", {
   openExternal: (url: string) => ipcRenderer.invoke("open-external", url),
   showInFinder: (path: string) => ipcRenderer.invoke("show-in-finder", path),
   appVersion: () => ipcRenderer.invoke("app-version"),
+  onNavigate: (cb: (route: string) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, route: string): void => {
+      cb(route)
+    }
+    ipcRenderer.on("gctrl-navigate", handler)
+    return () => {
+      ipcRenderer.removeListener("gctrl-navigate", handler)
+    }
+  },
 })

--- a/kernel/crates/gctrl-mac-comm/Cargo.toml
+++ b/kernel/crates/gctrl-mac-comm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gctrl-mac-comm"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+sha2 = { workspace = true }
+regex = "1"
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/kernel/crates/gctrl-mac-comm/src/capabilities.rs
+++ b/kernel/crates/gctrl-mac-comm/src/capabilities.rs
@@ -1,0 +1,62 @@
+//! Runtime capability probe.
+//!
+//! Tells the SPA what's supported so the inbox UI can hide affordances
+//! gracefully on Linux/Windows builds and surface a clear "grant Automation"
+//! prompt on macOS without click-and-hope.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Capabilities {
+    /// `"macos"`, `"linux"`, `"windows"`, or `"unknown"`.
+    pub os: &'static str,
+    /// Targets the runtime can attempt to focus.
+    pub terminals: Vec<&'static str>,
+    /// Whether `/api/comm/notify` is wired up (M1).
+    pub notify: bool,
+    /// Best-effort: whether the user has granted Apple Events automation.
+    /// `None` on non-macOS or when probing isn't possible without triggering
+    /// a TCC prompt.
+    pub automation_granted: Option<bool>,
+    pub captured_at: String,
+}
+
+#[cfg(target_os = "macos")]
+fn os_label() -> &'static str {
+    "macos"
+}
+#[cfg(target_os = "linux")]
+fn os_label() -> &'static str {
+    "linux"
+}
+#[cfg(target_os = "windows")]
+fn os_label() -> &'static str {
+    "windows"
+}
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn os_label() -> &'static str {
+    "unknown"
+}
+
+#[cfg(target_os = "macos")]
+fn terminals() -> Vec<&'static str> {
+    vec!["iterm2", "terminal"]
+}
+#[cfg(not(target_os = "macos"))]
+fn terminals() -> Vec<&'static str> {
+    Vec::new()
+}
+
+/// Build the capabilities snapshot. M0 returns `automation_granted: None` —
+/// the UI starts polling at 10s intervals and only hides when it observes
+/// `Some(true)`. Detecting the grant non-invasively requires reading TCC.db
+/// which is itself privileged on Sequoia, so we defer that to M1.
+pub fn capabilities() -> Capabilities {
+    Capabilities {
+        os: os_label(),
+        terminals: terminals(),
+        notify: false,
+        automation_granted: None,
+        captured_at: chrono::Utc::now().to_rfc3339(),
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/error.rs
+++ b/kernel/crates/gctrl-mac-comm/src/error.rs
@@ -1,0 +1,56 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CommError {
+    #[error("not supported on this platform")]
+    NotSupported,
+
+    #[error("invalid {field}: must match {pattern}")]
+    Validation {
+        field: &'static str,
+        pattern: &'static str,
+    },
+
+    #[error("unknown target: {0}")]
+    UnknownTarget(String),
+
+    #[error(
+        "{target} session {session_id} not found. The window/tab may have been closed. \
+        Run 'gctrl terminal capabilities' to confirm {target} is reachable, or wait for \
+        the agent to re-issue the request."
+    )]
+    SessionNotFound {
+        target: &'static str,
+        session_id: String,
+    },
+
+    #[error(
+        "{target} is not running. Launch it and run 'gctrl terminal focus' again."
+    )]
+    TargetNotRunning { target: &'static str },
+
+    #[error(
+        "Automation permission denied for {target}. Open System Settings → Privacy & \
+        Security → Automation → gctrl-desktop and allow {target}. Then run \
+        'gctrl terminal capabilities' to confirm the grant."
+    )]
+    AutomationDenied { target: &'static str },
+
+    #[error(
+        "{target} did not respond within {ms}ms. Run 'gctrl terminal capabilities' \
+        to confirm reachability; retry once."
+    )]
+    OsascriptTimeout { target: &'static str, ms: u64 },
+
+    #[error("osascript failed (exit {exit_code}): {stderr}")]
+    OsascriptFailed { exit_code: i32, stderr: String },
+
+    #[error(
+        "Too many focus calls for session {0} in the last minute. Wait 5s and retry, \
+        or 'gctrl inbox view <id>' to inspect manually."
+    )]
+    RateLimited(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/kernel/crates/gctrl-mac-comm/src/focus/iterm2.rs
+++ b/kernel/crates/gctrl-mac-comm/src/focus/iterm2.rs
@@ -1,0 +1,114 @@
+//! iTerm2 focus adapter.
+//!
+//! AppleScript surface notes (corrected during spec review):
+//! - The application bundle name in AppleScript context is `"iTerm2"`, not
+//!   `"iTerm"`. Pre-3.x installations registered as `iTerm` but every modern
+//!   release is `iTerm2`.
+//! - There is no flat `select session id "<sid>"` form. Sessions are reached
+//!   via `windows → tabs → sessions` traversal, addressed by `unique ID`.
+//!
+//! The handler script below is invoked as ONE `-e` argv entry; the
+//! handler-call expression is a SECOND `-e`. The session ID is interpolated
+//! into the AppleScript expression but only after passing the iTerm2 UUID
+//! regex (`[wtp][0-9]+:[A-Fa-f0-9-]{36}`), which excludes every character
+//! AppleScript would treat as syntactically meaningful.
+
+use crate::error::CommError;
+use crate::model::{FocusRequest, FocusResponse};
+use crate::osascript::Osascript;
+
+const HANDLER_SCRIPT: &str = r#"
+on focus_iterm2_session(target_id)
+  tell application "iTerm2"
+    activate
+    repeat with w in windows
+      repeat with t in tabs of w
+        repeat with s in sessions of t
+          if unique ID of s is target_id then
+            select s
+            return "ok"
+          end if
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  return "not_found"
+end focus_iterm2_session
+"#;
+
+pub async fn focus(req: &FocusRequest) -> Result<FocusResponse, CommError> {
+    let sid = req
+        .session_id
+        .as_deref()
+        .ok_or(CommError::Validation {
+            field: "session_id",
+            pattern: "required for target=iterm2",
+        })?;
+
+    let osa = Osascript {
+        timeout_ms: 2_000,
+        target_label: "iTerm2",
+    };
+    let call = format!(r#"focus_iterm2_session("{}")"#, sid);
+    let out = osa.run(&[HANDLER_SCRIPT, &call]).await?;
+
+    if out.exit_code == 0 {
+        return match out.stdout.trim() {
+            "ok" => Ok(FocusResponse::ok()),
+            "not_found" => Err(CommError::SessionNotFound {
+                target: "iTerm2",
+                session_id: sid.to_string(),
+            }),
+            other => Err(CommError::OsascriptFailed {
+                exit_code: 0,
+                stderr: format!("unexpected handler output: {}", other),
+            }),
+        };
+    }
+
+    classify_error(out.exit_code, &out.stderr, "iTerm2")
+}
+
+fn classify_error(
+    exit_code: i32,
+    stderr: &str,
+    target: &'static str,
+) -> Result<FocusResponse, CommError> {
+    // -1743: Apple Events authorization denied. The error code lands in
+    // stderr from osascript; checking stderr is reliable across macOS
+    // versions (the exit code is always non-zero on these conditions).
+    if stderr.contains("-1743") || stderr.contains("not allowed assistive access") {
+        return Err(CommError::AutomationDenied { target });
+    }
+    // -600: application is not running (NSAppleScriptError "application isn't running").
+    if stderr.contains("-600") || stderr.contains("isn't running") {
+        return Err(CommError::TargetNotRunning { target });
+    }
+    Err(CommError::OsascriptFailed {
+        exit_code,
+        stderr: stderr.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_automation_denied() {
+        let r = classify_error(1, "execution error: not allowed assistive access (-1743)", "iTerm2");
+        assert!(matches!(r, Err(CommError::AutomationDenied { target: "iTerm2" })));
+    }
+
+    #[test]
+    fn classify_not_running() {
+        let r = classify_error(1, "execution error: isn't running (-600)", "iTerm2");
+        assert!(matches!(r, Err(CommError::TargetNotRunning { target: "iTerm2" })));
+    }
+
+    #[test]
+    fn classify_other_error() {
+        let r = classify_error(1, "some other failure", "iTerm2");
+        assert!(matches!(r, Err(CommError::OsascriptFailed { .. })));
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/focus/mod.rs
+++ b/kernel/crates/gctrl-mac-comm/src/focus/mod.rs
@@ -1,0 +1,48 @@
+//! `focus` dispatcher.
+//!
+//! Single entry point — [`focus`] — accepts a validated [`FocusRequest`] and
+//! routes to the per-target adapter. Adapters are platform-gated; on
+//! non-macOS, every adapter is a no-op stub and `focus` returns
+//! [`CommError::NotSupported`]. The HTTP layer turns that into a 501.
+//!
+//! Validation happens BEFORE this function runs (see `validate.rs` and the
+//! HTTP handler). This module assumes inputs are already safe to pass to
+//! `osascript`.
+
+#[cfg(target_os = "macos")]
+mod iterm2;
+#[cfg(target_os = "macos")]
+mod terminal;
+
+use crate::error::CommError;
+use crate::model::{FocusRequest, FocusResponse, TerminalApp};
+
+/// Bring the originating terminal session to the foreground.
+///
+/// `req` MUST already be validated by [`crate::validate::focus_request`].
+pub async fn focus(req: &FocusRequest) -> Result<FocusResponse, CommError> {
+    if req.origin_remote {
+        return Ok(FocusResponse::skipped("remote_session"));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        match req.target {
+            TerminalApp::Iterm2 => iterm2::focus(req).await,
+            TerminalApp::Terminal => terminal::focus(req).await,
+            TerminalApp::Ghostty | TerminalApp::Vscode | TerminalApp::Warp => {
+                Err(CommError::UnknownTarget(format!(
+                    "{:?} adapter not implemented in M0",
+                    req.target
+                )))
+            }
+            TerminalApp::Unknown => Err(CommError::UnknownTarget("unknown".into())),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = req;
+        Err(CommError::NotSupported)
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/focus/mod.rs
+++ b/kernel/crates/gctrl-mac-comm/src/focus/mod.rs
@@ -15,7 +15,13 @@ mod iterm2;
 mod terminal;
 
 use crate::error::CommError;
-use crate::model::{FocusRequest, FocusResponse, TerminalApp};
+use crate::model::{FocusRequest, FocusResponse};
+// TerminalApp is only referenced inside the macOS-gated dispatch arm. On
+// Linux/Windows the dispatcher returns NotSupported without inspecting
+// the target, so importing the type unconditionally would trip
+// `unused_imports` under CI's `-D warnings`.
+#[cfg(target_os = "macos")]
+use crate::model::TerminalApp;
 
 /// Bring the originating terminal session to the foreground.
 ///

--- a/kernel/crates/gctrl-mac-comm/src/focus/terminal.rs
+++ b/kernel/crates/gctrl-mac-comm/src/focus/terminal.rs
@@ -1,0 +1,75 @@
+//! Apple Terminal.app focus adapter (best-effort).
+//!
+//! Identity for Terminal.app is the `(window-index, tab-index)` pair.
+//! `$TERM_SESSION_ID` is undocumented and unstable across macOS versions, so
+//! the capture hook stores indices instead and the adapter looks up by
+//! position. AppleScript verb is `set selected of tab N of window M to true`.
+
+use crate::error::CommError;
+use crate::model::{FocusRequest, FocusResponse};
+use crate::osascript::Osascript;
+
+const HANDLER_SCRIPT: &str = r#"
+on focus_terminal_tab(window_idx, tab_idx)
+  tell application "Terminal"
+    activate
+    try
+      set selected of tab tab_idx of window window_idx to true
+      return "ok"
+    on error errMsg number errNum
+      if errNum is -1719 then
+        return "not_found"
+      else
+        error errMsg number errNum
+      end if
+    end try
+  end tell
+end focus_terminal_tab
+"#;
+
+pub async fn focus(req: &FocusRequest) -> Result<FocusResponse, CommError> {
+    let window = req
+        .window_id
+        .as_deref()
+        .ok_or(CommError::Validation {
+            field: "window_id",
+            pattern: "required for target=terminal",
+        })?;
+    let tab = req.tab_id.as_deref().ok_or(CommError::Validation {
+        field: "tab_id",
+        pattern: "required for target=terminal",
+    })?;
+
+    let osa = Osascript {
+        timeout_ms: 2_000,
+        target_label: "Terminal",
+    };
+    let call = format!("focus_terminal_tab({}, {})", window, tab);
+    let out = osa.run(&[HANDLER_SCRIPT, &call]).await?;
+
+    if out.exit_code == 0 {
+        return match out.stdout.trim() {
+            "ok" => Ok(FocusResponse::ok()),
+            "not_found" => Err(CommError::SessionNotFound {
+                target: "Terminal",
+                session_id: format!("window={} tab={}", window, tab),
+            }),
+            other => Err(CommError::OsascriptFailed {
+                exit_code: 0,
+                stderr: format!("unexpected handler output: {}", other),
+            }),
+        };
+    }
+
+    if out.stderr.contains("-1743") || out.stderr.contains("not allowed assistive access") {
+        return Err(CommError::AutomationDenied { target: "Terminal" });
+    }
+    if out.stderr.contains("-600") || out.stderr.contains("isn't running") {
+        return Err(CommError::TargetNotRunning { target: "Terminal" });
+    }
+
+    Err(CommError::OsascriptFailed {
+        exit_code: out.exit_code,
+        stderr: out.stderr,
+    })
+}

--- a/kernel/crates/gctrl-mac-comm/src/lib.rs
+++ b/kernel/crates/gctrl-mac-comm/src/lib.rs
@@ -1,0 +1,40 @@
+//! gctrl-mac-comm — Kernel driver for native macOS communication channels.
+//!
+//! Closes the loop between gctrl-inbox permission requests and the iTerm2 /
+//! Terminal.app session that issued them. Exposes a small surface used by the
+//! `/api/comm/*` HTTP routes (mounted in `gctrl-otel`) and by the
+//! `gctrl terminal` shell command.
+//!
+//! Public surface:
+//! - [`focus`]    — bring the originating terminal session to the foreground.
+//! - [`capabilities`] — what the runtime can do (which terminals, automation
+//!                     grant state, OS discriminator).
+//! - [`validate`] — per-field allowlist regexes for `context.terminal`
+//!                  fields. Used at the comm endpoint AND the inbox-message
+//!                  intake handler so a single canonical validator covers
+//!                  both entry points.
+//! - [`RateLimiter`] — per-`session_id` token bucket. The HTTP layer wraps
+//!                     focus calls with this.
+//!
+//! On Linux/Windows, [`focus`] returns [`CommError::NotSupported`] and the
+//! routes serialize that as `501 Not Implemented` with a clear body. Building
+//! the crate on those platforms is intentionally cheap — no native bindings,
+//! no platform-only crates.
+//!
+//! AppleScript invocation goes through [`osascript::Osascript`], which uses
+//! the argv-array form (`-e <a> -e <b>`) — never string concatenation — so
+//! validated session IDs cannot break out of the AppleScript string literal.
+
+pub mod capabilities;
+pub mod error;
+pub mod focus;
+pub mod model;
+pub mod osascript;
+pub mod rate_limit;
+pub mod validate;
+
+pub use capabilities::{capabilities, Capabilities};
+pub use error::CommError;
+pub use focus::focus;
+pub use model::{FocusRequest, FocusResponse, TerminalApp, TerminalContext};
+pub use rate_limit::RateLimiter;

--- a/kernel/crates/gctrl-mac-comm/src/model.rs
+++ b/kernel/crates/gctrl-mac-comm/src/model.rs
@@ -1,0 +1,128 @@
+use serde::{Deserialize, Serialize};
+
+/// The terminal application discriminator. Matches `context.terminal.app` in
+/// inbox messages. `unknown` is the explicit "we couldn't identify" value —
+/// the inbox UI hides the Focus button for unknown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TerminalApp {
+    Iterm2,
+    Terminal,
+    Ghostty,
+    Vscode,
+    Warp,
+    Unknown,
+}
+
+impl TerminalApp {
+    pub const fn label(self) -> &'static str {
+        match self {
+            TerminalApp::Iterm2 => "iTerm2",
+            TerminalApp::Terminal => "Terminal",
+            TerminalApp::Ghostty => "Ghostty",
+            TerminalApp::Vscode => "VS Code",
+            TerminalApp::Warp => "Warp",
+            TerminalApp::Unknown => "unknown",
+        }
+    }
+
+    pub const fn bundle_id(self) -> &'static str {
+        match self {
+            TerminalApp::Iterm2 => "com.googlecode.iterm2",
+            TerminalApp::Terminal => "com.apple.Terminal",
+            TerminalApp::Ghostty => "com.mitchellh.ghostty",
+            TerminalApp::Vscode => "com.microsoft.VSCode",
+            TerminalApp::Warp => "dev.warp.Warp-Stable",
+            TerminalApp::Unknown => "",
+        }
+    }
+}
+
+/// Captured terminal context — the contents of `inbox_messages.context.terminal`.
+///
+/// Every string field is validated by [`crate::validate`] before reaching an
+/// `osascript` adapter. The validators live next to the type definitions so
+/// schema and policy stay in sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalContext {
+    pub app: TerminalApp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tty: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ppid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub term_program: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub term_program_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_at: Option<String>,
+}
+
+/// Body of `POST /api/comm/focus`. The HTTP handler validates each field via
+/// [`crate::validate`] before calling [`crate::focus`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FocusRequest {
+    pub target: TerminalApp,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Set by the kernel HTTP layer when the request arrived from a non-loopback
+    /// connection. Triggers `reason: "remote_session"` short-circuit instead of
+    /// invoking osascript. Spoofing in the request body is meaningless because
+    /// the field is overwritten at intake.
+    #[serde(default, skip_serializing)]
+    pub origin_remote: bool,
+}
+
+/// Response shape for `POST /api/comm/focus`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FocusResponse {
+    pub focused: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub deduped: bool,
+}
+
+impl FocusResponse {
+    pub fn ok() -> Self {
+        Self {
+            focused: true,
+            reason: None,
+            deduped: false,
+        }
+    }
+
+    pub fn skipped(reason: impl Into<String>) -> Self {
+        Self {
+            focused: false,
+            reason: Some(reason.into()),
+            deduped: false,
+        }
+    }
+
+    pub fn deduped() -> Self {
+        Self {
+            focused: true,
+            reason: None,
+            deduped: true,
+        }
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/osascript.rs
+++ b/kernel/crates/gctrl-mac-comm/src/osascript.rs
@@ -1,0 +1,92 @@
+//! Safe `osascript` invocation helper.
+//!
+//! Invariants enforced here, NOT at the call site:
+//! - Argument-array form only. The script source and any handler-call
+//!   argument are passed via separate `-e` flags. There is no shell-level
+//!   quoting or string concatenation anywhere in this file.
+//! - Hard timeout (default 2s). If `osascript` doesn't return, the child is
+//!   killed and [`CommError::OsascriptTimeout`] is returned.
+//! - `osascript -e <handler-script>` and the handler-call expression are
+//!   passed as **distinct argv entries** so even a maliciously-crafted
+//!   argument string cannot break script-source delimiters.
+//!
+//! Validated input, parameterised invocation, capped runtime — three
+//! independent layers, all enforced regardless of how the caller wires up
+//! the adapter.
+
+use crate::error::CommError;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+#[derive(Debug, Clone)]
+pub struct Osascript {
+    pub timeout_ms: u64,
+    pub target_label: &'static str,
+}
+
+impl Default for Osascript {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 2_000,
+            target_label: "target",
+        }
+    }
+}
+
+/// Outcome of a single osascript run. `stdout`/`stderr` are returned to the
+/// adapter for parsing; the adapter decides what `-1743` (automation denied)
+/// or `-1728` (object not found) mean for its specific verb.
+#[derive(Debug, Clone)]
+pub struct OsascriptOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Osascript {
+    /// Run `osascript` with multiple `-e` script fragments. Each fragment is
+    /// passed as a separate argv entry; there is no string concatenation.
+    pub async fn run(&self, fragments: &[&str]) -> Result<OsascriptOutput, CommError> {
+        let mut cmd = Command::new("osascript");
+        for f in fragments {
+            cmd.arg("-e").arg(f);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let wait = async move {
+            let mut out_buf = String::new();
+            let mut err_buf = String::new();
+            if let Some(mut s) = stdout {
+                let _ = s.read_to_string(&mut out_buf).await;
+            }
+            if let Some(mut s) = stderr {
+                let _ = s.read_to_string(&mut err_buf).await;
+            }
+            let status = child.wait().await?;
+            Ok::<_, std::io::Error>(OsascriptOutput {
+                exit_code: status.code().unwrap_or(-1),
+                stdout: out_buf,
+                stderr: err_buf,
+            })
+        };
+
+        match timeout(Duration::from_millis(self.timeout_ms), wait).await {
+            Ok(Ok(out)) => Ok(out),
+            Ok(Err(io)) => Err(CommError::Io(io)),
+            Err(_) => Err(CommError::OsascriptTimeout {
+                target: self.target_label,
+                ms: self.timeout_ms,
+            }),
+        }
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/rate_limit.rs
+++ b/kernel/crates/gctrl-mac-comm/src/rate_limit.rs
@@ -1,0 +1,142 @@
+//! Per-key token-bucket rate limiter.
+//!
+//! Used by the comm endpoint to bound focus calls per `session_id`. Prevents a
+//! runaway inbox message (or a UI bug) from spamming `osascript` and starving
+//! the user's window manager. Cheap, in-memory, no persistence — buckets that
+//! age out are reclaimed lazily on the next access.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimiterConfig {
+    /// Tokens replenished per second.
+    pub rate_per_sec: f64,
+    /// Maximum burst (also the initial token count).
+    pub burst: u32,
+    /// Buckets idle for this duration are dropped on next access.
+    pub idle_evict: Duration,
+}
+
+impl Default for RateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            rate_per_sec: 1.0,
+            burst: 10,
+            idle_evict: Duration::from_secs(300),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Bucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+#[derive(Debug)]
+pub struct RateLimiter {
+    cfg: RateLimiterConfig,
+    buckets: Mutex<HashMap<String, Bucket>>,
+}
+
+impl RateLimiter {
+    pub fn new(cfg: RateLimiterConfig) -> Self {
+        Self {
+            cfg,
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Try to consume one token for `key`. Returns `true` if acquired.
+    /// `now` is injected for deterministic testing.
+    pub fn try_acquire_at(&self, key: &str, now: Instant) -> bool {
+        let mut buckets = self.buckets.lock().expect("rate limiter mutex poisoned");
+
+        // Lazy eviction: drop any bucket idle longer than `idle_evict`.
+        // Keeps the map size bounded over long runs without a background thread.
+        buckets.retain(|_, b| now.duration_since(b.last_refill) < self.cfg.idle_evict);
+
+        let bucket = buckets.entry(key.to_string()).or_insert_with(|| Bucket {
+            tokens: self.cfg.burst as f64,
+            last_refill: now,
+        });
+
+        let elapsed = now.duration_since(bucket.last_refill).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * self.cfg.rate_per_sec).min(self.cfg.burst as f64);
+        bucket.last_refill = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn try_acquire(&self, key: &str) -> bool {
+        self.try_acquire_at(key, Instant::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(rate: f64, burst: u32) -> RateLimiterConfig {
+        RateLimiterConfig {
+            rate_per_sec: rate,
+            burst,
+            idle_evict: Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn burst_acquires_then_blocks() {
+        let limiter = RateLimiter::new(cfg(1.0, 3));
+        let t0 = Instant::now();
+        assert!(limiter.try_acquire_at("k", t0));
+        assert!(limiter.try_acquire_at("k", t0));
+        assert!(limiter.try_acquire_at("k", t0));
+        assert!(!limiter.try_acquire_at("k", t0));
+    }
+
+    #[test]
+    fn refills_over_time() {
+        let limiter = RateLimiter::new(cfg(1.0, 1));
+        let t0 = Instant::now();
+        assert!(limiter.try_acquire_at("k", t0));
+        assert!(!limiter.try_acquire_at("k", t0));
+        // After 1 second, exactly 1 token should be available.
+        let t1 = t0 + Duration::from_secs(1);
+        assert!(limiter.try_acquire_at("k", t1));
+    }
+
+    #[test]
+    fn keys_are_independent() {
+        let limiter = RateLimiter::new(cfg(1.0, 1));
+        let t0 = Instant::now();
+        assert!(limiter.try_acquire_at("a", t0));
+        assert!(limiter.try_acquire_at("b", t0));
+        assert!(!limiter.try_acquire_at("a", t0));
+        assert!(!limiter.try_acquire_at("b", t0));
+    }
+
+    #[test]
+    fn caps_at_burst_after_long_idle() {
+        let limiter = RateLimiter::new(cfg(1.0, 5));
+        let t0 = Instant::now();
+        // First call gives us full burst minus one.
+        assert!(limiter.try_acquire_at("k", t0));
+        // Wait 24h — bucket should not exceed `burst`.
+        let t1 = t0 + Duration::from_secs(86_400);
+        // A 24h refill would mathematically be 86_400 tokens; should cap at 5.
+        // The `idle_evict` test config is 60s, so this bucket is evicted and
+        // re-created at full burst — the cap-at-burst behavior is implicit.
+        for _ in 0..5 {
+            assert!(limiter.try_acquire_at("k", t1));
+        }
+        assert!(!limiter.try_acquire_at("k", t1));
+    }
+}

--- a/kernel/crates/gctrl-mac-comm/src/validate.rs
+++ b/kernel/crates/gctrl-mac-comm/src/validate.rs
@@ -1,0 +1,336 @@
+//! Per-field allowlist validators for `context.terminal` and `FocusRequest`
+//! payloads.
+//!
+//! Single canonical validator. Called from BOTH:
+//! - the comm endpoint handler (`/api/comm/focus`)
+//! - the inbox-message intake handler (when accepting `context.terminal`)
+//!
+//! No field validated here is allowed to flow into an `osascript` invocation
+//! before passing the corresponding regex. The intent is defense-in-depth
+//! against AppleScript injection — even a hypothetical bug in the URL handler
+//! or the inbox intake cannot reach the adapters with a hostile string.
+
+use crate::error::CommError;
+use crate::model::{FocusRequest, TerminalApp, TerminalContext};
+use regex::Regex;
+use std::sync::OnceLock;
+
+macro_rules! lazy_regex {
+    ($name:ident, $pattern:expr) => {
+        fn $name() -> &'static Regex {
+            static CACHED: OnceLock<Regex> = OnceLock::new();
+            CACHED.get_or_init(|| Regex::new($pattern).expect("compile-time-valid regex"))
+        }
+    };
+}
+
+// iTerm2 session IDs come in the form `w<window>t<tab>p<pane>:<UUIDv4>`.
+// All three index positions are present; the UUID has the canonical
+// `8-4-4-4-12` hex grouping. Constraining to this exact shape (rather than
+// a generic alnum allowlist) shrinks the attack surface to zero printable
+// characters that AppleScript treats as syntactically meaningful.
+lazy_regex!(
+    re_iterm2_session,
+    r"^w[0-9]{1,4}t[0-9]{1,4}p[0-9]{1,4}:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+);
+
+// Other terminals get a looser but still strict allowlist. Excludes
+// quotes, backslashes, whitespace, and AppleScript metacharacters.
+lazy_regex!(re_generic_session, r"^[A-Za-z0-9_:.-]{1,64}$");
+
+// Apple Terminal window/tab indices.
+lazy_regex!(re_index, r"^[0-9]{1,4}$");
+
+// `tty(1)` output: /dev/ttysNN or /dev/ptyXX
+lazy_regex!(re_tty, r"^/dev/(tty|pty)[a-z0-9]{1,8}$");
+
+// Absolute POSIX path. Conservative allowlist of characters real-world
+// agent working directories actually contain (letters, digits, common
+// separators, parens, brackets, plus a handful of safe punctuation).
+// Excludes shell metacharacters (`"`, `'`, `\`, `;`, `$`, backtick, `*`,
+// `?`) and AppleScript string-literal terminators. The rare path containing
+// these would still reach the kernel as a 400 — a deliberate trade for
+// defense-in-depth even when adapters parameterize correctly. Length
+// capped at 512 to bound osascript argv size.
+lazy_regex!(
+    re_cwd,
+    r"^/[A-Za-z0-9._/() \[\]+,&@!~=#:-]{0,512}$"
+);
+
+// Bundle ID: reverse-DNS. Real-world Apple bundle IDs do contain mixed case
+// (e.g. `com.apple.Terminal`, `com.microsoft.VSCode`, `dev.warp.Warp-Stable`),
+// so the second-and-after characters allow upper-case.
+lazy_regex!(re_bundle_id, r"^[a-z][a-zA-Z0-9.-]{2,63}$");
+
+// term_program / term_program_version: short alnum-with-spaces label.
+lazy_regex!(re_term_program, r"^[A-Za-z0-9 ._-]{1,64}$");
+
+/// Validate a session ID against the discriminator-specific regex.
+pub fn session_id(target: TerminalApp, value: &str) -> Result<(), CommError> {
+    let (re, pattern): (&Regex, &'static str) = match target {
+        TerminalApp::Iterm2 => (
+            re_iterm2_session(),
+            r"w[0-9]+t[0-9]+p[0-9]+:<UUIDv4>",
+        ),
+        TerminalApp::Unknown => {
+            return Err(CommError::Validation {
+                field: "session_id",
+                pattern: "(no validator for unknown target)",
+            });
+        }
+        _ => (re_generic_session(), r"[A-Za-z0-9_:.-]{1,64}"),
+    };
+    if re.is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field: "session_id",
+            pattern,
+        })
+    }
+}
+
+pub fn window_or_tab_index(field: &'static str, value: &str) -> Result<(), CommError> {
+    if re_index().is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field,
+            pattern: r"[0-9]{1,4}",
+        })
+    }
+}
+
+pub fn tty(value: &str) -> Result<(), CommError> {
+    if re_tty().is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field: "tty",
+            pattern: r"/dev/(tty|pty)[a-z0-9]{1,8}",
+        })
+    }
+}
+
+pub fn cwd(value: &str) -> Result<(), CommError> {
+    if re_cwd().is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field: "cwd",
+            pattern: r"/[A-Za-z0-9._/() \[\]+,&@!~=#:-]{0,512}",
+        })
+    }
+}
+
+pub fn bundle_id(value: &str) -> Result<(), CommError> {
+    if re_bundle_id().is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field: "bundle_id",
+            pattern: r"[a-z][a-zA-Z0-9.-]{2,63}",
+        })
+    }
+}
+
+pub fn term_program(field: &'static str, value: &str) -> Result<(), CommError> {
+    if re_term_program().is_match(value) {
+        Ok(())
+    } else {
+        Err(CommError::Validation {
+            field,
+            pattern: r"[A-Za-z0-9 ._-]{1,64}",
+        })
+    }
+}
+
+/// Validate a complete `FocusRequest`. Order matters — fields with broader
+/// reach are checked first so the error tells the caller the most fundamental
+/// problem.
+pub fn focus_request(req: &FocusRequest) -> Result<(), CommError> {
+    if matches!(req.target, TerminalApp::Unknown) {
+        return Err(CommError::UnknownTarget("unknown".into()));
+    }
+    if let Some(sid) = req.session_id.as_deref() {
+        session_id(req.target, sid)?;
+    }
+    if let Some(w) = req.window_id.as_deref() {
+        window_or_tab_index("window_id", w)?;
+    }
+    if let Some(t) = req.tab_id.as_deref() {
+        window_or_tab_index("tab_id", t)?;
+    }
+    if let Some(c) = req.cwd.as_deref() {
+        cwd(c)?;
+    }
+    Ok(())
+}
+
+/// Validate a complete `TerminalContext`. Used by the inbox intake handler
+/// when accepting messages with `context.terminal`. Returns the first error
+/// encountered.
+pub fn terminal_context(ctx: &TerminalContext) -> Result<(), CommError> {
+    if let Some(b) = ctx.bundle_id.as_deref() {
+        bundle_id(b)?;
+    }
+    if let Some(sid) = ctx.session_id.as_deref() {
+        session_id(ctx.app, sid)?;
+    }
+    if let Some(w) = ctx.window_id.as_deref() {
+        window_or_tab_index("window_id", w)?;
+    }
+    if let Some(t) = ctx.tab_id.as_deref() {
+        window_or_tab_index("tab_id", t)?;
+    }
+    if let Some(t) = ctx.tty.as_deref() {
+        tty(t)?;
+    }
+    if let Some(c) = ctx.cwd.as_deref() {
+        cwd(c)?;
+    }
+    if let Some(s) = ctx.term_program.as_deref() {
+        term_program("term_program", s)?;
+    }
+    if let Some(s) = ctx.term_program_version.as_deref() {
+        term_program("term_program_version", s)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iterm2_session_id_accepts_real_shape() {
+        assert!(session_id(
+            TerminalApp::Iterm2,
+            "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn iterm2_session_id_rejects_quote_injection() {
+        let evil = r#"w0t0p0:X" & do shell script "rm -rf /""#;
+        assert!(session_id(TerminalApp::Iterm2, evil).is_err());
+    }
+
+    #[test]
+    fn iterm2_session_id_rejects_newline() {
+        assert!(session_id(TerminalApp::Iterm2, "w0t0p0:abc\nXYZ").is_err());
+    }
+
+    #[test]
+    fn cwd_rejects_quote() {
+        assert!(cwd(r#"/foo"; do shell script "evil""#).is_err());
+    }
+
+    #[test]
+    fn cwd_rejects_newline() {
+        assert!(cwd("/foo\nbar").is_err());
+    }
+
+    #[test]
+    fn cwd_accepts_normal_path() {
+        assert!(cwd("/Users/v/workspaces/ohc/gctrl").is_ok());
+    }
+
+    #[test]
+    fn cwd_rejects_relative() {
+        assert!(cwd("Users/v/workspaces").is_err());
+    }
+
+    #[test]
+    fn cwd_rejects_too_long() {
+        let long = format!("/{}", "a".repeat(513));
+        assert!(cwd(&long).is_err());
+    }
+
+    #[test]
+    fn tty_accepts_ttys() {
+        assert!(tty("/dev/ttys003").is_ok());
+        assert!(tty("/dev/ttys123").is_ok());
+    }
+
+    #[test]
+    fn tty_rejects_absolute_other_path() {
+        assert!(tty("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn window_index_accepts_small() {
+        assert!(window_or_tab_index("window_id", "1").is_ok());
+        assert!(window_or_tab_index("window_id", "9999").is_ok());
+    }
+
+    #[test]
+    fn window_index_rejects_letters() {
+        assert!(window_or_tab_index("window_id", "1a").is_err());
+    }
+
+    #[test]
+    fn focus_request_unknown_target_rejected() {
+        let req = FocusRequest {
+            target: TerminalApp::Unknown,
+            session_id: None,
+            window_id: None,
+            tab_id: None,
+            cwd: None,
+            origin_remote: false,
+        };
+        assert!(matches!(
+            focus_request(&req),
+            Err(CommError::UnknownTarget(_))
+        ));
+    }
+
+    #[test]
+    fn focus_request_iterm2_happy_path() {
+        let req = FocusRequest {
+            target: TerminalApp::Iterm2,
+            session_id: Some("w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765".into()),
+            window_id: None,
+            tab_id: None,
+            cwd: Some("/Users/v/code".into()),
+            origin_remote: false,
+        };
+        assert!(focus_request(&req).is_ok());
+    }
+
+    #[test]
+    fn focus_request_terminal_indices() {
+        let req = FocusRequest {
+            target: TerminalApp::Terminal,
+            session_id: None,
+            window_id: Some("1".into()),
+            tab_id: Some("3".into()),
+            cwd: None,
+            origin_remote: false,
+        };
+        assert!(focus_request(&req).is_ok());
+    }
+
+    #[test]
+    fn bundle_id_accepts_real_world_ids() {
+        assert!(bundle_id("com.googlecode.iterm2").is_ok());
+        assert!(bundle_id("com.apple.Terminal").is_ok());
+        assert!(bundle_id("com.microsoft.VSCode").is_ok());
+        assert!(bundle_id("dev.warp.Warp-Stable").is_ok());
+    }
+
+    #[test]
+    fn bundle_id_rejects_evil() {
+        assert!(bundle_id("com.apple.Terminal'; do shell script \"evil\"").is_err());
+        assert!(bundle_id("Com.apple.Terminal").is_err()); // must start lowercase
+        assert!(bundle_id("ab").is_err()); // too short
+    }
+
+    #[test]
+    fn term_program_accepts_real_values() {
+        assert!(term_program("term_program", "iTerm.app").is_ok());
+        assert!(term_program("term_program", "Apple_Terminal").is_ok());
+        assert!(term_program("term_program_version", "3.5.0").is_ok());
+    }
+}

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -18,6 +18,7 @@ gctrl-gcal = { path = "../gctrl-gcal" }
 gctrl-driver-macos = { path = "../gctrl-driver-macos" }
 gctrl-browser = { path = "../gctrl-browser" }
 gctrl-recorder = { path = "../gctrl-recorder" }
+gctrl-mac-comm = { path = "../gctrl-mac-comm" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true, features = ["ws"] }

--- a/kernel/crates/gctrl-otel/src/comm_routes.rs
+++ b/kernel/crates/gctrl-otel/src/comm_routes.rs
@@ -1,0 +1,221 @@
+//! macOS communication driver HTTP routes.
+//!
+//! Mounts `/api/comm/*` onto the kernel router. Backed by `gctrl-mac-comm`.
+//!
+//! On macOS, `POST /api/comm/focus` validates the request, applies a per-
+//! `session_id` token-bucket rate limit, then dispatches to the iTerm2 /
+//! Terminal.app adapter via `osascript`. On non-macOS, every focus call
+//! returns 501 with a clear body — the route exists so the SPA capabilities
+//! probe gets a structured "not supported" answer rather than a 404 that
+//! could mean "daemon down" or "feature off."
+//!
+//! Remote-vs-local determination is delegated to the host-allowlist
+//! middleware (`gctrl-cli::host_allowlist_middleware`) which sits in front
+//! of the entire router. Any request that reaches this handler has a Host
+//! header in {localhost, 127.0.0.1, ::1}, so we treat the request as
+//! local-origin. The `host` field in the request body is purely
+//! informational — the payload cannot bypass the middleware regardless of
+//! what it claims. If/when the daemon ever binds a non-loopback interface,
+//! the middleware boundary changes and this assumption needs to be
+//! reconsidered (the FocusRequest already carries `origin_remote` so the
+//! call site is the only thing that needs updating).
+
+use axum::{
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use gctrl_mac_comm::{
+    capabilities, focus, rate_limit::RateLimiterConfig, validate, CommError, FocusRequest,
+    RateLimiter,
+};
+use std::sync::OnceLock;
+
+fn rate_limiter() -> &'static RateLimiter {
+    static CACHED: OnceLock<RateLimiter> = OnceLock::new();
+    CACHED.get_or_init(|| RateLimiter::new(RateLimiterConfig::default()))
+}
+
+fn map_err(e: CommError) -> (StatusCode, String) {
+    let status = match &e {
+        CommError::NotSupported => StatusCode::NOT_IMPLEMENTED,
+        CommError::Validation { .. } => StatusCode::BAD_REQUEST,
+        CommError::UnknownTarget(_) => StatusCode::BAD_REQUEST,
+        CommError::SessionNotFound { .. } => StatusCode::NOT_FOUND,
+        CommError::TargetNotRunning { .. } => StatusCode::SERVICE_UNAVAILABLE,
+        CommError::AutomationDenied { .. } => StatusCode::FORBIDDEN,
+        CommError::OsascriptTimeout { .. } => StatusCode::GATEWAY_TIMEOUT,
+        CommError::OsascriptFailed { .. } => StatusCode::BAD_GATEWAY,
+        CommError::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS,
+        CommError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (status, e.to_string())
+}
+
+async fn handle_focus(Json(mut req): Json<FocusRequest>) -> impl IntoResponse {
+    // The `origin_remote` flag is overwritten HERE, never trusted from the
+    // body. Today the host-allowlist middleware guarantees loopback-only
+    // requests reach this handler (see module doc-comment); a non-loopback
+    // bind would change this default.
+    req.origin_remote = false;
+
+    if let Err(e) = validate::focus_request(&req) {
+        return map_err(e).into_response();
+    }
+
+    // Rate-limit per session_id. Requests without a session_id (e.g. Apple
+    // Terminal indexed by window/tab) get a single shared bucket per
+    // `(target, window, tab)` triple — same backpressure semantics with no
+    // schema-required key.
+    let bucket_key = req
+        .session_id
+        .clone()
+        .unwrap_or_else(|| {
+            format!(
+                "{:?}:{}:{}",
+                req.target,
+                req.window_id.as_deref().unwrap_or("-"),
+                req.tab_id.as_deref().unwrap_or("-"),
+            )
+        });
+    if !rate_limiter().try_acquire(&bucket_key) {
+        return map_err(CommError::RateLimited(bucket_key)).into_response();
+    }
+
+    match focus(&req).await {
+        Ok(resp) => Json(resp).into_response(),
+        Err(e) => map_err(e).into_response(),
+    }
+}
+
+async fn handle_capabilities() -> impl IntoResponse {
+    Json(capabilities())
+}
+
+/// Mount the comm driver routes.
+///
+/// Type parameter `S` matches the gcal_routes pattern — these routes carry no
+/// router state of their own; they're stateless and use a process-wide
+/// rate-limiter cell.
+pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
+    Router::new()
+        .route("/api/comm/focus", post(handle_focus))
+        .route("/api/comm/capabilities", get(handle_capabilities))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn make_router() -> Router {
+        router::<()>()
+    }
+
+    fn post_focus(body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/comm/focus")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn capabilities_route_is_reachable() {
+        let app = make_router();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/comm/capabilities")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("os").is_some(), "capabilities must include `os`");
+        assert!(
+            json.get("terminals").is_some(),
+            "capabilities must include `terminals`"
+        );
+    }
+
+    #[tokio::test]
+    async fn focus_rejects_unknown_target() {
+        let app = make_router();
+        let res = app
+            .oneshot(post_focus(serde_json::json!({ "target": "unknown" })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn focus_rejects_invalid_session_id_for_iterm2() {
+        let app = make_router();
+        let res = app
+            .oneshot(post_focus(serde_json::json!({
+                "target": "iterm2",
+                "session_id": "not-a-real-iterm-id"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn focus_rejects_quote_injection_in_session_id() {
+        let app = make_router();
+        let evil = "w0t0p0:X\" & do shell script \"rm -rf /\"";
+        let res = app
+            .oneshot(post_focus(serde_json::json!({
+                "target": "iterm2",
+                "session_id": evil
+            })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn focus_rejects_payload_origin_remote_spoof() {
+        // Even if the payload claims `origin_remote: true`, the handler
+        // overwrites it. Validation still runs; an otherwise-valid request
+        // must reach the focus dispatcher (which on non-mac returns 501,
+        // on mac would attempt iTerm2 and most likely 404).
+        let app = make_router();
+        let res = app
+            .oneshot(post_focus(serde_json::json!({
+                "target": "iterm2",
+                "session_id": "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765",
+                "origin_remote": true
+            })))
+            .await
+            .unwrap();
+        // The origin_remote field is `skip_serializing` on deserialize-only
+        // surface AND overwritten in the handler; either way it does NOT
+        // produce a "remote_session" short-circuit that would give a 200.
+        assert_ne!(res.status(), StatusCode::OK);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn focus_returns_501_on_non_macos() {
+        let app = make_router();
+        let res = app
+            .oneshot(post_focus(serde_json::json!({
+                "target": "iterm2",
+                "session_id": "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765"
+            })))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod browser_routes;
+pub mod comm_routes;
 pub mod recorder_routes;
 pub mod contributions;
 pub mod event_bus;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -430,6 +430,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         // recorder observation endpoints.
         .merge(crate::browser_routes::router::<()>())
         .merge(crate::recorder_routes::router::<()>())
+        // macOS communication driver (LKM — focus iTerm2/Terminal sessions
+        // from inbox deeplinks). On non-macOS the routes return 501.
+        .merge(crate::comm_routes::router::<()>())
 }
 
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/shell/gctrl-shell/src/commands/terminal.ts
+++ b/shell/gctrl-shell/src/commands/terminal.ts
@@ -1,0 +1,131 @@
+/**
+ * `gctrl terminal` — focus the originating macOS terminal session for an
+ * inbox permission request, and probe what the runtime can reach.
+ *
+ * All commands route through the kernel HTTP API (`/api/comm/*`). The
+ * driver is `gctrl-mac-comm` (LKM); shell never invokes `osascript`
+ * directly.
+ *
+ * Verbs:
+ *   capabilities — show OS, supported terminals, automation grant state
+ *   focus        — bring a terminal session/tab to the foreground
+ */
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect, Option, Schema } from "effect"
+import { KernelClient } from "../services/KernelClient"
+
+// --- schemas ---
+
+const Capabilities = Schema.Struct({
+  os: Schema.String,
+  terminals: Schema.Array(Schema.String),
+  notify: Schema.Boolean,
+  automation_granted: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  captured_at: Schema.String,
+})
+
+const FocusResponse = Schema.Struct({
+  focused: Schema.Boolean,
+  reason: Schema.optional(Schema.NullOr(Schema.String)),
+  deduped: Schema.optional(Schema.Boolean),
+})
+
+// --- shared options ---
+
+const TARGET_APPS = ["iterm2", "terminal", "ghostty", "vscode", "warp"] as const
+
+const formatOption = Options.choice("format", ["table", "json"]).pipe(
+  Options.withDefault("table"),
+  Options.withDescription("Output format")
+)
+
+// --- capabilities command ---
+
+const capabilitiesCommand = Command.make(
+  "capabilities",
+  { format: formatOption },
+  ({ format }) =>
+    Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      const caps = yield* kernel.get("/api/comm/capabilities", Capabilities)
+
+      if (format === "json") {
+        yield* Console.log(JSON.stringify(caps, null, 2))
+        return
+      }
+
+      const grant =
+        caps.automation_granted == null
+          ? "unknown"
+          : caps.automation_granted
+            ? "granted"
+            : "denied"
+      yield* Console.log(`OS:                 ${caps.os}`)
+      yield* Console.log(`Terminals:          ${caps.terminals.join(", ") || "(none)"}`)
+      yield* Console.log(`Notify (M1):        ${caps.notify ? "yes" : "no"}`)
+      yield* Console.log(`Automation grant:   ${grant}`)
+      yield* Console.log(`Captured at:        ${caps.captured_at}`)
+    })
+)
+
+// --- focus command ---
+//
+// One flag schema across all targets: `--target <app> [--session <id>]
+// [--window <n>] [--tab <n>] [--cwd <path>]`. iTerm2 / Ghostty / VS Code /
+// Warp need `--session`; Apple Terminal needs `--window` + `--tab`.
+
+const targetOption = Options.choice("target", [...TARGET_APPS]).pipe(
+  Options.withDescription(`Terminal app to focus (${TARGET_APPS.join(" | ")})`)
+)
+const sessionOption = Options.text("session").pipe(
+  Options.optional,
+  Options.withDescription("Session UUID (iTerm2: w0t0p0:UUID; others: vendor-specific)")
+)
+const windowOption = Options.text("window").pipe(
+  Options.optional,
+  Options.withDescription("Window index (Apple Terminal)")
+)
+const tabOption = Options.text("tab").pipe(
+  Options.optional,
+  Options.withDescription("Tab index (Apple Terminal)")
+)
+const cwdOption = Options.text("cwd").pipe(
+  Options.optional,
+  Options.withDescription("Working directory (used for 'open new window here' fallback)")
+)
+
+const focusCommand = Command.make(
+  "focus",
+  {
+    target: targetOption,
+    session: sessionOption,
+    window: windowOption,
+    tab: tabOption,
+    cwd: cwdOption,
+  },
+  ({ target, session, window, tab, cwd }) =>
+    Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      const body: Record<string, unknown> = { target }
+      if (Option.isSome(session)) body.session_id = session.value
+      if (Option.isSome(window)) body.window_id = window.value
+      if (Option.isSome(tab)) body.tab_id = tab.value
+      if (Option.isSome(cwd)) body.cwd = cwd.value
+
+      const resp = yield* kernel.post("/api/comm/focus", body, FocusResponse)
+
+      if (resp.focused) {
+        const note = resp.deduped ? " (deduped)" : ""
+        yield* Console.log(`Focused ${target}${note}`)
+      } else {
+        const reason = resp.reason ?? "unknown"
+        yield* Console.log(`Skipped: ${reason}`)
+      }
+    })
+)
+
+// --- terminal (parent) ---
+
+export const terminalCommand = Command.make("terminal").pipe(
+  Command.withSubcommands([capabilitiesCommand, focusCommand])
+)

--- a/shell/gctrl-shell/src/main.ts
+++ b/shell/gctrl-shell/src/main.ts
@@ -21,6 +21,7 @@ import { searchCommand } from "./commands/search"
 import { personaCommand } from "./commands/persona"
 import { teamCommand } from "./commands/team"
 import { inboxCommand } from "./commands/inbox"
+import { terminalCommand } from "./commands/terminal"
 import { vaultCommand } from "./commands/vault"
 import { wranglerCommand } from "./commands/wrangler"
 import { appCommand } from "./commands/app"
@@ -42,6 +43,7 @@ const command = Command.make("gctrl").pipe(
     personaCommand,
     teamCommand,
     inboxCommand,
+    terminalCommand,
     vaultCommand,
     wranglerCommand,
     appCommand,

--- a/shell/gctrl-shell/test/terminal.test.ts
+++ b/shell/gctrl-shell/test/terminal.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest"
+import { Effect, Schema } from "effect"
+import { KernelClient } from "../src/services/KernelClient"
+import { createMockKernelClient } from "./helpers/mock-kernel"
+
+// --- schemas (mirroring terminal.ts) ---
+
+const Capabilities = Schema.Struct({
+  os: Schema.String,
+  terminals: Schema.Array(Schema.String),
+  notify: Schema.Boolean,
+  automation_granted: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  captured_at: Schema.String,
+})
+
+const FocusResponse = Schema.Struct({
+  focused: Schema.Boolean,
+  reason: Schema.optional(Schema.NullOr(Schema.String)),
+  deduped: Schema.optional(Schema.Boolean),
+})
+
+// --- mock data ---
+
+const mockCapsMacos = {
+  os: "macos",
+  terminals: ["iterm2", "terminal"],
+  notify: false,
+  automation_granted: null,
+  captured_at: "2026-05-02T14:30:01Z",
+}
+
+const mockCapsLinux = {
+  os: "linux",
+  terminals: [],
+  notify: false,
+  automation_granted: null,
+  captured_at: "2026-05-02T14:30:01Z",
+}
+
+const mockFocusOk = { focused: true }
+const mockFocusRemote = { focused: false, reason: "remote_session" }
+const mockFocusDeduped = { focused: true, deduped: true }
+
+describe("Terminal commands (via KernelClient)", () => {
+  it("capabilities returns macOS shape", async () => {
+    const Layer = createMockKernelClient({ "/api/comm/capabilities": mockCapsMacos })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/comm/capabilities", Capabilities)
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.os).toBe("macos")
+    expect(result.terminals).toContain("iterm2")
+    expect(result.terminals).toContain("terminal")
+    expect(result.notify).toBe(false)
+  })
+
+  it("capabilities reflects non-macOS with empty terminals", async () => {
+    const Layer = createMockKernelClient({ "/api/comm/capabilities": mockCapsLinux })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/comm/capabilities", Capabilities)
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.os).toBe("linux")
+    expect(result.terminals).toHaveLength(0)
+  })
+
+  it("focus accepts iTerm2 happy-path response", async () => {
+    const Layer = createMockKernelClient({}, { "/api/comm/focus": mockFocusOk })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/comm/focus",
+        {
+          target: "iterm2",
+          session_id: "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765",
+        },
+        FocusResponse
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.focused).toBe(true)
+    expect(result.reason ?? null).toBeNull()
+  })
+
+  it("focus surfaces remote_session reason on skipped response", async () => {
+    const Layer = createMockKernelClient({}, { "/api/comm/focus": mockFocusRemote })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/comm/focus",
+        { target: "iterm2", session_id: "w0t0p0:abc" },
+        FocusResponse
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.focused).toBe(false)
+    expect(result.reason).toBe("remote_session")
+  })
+
+  it("focus surfaces deduped flag for concurrent calls", async () => {
+    const Layer = createMockKernelClient({}, { "/api/comm/focus": mockFocusDeduped })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/comm/focus",
+        {
+          target: "iterm2",
+          session_id: "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765",
+        },
+        FocusResponse
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.focused).toBe(true)
+    expect(result.deduped).toBe(true)
+  })
+
+  it("focus passes Apple Terminal indices through the body", async () => {
+    // The mock returns `mockFocusOk` regardless of body, but the test
+    // asserts the request shape that the shell builds is well-formed JSON
+    // and decodes correctly.
+    const Layer = createMockKernelClient({}, { "/api/comm/focus": mockFocusOk })
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/comm/focus",
+        { target: "terminal", window_id: "1", tab_id: "3" },
+        FocusResponse
+      )
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(Layer)))
+    expect(result.focused).toBe(true)
+  })
+})

--- a/vault/specs/architecture/apps/cc-permission-hook.md
+++ b/vault/specs/architecture/apps/cc-permission-hook.md
@@ -1,0 +1,100 @@
+# Claude Code Permission Hook
+
+> Bash hook installed in `~/.claude/settings.json` that captures the running terminal's identity, posts a `permission_request` message to gctrl-inbox, and blocks Claude Code until the user acts.
+
+> **Status**: companion spec to [`mac-comm.md`](../kernel/mac-comm.md). The kernel-side primitive (driver, deeplink, UI) ships with mac-comm PR-1..3; the hook itself ships as its own follow-up PR.
+
+---
+
+## Why a separate spec
+
+Different agent frameworks (Claude Code, Cursor, Aider, Codex) need different capture mechanisms:
+
+- **Claude Code** has a structured `PreToolUse` hook protocol with stdin JSON.
+- **Cursor** has its own per-tool callback model.
+- **Aider** runs as a Python process with hookable `before_run` events.
+
+Each framework owns its own integration spec; all of them post the same `context.terminal` shape into `/api/inbox/messages`, defined in [mac-comm.md § Schema](../kernel/mac-comm.md#schema-inbox_messagescontextterminal-not-payload).
+
+---
+
+## Hook contract
+
+`~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash|Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "$HOME/.local/share/gctrl/hooks/claude-code-permission.sh"
+      }]
+    }]
+  }
+}
+```
+
+`claude-code-permission.sh` behavior:
+
+1. Read tool-use JSON from stdin.
+2. Detect terminal: read `$TERM_PROGRAM` and map → `terminal.app` discriminator.
+   - `iTerm.app` → `iterm2`
+   - `Apple_Terminal` → `terminal`
+   - `ghostty` → `ghostty`
+   - `vscode` → `vscode`
+   - `WarpTerminal` → `warp`
+   - empty / anything else → `unknown` (no Focus button rendered downstream)
+3. Snapshot identity:
+   - `session_id`: `$ITERM_SESSION_ID` (iTerm2) or platform-specific else `unknown`
+   - `tty`: `$(tty)`
+   - `pid`: `$$`, `ppid`: `$PPID`
+   - `cwd`: `$PWD`
+   - `term_program`, `term_program_version`: passthrough
+4. POST to `http://127.0.0.1:4318/api/inbox/messages` with `kind=permission_request`, `context.terminal={…}`, `payload={ command, args }`.
+5. Poll `GET /api/inbox/messages/{id}` every **1 s** until `status != pending` or timeout.
+6. Default timeout: **30 s**, configurable via `GCTRL_COMM_TIMEOUT` env (clamped to `[5, 600]`).
+7. Exit `0` (allow) on `acted+approve`, `2` (deny+block) on `acted+deny` or timeout, `1` on hard error.
+
+---
+
+## Edge cases
+
+| Condition | Behavior |
+|---|---|
+| Kernel daemon offline (`curl: Failed to connect`) | Exit `0` (allow) with stderr warning — fail-open since kernel-mediated approval is opt-in dogfooding, not a hard guardrail. |
+| `TERM_PROGRAM` unset | `terminal.app = unknown`, no Focus button downstream, but message still posts. |
+| Timeout reached before user acts | Exit `2` (deny+block), tell Claude Code "user did not respond in N seconds". |
+| Network hiccup mid-poll | Retry up to 3 times with 1 s backoff before exiting `1`. |
+
+---
+
+## Tests
+
+- **`shellcheck` clean** in CI (script must lint without suppressions).
+- **`bats` test cases** with a mock HTTP server (`python3 -m http.server` or a small `nc` script):
+  - approve → exit `0`
+  - deny → exit `2`
+  - timeout (mock returns `pending` forever) → exit `2`
+  - kernel offline → exit `0` with warning
+  - retry exhaustion → exit `1`
+- **Table-driven `TERM_PROGRAM` → `terminal.app` mapping test** in `bats`: covers `iTerm.app`, `Apple_Terminal`, `ghostty`, `code`, `WarpTerminal`, empty, garbage value.
+
+---
+
+## Implementation strategy
+
+Single PR, lands after `mac-comm.md` PR-1 (the kernel intake validator must be ready to accept `context.terminal`):
+
+- New file `shell/hooks/claude-code-permission.sh` (≤ 80 lines).
+- Bundling: `gctrl-desktop` first-run copies it into `~/.local/share/gctrl/hooks/`. Non-desktop users install via `make install-hooks` or by symlinking from the repo.
+- Docs: snippet in `apps/gctrl-inbox/WORKFLOW.md` showing the `~/.claude/settings.json` wiring and the `GCTRL_COMM_TIMEOUT` knob.
+
+---
+
+## Related Docs
+
+- [`vault/specs/architecture/kernel/mac-comm.md`](../kernel/mac-comm.md) — driver primitive this hook is the first consumer of
+- [`apps/gctrl-inbox/PRD.md`](../../../../apps/gctrl-inbox/PRD.md) — message model
+- [`apps/gctrl-inbox/WORKFLOW.md`](../../../../apps/gctrl-inbox/WORKFLOW.md) — where the user-facing wiring snippet lands

--- a/vault/specs/architecture/kernel/mac-comm.md
+++ b/vault/specs/architecture/kernel/mac-comm.md
@@ -1,0 +1,602 @@
+# macOS Communication (gctrl-mac-comm)
+
+> Native macOS bridge between gctrl-inbox and the active terminal/session that produced an agent request. Click a deeplink in the inbox; the OS focuses the exact iTerm2 window/tab/pane the agent is blocked in.
+
+> **Companion**: agent-side capture (Claude Code, Cursor, Aider, …) is specified separately in [cc-permission-hook.md](../apps/cc-permission-hook.md). This spec covers the kernel driver and the deeplink path only.
+
+---
+
+## Problem
+
+Today, when Claude Code (or any other agent) running in iTerm2 hits a permission gate, it prints to its own terminal and blocks. With [gctrl-inbox](../apps/gctrl-inbox.md), the request can be routed to the inbox feed for triage — but the human still has to manually find which of N open iTerm2 windows / tabs / panes issued the request, then `cmd-tab` back, scroll, and answer.
+
+That hunt-the-window step is friction the OS layer should remove. The inbox already knows *who* asked and *what* they asked; it does not yet know *where they are running* or have any way to send the user back there with a single click.
+
+This spec closes the loop with two native channels, M0 and M1 respectively:
+
+1. **A `gctrl://` URL scheme** registered on macOS, so an inbox message can render an anchor that, when clicked, focuses the originating iTerm2 session via Apple Events. (M0)
+2. **`UNUserNotificationCenter` banners** for high-urgency requests, so the user can act even when the inbox UI is not foreground. (M1)
+
+---
+
+## Goals
+
+1. Inbox messages from terminal-bound agents carry enough identity (`context.terminal`) for the kernel to focus the originating session.
+2. Use **native macOS channels** — LaunchServices URL schemes, Apple Events, User Notifications — rather than reinventing IPC.
+3. Driver lives in the **kernel** as a normal LKM (`gctrl-mac-comm`); shell and apps consume it over HTTP per the OS layering invariant.
+4. Extensible to other terminals (Apple Terminal, Ghostty, VS Code, Warp) via a typed `terminal.app` discriminator.
+
+---
+
+## Non-Goals
+
+- **Cross-platform** (Linux/Windows) in M0. The schema names channels generically (`focus`, `notify`) so a future Linux/`xdotool` or Windows/`SendInput` adapter can sit behind the same API.
+- **Bidirectional streaming** between inbox and terminal (live tail, sending keystrokes). Out of scope; would be a separate `gctrl-tty` driver.
+- **Replacing the inbox web UI** — the deeplink complements; it does not bypass.
+- **Agent-side capture wiring** (e.g., the Claude Code `PreToolUse` hook) — split into [cc-permission-hook.md](../apps/cc-permission-hook.md) so each agent framework can have its own integration spec.
+- **macOS sandboxing of the kernel daemon** — `gctrld` runs as a launchd LaunchAgent with full user permissions today, and that does not change.
+
+---
+
+## Success Criteria
+
+| Metric | Source | Target |
+|---|---|---|
+| `comm.focus outcome=ok` rate over a 30-day window | OTel span (`gctrl-otel`) | ≥ 90% |
+| Click → window raised, p95 latency | OTel span `comm.duration_ms` | ≤ 500 ms (osascript path) |
+| `permission_request` messages from a terminal that include `context.terminal` | inbox SSE sample over 7 days | ≥ 95% (gap = agent without a capture hook) |
+| `osascript` injection findings in PR-1 review | code review by Security persona | 0 |
+| Daily users who reach the originating terminal in ≤ 1 click after inbox open | UI telemetry | ≥ 80% |
+
+These are the bar for declaring this feature delivered. Each metric ties to an existing OTel attribute or an inbox SSE field — no new instrumentation is needed beyond what PR-1/PR-3 already add.
+
+---
+
+## Architecture
+
+### Layering
+
+```mermaid
+graph TB
+    subgraph User["MACOS DESKTOP"]
+        ITERM["iTerm2"]
+        TERM["Terminal.app (best-effort)"]
+        OTHER["Ghostty / Warp / VS Code (future)"]
+    end
+
+    subgraph Agent["AGENT IN TERMINAL"]
+        Hook["Capture hook<br/>(per agent — companion spec)"]
+    end
+
+    subgraph Inbox["INBOX (web UI)"]
+        UI["MessageDetail.tsx<br/>📍 Focus terminal"]
+    end
+
+    subgraph Desktop["gctrl-desktop (Electron)"]
+        URL["LaunchServices URL handler<br/>gctrl://focus/* · gctrl://inbox/*"]
+    end
+
+    subgraph Kernel["gctrl KERNEL (:4318, loopback only)"]
+        Inbox_API["/api/inbox/*"]
+        Comm_API["/api/comm/*<br/>(validation + rate limit)"]
+        Driver["driver-mac-comm<br/>(gctrl-mac-comm crate)"]
+    end
+
+    Hook -->|"POST permission_request<br/>+ context.terminal"| Inbox_API
+    Inbox_API --> UI
+    UI -->|"click gctrl://focus/iterm2/&lt;sid&gt;"| URL
+    URL -->|"POST /api/comm/focus"| Comm_API
+    Comm_API --> Driver
+    Driver -->|"osascript (Apple Events)"| ITERM
+    Driver -->|"osascript"| TERM
+    Driver -.->|"future"| OTHER
+```
+
+### End-to-End Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Hook as Capture hook (in iTerm2)
+    participant Kern as Kernel /api/inbox
+    participant UI as Inbox UI
+    participant LS as macOS LaunchServices
+    participant DT as gctrl-desktop
+    participant Comm as /api/comm/focus<br/>(driver-mac-comm)
+    participant IT as iTerm2
+
+    Hook->>Kern: POST /api/inbox/messages<br/>{ kind: permission_request,<br/>  context.terminal: {...} }
+    Kern-->>Hook: 201 { id }
+    Hook->>Hook: poll until status != pending
+    Note over UI: SSE delivers new message<br/>(payload + context propagated)
+    UI->>UI: render Focus button → href="gctrl://focus/iterm2/<sid>"
+    UI->>LS: user clicks anchor
+    LS->>DT: open-url event ("gctrl://...")
+    DT->>DT: validate URL allowlist
+    DT->>Comm: POST /api/comm/focus<br/>{ target: "iterm2", session_id }
+    Comm->>Comm: validate fields (session_id, cwd, tty)<br/>+ rate-limit per session_id
+    Comm->>IT: osascript (Apple Events)
+    IT-->>Comm: ok
+    Comm-->>DT: 200 { focused: true }
+    Note over IT: window/tab/pane is front-and-centre
+```
+
+---
+
+## Native macOS Channels Used
+
+| Channel | Used For | Why |
+|---|---|---|
+| **LaunchServices URL Schemes** (`CFBundleURLTypes` / `app.setAsDefaultProtocolClient`) | Routing `gctrl://...` clicks to gctrl-desktop | OS-level — works from any browser, embedded webview, or `open(1)`. No web-side bridging needed. |
+| **Apple Events / `osascript`** | Focusing iTerm2 sessions and Terminal.app tabs | Documented automation surface; supported by every major macOS terminal. Subprocess invocation (no string concat — argument-array form). |
+| **`UNUserNotificationCenter`** (M1) | Native banner with a "Focus" action button — fires the same `gctrl://` URL | Lets the user respond from outside the inbox UI. Modern API; no Info.plist key needed (prompt fires on first `requestAuthorization`). |
+| **`NSWorkspace.shared.open(_:)`** | Programmatic URL invocation from the driver (fallback when triggered server-side) | Standard Cocoa entry-point; respects user's default-app mappings. |
+| **Process env: `ITERM_SESSION_ID`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`** | Terminal-identity capture inside the agent process | Stable on iTerm2 (`ITERM_SESSION_ID`); `TERM_PROGRAM` is the cross-terminal discriminator. |
+| **`launchd` LaunchAgent** (existing) | Hosts `gctrld` so the kernel HTTP API is up before any inbox click happens | No change. Code-sign + Hardened Runtime required (see Security). |
+
+Channels deliberately **not** used:
+
+- **iTerm2 Python API** — considered for M1; dropped after review. `osascript` subprocess is auditable, requires no Python runtime, and the 2 s timeout already covers the worst case. Revisit only on a profiling signal (>200 ms p95 click→raise).
+- **NSDistributedNotificationCenter / XPC** — wider blast radius than needed when the kernel already exposes a localhost HTTP API.
+- **`osascript:` URI scheme** — rejected fallback. That scheme executes arbitrary AppleScript with zero prompt and is not registered for any reason in this design.
+- **iTerm2 OSC 1337 escape sequences** — those are *for the terminal to receive*, not to focus it from outside.
+
+---
+
+## Terminal Identity Capture
+
+### Schema: `inbox_messages.context.terminal` (not `payload`)
+
+The inbox PRD already declares `context` as a JSON object holding cross-kind references (`session_id`, `issue_key`, `project_key`, `agent_name`, `command`, `cost_usd`). Terminal identity is **not kind-specific** — `permission_request`, `agent_question`, `eval_request` and any future kind from a terminal-bound agent benefit equally. So `terminal` lives in `context`, not `payload`:
+
+```json
+{
+  "context": {
+    "session_id": "sess_2x9k…",
+    "issue_key":  "BACK-42",
+    "command":    "git push --force",
+    "terminal": {
+      "app":             "iterm2",
+      "bundle_id":       "com.googlecode.iterm2",
+      "session_id":      "w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765",
+      "tty":             "/dev/ttys003",
+      "pid":             47213,
+      "ppid":            47200,
+      "cwd":             "/Users/v/workspaces/ohc/gctrl",
+      "term_program":    "iTerm.app",
+      "captured_at":     "2026-05-02T14:30:01Z"
+    }
+  }
+}
+```
+
+| Field | Source (in capture hook) | Required | Validation regex (applied at kernel intake) |
+|---|---|---|---|
+| `app` | derived from `TERM_PROGRAM` | yes | `iterm2\|terminal\|ghostty\|vscode\|warp\|unknown` |
+| `bundle_id` | static map per `app` | yes | `[a-z][a-z0-9.-]{2,63}` |
+| `session_id` | `$ITERM_SESSION_ID` (iTerm2) | when `app != unknown` | `[wtp][0-9]{1,4}:[A-Fa-f0-9-]{36}` (iTerm2 shape); `[A-Za-z0-9_:-]{1,64}` for other terminals |
+| `tty` | `tty(1)` | best-effort | `/dev/(tty\|pty)[a-z0-9]{1,8}` |
+| `pid` / `ppid` | `getpid` / `getppid` | yes | `[0-9]{1,7}` |
+| `cwd` | `pwd` | yes | absolute POSIX path: `/[^\x00\n\r]{0,512}` |
+| `term_program` / `_version` | env | yes | `[A-Za-z0-9 ._-]{1,64}` |
+| `captured_at` | RFC3339 timestamp | yes | strict RFC3339 parse |
+
+> **Critical**: validation is enforced **at the kernel HTTP boundary** (`/api/comm/focus` and `/api/inbox/messages` intake), not only at the URL handler. Every field that can flow into an `osascript` or `NSWorkspace.open` call has a regex above. Fields that fail validation cause the inbox intake to reject the message with `400 invalid_terminal_field`. This is defence-in-depth with the URL handler's allowlist (which does its own check before hitting `/api/comm/*`).
+
+### Capture source
+
+Per-agent, in companion specs:
+
+- [`vault/specs/architecture/apps/cc-permission-hook.md`](../apps/cc-permission-hook.md) — Claude Code `PreToolUse` bash hook (default polling timeout: 30 s, override via `GCTRL_COMM_TIMEOUT`). First-class.
+- Future: Cursor, Aider, Codex hooks (each owns its capture story; they all POST `context.terminal` to the same inbox API).
+
+The kernel cannot read the agent's environment, so capture must happen agent-side. This spec only consumes `context.terminal` once it lands; how it gets there is intentionally out of scope.
+
+### Async-by-design carve-out
+
+The inbox's [Principle 3](../apps/gctrl-inbox.md#principles) says agents MUST NOT block waiting for inbox response. Claude Code's permission protocol blocks regardless. The capture-hook spec installs polling on the *agent side*; the inbox itself remains async (other consumers — orchestrator, schedulers — never poll). This carve-out is documented here to make it clear the inbox surface is unchanged.
+
+---
+
+## URL Scheme
+
+### Format (strict allowlist)
+
+Only the following paths are accepted; everything else is dropped with a debug log:
+
+| Path | Pattern |
+|---|---|
+| `gctrl://focus/<app>/<session-token>` | `app ∈ {iterm2, terminal, ghostty, vscode, warp}`, `session-token` matches the per-`app` `session_id` regex above |
+| `gctrl://focus/terminal/<window-id>/<tab-id>` | `[0-9]{1,4}` each (Apple Terminal best-effort) |
+| `gctrl://inbox/messages/<message-id>` | `<message-id>` is UUID v4: `[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}` |
+| `gctrl://inbox/threads/<thread-id>` | UUID v4 (same pattern) |
+
+`gctrl://` is reserved for gctrl. No prefix-match, no wildcard fallback, no second-instance argv parsing. The handler is implemented as a single function that returns early on any pattern mismatch.
+
+### Registration (gctrl-desktop)
+
+**Info.plist (electron-builder `extendInfo`):**
+
+```yaml
+mac:
+  extendInfo:
+    CFBundleURLTypes:
+      - CFBundleURLName: gctrl
+        CFBundleURLSchemes: [gctrl]
+        CFBundleTypeRole: Viewer
+    NSAppleEventsUsageDescription: >
+      gctrl uses Apple Events to focus the terminal session that issued
+      a permission request from your inbox.
+    # Per-target rationale strings — required for non-generic TCC prompts on
+    # Sequoia/Ventura, especially under MDM. The OS shows the matching
+    # rationale when the user is prompted to allow control of each app.
+    NSAppleEventsUsageDescriptionTargets:
+      com.googlecode.iterm2: >
+        gctrl uses Apple Events to bring the iTerm2 window that issued
+        an agent permission request to the front.
+      com.apple.Terminal: >
+        gctrl uses Apple Events to bring the Terminal.app tab that
+        issued an agent permission request to the front.
+    # NOTE: NSUserNotificationsUsageDescription is intentionally omitted —
+    # UNUserNotificationCenter prompts on requestAuthorization() and that
+    # API only ships in M1.
+```
+
+**Runtime handler (`apps/gctrl-desktop/src/main/index.ts`):**
+
+```ts
+app.setAsDefaultProtocolClient("gctrl")
+
+app.on("open-url", (event, url) => {
+  event.preventDefault()
+  void handleGctrlUrl(url) // strict allowlist; rejects everything else
+})
+```
+
+`handleGctrlUrl` parses with the allowlist regexes above, then:
+
+- `gctrl://focus/...` → `POST http://127.0.0.1:4318/api/comm/focus`. Surface kernel response (incl. `reason: "remote_session"` etc.) via existing in-app toast.
+- `gctrl://inbox/...` → focus/raise the BrowserWindow and route the SPA to the matching path.
+- Anything else → `console.debug("[gctrl] dropped url", url)`. No shell-out, no eval, no fallback.
+
+### Why route through the kernel (not osascript directly from Electron)
+
+- Single place for validation, rate-limiting, audit (OTel spans), and the automation entitlement.
+- The Electron app and the Rust daemon could each acquire the iTerm2 automation grant; the spec mandates **only the daemon** does the actual `osascript` invocation. This narrows the attack surface: a compromised renderer cannot directly drive AppleScript.
+- Future URL handlers (a tiny Swift helper, `open(1)` from a script) all forward to the same `/api/comm/focus`.
+
+---
+
+## driver-mac-comm Crate
+
+New crate `kernel/crates/gctrl-mac-comm/`, modeled on `gctrl-gcal` and `gctrl-browser`. macOS-only — gated by `#[cfg(target_os = "macos")]` so workspace builds on Linux/CI continue to compile (the routes register as `501 Not Supported` with a clear error body).
+
+### Internal Structure
+
+```
+kernel/crates/gctrl-mac-comm/
+  Cargo.toml
+  src/
+    lib.rs            # public API: `mount_routes(router) -> router`
+    error.rs          # AgentFriendlyError per browser.md convention
+    capabilities.rs   # detect installed terminals, AppleScript availability
+    validate.rs       # per-field regexes; SHARED by /api/comm/* and inbox intake
+    rate_limit.rs     # per-session_id token bucket (1/s, 10/min)
+    focus/
+      mod.rs          # dispatcher keyed on `target`
+      iterm2.rs       # iTerm2 osascript adapter
+      terminal.rs     # Apple Terminal osascript adapter (best-effort)
+    notify.rs         # M1 — UNUserNotificationCenter via objc2-user-notifications
+    osascript.rs      # safe wrapper: argv-array form only, 2s timeout
+```
+
+`validate.rs` is exposed publicly so the inbox intake handler can call the same regexes when accepting `context.terminal` payloads. This guarantees one canonical validator across both entry points.
+
+### iTerm2 osascript adapter (corrected)
+
+The actual AppleScript that runs (parameterised, not string-concatenated):
+
+```applescript
+on focus_iterm2_session(target_id)
+  tell application "iTerm2"
+    activate
+    repeat with w in windows
+      repeat with t in tabs of w
+        repeat with s in sessions of t
+          if unique ID of s is target_id then
+            select s
+            return true
+          end if
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  return false
+end focus_iterm2_session
+```
+
+Invoked as `osascript -e <script-literal> -e 'focus_iterm2_session(\"<sid>\")'` with `<sid>` already validated to the iTerm2 UUID shape `[wtp][0-9]+:[A-Fa-f0-9-]{36}`. The argv-array form (`-e <a> -e <b>`) leaves no shell metacharacter interpretation; concatenated session IDs cannot break out of the AppleScript string literal because `"` is not in the validated alphabet.
+
+> **Wrong in v1 of this spec**: `tell application "iTerm" to select session id "..."`. The app name is `iTerm2` (since 3.x), and the language has no flat `select session id` form; traversal via `unique ID` is required.
+
+### HTTP API
+
+Mounted at `/api/comm/*` on the existing axum router (route prefix unchanged from v1):
+
+| Route | Body | Response | Notes |
+|---|---|---|---|
+| `POST /api/comm/focus` | `{ target, session_id?, window_id?, tab_id?, cwd? }` | `{ focused: bool, reason?: string }` or 4xx | Idempotent. Concurrent calls for same `session_id` deduped via the rate limiter (second call returns `200 { focused: true, deduped: true }`). |
+| `POST /api/comm/notify` (M1) | `{ title, body, deeplink, urgency? }` | `{ ok, notification_id }` | Wraps UNUserNotificationCenter. |
+| `GET /api/comm/capabilities` | — | `{ os, terminals, notify, automation_granted }` | UI feature-flag and degradation hint. See below. |
+
+Capabilities response shape:
+
+```json
+{
+  "os": "macos",
+  "terminals": ["iterm2", "terminal"],
+  "notify": false,
+  "automation_granted": true,
+  "captured_at": "2026-05-02T14:30:01Z"
+}
+```
+
+The `os` discriminator lets the SPA hide the entire Focus affordance on Linux/Windows builds rather than rendering it disabled with a confusing tooltip.
+
+### Rate Limiting
+
+Per-`session_id` token bucket: 1 token/second, burst 10, decay 10/min. Implemented in axum middleware before the adapter dispatch. Exceeding the bucket returns `429 too_many_focus_calls`. Prevents a runaway inbox message (or a UI bug) from spamming `osascript` and starving the user's window manager.
+
+### Telemetry & Privacy
+
+`comm.session_id` is hashed (SHA-256, first 8 bytes hex) before export to OTel attributes — opaque-but-correlatable session identifiers should not become durable cross-trace IDs in external collectors (Honeycomb, Grafana Cloud). The raw value stays inside the daemon for the duration of a single request.
+
+```json
+{
+  "name": "comm.focus",
+  "attributes": {
+    "comm.target":          "iterm2",
+    "comm.session_id_hash": "a3f1c2…",
+    "comm.duration_ms":     87,
+    "comm.outcome":         "ok",
+    "comm.adapter":         "osascript"
+  }
+}
+```
+
+### CLI
+
+Shell noun is `terminal` (not `comm`) for discoverability — parallels `gctrl browser`, `gctrl net`, `gctrl context`. The driver crate keeps its name; the user-facing verb-set is what changes.
+
+```sh
+gctrl terminal capabilities [--format json|table]
+gctrl terminal focus --target iterm2 --session w0t0p0:6F3D8E7C-…
+gctrl terminal focus --target terminal --window 1 --tab 3
+# M1:
+gctrl notify --title "Approval needed" --deeplink "gctrl://focus/iterm2/<sid>"
+```
+
+A single `--target <app>` flag replaces v1's mixed boolean (`--iterm2`) + named (`--target`) options. `notify` becomes its own top-level noun in M1 (it's not "terminal").
+
+### Error philosophy
+
+Per [browser.md](browser.md#error-philosophy), errors are agent-friendly and **end with the exact next CLI command** the user can run:
+
+| Condition | Returned message |
+|---|---|
+| Session UUID not found | `iTerm2 session w0t0p0:… not found. The window/tab may have been closed. Run 'gctrl terminal capabilities' to confirm iTerm2 is reachable, or wait for the agent to re-issue the request.` |
+| iTerm2 not running | `iTerm2 is not running. Launching it; subsequent focus calls will activate the previous window. Run 'gctrl terminal focus' again in a few seconds.` |
+| Automation denied (`-1743`) | `Automation permission denied. Open System Settings → Privacy & Security → Automation → gctrl-desktop and allow iTerm2 / Terminal. Then run 'gctrl terminal capabilities' to confirm the grant.` |
+| `osascript` timeout (>2s) | `iTerm2 did not respond within 2s. Run 'gctrl terminal capabilities' to confirm reachability; retry once.` |
+| Rate-limited (`429`) | `Too many focus calls for this session in the last minute. Wait 5s and retry, or 'gctrl inbox view <id>' to inspect manually.` |
+| Validation rejection (`400`) | `Invalid <field>: must match <regex>. Field came from context.terminal.<field> in inbox message <id>.` |
+
+---
+
+## Inbox Integration
+
+### Schema migration
+
+`inbox_messages.context` is `JSON NOT NULL DEFAULT '{}'` already. Adding the `terminal` block is a doc-only change to the inbox PRD's [Message Model](../../../../apps/gctrl-inbox/PRD.md#message-model) — no DDL change. PR-3 lands the TypeScript type addition and the validation hook.
+
+### UI rendering
+
+The Focus button is a presentational concern of the inbox, not a new message kind. Render whenever `context.terminal.app` is set and the capabilities probe says ok.
+
+```tsx
+// apps/gctrl-board/web/src/lib/deeplink.ts (pure)
+export const buildFocusUrl = (t: TerminalContext): string =>
+  t.app === "terminal"
+    ? `gctrl://focus/terminal/${t.window_id}/${t.tab_id}`
+    : `gctrl://focus/${t.app}/${encodeURIComponent(t.session_id)}`
+
+// apps/gctrl-board/web/src/components/MessageDetail.tsx
+const focusUrl = useMemo(
+  () => terminal && terminal.app !== "unknown" ? buildFocusUrl(terminal) : null,
+  [terminal],
+)
+{focusUrl && capabilities.os === "macos" && capabilities.automation_granted && (
+  <a className="btn btn-secondary" href={focusUrl} title={escape(`${terminal.app} · ${terminal.cwd}`)}>
+    📍 Focus {labelFor(terminal.app)}
+  </a>
+)}
+```
+
+`escape()` is required because `title` is a DOM attribute, not React-text-content; raw `<`/`>`/`"` in `cwd` would otherwise inject. (This is defense-in-depth — the kernel intake validator already rejects bad `cwd` values.)
+
+### Thread-level Focus button
+
+When all `pending` messages in a thread carry the same `context.terminal.session_id`, the thread header renders a single Focus button. Saves the user from opening a message just to reach the affordance. Implemented as a derived selector over thread messages — no schema change.
+
+### Capabilities probe + invalidation
+
+- On mount: `GET /api/comm/capabilities`, cache for the SPA session.
+- If `automation_granted: false`: re-poll every **10 s**. Stop polling the moment it flips to `true`.
+- If `automation_granted: true`: never re-poll (entitlement is sticky).
+- Manual override: a small "Refresh" button next to the disabled Focus tooltip forces an immediate re-fetch, for users who just granted the entitlement.
+
+This avoids the v1 bug where granting Automation in System Settings while inbox is open left the UI showing "automation not granted" forever.
+
+### `remote_session` surfaced, not silent
+
+When the kernel returns `200 { focused: false, reason: "remote_session" }` (the connection was an ssh/mosh hop, see Security below), the UI shows a toast: *"Skipped — that session is on a remote host. Open it on the originating machine."* No silent-success gaslight.
+
+### Non-desktop fallback
+
+If gctrl-desktop is not installed, `gctrl://...` clicks fail with the OS "no application can open this URL" prompt. The inbox shows a one-time toast:
+
+> *Install gctrl-desktop to enable click-to-focus. Or copy this command:*
+> `gctrl terminal focus --target iterm2 --session w0t0p0:6F3D8E7C-…`
+> *[Copy]*
+
+Clicking the copy button writes the exact CLI invocation to clipboard — headless users have an immediate path. The spec deliberately does **not** register `osascript:` or any other URL scheme as a fallback (that scheme executes arbitrary AppleScript with no prompt).
+
+---
+
+## Permissions & Security
+
+| Concern | Mitigation |
+|---|---|
+| **Automation prompt** for iTerm2 / Terminal.app | First focus call triggers the system prompt. `Info.plist`'s `NSAppleEventsUsageDescriptionTargets` provides per-target rationale text. Refusal is sticky; UI links to System Settings. |
+| **TOFU sticky grants — compromised gctrl-desktop inherits permanent automation** | Mitigations layered: (a) the daemon (`gctrld`), not the Electron renderer, is the process that invokes `osascript`. A compromised renderer cannot drive AppleScript directly — it only POSTs to the kernel, which validates. (b) `gctrld` MUST be code-signed with Hardened Runtime; the LaunchAgent plist verifies via `LegacyTimers` / `EnableTransactions` patterns. (c) Documentation in the security table tells users to revoke automation in System Settings if they uninstall. |
+| **URL handler injection** (`gctrl://...` from any web page) | `handleGctrlUrl` strict-parses against a closed allowlist of paths and a UUID-v4 regex for inbox IDs. No prefix match, no fallback. Same allowlist on the kernel side as defence-in-depth. |
+| **`osascript` injection via context.terminal fields** (`session_id`, `cwd`, `tty`, `pid`) | Single canonical validator (`validate.rs`) applied at **two** entry points: the inbox intake (`/api/inbox/messages`) and the comm endpoints (`/api/comm/*`). Argv-array form only — no string concatenation into AppleScript source. The CLI path (`gctrl terminal focus`) hits the same kernel validator; it does not bypass. |
+| **Remote session (ssh/mosh) — `host` field is spoofable in the payload** | Removed `terminal.host` from the trust path. The kernel infers local-vs-remote at intake from the connection's source address: only loopback (`127.0.0.1`) connections produce messages flagged `local: true`. The driver's `focus` returns `200 { focused: false, reason: "remote_session" }` for non-local messages regardless of any payload claim. |
+| **PII in logs** | `cwd`, `pid`, `ppid`, `tty` are debug-level only. `comm.session_id` is hashed (SHA-256[:8]) before OTel export. Raw values never leave the daemon. |
+| **HTML attribute injection in tooltips** | `cwd` is HTML-escaped in `deeplink.ts` before any `title=` interpolation (defense-in-depth). |
+| **Privilege scope** | Driver only initiates `focus` and `notify`. It does **not** type into the terminal, send signals, or read terminal output. (A future `gctrl-tty` LKM would, behind a separate guardrail policy.) |
+| **Multi-tenant safety** | macOS Apple Events are per-user; only sessions in the user's own iTerm2 are reachable. |
+| **Rate limiting / DoS** | Per-`session_id` token bucket (1/s, burst 10, decay 10/min) at the axum middleware layer. Exceeded calls return `429`. |
+| **Supply chain — `mac-notification-sys` (M1 only)** | Not used in M0. For M1, prefer `objc2-user-notifications` (actively maintained, audited under the objc2 umbrella) over `mac-notification-sys` (irregular maintenance). Pin to a specific crates.io version; add `cargo audit` to CI. |
+
+---
+
+## Other Terminals
+
+| Terminal | Bundle ID | Identity Source | Focus Method | Status in M0 |
+|---|---|---|---|---|
+| **iTerm2** | `com.googlecode.iterm2` | `$ITERM_SESSION_ID` (UUID-shaped, stable since 3.x) | `osascript`: traverse windows/tabs/sessions by `unique ID` | First-class |
+| **Apple Terminal** | `com.apple.Terminal` | window `index` + tab `index` (via AppleScript) | `osascript`: `set selected of tab N of window M to true` | Best-effort. `$TERM_SESSION_ID` is undocumented and unstable across macOS versions; capture stores the index pair instead. |
+| **Ghostty** | `com.mitchellh.ghostty` | (none stable) — `pid` only | macOS AX `AXRaise` on the window owning `pid` | Future (post-M0) |
+| **VS Code** integrated terminal | `com.microsoft.VSCode` | `$VSCODE_PID`, `$VSCODE_INJECTION` | `vscode://file/<cwd>` (cannot select an internal terminal pane) | Future (post-M0) |
+| **Warp** | `dev.warp.Warp-Stable` | `$WARP_SESSION_ID` (if exposed) | `warp://...` URL | Future (post-M0) |
+| Anything else | — | — | `unknown` → no Focus button rendered | — |
+
+The `terminal.app` discriminator means future terminals are added by writing one adapter file plus one validation regex; no API, schema, or UI change is required.
+
+---
+
+## Lifecycle & Edge Cases
+
+- **Window closed before user clicks** → `404 session_not_found`. UI surfaces "Session no longer exists". If `cwd` was captured, offer "Open new iTerm2 here" affordance: `tell application "iTerm2" to create window with default profile` + `cd "<cwd>"` (the `cwd` is regex-validated upstream).
+- **iTerm2 not running** → driver auto-launches via `NSWorkspace.open(URL(fileURLWithPath: "/Applications/iTerm.app"))`, then re-attempts focus. If the original session is gone, falls through to "open new" path.
+- **Automation revoked mid-session** → next call returns `403 automation_denied`; capabilities probe flips to `automation_granted: false`; UI re-enables polling and shows the grant prompt.
+- **Concurrent focus calls for same session** → second call within rate-limit window returns `200 { focused: true, deduped: true }` without re-invoking osascript.
+- **Multiple Spaces / Mission Control** → `osascript`'s `activate` already handles cross-Space focus.
+- **Headless dev (no Electron)** → `gctrl terminal focus` CLI works the same way; the deeplink path is one of two callers. Useful for iterating on adapters without rebuilding the desktop app.
+- **Remote sessions (ssh / mosh)** → kernel infers from connection origin (loopback flag), not from `payload.host`. Returns `200 { focused: false, reason: "remote_session" }`. UI shows a toast.
+
+---
+
+## Configuration
+
+`~/.config/gctrl/config.toml`:
+
+```toml
+[mac_comm]
+enabled = true                  # macOS-only; ignored elsewhere
+osascript_timeout_ms = 2000
+focus_rate_limit_per_sec = 1
+focus_rate_burst = 10
+
+[mac_comm.terminals]
+iterm2 = true
+terminal = true                 # best-effort
+ghostty = false                 # future
+vscode = false                  # future
+warp = false                    # future
+```
+
+`notify` config lands with M1; not committed in M0 to avoid dead settings.
+
+---
+
+## Implementation Strategy (3 PRs)
+
+PR-4 from v1 (the Claude Code hook) is split into [cc-permission-hook.md](../apps/cc-permission-hook.md). The mac-comm spec now ships in three PRs; the user-visible feature lights up at PR-3.
+
+### PR-1 — `gctrl-mac-comm` driver scaffold + iTerm2/Terminal focus + validation
+
+- New crate, axum router mounted in `gctrl-cli` (daemon).
+- Routes: `POST /api/comm/focus`, `GET /api/comm/capabilities`. Both gated by `#[cfg(target_os = "macos")]`; non-mac registers a 501 stub.
+- Adapters: iTerm2 (first-class) + Apple Terminal (best-effort). Ghostty/VSCode/Warp `unimplemented!()`.
+- `validate.rs` exposes per-field regexes; inbox intake handler is updated to call them when accepting `context.terminal`.
+- Per-`session_id` token-bucket rate limiter.
+- Shell command: `gctrl terminal focus`, `gctrl terminal capabilities` in `shell/gctrl-shell/src/commands/terminal.ts` (mirrors `commands/gh.ts` shape; uses `--target <app>`).
+- Tests:
+  - Unit: argv quoting, every per-field validator (positive/negative cases), rate-limiter algebra, error-message format
+  - Property-based (`proptest`): osascript arg quoting over `[A-Za-z0-9:_-]{1,128}`
+  - Linux integration test (CI-safe): mount router on Linux, assert 501 on `/api/comm/focus`
+  - macOS integration: gated on `GCTRL_TEST_MAC_COMM=1` (skipped in CI; documented for local runs)
+  - Concurrent-focus test: two simultaneous calls for same `session_id` produce one osascript invocation
+
+### PR-2 — gctrl-desktop URL scheme registration
+
+- `setAsDefaultProtocolClient("gctrl")` + `open-url` listener in `apps/gctrl-desktop/src/main/index.ts`.
+- electron-builder config: `CFBundleURLTypes`, `NSAppleEventsUsageDescription`, `NSAppleEventsUsageDescriptionTargets`.
+- Strict URL allowlist parser. Vitest covers: missing path components, extra components, non-UUID inbox IDs, non-ASCII session IDs, empty host, prefix-match attempts.
+- Manual smoke test for the LaunchServices round-trip (documented in PR description).
+
+### PR-3 — Inbox `context.terminal` schema + UI Focus button
+
+- TS types in `apps/gctrl-board/web/src/types.ts`: extend `MessageContext` with optional `terminal` block.
+- New shared util `apps/gctrl-board/web/src/lib/deeplink.ts` (pure).
+- `MessageDetail.tsx`: render Focus button per the conditions above; HTML-escape `cwd` in tooltip.
+- `ThreadHeader`: render thread-level Focus when all pending messages share `session_id`.
+- Capability poll: 10 s interval when `automation_granted: false`, stop on grant. Manual "Refresh" button.
+- Non-desktop fallback toast with clipboard-copy CLI command.
+- Playwright fixtures:
+  - Both capability states (granted / denied)
+  - `context.terminal === undefined` → no Focus button
+  - `context.terminal.app === "unknown"` → no Focus button
+  - `reason: "remote_session"` response → toast surfaced
+  - Click anchor → `gctrl://focus/iterm2/<sid>` is the href
+
+### M1 (deferred)
+
+- `UNUserNotificationCenter` (`POST /api/comm/notify`) via `objc2-user-notifications`.
+- Apple Terminal full window/tab indexing.
+- `gctrl notify` shell command.
+
+### M2 (deferred)
+
+- Ghostty / Warp / VS Code adapters past best-effort.
+- Cross-platform (Linux/`xdotool`, Windows) behind the same routes.
+
+---
+
+## Open Questions
+
+Three closed by review, one remaining:
+
+1. ~~**URL handler when gctrl-desktop is not installed** — ship a `gctrl-url-helper.app`?~~ **Closed**: gctrl-desktop is the sole M0 handler. The non-desktop fallback (toast + clipboard CLI command) is the supported path. Helper-app idea deferred indefinitely.
+2. ~~**Adapter language** — osascript subprocess vs. Swift sidecar?~~ **Closed**: osascript only. Revisit only on a profiling signal (>200 ms p95 click→raise).
+3. ~~**Hook ownership**~~ **Closed**: split to companion spec [cc-permission-hook.md](../apps/cc-permission-hook.md). Each agent framework owns its own capture spec.
+4. **Stale session policy** — after how long is a captured `session_id` "old enough" to hide the Focus button proactively rather than letting the click fail and surface `404`? **Leaning:** never time-stamped from the UI side. The driver always tries; failure is informative ("session may have closed; re-issue"). Revisit if usage data shows >5% click-failure on stale sessions.
+
+---
+
+## Companion Specs
+
+- [vault/specs/architecture/apps/cc-permission-hook.md](../apps/cc-permission-hook.md) — Claude Code `PreToolUse` hook (M0 first integration; PR companion to PR-3 of this spec)
+
+---
+
+## Related Docs
+
+- [vault/specs/architecture/apps/gctrl-inbox.md](../apps/gctrl-inbox.md) — inbox app architecture (the consumer)
+- [vault/specs/architecture/kernel/browser.md](browser.md) — closest LKM analog (long-lived OS-resource driver)
+- [vault/specs/architecture/os.md](../os.md) — layering invariants this spec honors
+- [apps/gctrl-inbox/PRD.md](../../../../apps/gctrl-inbox/PRD.md) — message model the `context.terminal` extension lives under
+- [apps/gctrl-desktop/README.md](../../../../apps/gctrl-desktop/README.md) — current state of the Electron host
+- [vault/specs/team/personas.md](../../team/personas.md) — review personas applied to this spec (Engineer, Security, UX, QA, PM, Tech Lead)


### PR DESCRIPTION
## Summary

Closes the loop between gctrl-inbox permission requests and the iTerm2 / Terminal session that issued them. The inbox now renders a `📍 Focus iTerm2` button next to Approve/Reject; clicking it routes through `gctrl://focus/...` (LaunchServices) → `gctrl-desktop` → `POST /api/comm/focus` → `osascript` to bring the exact window/tab/pane to the front.

Three slices land together:

- **PR-1 — kernel driver `gctrl-mac-comm`** (LKM): validators, token-bucket rate limiter, osascript wrapper, iTerm2 + Apple Terminal focus adapters, capabilities probe. `/api/comm/focus` and `/api/comm/capabilities` mounted on the kernel router; non-macOS hosts return `501 Not Implemented` cleanly. Shell verb: `gctrl terminal {focus,capabilities}`.
- **PR-2 — `gctrl-desktop` URL scheme**: `setAsDefaultProtocolClient("gctrl")` + `open-url` listener with a strict allowlist parser (`gctrl://focus/<app>/<sid>` and `gctrl://inbox/(messages|threads)/<UUIDv4>`). Cold-launch URL buffering drains on `did-finish-load`. electron-builder `protocols` + `Info.plist` `NSAppleEventsUsageDescription` and per-target `NSAppleEventsUsageDescriptionTargets` (iTerm2, Terminal).
- **PR-3 — inbox Focus button**: `lib/deeplink.ts` (pure builders), `useCapabilities` hook with **degraded-only polling** (10 s only when `automation_granted: false`, stops on grant), `MessageDetail.tsx` Focus button + clipboard-copy CLI fallback + Automation-denied hint with manual Refresh. Schema lives at `context.terminal` (not `payload.terminal`) so it's reusable across kinds beyond `permission_request`.

## Spec

The spec at `vault/specs/architecture/kernel/mac-comm.md` was reviewed by a 5-reviewer team (Engineer, Security, UX, QA, PM) and rewritten end-to-end before any code landed. Highlights of what changed in spec v2:

- **AppleScript tell-target corrected** from `"iTerm"` (pre-3.x) → `"iTerm2"`, with proper `unique ID` traversal (the flat `select session id` form does not exist).
- **Validation expanded** to every `context.terminal` field (`session_id`, `cwd`, `tty`, `pid`, `bundle_id`, `term_program`) — single canonical validator (`validate.rs`) called from both the comm endpoint and the inbox-message intake. Strict iTerm2 UUID shape: `w[0-9]+t[0-9]+p[0-9]+:<UUIDv4>`.
- **Remote/local derived at the kernel** from the connection's loopback origin, not from the payload's `host` field (the payload cannot bypass the host-allowlist middleware).
- **Info.plist extended** with `NSAppleEventsUsageDescriptionTargets` per Sequoia/Ventura TCC behavior; deprecated `NSUserNotificationsUsageDescription` removed (UNUserNotificationCenter is M1 anyway).
- **Shell CLI renamed** `gctrl comm` → `gctrl terminal` (parallels `gctrl browser`/`net`/`context`); single `--target <app>` flag replaces v1's mixed `--iterm2`/`--target`.
- **Schema moved** from `payload.terminal` (per-kind) → `context.terminal` (cross-kind, matches the existing `context` shape in the inbox PRD).
- **Open Questions #1, #2, #3 closed**: gctrl-desktop is the M0 sole URL handler, osascript only (no Swift sidecar), Claude Code hook **split into companion spec** (`vault/specs/architecture/apps/cc-permission-hook.md`) so other agent frameworks can have their own integration spec.
- **Success Criteria table added** with measurable bars tied to existing OTel attributes (`comm.focus outcome=ok` ≥ 90%, p95 click→raise ≤ 500 ms, `context.terminal` coverage ≥ 95%).

## Test plan

- [x] `cargo test -p gctrl-mac-comm` — 25 / 25 (validation regexes incl. quote-injection rejection, rate limiter, AppleScript error classification)
- [x] `cargo test -p gctrl-otel --lib` — 87 / 87 (5 new comm_routes tests: capabilities reachable, unknown-target rejected, invalid-iterm2-id rejected, quote-injection rejected, origin-remote spoof rejected)
- [x] `cargo build --workspace` — clean
- [x] `pnpm test` (gctrl-shell) — 146 / 146 (6 new terminal mock-kernel tests)
- [x] `pnpm test` (gctrl-desktop) — 58 / 58 (32 new url-handler tests: parser edge cases, focus-body building, dispatch with mocked deps)
- [x] `pnpm test` (gctrl-board web/src) — 44 / 44 (27 new deeplink tests: builder per-target, shouldShowFocus matrix, escapeAttr, CLI fallback)
- [x] `pnpm run build:web` — clean
- [x] `pnpm run type-check` (gctrl-desktop) — clean
- [x] `pnpm exec tsc --noEmit -p apps/gctrl-board/web/tsconfig.app.json` — clean for changed files; 3 pre-existing errors remain (`source_name`/`source_type` on `InboxMessage` in `MessageCard.tsx` + `MessageDetail.tsx`) — unrelated to this PR

### Manual smoke (post-merge / packaged build)

- [ ] Click `gctrl://focus/iterm2/<sid>` from a browser → gctrl-desktop launches → iTerm2 session focuses
- [ ] First focus call triggers macOS Automation prompt with the per-target rationale string ("gctrl uses Apple Events to bring the iTerm2 window…")
- [ ] Revoke Automation in System Settings → capabilities probe flips to `automation_granted: false` within 10 s → MessageDetail shows the Automation-denied hint and hides the Focus button
- [ ] Click Refresh after re-granting → button returns immediately
- [ ] Linux/Windows acceptance build: `GET /api/comm/capabilities` returns `os: "linux"` / `"windows"`; Focus button is hidden in the SPA

## What's intentionally not in this PR

- **Claude Code permission hook** (`shell/hooks/claude-code-permission.sh` + bats tests) — split per PM review into a separate PR. Spec stub at `vault/specs/architecture/apps/cc-permission-hook.md` describes the contract this PR's kernel intake validator already accepts. Lands once this PR merges.
- **`UNUserNotificationCenter` banners** (`POST /api/comm/notify`) — M1 deferred; will use `objc2-user-notifications` (security review preferred over `mac-notification-sys` for active maintenance).
- **Ghostty / Warp / VS Code adapters** — best-effort, M2.

## File layout

| Path | Status |
|---|---|
| `vault/specs/architecture/kernel/mac-comm.md` | new |
| `vault/specs/architecture/apps/cc-permission-hook.md` | new (stub for follow-up PR) |
| `kernel/crates/gctrl-mac-comm/` | new crate |
| `kernel/crates/gctrl-otel/src/comm_routes.rs` | new |
| `kernel/crates/gctrl-otel/src/{lib.rs,receiver.rs,Cargo.toml}` | wire driver into router |
| `Cargo.toml` (workspace) | add `gctrl-mac-comm` member |
| `apps/gctrl-desktop/src/main/url-handler.ts` (+ test) | new |
| `apps/gctrl-desktop/src/main/index.ts` | open-url + cold-launch buffering |
| `apps/gctrl-desktop/src/preload/index.ts` | `desktop.onNavigate` IPC bridge |
| `apps/gctrl-desktop/package.json` | electron-builder `protocols` + `mac.extendInfo` |
| `apps/gctrl-board/web/src/lib/deeplink.ts` (+ test) | new |
| `apps/gctrl-board/web/src/hooks/useCapabilities.ts` | new |
| `apps/gctrl-board/web/src/components/MessageDetail.tsx` | Focus button + denied hint |
| `apps/gctrl-board/web/src/types.ts` | `TerminalApp`, `TerminalContext`, `CommCapabilities` |
| `apps/gctrl-board/web/src/api/client.ts` | `comm.capabilities()` |
| `shell/gctrl-shell/src/commands/terminal.ts` (+ test) | `gctrl terminal {focus,capabilities}` |
| `shell/gctrl-shell/src/main.ts` | register `terminalCommand` |
