### PR TITLE
feat(shell): gctrl app install / list / status / reload / uninstall

### DIFF
--- a/shell/gctrl-shell/src/commands/app.ts
+++ b/shell/gctrl-shell/src/commands/app.ts
@@ -8,9 +8,10 @@
  * `apps/<name>/`. Default model is claude-opus-4-7.
  */
 import { Command, Options, Args } from "@effect/cli"
-import { Console, Effect, Option } from "effect"
+import { Console, Effect, Option, Schema } from "effect"
 import { mkdir, readFile, writeFile, access } from "node:fs/promises"
 import { join, resolve } from "node:path"
+import { KernelClient } from "../services/KernelClient"
 
 const DEFAULT_LLM_URL = "http://127.0.0.1:4319/v1/chat/completions"
 const DEFAULT_MODEL = "claude-opus-4-7"
@@ -284,8 +285,244 @@ const bootstrapCommand = Command.make(
     ),
 )
 
+// =============================================================================
+// install / list / status / reload / uninstall — gctrl-app.toml workflow.
+//
+// The kernel handles parsing + validation + persistence. The shell just
+// reads the manifest from disk and POSTs it through KernelClient. See
+// vault/specs/architecture/app-install-protocol.md for the contract.
+// =============================================================================
+
+// --- schemas (mirror kernel/crates/gctrl-core::AppInstall + AppBinding + VaultMount) ---
+
+const AppInstallSchema = Schema.Struct({
+  name: Schema.String,
+  version: Schema.String,
+  source_ref: Schema.String,
+  manifest_sha: Schema.String,
+  installed_at: Schema.String,
+  reloaded_at: Schema.NullOr(Schema.String),
+})
+
+const AppBindingSchema = Schema.Struct({
+  install_name: Schema.String,
+  capability: Schema.String,
+  driver_id: Schema.String,
+  required: Schema.Boolean,
+  resolved_at: Schema.String,
+})
+
+const VaultMountSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  root_path: Schema.String,
+  kind: Schema.String,
+  app_id: Schema.NullOr(Schema.String),
+})
+
+const AppInstallViewSchema = Schema.Struct({
+  install: AppInstallSchema,
+  bindings: Schema.Array(AppBindingSchema),
+  vault_mounts: Schema.Array(VaultMountSchema),
+})
+
+const AppInstallListSchema = Schema.Array(AppInstallSchema)
+
+const CapabilitySchema = Schema.Struct({
+  id: Schema.String,
+  default_driver: Schema.String,
+  route_prefix: Schema.String,
+  description: Schema.String,
+})
+const CapabilityListSchema = Schema.Array(CapabilitySchema)
+
+const VoidSchema = Schema.Struct({})
+
+// --- shared helpers ---
+
+const readManifest = (path: string) =>
+  Effect.tryPromise({
+    try: () => readFile(resolve(path), "utf8"),
+    catch: (e) => new BootstrapError(`Cannot read manifest at ${path}: ${e}`),
+  })
+
+const printInstallView = (view: typeof AppInstallViewSchema.Type) =>
+  Effect.gen(function* () {
+    yield* Console.log(`✓ ${view.install.name}@${view.install.version}`)
+    yield* Console.log(`  source_ref:   ${view.install.source_ref}`)
+    yield* Console.log(`  manifest_sha: ${view.install.manifest_sha.slice(0, 12)}…`)
+    yield* Console.log(`  installed_at: ${view.install.installed_at}`)
+    if (view.install.reloaded_at !== null) {
+      yield* Console.log(`  reloaded_at:  ${view.install.reloaded_at}`)
+    }
+    if (view.bindings.length > 0) {
+      yield* Console.log(`\n  capabilities (${view.bindings.length}):`)
+      for (const b of view.bindings) {
+        const tag = b.required ? "required" : "optional"
+        yield* Console.log(
+          `    ${b.capability.padEnd(24)} → ${b.driver_id.padEnd(20)} (${tag})`,
+        )
+      }
+    }
+    if (view.vault_mounts.length > 0) {
+      yield* Console.log(`\n  vault project keys:`)
+      for (const m of view.vault_mounts) {
+        yield* Console.log(`    ${m.name} (kind=${m.kind})`)
+      }
+    }
+  })
+
+// --- install ---
+
+const manifestPathArg = Args.text({ name: "manifest-path" }).pipe(
+  Args.withDescription(
+    "Path to the app's gctrl-app.toml (typically apps/<name>/gctrl-app.toml).",
+  ),
+)
+
+const sourceRefOpt = Options.text("source-ref").pipe(
+  Options.optional,
+  Options.withDescription(
+    "Override the source_ref recorded with the install (default: absolute manifest path).",
+  ),
+)
+
+const installCommand = Command.make(
+  "install",
+  { manifestPath: manifestPathArg, sourceRef: sourceRefOpt },
+  ({ manifestPath, sourceRef }) =>
+    Effect.gen(function* () {
+      const text = yield* readManifest(manifestPath)
+      const ref = Option.getOrElse(sourceRef, () => resolve(manifestPath))
+      const kernel = yield* KernelClient
+      const view = yield* kernel.post(
+        "/api/app/installs",
+        { source_ref: ref, manifest_text: text },
+        AppInstallViewSchema,
+      )
+      yield* printInstallView(view)
+    }).pipe(
+      Effect.catchTag("BootstrapError", (e) =>
+        Effect.gen(function* () {
+          yield* Console.error(`✗ ${e.message}`)
+          yield* Effect.sync(() => process.exit(1))
+        }),
+      ),
+    ),
+).pipe(Command.withDescription("Install a gctrl app from its gctrl-app.toml manifest."))
+
+// --- list ---
+
+const listCommand = Command.make("list", {}, () =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const installs = yield* kernel.get("/api/app/installs", AppInstallListSchema)
+    if (installs.length === 0) {
+      yield* Console.log("No apps installed.")
+      return
+    }
+    yield* Console.log(
+      `${"NAME".padEnd(24)} ${"VERSION".padEnd(12)} ${"INSTALLED".padEnd(20)} SOURCE`,
+    )
+    yield* Console.log("-".repeat(80))
+    for (const i of installs) {
+      yield* Console.log(
+        `${i.name.padEnd(24)} ${i.version.padEnd(12)} ${i.installed_at.slice(0, 19).padEnd(20)} ${i.source_ref}`,
+      )
+    }
+  }),
+).pipe(Command.withDescription("List installed apps."))
+
+// --- status ---
+
+const nameArgGeneric = Args.text({ name: "name" }).pipe(
+  Args.withDescription("App name (matches the manifest's [app] name)."),
+)
+
+const statusCommand = Command.make("status", { name: nameArgGeneric }, ({ name }) =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const view = yield* kernel.get(`/api/app/installs/${name}`, AppInstallViewSchema)
+    yield* printInstallView(view)
+  }),
+).pipe(Command.withDescription("Show install record + bindings + vault project keys for an app."))
+
+// --- reload ---
+
+const reloadCommand = Command.make(
+  "reload",
+  { name: nameArgGeneric, manifestPath: manifestPathArg, sourceRef: sourceRefOpt },
+  ({ name, manifestPath, sourceRef }) =>
+    Effect.gen(function* () {
+      const text = yield* readManifest(manifestPath)
+      const ref = Option.getOrElse(sourceRef, () => resolve(manifestPath))
+      const kernel = yield* KernelClient
+      const view = yield* kernel.post(
+        `/api/app/installs/${name}/reload`,
+        { source_ref: ref, manifest_text: text },
+        AppInstallViewSchema,
+      )
+      yield* printInstallView(view)
+    }).pipe(
+      Effect.catchTag("BootstrapError", (e) =>
+        Effect.gen(function* () {
+          yield* Console.error(`✗ ${e.message}`)
+          yield* Effect.sync(() => process.exit(1))
+        }),
+      ),
+    ),
+).pipe(Command.withDescription("Re-apply a manifest after editing it (e.g. on version bump)."))
+
+// --- uninstall ---
+
+const uninstallCommand = Command.make("uninstall", { name: nameArgGeneric }, ({ name }) =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    yield* kernel.delete(`/api/app/installs/${name}`)
+    yield* Console.log(`✓ Uninstalled ${name}`)
+    yield* Console.log(
+      `  Vault project-key registrations dropped; files in the kernel vault root were NOT touched.`,
+    )
+  }),
+).pipe(
+  Command.withDescription(
+    "Uninstall an app — drops install record, bindings, and project-key registrations (files preserved).",
+  ),
+)
+
+// --- capabilities ---
+
+const capabilitiesCommand = Command.make("capabilities", {}, () =>
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    const caps = yield* kernel.get("/api/app/capabilities", CapabilityListSchema)
+    yield* Console.log(`${"ID".padEnd(24)} ${"DEFAULT DRIVER".padEnd(24)} ROUTE PREFIX`)
+    yield* Console.log("-".repeat(80))
+    for (const c of caps) {
+      yield* Console.log(
+        `${c.id.padEnd(24)} ${c.default_driver.padEnd(24)} ${c.route_prefix}`,
+      )
+    }
+  }),
+).pipe(
+  Command.withDescription(
+    "List the capabilities this kernel knows how to fulfill (the registry).",
+  ),
+)
+
+// Suppress unused-warning for VoidSchema (kept for future delete/reload responses).
+void VoidSchema
+
 // --- app (parent) ---
 
 export const appCommand = Command.make("app").pipe(
-  Command.withSubcommands([bootstrapCommand]),
+  Command.withSubcommands([
+    bootstrapCommand,
+    installCommand,
+    listCommand,
+    statusCommand,
+    reloadCommand,
+    uninstallCommand,
+    capabilitiesCommand,
+  ]),
 )

--- a/shell/gctrl-shell/test/app-install.test.ts
+++ b/shell/gctrl-shell/test/app-install.test.ts
@@ -1,0 +1,248 @@
+/**
+ * `gctrl app install/list/status/reload/uninstall` tests.
+ *
+ * Verifies the shell wraps /api/app/* correctly via mocked KernelClient.
+ * The Rust kernel side is tested separately under
+ * kernel/crates/gctrl-otel/src/receiver.rs (PR-α.3).
+ */
+import { describe, expect, it } from "vitest"
+import { Effect, Schema } from "effect"
+import { KernelClient } from "../src/services/KernelClient"
+import { createMockKernelClient } from "./helpers/mock-kernel"
+
+// --- schemas (mirroring src/commands/app.ts) ---
+
+const AppInstall = Schema.Struct({
+  name: Schema.String,
+  version: Schema.String,
+  source_ref: Schema.String,
+  manifest_sha: Schema.String,
+  installed_at: Schema.String,
+  reloaded_at: Schema.NullOr(Schema.String),
+})
+
+const AppBinding = Schema.Struct({
+  install_name: Schema.String,
+  capability: Schema.String,
+  driver_id: Schema.String,
+  required: Schema.Boolean,
+  resolved_at: Schema.String,
+})
+
+const VaultMount = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  root_path: Schema.String,
+  kind: Schema.String,
+  app_id: Schema.NullOr(Schema.String),
+})
+
+const AppInstallView = Schema.Struct({
+  install: AppInstall,
+  bindings: Schema.Array(AppBinding),
+  vault_mounts: Schema.Array(VaultMount),
+})
+
+const AppInstallList = Schema.Array(AppInstall)
+
+const Capability = Schema.Struct({
+  id: Schema.String,
+  default_driver: Schema.String,
+  route_prefix: Schema.String,
+  description: Schema.String,
+})
+const CapabilityList = Schema.Array(Capability)
+
+// --- fixtures ---
+
+const installRow = {
+  name: "uebermensch",
+  version: "0.2.0",
+  source_ref: "/path/to/uebermensch/gctrl-app.toml",
+  manifest_sha: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  installed_at: "2026-05-03T12:00:00Z",
+  reloaded_at: null,
+}
+
+const installRowReloaded = {
+  ...installRow,
+  version: "0.3.0",
+  reloaded_at: "2026-05-03T13:00:00Z",
+}
+
+const bindings = [
+  {
+    install_name: "uebermensch",
+    capability: "deliverer.telegram",
+    driver_id: "driver-telegram",
+    required: true,
+    resolved_at: "2026-05-03T12:00:00Z",
+  },
+  {
+    install_name: "uebermensch",
+    capability: "llm",
+    driver_id: "driver-llm",
+    required: true,
+    resolved_at: "2026-05-03T12:00:00Z",
+  },
+  {
+    install_name: "uebermensch",
+    capability: "gcal",
+    driver_id: "driver-gcal",
+    required: false,
+    resolved_at: "2026-05-03T12:00:00Z",
+  },
+]
+
+const vaultMounts = [
+  {
+    id: "mount-uuid",
+    name: "UBER",
+    root_path: "UBER",
+    kind: "app",
+    app_id: "uebermensch",
+  },
+]
+
+const installView = {
+  install: installRow,
+  bindings,
+  vault_mounts: vaultMounts,
+}
+
+const reloadedView = {
+  install: installRowReloaded,
+  bindings,
+  vault_mounts: vaultMounts,
+}
+
+const capabilities = [
+  {
+    id: "llm",
+    default_driver: "driver-llm",
+    route_prefix: "/api/llm",
+    description: "LLM relay",
+  },
+  {
+    id: "deliverer.telegram",
+    default_driver: "driver-telegram",
+    route_prefix: "/api/telegram",
+    description: "Telegram",
+  },
+]
+
+// --- mock layer ---
+
+const MockLayer = createMockKernelClient(
+  {
+    "/api/app/installs": [installRow],
+    "/api/app/installs/uebermensch": installView,
+    "/api/app/capabilities": capabilities,
+  },
+  {
+    "/api/app/installs": installView,
+    "/api/app/installs/uebermensch/reload": reloadedView,
+  },
+)
+
+const EmptyLayer = createMockKernelClient(
+  {
+    "/api/app/installs": [],
+    "/api/app/capabilities": capabilities,
+  },
+  {},
+)
+
+describe("gctrl app install/list/status/reload/uninstall (via KernelClient)", () => {
+  it("install returns the AppInstallView with bindings + mounts", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/app/installs",
+        { source_ref: "/path/to/manifest.toml", manifest_text: "[app]\nname = ..." },
+        AppInstallView,
+      )
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.install.name).toBe("uebermensch")
+    expect(result.install.version).toBe("0.2.0")
+    expect(result.bindings).toHaveLength(3)
+    expect(result.bindings.find((b) => b.capability === "llm")?.driver_id).toBe("driver-llm")
+    expect(result.vault_mounts[0].name).toBe("UBER")
+    expect(result.vault_mounts[0].app_id).toBe("uebermensch")
+  })
+
+  it("list returns AppInstall array", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/app/installs", AppInstallList)
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("uebermensch")
+  })
+
+  it("list on empty kernel returns empty array", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/app/installs", AppInstallList)
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(EmptyLayer)))
+    expect(result).toEqual([])
+  })
+
+  it("status returns the full view for a known install", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/app/installs/uebermensch", AppInstallView)
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.install.name).toBe("uebermensch")
+    expect(result.bindings.find((b) => b.capability === "gcal")?.required).toBe(false)
+    expect(result.bindings.find((b) => b.capability === "llm")?.required).toBe(true)
+  })
+
+  it("reload returns view with reloaded_at populated and bumped version", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.post(
+        "/api/app/installs/uebermensch/reload",
+        { source_ref: "/path/to/manifest.toml", manifest_text: "[app]\nname = ..." },
+        AppInstallView,
+      )
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.install.version).toBe("0.3.0")
+    expect(result.install.reloaded_at).toBe("2026-05-03T13:00:00Z")
+  })
+
+  it("uninstall succeeds (delete returns void)", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      yield* kernel.delete("/api/app/installs/uebermensch")
+      return "ok"
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result).toBe("ok")
+  })
+
+  it("capabilities returns the registry list", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/app/capabilities", CapabilityList)
+    })
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result).toHaveLength(2)
+    expect(result.map((c) => c.id)).toEqual(["llm", "deliverer.telegram"])
+    expect(result[0].route_prefix).toBe("/api/llm")
+  })
+
+  it("status on unknown app surfaces a KernelError", async () => {
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/app/installs/never-installed", AppInstallView)
+    })
+    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(EmptyLayer)))
+    expect(exit._tag).toBe("Failure")
+  })
+})


### PR DESCRIPTION
## Summary

PR-α.4 of the install-protocol implementation. Wraps the kernel `/api/app/*` routes (#168) as Effect-TS subcommands under the existing `gctrl app` namespace.

Targets `main` directly. Logical dependency on #168 (HTTP routes) — the manual smoke path needs those routes live, but the unit tests use a mock `KernelClient` so this PR can land independently.

## What lands

### New subcommands

| Command | Behavior |
|---|---|
| `gctrl app install <manifest-path>` | Reads gctrl-app.toml, POSTs to `/api/app/installs`. Optional `--source-ref` overrides the recorded source ref (default: absolute path). |
| `gctrl app list` | Tabular `NAME / VERSION / INSTALLED / SOURCE`. |
| `gctrl app status <name>` | Install record + bindings (required first, alphabetical) + vault project keys owned by the app. |
| `gctrl app reload <name> <manifest-path>` | Re-applies a manifest. Kernel rejects rename via reload. |
| `gctrl app uninstall <name>` | Drops install + bindings + project-key registrations. Files in the vault root are **not** deleted. |
| `gctrl app capabilities` | Lists the kernel's capability registry (id / default driver / route prefix). |

### Operator UX

```
$ gctrl app install apps/uebermensch/gctrl-app.toml
✓ uebermensch@0.2.0
  source_ref:   /Users/me/.../apps/uebermensch/gctrl-app.toml
  manifest_sha: 8a4b1f2e9c3d…
  installed_at: 2026-05-03T12:00:00Z

  capabilities (9):
    deliverer.discord       → driver-discord       (required)
    deliverer.telegram      → driver-telegram      (required)
    llm                     → driver-llm           (required)
    secrets                 → driver-secrets       (required)
    vault.sync              → gctrl-sync.vault     (required)
    vault.write             → kernel-vault-fs      (required)
    browser.cdp             → driver-browser       (optional)
    gcal                    → driver-gcal          (optional)
    search.brave            → driver-brave         (optional)

  vault project keys:
    UBER (kind=app)
```

All commands route through `KernelClient` — no direct fetch, no secrets in the shell. Schemas mirror `gctrl_core::AppInstall + AppBinding + VaultMount + AppInstallView` from #167.

## Test plan

- [x] `pnpm test` — **148 passing** (8 new in `test/app-install.test.ts`, 0 regressions)
- [x] `pnpm exec biome lint shell/*/src/ shell/*/test/ apps/*/src/` — 0 errors (29 pre-existing warnings unchanged)

8 new tests against `createMockKernelClient`:

- [x] `install` POSTs and decodes `AppInstallView` (install + bindings + mounts)
- [x] `list` returns array; empty array for fresh kernel
- [x] `status` returns the full view; unknown name surfaces `KernelError`
- [x] `reload` returns view with `reloaded_at` populated + bumped version
- [x] `uninstall` succeeds against the mock delete handler
- [x] `capabilities` returns the registry list with `route_prefix` preserved

## Out of scope (deferred)

- **Git-URL source refs** — only filesystem paths in v1. `gctrl app install git+https://...` would need the kernel to fetch + cache, which is its own follow-up.
- **Per-app schedule registration** — the install handler doesn't yet wire `[[schedule]]` entries from the manifest into kernel `schedules`. The shell side is ready for it; the kernel-side wiring is the next thin slice.

## Stack

- ✅ #166 — capability registry + manifest parser **(merged)**
- 🟡 #167 — install storage tables + CRUD (rebased onto main)
- 🟡 #168 — `/api/app/*` HTTP routes (stacked on #167)
- **This PR** — `gctrl app install/list/status/reload/uninstall` shell subcommands ← *you are here*
