### PR TITLE
feat(gctrl-board): Schedule page (M1b) — KPI rollup + status grid + run history drawer

### DIFF
--- a/apps/gctrl-board/playwright.config.ts
+++ b/apps/gctrl-board/playwright.config.ts
@@ -59,6 +59,12 @@ export default defineConfig({
           // kernel-only. Skip in remote mode for the same reason as
           // agent-integration above.
           "**/analytics-dashboard.spec.ts",
+          // Schedule page tests seed via `POST /api/schedules` directly
+          // against the kernel; deployed Workers proxy to KERNEL_URL
+          // when set, but the schedule routes are kernel-only and the
+          // preview Worker has no reachable kernel. Same shape as the
+          // analytics-dashboard skip above.
+          "**/schedule-page.spec.ts",
         ],
       }
     : {}),

--- a/apps/gctrl-board/tests/acceptance/schedule-page.spec.ts
+++ b/apps/gctrl-board/tests/acceptance/schedule-page.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Schedule page (M1b) — acceptance tests.
+ *
+ * Drives `/schedule` against a live kernel. The kernel auto-plants
+ * `_internal.scheduler_runs_gc` on startup (see PR-2 of M1a) so the
+ * page is never *truly* empty — every assertion accounts for at
+ * least one routine being present at boot.
+ *
+ * Tests seed user routines via direct kernel HTTP (`POST
+ * /api/schedules`) bypassing the UI; UI is for the assertions only,
+ * per the acceptance-fixture authoring rules in CLAUDE.md.
+ */
+import { test, expect } from "./fixtures/test"
+
+const KERNEL_BASE = `http://localhost:${process.env.GCTRL_KERNEL_PORT ?? 14318}`
+
+interface CreatedSchedule {
+  id: string
+  name: string
+}
+
+async function createUserSchedule(name: string, cron = "0 */2 * * *"): Promise<CreatedSchedule> {
+  const res = await fetch(`${KERNEL_BASE}/api/schedules`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name,
+      cron,
+      target_url: "http://127.0.0.1:1/never-fires",
+      target_method: "POST",
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`createUserSchedule(${name}) failed: ${res.status} ${await res.text()}`)
+  }
+  return (await res.json()) as CreatedSchedule
+}
+
+async function deleteSchedule(idOrName: string): Promise<void> {
+  await fetch(`${KERNEL_BASE}/api/schedules/${encodeURIComponent(idOrName)}`, {
+    method: "DELETE",
+  })
+}
+
+test.describe("Schedule page (/schedule) — M1b", () => {
+  test("loads with KPI strip + status grid", async ({ page }) => {
+    await page.goto("/schedule")
+    // KPI strip renders kernel-computed counts. The bootstrap GC row
+    // means total >= 1 even on a fresh kernel.
+    await expect(page.getByTestId("schedule-kpi")).toBeVisible()
+    await expect(page.getByTestId("schedule-grid")).toBeVisible()
+    // Page title in header reflects the new route.
+    await expect(page.locator("header h1")).toContainText("schedule")
+  })
+
+  test("nav-sidebar entry navigates to /schedule and back", async ({ page }) => {
+    await page.goto("/")
+    const navBtn = page.getByTestId("nav-schedule")
+    await expect(navBtn).toBeVisible()
+    await navBtn.click()
+    await expect(page).toHaveURL(/\/schedule\/?$/)
+    await expect(page.getByTestId("schedule-kpi")).toBeVisible()
+  })
+
+  test("user-created routine appears in the grid grouped by prefix", async ({ page }) => {
+    const stamp = Date.now().toString(36).slice(-4)
+    const name = `audit.codebase-${stamp}`
+    const created = await createUserSchedule(name)
+    try {
+      await page.goto("/schedule")
+      const card = page.locator(`[data-routine-name="${name}"]`)
+      await expect(card).toBeVisible({ timeout: 5_000 })
+      // Health on a freshly-created routine that has never fired must
+      // be "pending" — the kernel-computed derived column.
+      await expect(card.getByTestId("schedule-health")).toHaveAttribute(
+        "data-health",
+        "pending",
+      )
+    } finally {
+      await deleteSchedule(created.id)
+    }
+  })
+
+  test("deep-link /schedule/:name opens the detail drawer", async ({ page }) => {
+    const stamp = Date.now().toString(36).slice(-4)
+    const name = `gap.deeplink-${stamp}`
+    const created = await createUserSchedule(name)
+    try {
+      await page.goto(`/schedule/${name}`)
+      const drawer = page.getByTestId("schedule-drawer")
+      await expect(drawer).toBeVisible({ timeout: 5_000 })
+      // Drawer header shows the routine name.
+      await expect(drawer).toContainText(name)
+      // No fires yet → empty-runs hint.
+      await expect(page.getByTestId("schedule-drawer-empty-runs")).toBeVisible()
+    } finally {
+      await deleteSchedule(created.id)
+    }
+  })
+
+  test("close button on the drawer returns to /schedule", async ({ page }) => {
+    const stamp = Date.now().toString(36).slice(-4)
+    const name = `digest.close-${stamp}`
+    const created = await createUserSchedule(name)
+    try {
+      await page.goto(`/schedule/${name}`)
+      await expect(page.getByTestId("schedule-drawer")).toBeVisible()
+      await page.getByTestId("schedule-drawer-close").click()
+      await expect(page).toHaveURL(/\/schedule\/?$/)
+      await expect(page.getByTestId("schedule-drawer")).not.toBeVisible()
+    } finally {
+      await deleteSchedule(created.id)
+    }
+  })
+
+  test("kpi-runs reflects manual fire of an http routine", async ({ page }) => {
+    const stamp = Date.now().toString(36).slice(-4)
+    const name = `digest.runnow-${stamp}`
+    const created = await createUserSchedule(name)
+    try {
+      // Manual fire via the kernel — same path the UI's "run now"
+      // button hits. The target URL points at port 1 which won't
+      // accept connections, so the run is recorded as a failure.
+      // That's fine — the assertion is "the runs counter advanced",
+      // not "the run succeeded".
+      const fireRes = await fetch(`${KERNEL_BASE}/api/schedules/${name}/run`, {
+        method: "POST",
+      })
+      expect(fireRes.ok).toBeTruthy()
+
+      await page.goto("/schedule")
+      // Wait until the KPI strip shows at least 1 run in 24h.
+      await expect
+        .poll(
+          async () => {
+            const txt = await page.getByTestId("schedule-kpi-runs").innerText()
+            const m = txt.match(/^[A-Z\s()0-9]*?\n(\d+)/m)
+            return m ? Number(m[1]) : 0
+          },
+          { timeout: 5_000 },
+        )
+        .toBeGreaterThan(0)
+    } finally {
+      await deleteSchedule(created.id)
+    }
+  })
+})

--- a/apps/gctrl-board/web/src/App.tsx
+++ b/apps/gctrl-board/web/src/App.tsx
@@ -11,6 +11,7 @@ import { ProjectSelector } from "./components/ProjectSelector"
 import { NavSidebar } from "./components/NavSidebar"
 import { InboxPage } from "./pages/InboxPage"
 import { AnalyticsPage } from "./pages/AnalyticsPage"
+import { SchedulePage } from "./pages/SchedulePage"
 import { MacosSpacesPage } from "./pages/MacosSpacesPage"
 import { api } from "./api/client"
 import type { Issue, InboxStats } from "./types"
@@ -233,9 +234,11 @@ export function App() {
       ? "inbox"
       : route.page === "analytics"
         ? "analytics"
-        : route.page === "settings"
-          ? "settings"
-          : "board"
+        : route.page === "schedule"
+          ? "schedule"
+          : route.page === "settings"
+            ? "settings"
+            : "board"
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-200 font-body grid-bg flex">
@@ -366,6 +369,8 @@ export function App() {
           </>
         ) : route.page === "inbox" ? (
           <InboxPage />
+        ) : route.page === "schedule" ? (
+          <SchedulePage route={route} navigate={navigate} />
         ) : route.page === "settings" ? (
           <MacosSpacesPage />
         ) : (

--- a/apps/gctrl-board/web/src/api/client.test.ts
+++ b/apps/gctrl-board/web/src/api/client.test.ts
@@ -116,4 +116,90 @@ describe("api client base URL resolution", () => {
     expect(init?.method).toBe("POST")
     expect(res.accessibility).toBe("denied")
   })
+
+  // ── Schedules (M1a kernel substrate) ──
+
+  it("schedules.list hits /api/schedules at the kernel root", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ schedules: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.schedules.list()
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/schedules")
+  })
+
+  it("schedules.summary hits /api/schedules/summary", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            total: 0,
+            by_health: { green: 0, amber: 0, red: 0, pending: 0, paused: 0 },
+            runs_last_24h: { success: 0, failure: 0 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    const summary = await api.schedules.summary()
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/schedules/summary")
+    expect(summary.total).toBe(0)
+  })
+
+  it("schedules.runs encodes the schedule name + applies filters", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ schedule_id: "x", schedule_name: "audit.codebase", runs: [] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.schedules.runs("audit.codebase", {
+      since: "2026-05-01T00:00:00Z",
+      status: "failure",
+      limit: 50,
+    })
+    const [url] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe(
+      "/api/schedules/audit.codebase/runs?since=2026-05-01T00%3A00%3A00Z&status=failure&limit=50",
+    )
+  })
+
+  it("schedules.runNow POSTs to the kernel manual-fire endpoint", async () => {
+    fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ id: "x", name: "audit.codebase", fired: true, status: 200, error: null }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.schedules.runNow("audit.codebase")
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/schedules/audit.codebase/run")
+    expect(init?.method).toBe("POST")
+  })
+
+  it("schedules.enable / disable POST to toggle endpoints", async () => {
+    fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+    setDesktop(undefined)
+    await api.schedules.enable("audit.codebase")
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/schedules/audit.codebase/enable")
+    expect(fetchMock.mock.calls[0][1]?.method).toBe("POST")
+    await api.schedules.disable("audit.codebase")
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/schedules/audit.codebase/disable")
+    expect(fetchMock.mock.calls[1][1]?.method).toBe("POST")
+  })
 })

--- a/apps/gctrl-board/web/src/api/client.ts
+++ b/apps/gctrl-board/web/src/api/client.ts
@@ -28,6 +28,11 @@ import type {
   NetDomainsResponse,
   NetDailyResponse,
   NetTrafficRecord,
+  Schedule,
+  SchedulesSummary,
+  ScheduleRunsResponse,
+  ScheduleRunsGlobalResponse,
+  ScheduleRunNowResult,
 } from "../types"
 
 const BASE = "/api/board"
@@ -386,6 +391,65 @@ export const api = {
         `/api/macos/permissions/accessibility/prompt`,
         { method: "POST" },
       ),
+  },
+
+  /// Schedule (kernel `gctrl-scheduler`) routes — M1a substrate.
+  /// Spec: vault/specs/architecture/apps/gctrl-schedule.md.
+  schedules: {
+    /** `GET /api/schedules` — kernel-populated `health` field per row. */
+    list: () =>
+      request<{ schedules: Schedule[] }>(`/api/schedules`),
+
+    /** `GET /api/schedules/summary` — KPI strip source. SPA never
+     *  recomputes the counts (spec § 5.6). */
+    summary: () => request<SchedulesSummary>(`/api/schedules/summary`),
+
+    /** `GET /api/schedules/{id_or_name}` — single row + computed health. */
+    get: (idOrName: string) =>
+      request<Schedule>(`/api/schedules/${encodeURIComponent(idOrName)}`),
+
+    /** `GET /api/schedules/{id_or_name}/runs` — per-schedule history. */
+    runs: (
+      idOrName: string,
+      params?: { since?: string; status?: string; limit?: number },
+    ) => {
+      const qs = new URLSearchParams()
+      if (params?.since) qs.set("since", params.since)
+      if (params?.status) qs.set("status", params.status)
+      if (params?.limit !== undefined) qs.set("limit", String(params.limit))
+      const q = qs.toString()
+      return request<ScheduleRunsResponse>(
+        `/api/schedules/${encodeURIComponent(idOrName)}/runs${q ? `?${q}` : ""}`,
+      )
+    },
+
+    /** `GET /api/schedules/runs` — cross-schedule failure feed. */
+    runsGlobal: (params?: { since?: string; status?: string; limit?: number }) => {
+      const qs = new URLSearchParams()
+      if (params?.since) qs.set("since", params.since)
+      if (params?.status) qs.set("status", params.status)
+      if (params?.limit !== undefined) qs.set("limit", String(params.limit))
+      const q = qs.toString()
+      return request<ScheduleRunsGlobalResponse>(
+        `/api/schedules/runs${q ? `?${q}` : ""}`,
+      )
+    },
+
+    /** `POST /api/schedules/{id_or_name}/run` — manual fire. */
+    runNow: (idOrName: string) =>
+      request<ScheduleRunNowResult>(
+        `/api/schedules/${encodeURIComponent(idOrName)}/run`,
+        { method: "POST" },
+      ),
+
+    enable: (idOrName: string) =>
+      request<null>(`/api/schedules/${encodeURIComponent(idOrName)}/enable`, {
+        method: "POST",
+      }),
+    disable: (idOrName: string) =>
+      request<null>(`/api/schedules/${encodeURIComponent(idOrName)}/disable`, {
+        method: "POST",
+      }),
   },
 }
 

--- a/apps/gctrl-board/web/src/components/NavSidebar.tsx
+++ b/apps/gctrl-board/web/src/components/NavSidebar.tsx
@@ -54,6 +54,26 @@ function AnalyticsIcon({ active }: { active: boolean }) {
   )
 }
 
+function ScheduleIcon({ active }: { active: boolean }) {
+  const color = active ? "text-emerald-400" : "text-zinc-500"
+  return (
+    <svg
+      className={`w-5 h-5 ${color} transition-colors duration-150`}
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Clock outline — circular face with 12-3 hands. Same inline-SVG
+        * style as the other nav icons; spec § 7.4 ("clock outline"). */}
+      <circle cx="10" cy="10" r="7" />
+      <path d="M10 6v4l2.5 2" />
+    </svg>
+  )
+}
+
 function SettingsIcon({ active }: { active: boolean }) {
   const color = active ? "text-emerald-400" : "text-zinc-500"
   return (
@@ -88,6 +108,7 @@ export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
   const isBoardActive = route.page === "board"
   const isInboxActive = route.page === "inbox"
   const isAnalyticsActive = route.page === "analytics"
+  const isScheduleActive = route.page === "schedule"
   const isSettingsActive = route.page === "settings"
 
   return (
@@ -125,6 +146,17 @@ export function NavSidebar({ route, navigate, unreadCount }: NavSidebarProps) {
         title="Analytics"
       >
         <AnalyticsIcon active={isAnalyticsActive} />
+      </button>
+
+      {/* Schedule nav item */}
+      <button
+        onClick={() => navigate("/schedule")}
+        data-testid="nav-schedule"
+        className={`w-10 h-10 flex items-center justify-center rounded-md transition-all duration-150 cursor-pointer
+          ${isScheduleActive ? "bg-emerald-500/10" : "hover:bg-zinc-800/60"}`}
+        title="Schedule"
+      >
+        <ScheduleIcon active={isScheduleActive} />
       </button>
 
       {/* Spacer */}

--- a/apps/gctrl-board/web/src/hooks/useRoute.test.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import { parseRoute } from "./useRoute"
+
+// Each test asserts the exact discriminated-union shape `parseRoute`
+// returns. The Schedule routes are new in M1b — adding a fourth
+// top-level page to a closed union; the existing pages MUST keep
+// parsing the same.
+
+describe("parseRoute — schedule routes (M1b)", () => {
+  it("/schedule → schedule page with no name + no runId", () => {
+    expect(parseRoute("/schedule")).toEqual({
+      page: "schedule",
+      name: null,
+      runId: null,
+    })
+    expect(parseRoute("/schedule/")).toEqual({
+      page: "schedule",
+      name: null,
+      runId: null,
+    })
+  })
+
+  it("/schedule/:name → schedule page with the routine name", () => {
+    expect(parseRoute("/schedule/audit.codebase")).toEqual({
+      page: "schedule",
+      name: "audit.codebase",
+      runId: null,
+    })
+  })
+
+  it("/schedule/:name/runs/:run_id → schedule with name + runId", () => {
+    expect(parseRoute("/schedule/audit.codebase/runs/abc-123")).toEqual({
+      page: "schedule",
+      name: "audit.codebase",
+      runId: "abc-123",
+    })
+  })
+
+  it("regression: /schedule/:name does NOT shadow /analytics/sessions/:id", () => {
+    // `parseRoute` matches in priority order; the analytics-sessions
+    // pattern is more specific and must still win for analytics paths.
+    expect(parseRoute("/analytics/sessions/sess-1")).toEqual({
+      page: "analytics",
+      tab: "sessions",
+      sessionId: "sess-1",
+    })
+  })
+
+  it("regression: existing routes still parse after the schedule branch", () => {
+    expect(parseRoute("/")).toEqual({
+      page: "board",
+      projectKey: null,
+      view: "kanban",
+    })
+    expect(parseRoute("/inbox")).toEqual({
+      page: "inbox",
+      threadId: null,
+    })
+    expect(parseRoute("/analytics")).toEqual({
+      page: "analytics",
+      tab: "overview",
+      sessionId: null,
+    })
+    expect(parseRoute("/settings/macos-spaces")).toEqual({
+      page: "settings",
+      section: "macos-spaces",
+    })
+  })
+
+  it("an unknown path falls back to the board (no false schedule match)", () => {
+    expect(parseRoute("/garbage")).toEqual({
+      page: "board",
+      projectKey: null,
+      view: "kanban",
+    })
+    // Specifically — `/scheduler` (singular ≠ plural) MUST NOT be
+    // mistaken for /schedule.
+    expect(parseRoute("/scheduler")).toEqual({
+      page: "board",
+      projectKey: null,
+      view: "kanban",
+    })
+  })
+})

--- a/apps/gctrl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.ts
@@ -14,8 +14,9 @@ export type Route =
   | { page: "inbox"; threadId: string | null }
   | { page: "analytics"; tab: AnalyticsTab; sessionId: string | null }
   | { page: "settings"; section: "macos-spaces" }
+  | { page: "schedule"; name: string | null; runId: string | null }
 
-function parseRoute(pathname: string): Route {
+export function parseRoute(pathname: string): Route {
   // /analytics/sessions/:sessionId
   const analyticsSession = pathname.match(/^\/analytics\/sessions\/([^/]+)/)
   if (analyticsSession) {
@@ -38,6 +39,23 @@ function parseRoute(pathname: string): Route {
   // /settings/macos-spaces
   if (pathname === "/settings/macos-spaces" || pathname === "/settings/macos-spaces/") {
     return { page: "settings", section: "macos-spaces" }
+  }
+
+  // /schedule/:name/runs/:run_id — most-specific first
+  const scheduleRun = pathname.match(/^\/schedule\/([^/]+)\/runs\/([^/]+)\/?$/)
+  if (scheduleRun) {
+    return { page: "schedule", name: scheduleRun[1], runId: scheduleRun[2] }
+  }
+
+  // /schedule/:name
+  const scheduleName = pathname.match(/^\/schedule\/([^/]+)\/?$/)
+  if (scheduleName) {
+    return { page: "schedule", name: scheduleName[1], runId: null }
+  }
+
+  // /schedule
+  if (pathname === "/schedule" || pathname === "/schedule/") {
+    return { page: "schedule", name: null, runId: null }
   }
 
   // /inbox/:threadId

--- a/apps/gctrl-board/web/src/hooks/useScheduleRuns.ts
+++ b/apps/gctrl-board/web/src/hooks/useScheduleRuns.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react"
+import { api } from "@/api/client"
+import type { ScheduleRun } from "@/types"
+
+interface UseScheduleRunsParams {
+  /** RFC3339 lower bound on `started_at`. */
+  since?: string
+  status?: string
+  limit?: number
+}
+
+/** Per-routine run history for the sparkline + detail-drawer Runs tab.
+ *
+ *  Polled, not streamed — spec § 7.5 defers SSE to the backlog. The
+ *  caller (sparkline / drawer) decides limit; the kernel clamps at
+ *  500 anyway.
+ */
+export function useScheduleRuns(
+  scheduleNameOrId: string | null,
+  params?: UseScheduleRunsParams,
+): {
+  runs: ScheduleRun[]
+  loading: boolean
+  error: string | null
+} {
+  const [runs, setRuns] = useState<ScheduleRun[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stringify params so the dep array is stable. Two callers with
+  // identical filters won't trigger refetches.
+  const paramsKey = JSON.stringify(params ?? {})
+
+  useEffect(() => {
+    if (scheduleNameOrId == null) {
+      setRuns([])
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    api.schedules
+      .runs(scheduleNameOrId, params)
+      .then((res) => {
+        if (cancelled) return
+        setRuns(res.runs)
+        setError(null)
+        setLoading(false)
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : String(e))
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scheduleNameOrId, paramsKey])
+
+  return { runs, loading, error }
+}

--- a/apps/gctrl-board/web/src/pages/SchedulePage.tsx
+++ b/apps/gctrl-board/web/src/pages/SchedulePage.tsx
@@ -1,0 +1,745 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { api } from "@/api/client"
+import type {
+  ScheduleHealth,
+  Schedule,
+  ScheduleRun,
+  SchedulesSummary,
+} from "@/types"
+import type { Route } from "@/hooks/useRoute"
+import { useScheduleRuns } from "@/hooks/useScheduleRuns"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+interface SchedulePageProps {
+  route: Extract<Route, { page: "schedule" }>
+  navigate: (path: string) => void
+}
+
+/**
+ * `/schedule` — top-of-page CI-style health roll-up + per-routine
+ * status grid with deep-link to a detail drawer for run history.
+ *
+ * Rollup KPIs come from `GET /api/schedules/summary` only — never
+ * recomputed in the browser (spec § 5.6). Per-row `health` comes from
+ * the kernel's derived column on `GET /api/schedules` (also § 5.6).
+ *
+ * The Edit tab on the detail drawer is intentionally absent in M1b;
+ * `PATCH /api/schedules/{id}` exists kernel-side (M1a PR-3) but the UI
+ * surface lands in M1c alongside the `<SessionsTab>` refactor.
+ */
+export function SchedulePage({ route, navigate }: SchedulePageProps) {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [summary, setSummary] = useState<SchedulesSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [list, sum] = await Promise.all([
+        api.schedules.list(),
+        api.schedules.summary(),
+      ])
+      setSchedules(list.schedules)
+      setSummary(sum)
+      setError(null)
+      setLoading(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    // 30s background poll. Per spec § 7.5 a dedicated SSE stream is
+    // deferred — at the routine cadence (≤ dozens of fires/day)
+    // polling is sufficient.
+    const t = setInterval(refresh, 30_000)
+    return () => clearInterval(t)
+  }, [refresh])
+
+  const selected = useMemo(
+    () =>
+      route.name != null
+        ? schedules.find((s) => s.name === route.name) ?? null
+        : null,
+    [route.name, schedules],
+  )
+
+  const onSelect = useCallback(
+    (s: Schedule | null) => {
+      if (s) navigate(`/schedule/${s.name}`)
+      else navigate("/schedule")
+    },
+    [navigate],
+  )
+
+  const handleRunNow = useCallback(
+    async (s: Schedule) => {
+      try {
+        await api.schedules.runNow(s.name)
+        await refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e))
+      }
+    },
+    [refresh],
+  )
+
+  const handleToggle = useCallback(
+    async (s: Schedule) => {
+      try {
+        if (s.enabled) await api.schedules.disable(s.name)
+        else await api.schedules.enable(s.name)
+        await refresh()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e))
+      }
+    },
+    [refresh],
+  )
+
+  if (error) {
+    return (
+      <div className="p-8 text-rose-400 font-mono text-sm" data-testid="schedule-error">
+        Failed to load schedules: {error}
+        <div className="mt-2 text-zinc-500">
+          Is the kernel running on :4318? `gctrld serve` plants
+          `_internal.scheduler_runs_gc` on startup; if you can't see
+          schedules at all, the daemon is down.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-w-0 bg-background">
+      <KpiStrip summary={summary} loading={loading} />
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 min-w-0 border-r border-border overflow-auto">
+          <StatusGrid
+            schedules={schedules}
+            loading={loading}
+            selectedName={route.name}
+            onSelect={onSelect}
+            onRunNow={handleRunNow}
+            onToggle={handleToggle}
+          />
+        </div>
+        {selected && (
+          <RoutineDetailDrawer
+            schedule={selected}
+            onClose={() => onSelect(null)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ───────────────────────── KPI strip ─────────────────────────
+
+function KpiStrip({
+  summary,
+  loading,
+}: {
+  summary: SchedulesSummary | null
+  loading: boolean
+}) {
+  if (loading || !summary) {
+    return (
+      <div
+        className="h-24 border-b border-border flex items-center px-6 text-muted-foreground/70 font-mono text-sm"
+        data-testid="schedule-kpi-loading"
+      >
+        Loading…
+      </div>
+    )
+  }
+  const r24 = summary.runs_last_24h
+  return (
+    <div
+      className="grid grid-cols-3 gap-4 p-6 border-b border-border"
+      data-testid="schedule-kpi"
+    >
+      <Kpi
+        label="Routines"
+        value={summary.total}
+        sub={`${summary.by_health.paused} paused`}
+      />
+      <HealthKpi by={summary.by_health} />
+      <RunsKpi runs={r24} />
+    </div>
+  )
+}
+
+function Kpi({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: string | number
+  sub?: string
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="text-[11px] font-mono tracking-wider text-muted-foreground uppercase mb-1">
+          {label}
+        </div>
+        <div className="text-2xl font-display font-semibold text-foreground">
+          {value}
+        </div>
+        {sub && (
+          <div className="text-[11px] font-mono text-muted-foreground/70 mt-1">
+            {sub}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function HealthKpi({ by }: { by: SchedulesSummary["by_health"] }) {
+  const total = by.green + by.amber + by.red + by.pending + by.paused
+  return (
+    <Card data-testid="schedule-kpi-health">
+      <CardContent className="p-4">
+        <div className="text-[11px] font-mono tracking-wider text-muted-foreground uppercase mb-2">
+          Health
+        </div>
+        <div className="flex items-end gap-3">
+          <Pill tone="green" count={by.green} label="green" />
+          <Pill tone="amber" count={by.amber} label="amber" />
+          <Pill tone="red" count={by.red} label="red" />
+          <Pill tone="muted" count={by.pending} label="pending" />
+          <Pill tone="muted" count={by.paused} label="paused" />
+        </div>
+        {total === 0 && (
+          <div className="text-[11px] font-mono text-muted-foreground/70 mt-2">
+            no routines registered
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function Pill({
+  tone,
+  count,
+  label,
+}: {
+  tone: "green" | "amber" | "red" | "muted"
+  count: number
+  label: string
+}) {
+  const toneClasses: Record<typeof tone, string> = {
+    green: "text-emerald-400",
+    amber: "text-amber-400",
+    red: "text-rose-400",
+    muted: "text-zinc-400",
+  }
+  return (
+    <div className="flex flex-col items-start" data-testid={`schedule-pill-${label}`}>
+      <span className={cn("text-xl font-display font-semibold", toneClasses[tone])}>
+        {count}
+      </span>
+      <span className="text-[10px] font-mono text-muted-foreground/70 uppercase tracking-wider">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function RunsKpi({ runs }: { runs: SchedulesSummary["runs_last_24h"] }) {
+  const total = runs.success + runs.failure
+  const pct = total > 0 ? (runs.success / total) * 100 : 0
+  return (
+    <Card data-testid="schedule-kpi-runs">
+      <CardContent className="p-4">
+        <div className="text-[11px] font-mono tracking-wider text-muted-foreground uppercase mb-1">
+          Runs (24h)
+        </div>
+        <div className="text-2xl font-display font-semibold text-foreground">
+          {total}
+        </div>
+        {total > 0 && (
+          <>
+            <div className="mt-2 h-1.5 bg-zinc-900 border border-zinc-800 relative overflow-hidden">
+              <div
+                className="absolute inset-y-0 left-0 bg-emerald-500/50"
+                style={{ width: `${pct}%` }}
+              />
+              <div
+                className="absolute inset-y-0 right-0 bg-rose-500/50"
+                style={{ width: `${100 - pct}%` }}
+              />
+            </div>
+            <div className="flex gap-3 mt-1 text-[10px] font-mono text-muted-foreground/70">
+              <span className="text-emerald-400">{runs.success}</span>
+              <span>/</span>
+              <span className={runs.failure > 0 ? "text-rose-400" : ""}>
+                {runs.failure}
+              </span>
+            </div>
+          </>
+        )}
+        {total === 0 && (
+          <div className="text-[11px] font-mono text-muted-foreground/70 mt-1">
+            no fires in the last 24h
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ───────────────────────── Status grid ─────────────────────────
+
+function StatusGrid({
+  schedules,
+  loading,
+  selectedName,
+  onSelect,
+  onRunNow,
+  onToggle,
+}: {
+  schedules: Schedule[]
+  loading: boolean
+  selectedName: string | null
+  onSelect: (s: Schedule) => void
+  onRunNow: (s: Schedule) => void
+  onToggle: (s: Schedule) => void
+}) {
+  if (loading) {
+    return (
+      <div
+        className="p-8 text-muted-foreground/70 font-mono text-sm"
+        data-testid="schedule-grid-loading"
+      >
+        Loading schedules…
+      </div>
+    )
+  }
+  if (schedules.length === 0) {
+    return (
+      <div
+        className="p-8 text-muted-foreground/70 font-mono text-sm leading-relaxed"
+        data-testid="schedule-empty"
+      >
+        No routines registered yet.
+        <div className="mt-2 text-zinc-600 text-[12px]">
+          The daemon plants <code>_internal.scheduler_runs_gc</code> on
+          startup automatically. User routines come from{" "}
+          <code>POST /api/schedules</code> (or vault catalog presets in M2).
+        </div>
+      </div>
+    )
+  }
+  // Group by name prefix per spec § 6.2 (`audit.*`, `gap.*`, …).
+  const grouped = groupByPrefix(schedules)
+  return (
+    <div className="p-4 space-y-6" data-testid="schedule-grid">
+      {grouped.map(({ prefix, rows }) => (
+        <div key={prefix}>
+          <div className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground/70 mb-2 px-2">
+            {prefix}
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            {rows.map((s) => (
+              <RoutineCard
+                key={s.id}
+                schedule={s}
+                selected={s.name === selectedName}
+                onSelect={() => onSelect(s)}
+                onRunNow={() => onRunNow(s)}
+                onToggle={() => onToggle(s)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function groupByPrefix(
+  schedules: Schedule[],
+): { prefix: string; rows: Schedule[] }[] {
+  const map = new Map<string, Schedule[]>()
+  for (const s of schedules) {
+    // First dotted segment, or "other" if the name has no dot.
+    const idx = s.name.indexOf(".")
+    const prefix = idx > 0 ? s.name.slice(0, idx) : "other"
+    if (!map.has(prefix)) map.set(prefix, [])
+    map.get(prefix)!.push(s)
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([prefix, rows]) => ({
+      prefix,
+      rows: rows.sort((a, b) => a.name.localeCompare(b.name)),
+    }))
+}
+
+function RoutineCard({
+  schedule,
+  selected,
+  onSelect,
+  onRunNow,
+  onToggle,
+}: {
+  schedule: Schedule
+  selected: boolean
+  onSelect: () => void
+  onRunNow: () => void
+  onToggle: () => void
+}) {
+  return (
+    <Card
+      className={cn(
+        "cursor-pointer transition-colors",
+        selected
+          ? "border-primary/40 bg-primary/5"
+          : "hover:border-zinc-700/80",
+      )}
+      onClick={onSelect}
+      data-testid="schedule-card"
+      data-routine-name={schedule.name}
+    >
+      <CardContent className="p-4 space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="text-[14px] font-mono text-foreground truncate">
+              {schedule.name}
+            </div>
+            <div className="text-[11px] font-mono text-muted-foreground/70 mt-0.5">
+              <code>{schedule.cron}</code>
+            </div>
+          </div>
+          <HealthBadge health={schedule.health} />
+        </div>
+        <Sparkline scheduleName={schedule.name} />
+        <div className="flex items-center gap-3 text-[11px] font-mono text-muted-foreground/70">
+          <span>
+            last:{" "}
+            {schedule.last_run_at
+              ? formatRelative(schedule.last_run_at)
+              : "—"}
+          </span>
+          <span className="text-zinc-700">·</span>
+          <span>
+            next:{" "}
+            {schedule.next_run_at
+              ? formatRelative(schedule.next_run_at)
+              : "—"}
+          </span>
+        </div>
+        <div className="flex gap-2 pt-1">
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onRunNow()
+            }}
+            data-testid="schedule-run-now"
+            className="px-2.5 py-1 text-[11px] font-mono border border-emerald-500/30 text-emerald-300
+              hover:bg-emerald-500/10 transition-colors"
+          >
+            run now
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggle()
+            }}
+            data-testid="schedule-toggle"
+            className={cn(
+              "px-2.5 py-1 text-[11px] font-mono border transition-colors",
+              schedule.enabled
+                ? "border-zinc-700 text-zinc-300 hover:bg-zinc-800/60"
+                : "border-amber-500/30 text-amber-300 hover:bg-amber-500/10",
+            )}
+          >
+            {schedule.enabled ? "disable" : "enable"}
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function HealthBadge({ health }: { health: ScheduleHealth | undefined }) {
+  // `health` should always be present on rows from the kernel, but
+  // tolerate `undefined` defensively (older daemon). Treat unknown as
+  // muted rather than throwing.
+  const tone = HEALTH_TONE[health ?? "pending"]
+  return (
+    <span
+      className={cn(
+        "px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider border rounded-sm shrink-0",
+        tone.text,
+        tone.border,
+        tone.bg,
+      )}
+      data-testid="schedule-health"
+      data-health={health ?? "unknown"}
+    >
+      {health ?? "unknown"}
+    </span>
+  )
+}
+
+const HEALTH_TONE: Record<
+  ScheduleHealth,
+  { text: string; border: string; bg: string }
+> = {
+  green: {
+    text: "text-emerald-400",
+    border: "border-emerald-500/30",
+    bg: "bg-emerald-500/10",
+  },
+  amber: {
+    text: "text-amber-400",
+    border: "border-amber-500/30",
+    bg: "bg-amber-500/10",
+  },
+  red: {
+    text: "text-rose-400",
+    border: "border-rose-500/30",
+    bg: "bg-rose-500/10",
+  },
+  pending: {
+    text: "text-zinc-400",
+    border: "border-zinc-700",
+    bg: "bg-zinc-900",
+  },
+  paused: {
+    text: "text-zinc-500",
+    border: "border-zinc-800",
+    bg: "bg-transparent",
+  },
+}
+
+// ───────────────────────── Sparkline ─────────────────────────
+
+/** Adaptive window per spec § 7.1: last 30 days for daily-or-faster
+ *  routines, last 12 weeks for weekly. We use a heuristic on the cron
+ *  string — if it has a fixed day-of-week field (5th token), treat
+ *  it as weekly. Otherwise daily-or-faster. */
+function sparklineWindowDays(cron: string): number {
+  const tokens = cron.trim().split(/\s+/)
+  // Standard 5-field cron: m h dom mon dow. dow is index 4.
+  // 6-field (with seconds): index 5. 7-field (with year): same index 5.
+  const dow = tokens.length === 5 ? tokens[4] : tokens[5] ?? ""
+  // A fixed dow means weekly cadence (e.g. "1" or "Mon"). Wildcards `*`
+  // and step `*/N` are NOT weekly.
+  const isWeekly = dow !== "" && dow !== "*" && !dow.startsWith("*/")
+  return isWeekly ? 12 * 7 : 30
+}
+
+function Sparkline({ scheduleName }: { scheduleName: string }) {
+  // Lazy: each card triggers its own runs query. At dozens of routines
+  // this is cheap and avoids a second prefetch. M1c will revisit if
+  // it shows up in CDP / heap traces.
+  const days = useMemo(() => 30, [])
+  const since = useMemo(
+    () => new Date(Date.now() - days * 86_400_000).toISOString(),
+    [days],
+  )
+  const { runs, loading } = useScheduleRuns(scheduleName, { since, limit: 30 })
+
+  if (loading) {
+    return (
+      <div className="h-3 flex items-center text-[10px] font-mono text-muted-foreground/40">
+        loading…
+      </div>
+    )
+  }
+  if (runs.length === 0) {
+    return (
+      <div
+        className="h-3 flex items-center text-[10px] font-mono text-muted-foreground/40"
+        data-testid="schedule-sparkline-empty"
+      >
+        no fires yet
+      </div>
+    )
+  }
+  // Latest first → render right-to-left so the rightmost dot is most recent.
+  const ordered = [...runs].reverse()
+  return (
+    <div
+      className="h-3 flex items-center gap-0.5"
+      data-testid="schedule-sparkline"
+      data-runs-count={ordered.length}
+    >
+      {ordered.map((r) => (
+        <span
+          key={r.id}
+          className={cn(
+            "block w-1.5 h-3 rounded-[1px]",
+            r.status === "success"
+              ? "bg-emerald-500/70"
+              : r.status === "interrupted"
+                ? "bg-zinc-500/60"
+                : "bg-rose-500/70",
+          )}
+          title={`${r.status} at ${new Date(r.started_at).toLocaleString()}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ───────────────────────── Detail drawer ─────────────────────────
+
+function RoutineDetailDrawer({
+  schedule,
+  onClose,
+}: {
+  schedule: Schedule
+  onClose: () => void
+}) {
+  const { runs, loading, error } = useScheduleRuns(schedule.name, { limit: 50 })
+  return (
+    <aside
+      className="w-[480px] min-w-[480px] bg-zinc-950 border-l border-zinc-800 flex flex-col overflow-hidden"
+      data-testid="schedule-drawer"
+    >
+      <header className="h-10 border-b border-zinc-800 flex items-center justify-between px-4">
+        <div className="text-[11px] font-mono tracking-wider text-zinc-400 uppercase truncate">
+          {schedule.name}
+        </div>
+        <button
+          onClick={onClose}
+          data-testid="schedule-drawer-close"
+          className="text-zinc-500 hover:text-zinc-200 text-lg leading-none cursor-pointer"
+          title="Close"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="p-4 space-y-2 border-b border-zinc-800">
+        <DetailRow label="Cron" value={<code>{schedule.cron}</code>} />
+        <DetailRow label="Target" value={schedule.target_kind.toUpperCase()} />
+        <DetailRow
+          label="Health"
+          value={<HealthBadge health={schedule.health} />}
+        />
+        <DetailRow
+          label="Run / fail"
+          value={`${schedule.run_count} / ${schedule.failure_count}`}
+        />
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className="px-4 py-2 text-[10px] font-mono uppercase tracking-wider text-muted-foreground/70 border-b border-zinc-800">
+          Runs
+        </div>
+        {loading && (
+          <div className="p-4 text-zinc-500 font-mono text-[12px]">
+            Loading run history…
+          </div>
+        )}
+        {error && (
+          <div className="p-4 text-rose-400 font-mono text-[12px]">
+            Failed to load runs: {error}
+          </div>
+        )}
+        {!loading && !error && runs.length === 0 && (
+          <div
+            className="p-4 text-zinc-500 font-mono text-[12px]"
+            data-testid="schedule-drawer-empty-runs"
+          >
+            No fire history yet.
+          </div>
+        )}
+        {!loading && !error && runs.length > 0 && (
+          <ul className="divide-y divide-zinc-800" data-testid="schedule-runs-list">
+            {runs.map((r) => (
+              <RunRow key={r.id} run={r} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between text-[12px] font-mono">
+      <span className="text-[10px] uppercase tracking-wider text-zinc-600">
+        {label}
+      </span>
+      <span className="text-zinc-200 truncate max-w-[60%] text-right">
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function RunRow({ run }: { run: ScheduleRun }) {
+  const [expanded, setExpanded] = useState(false)
+  const tone =
+    run.status === "success"
+      ? "text-emerald-400 border-emerald-500/30"
+      : run.status === "interrupted"
+        ? "text-zinc-400 border-zinc-700"
+        : "text-rose-400 border-rose-500/30"
+  return (
+    <li className="px-4 py-2" data-testid="schedule-run-row" data-run-status={run.status}>
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-3 text-[12px] font-mono cursor-pointer"
+      >
+        <span
+          className={cn(
+            "px-1.5 py-px text-[10px] uppercase tracking-wider border rounded-sm",
+            tone,
+          )}
+        >
+          {run.status}
+        </span>
+        <span className="text-muted-foreground/70">
+          {new Date(run.started_at).toLocaleString()}
+        </span>
+        <span className="ml-auto text-muted-foreground/70">
+          {run.duration_ms != null ? `${run.duration_ms}ms` : "—"}
+        </span>
+      </button>
+      {expanded && (run.error_preview || run.response_preview) && (
+        <pre
+          className="mt-2 px-3 py-2 bg-zinc-950/40 border border-zinc-800 text-[11px] text-zinc-300 whitespace-pre-wrap break-words"
+          data-testid="schedule-run-detail"
+        >
+          {run.error_preview ?? run.response_preview}
+        </pre>
+      )}
+    </li>
+  )
+}
+
+function formatRelative(rfc3339: string): string {
+  const ms = new Date(rfc3339).getTime() - Date.now()
+  const abs = Math.abs(ms)
+  const sec = Math.round(abs / 1000)
+  const min = Math.round(sec / 60)
+  const hr = Math.round(min / 60)
+  const day = Math.round(hr / 24)
+  const sign = ms < 0 ? "-" : "+"
+  if (sec < 60) return `${sign}${sec}s`
+  if (min < 60) return `${sign}${min}m`
+  if (hr < 48) return `${sign}${hr}h`
+  return `${sign}${day}d`
+}

--- a/apps/gctrl-board/web/src/types.ts
+++ b/apps/gctrl-board/web/src/types.ts
@@ -463,3 +463,101 @@ export interface AcceptanceRollup {
   running: number
   checks: AcceptanceCheckRow[]
 }
+
+/* ── Schedule (M1a kernel substrate) ── */
+
+/** Lowercase-serialised on the wire (kernel `ScheduleHealth` enum). */
+export type ScheduleHealth = "green" | "amber" | "red" | "pending" | "paused"
+
+export type ScheduleTargetKind = "http" | "exec"
+
+/** Per-row schedule shape from `GET /api/schedules`. The `health`
+ *  field is a kernel-computed derived column (spec § 5.6) — never
+ *  recompute on the client. */
+export interface Schedule {
+  id: string
+  name: string
+  cron: string
+  target_kind: ScheduleTargetKind
+  target_url: string
+  target_method: string
+  body_json: unknown | null
+  headers_json: Record<string, string> | null
+  command: string[] | null
+  cwd: string | null
+  env_keys: string[] | null
+  timeout_secs: number
+  enabled: boolean
+  next_run_at: string | null
+  last_run_at: string | null
+  last_status: number | null
+  last_response: string | null
+  last_error: string | null
+  run_count: number
+  failure_count: number
+  created_at: string
+  updated_at: string
+  /** Optional — populated by the storage read path; absent on rows
+   *  freshly built in tests. SPA assumes presence on real responses. */
+  health?: ScheduleHealth
+}
+
+/** Kernel-side aggregate from `GET /api/schedules/summary` (spec § 5.6). */
+export interface SchedulesSummary {
+  total: number
+  by_health: {
+    green: number
+    amber: number
+    red: number
+    pending: number
+    paused: number
+  }
+  runs_last_24h: {
+    success: number
+    failure: number
+  }
+}
+
+export type ScheduleRunStatus =
+  | "success"
+  | "failure"
+  | "timed_out"
+  | "refused"
+  | "interrupted"
+
+export type ScheduleFireKind = "cron" | "manual"
+
+/** One fire of a schedule. From `GET /api/schedules/{id}/runs` and
+ *  `GET /api/schedules/runs`. Spec § 5.1. */
+export interface ScheduleRun {
+  id: string
+  schedule_id: string
+  started_at: string
+  finished_at: string | null
+  status: ScheduleRunStatus
+  fire_kind: ScheduleFireKind
+  exit_code: number | null
+  http_status: number | null
+  response_preview: string | null
+  error_preview: string | null
+  duration_ms: number | null
+  created_at: string
+}
+
+export interface ScheduleRunsResponse {
+  schedule_id: string
+  schedule_name: string
+  runs: ScheduleRun[]
+}
+
+export interface ScheduleRunsGlobalResponse {
+  runs: ScheduleRun[]
+}
+
+export interface ScheduleRunNowResult {
+  id: string
+  name: string
+  fired: boolean
+  status: number | null
+  error: string | null
+}


### PR DESCRIPTION
## Summary

**M1b** from the [gctrl-schedule spec](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md) — adds the `/schedule` SPA surface, the operator-facing CI-style health view of routine agentic tasks fed by the M1a kernel substrate (#155 + #165). Mounts as a fourth top-level page in `gctrl-board` (peer to Board / Inbox / Analytics / Settings).

```mermaid
flowchart LR
  Nav["NavSidebar<br/>nav-schedule (clock icon)"]
  Page["/schedule SPA<br/>SchedulePage"]
  KPI["KPI strip<br/>(Routines / Health / Runs-24h)"]
  Grid["Status grid<br/>(grouped by prefix)"]
  Drawer["Detail drawer<br/>Runs tab"]
  Kernel[("kernel<br/>:4318")]
  Nav --> Page
  Page --> KPI
  Page --> Grid
  Grid --> Drawer
  KPI -->|GET /api/schedules/summary| Kernel
  Grid -->|GET /api/schedules| Kernel
  Drawer -->|GET /api/schedules/:name/runs| Kernel
```

## What ships

### Routing + nav

- Extended `Route` discriminated union (`useRoute.ts`) — fourth variant `{ page: "schedule"; name: string | null; runId: string | null }`. Three deep-linkable paths:
  - `/schedule`
  - `/schedule/:name`
  - `/schedule/:name/runs/:run_id`
- `<ScheduleIcon>` (clock outline, 12-3 hands) + `nav-schedule` button in `NavSidebar`.
- `parseRoute` exported so the route-parser test can call it directly.

### Page

- **KPI strip** — Routines / Health (green/amber/red/pending/paused) / Runs-24h (success-failure stacked bar). 100% sourced from `GET /api/schedules/summary` per spec § 5.6 — the SPA never recomputes the counts.
- **Status grid** — routines grouped by dotted-prefix (`audit.*`, `gap.*`, `_internal.*`, etc.). Each card shows name, cron, kernel-computed `health` badge, **per-card sparkline** of recent fires (success = emerald, failure = rose, interrupted = zinc), last/next run timestamps, and inline `run now` / `enable / disable` buttons.
- **Detail drawer** — right-side, deep-linkable. Runs tab lists history from `GET /api/schedules/:name/runs` with click-to-expand stdout/stderr previews. Edit / Sessions / Alerts tabs gated until M1c / M3.

### Types + API

- `types.ts`: `Schedule`, `ScheduleHealth`, `SchedulesSummary`, `ScheduleRun`, `ScheduleRunsResponse`, `ScheduleRunsGlobalResponse`, `ScheduleRunNowResult`. `health` is lowercase-serialised so kernel JSON round-trips with no client-side transform.
- `api.schedules.{list, summary, get, runs, runsGlobal, runNow, enable, disable}` — kernel-root paths (`/api/schedules*`), not `/api/board/*`.
- `useScheduleRuns` hook — params-stable polling fetcher; sparkline + drawer share it.

## Test plan

- [x] `pnpm run test` — **65 tests pass** (was 54), 7 files. New: 6 route-parser tests + 5 API-client tests.
  - Route parser: `/schedule`, `/schedule/:name`, `/schedule/:name/runs/:run_id`, regression guards (analytics-sessions still wins, `/scheduler` ≠ `/schedule`, existing routes unchanged).
  - API client: `list` hits kernel root, `summary` returns counts, `runs` filters URL-encoded, `runNow` POSTs, `enable/disable` POST.
- [x] Playwright `tests/acceptance/schedule-page.spec.ts` — **6 acceptance scenarios**:
  - Page loads with KPI strip + grid (kernel-bootstrap GC routine guarantees ≥ 1 row).
  - Nav-sidebar entry navigates to `/schedule`.
  - User-created routine appears with `pending` health.
  - Deep-link `/schedule/:name` opens detail drawer with empty-runs hint.
  - Close button returns to `/schedule` and hides the drawer.
  - Manual fire advances the Runs-24h KPI.
- [x] `pnpm run build:web` — 88 modules, 134 KB gzipped.
- [x] `tsc --noEmit -p web/tsconfig.app.json` clean for all new files (existing pre-PR errors in MessageCard/MessageDetail untouched).

## Out of scope

- **Edit tab** in the detail drawer — kernel PATCH ships in #165 (M1a PR-3) but the SPA wiring + `<SessionsTab>` refactor for `createdBy`/`agentNameMatch` props lands in M1c.
- **Sessions tab** — same M1c dependency.
- **Alerts tab** — needs M3 `kind = schedule_failed` whitelist + emit.
- **`gctrl routines` shell sugar** — also M1c.

## Spec links

- [§ 7 — UX](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#7-ux)
- [§ 4.4 — In scope (item 1)](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#41-in-scope)
- [§ 9.2 — M1b roadmap](../blob/main/vault/specs/architecture/apps/gctrl-schedule.md#92-m1b--schedule-page-minimum-p0)
