### PR TITLE
feat(analytics): slice usage by project and (agent × project)

### DIFF
--- a/kernel/crates/gctrl-cli/src/commands/analytics_cost.rs
+++ b/kernel/crates/gctrl-cli/src/commands/analytics_cost.rs
@@ -6,6 +6,8 @@ pub fn run(db_path: &str) -> Result<()> {
 
     let cost_by_model = store.get_cost_by_model(None)?;
     let cost_by_agent = store.get_cost_by_agent(None)?;
+    let cost_by_project = store.get_cost_by_project(None)?;
+    let cost_by_agent_project = store.get_cost_by_agent_project(None)?;
 
     println!("=== Cost by Model ===");
     if cost_by_model.is_empty() {
@@ -32,6 +34,31 @@ pub fn run(db_path: &str) -> Result<()> {
         for (agent, cost, sessions) in &cost_by_agent {
             let avg = if *sessions > 0 { cost / *sessions as f64 } else { 0.0 };
             println!("{:<25} {:>9.4} {:>10} (avg ${:.4}/s)", agent, cost, sessions, avg);
+        }
+    }
+
+    println!();
+    println!("=== Cost by Project ===");
+    if cost_by_project.is_empty() {
+        println!("  No data.");
+    } else {
+        println!("{:<25} {:>10} {:>10}", "PROJECT", "COST", "SESSIONS");
+        println!("{}", "-".repeat(47));
+        for (project, cost, sessions) in &cost_by_project {
+            let avg = if *sessions > 0 { cost / *sessions as f64 } else { 0.0 };
+            println!("{:<25} {:>9.4} {:>10} (avg ${:.4}/s)", project, cost, sessions, avg);
+        }
+    }
+
+    println!();
+    println!("=== Cost by Agent x Project ===");
+    if cost_by_agent_project.is_empty() {
+        println!("  No data.");
+    } else {
+        println!("{:<20} {:<20} {:>10} {:>10}", "AGENT", "PROJECT", "COST", "SESSIONS");
+        println!("{}", "-".repeat(62));
+        for (agent, project, cost, sessions) in &cost_by_agent_project {
+            println!("{:<20} {:<20} {:>9.4} {:>10}", agent, project, cost, sessions);
         }
     }
 

--- a/kernel/crates/gctrl-core/src/types.rs
+++ b/kernel/crates/gctrl-core/src/types.rs
@@ -116,6 +116,12 @@ pub struct Session {
     /// behaviour for legacy rows read out of the storage layer.
     #[serde(default)]
     pub created_by: CreatedBy,
+    /// Optional board project this session is attributed to. NULL for
+    /// pre-migration rows and for sessions with no project context
+    /// (e.g. ad-hoc daemon work). Surfaced as the `project` axis in
+    /// analytics rollups.
+    #[serde(default)]
+    pub project_id: Option<String>,
 }
 
 // --- OrchTask (Orchestrator claim record) ---
@@ -237,6 +243,11 @@ pub struct Span {
     pub started_at: DateTime<Utc>,
     pub duration_ms: u64,
     pub attributes: serde_json::Value,
+    /// Optional project attribution mirrored from the parent session.
+    /// Denormalised onto the span row so cost-by-project queries don't
+    /// need a sessions join. NULL for pre-migration rows.
+    #[serde(default)]
+    pub project_id: Option<String>,
 }
 
 // --- Traffic ---
@@ -958,6 +969,7 @@ mod tests {
             started_at: Utc::now(),
             duration_ms: 2000,
             attributes: serde_json::json!({"tool": "bash"}),
+            project_id: None,
         };
         let json = serde_json::to_string(&span).unwrap();
         let parsed: Span = serde_json::from_str(&json).unwrap();

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -868,9 +868,22 @@ async fn analytics_cost(
     let prov_slice = provenances.as_deref();
     let cost_by_model = state.store.get_cost_by_model(prov_slice).unwrap_or_default();
     let cost_by_agent = state.store.get_cost_by_agent(prov_slice).unwrap_or_default();
+    // Project axis is additive — older clients keep working off
+    // `by_model`/`by_agent`, newer clients pick up `by_project` and
+    // `by_agent_project` for the (agent × project) matrix.
+    let cost_by_project = state
+        .store
+        .get_cost_by_project(prov_slice)
+        .unwrap_or_default();
+    let cost_by_agent_project = state
+        .store
+        .get_cost_by_agent_project(prov_slice)
+        .unwrap_or_default();
     Json(serde_json::json!({
         "by_model": cost_by_model.iter().map(|(m, c, n)| serde_json::json!({"model": m, "cost": c, "calls": n})).collect::<Vec<_>>(),
         "by_agent": cost_by_agent.iter().map(|(a, c, n)| serde_json::json!({"agent": a, "cost": c, "sessions": n})).collect::<Vec<_>>(),
+        "by_project": cost_by_project.iter().map(|(p, c, n)| serde_json::json!({"project": p, "cost": c, "sessions": n})).collect::<Vec<_>>(),
+        "by_agent_project": cost_by_agent_project.iter().map(|(a, p, c, n)| serde_json::json!({"agent": a, "project": p, "cost": c, "sessions": n})).collect::<Vec<_>>(),
     })).into_response()
 }
 
@@ -1048,6 +1061,10 @@ async fn ingest_traces(
                     // Auto-create on OTLP ingest is the canonical
                     // `external` provenance — see analytics spec §1.
                     created_by: gctrl_core::CreatedBy::OtelIngest,
+                    // OTLP push doesn't carry project context yet; fill
+                    // in via a later UPDATE if the producer attaches a
+                    // project hint, or leave NULL.
+                    project_id: None,
                 };
                 if state.store.insert_session(&session).is_ok() {
                     started_emit.push(session);
@@ -5311,6 +5328,7 @@ mod tests {
                 total_input_tokens: 0,
                 total_output_tokens: 0,
                 created_by: gctrl_core::CreatedBy::Unknown,
+                project_id: None,
             })
             .unwrap();
 
@@ -5896,6 +5914,7 @@ Getting User settings...
             total_input_tokens: 0,
             total_output_tokens: 0,
             created_by: prov,
+            project_id: None,
         }
     }
 

--- a/kernel/crates/gctrl-otel/src/span_processor.rs
+++ b/kernel/crates/gctrl-otel/src/span_processor.rs
@@ -214,6 +214,10 @@ pub fn process_export_request(req: &OtlpExportRequest) -> Vec<Span> {
                     started_at,
                     duration_ms,
                     attributes: serde_json::Value::Object(attrs),
+                    // Filled in later by `update_session_aggregates`
+                    // once the span is associated with a session row
+                    // that carries a project_id.
+                    project_id: None,
                 });
             }
         }

--- a/kernel/crates/gctrl-otel/tests/analytics_by_project.rs
+++ b/kernel/crates/gctrl-otel/tests/analytics_by_project.rs
@@ -1,0 +1,153 @@
+//! Integration test for the project axis on `/api/analytics/cost`.
+//! Verifies that the route emits both `by_project` and the
+//! `by_agent_project` matrix, that `unassigned` surfaces sessions
+//! without a project_id, and that the slices sum back to the agent
+//! totals.
+
+use axum::body::Body;
+use chrono::Utc;
+use gctrl_core::{
+    CreatedBy, DeviceId, Session, SessionId, SessionStatus, Span, SpanId, SpanStatus, SpanType,
+    TraceId, WorkspaceId,
+};
+use gctrl_otel::create_router_from_arc;
+use gctrl_storage::DuckDbStore;
+use http::Request;
+use http_body_util::BodyExt;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn fixture_store() -> Arc<DuckDbStore> {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let now = Utc::now();
+
+    // Three sessions, three (agent, project) pairs incl. an unassigned
+    // bucket. Costs picked so each pair is uniquely identifiable.
+    for (id, agent, project, cost) in [
+        ("s1", "claude", Some("alpha"), 0.10),
+        ("s2", "codex", Some("alpha"), 0.20),
+        ("s3", "claude", None, 0.40),
+    ] {
+        store
+            .insert_session(&Session {
+                id: SessionId(id.into()),
+                workspace_id: WorkspaceId("ws".into()),
+                device_id: DeviceId("dev".into()),
+                agent_name: agent.into(),
+                started_at: now,
+                ended_at: None,
+                status: SessionStatus::Active,
+                total_cost_usd: cost,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                created_by: CreatedBy::Api,
+                project_id: project.map(str::to_string),
+            })
+            .unwrap();
+
+        store
+            .insert_span(&Span {
+                span_id: SpanId(format!("sp-{id}")),
+                trace_id: TraceId(format!("tr-{id}")),
+                parent_span_id: None,
+                session_id: SessionId(id.into()),
+                agent_name: agent.into(),
+                operation_name: "llm.call".into(),
+                span_type: SpanType::Generation,
+                model: Some("claude-opus-4".into()),
+                input_tokens: 0,
+                output_tokens: 0,
+                cost_usd: cost,
+                status: SpanStatus::Ok,
+                started_at: now,
+                duration_ms: 100,
+                attributes: serde_json::json!({}),
+                project_id: None,
+            })
+            .unwrap();
+    }
+    store
+}
+
+async fn fetch_json(app: axum::Router, uri: &str) -> serde_json::Value {
+    let req = Request::builder()
+        .uri(uri)
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert!(res.status().is_success(), "GET {uri} → {}", res.status());
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&body).unwrap()
+}
+
+fn project_cost(by_project: &serde_json::Value, project: &str) -> f64 {
+    by_project
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["project"].as_str() == Some(project))
+        .map(|r| r["cost"].as_f64().unwrap())
+        .unwrap_or(0.0)
+}
+
+fn matrix_cost(matrix: &serde_json::Value, agent: &str, project: &str) -> Option<f64> {
+    matrix.as_array().unwrap().iter().find_map(|r| {
+        if r["agent"].as_str() == Some(agent) && r["project"].as_str() == Some(project) {
+            Some(r["cost"].as_f64().unwrap())
+        } else {
+            None
+        }
+    })
+}
+
+#[tokio::test]
+async fn analytics_cost_emits_by_project_with_unassigned_bucket() {
+    let app = create_router_from_arc(fixture_store());
+    let v = fetch_json(app, "/api/analytics/cost").await;
+
+    let by_project = &v["by_project"];
+    assert!(by_project.is_array(), "by_project must be present");
+
+    assert!((project_cost(by_project, "alpha") - 0.30).abs() < 1e-9);
+    assert!((project_cost(by_project, "unassigned") - 0.40).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn analytics_cost_emits_agent_project_matrix() {
+    let app = create_router_from_arc(fixture_store());
+    let v = fetch_json(app, "/api/analytics/cost").await;
+
+    let matrix = &v["by_agent_project"];
+    assert!(matrix.is_array(), "by_agent_project must be present");
+    assert_eq!(matrix.as_array().unwrap().len(), 3);
+
+    assert_eq!(matrix_cost(matrix, "claude", "alpha"), Some(0.10));
+    assert_eq!(matrix_cost(matrix, "codex", "alpha"), Some(0.20));
+    assert_eq!(matrix_cost(matrix, "claude", "unassigned"), Some(0.40));
+}
+
+#[tokio::test]
+async fn agent_project_rows_sum_to_agent_totals() {
+    let app = create_router_from_arc(fixture_store());
+    let v = fetch_json(app, "/api/analytics/cost").await;
+
+    // Each agent's matrix rows must sum to the per-agent total. This
+    // is the integrity check that catches accidental row dropping or
+    // double-counting in future query rewrites.
+    let by_agent = v["by_agent"].as_array().unwrap();
+    let matrix = v["by_agent_project"].as_array().unwrap();
+    for agent_row in by_agent {
+        let agent = agent_row["agent"].as_str().unwrap();
+        let total = agent_row["cost"].as_f64().unwrap();
+        let matrix_total: f64 = matrix
+            .iter()
+            .filter(|r| r["agent"].as_str() == Some(agent))
+            .map(|r| r["cost"].as_f64().unwrap())
+            .sum();
+        assert!(
+            (matrix_total - total).abs() < 1e-9,
+            "agent {agent}: matrix sum {matrix_total} != by_agent total {total}",
+        );
+    }
+}

--- a/kernel/crates/gctrl-otel/tests/analytics_kind_filter.rs
+++ b/kernel/crates/gctrl-otel/tests/analytics_kind_filter.rs
@@ -44,6 +44,7 @@ fn fixture_store() -> Arc<DuckDbStore> {
                 total_input_tokens: 100,
                 total_output_tokens: 50,
                 created_by: prov,
+                project_id: None,
             })
             .unwrap();
 
@@ -64,6 +65,7 @@ fn fixture_store() -> Arc<DuckDbStore> {
                 started_at: now,
                 duration_ms: 1_500,
                 attributes: serde_json::json!({}),
+                project_id: None,
             })
             .unwrap();
     }

--- a/kernel/crates/gctrl-otel/tests/created_by_filter.rs
+++ b/kernel/crates/gctrl-otel/tests/created_by_filter.rs
@@ -32,6 +32,7 @@ fn store_with_provenance(rows: &[(&str, CreatedBy)]) -> Arc<DuckDbStore> {
                 total_input_tokens: 0,
                 total_output_tokens: 0,
                 created_by: *prov,
+                project_id: None,
             })
             .unwrap();
     }

--- a/kernel/crates/gctrl-storage/src/duckdb_store.rs
+++ b/kernel/crates/gctrl-storage/src/duckdb_store.rs
@@ -139,8 +139,8 @@ impl DuckDbStore {
     pub fn insert_session(&self, session: &Session) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT OR REPLACE INTO sessions (id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO sessions (id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by, project_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 session.id.0,
                 session.workspace_id.0,
@@ -153,6 +153,7 @@ impl DuckDbStore {
                 session.total_input_tokens as i64,
                 session.total_output_tokens as i64,
                 session.created_by.as_str(),
+                session.project_id,
             ],
         )
         .map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -162,8 +163,8 @@ impl DuckDbStore {
     pub fn insert_span(&self, span: &Span) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT OR REPLACE INTO spans (span_id, trace_id, parent_span_id, session_id, agent_name, operation_name, span_type, model, input_tokens, output_tokens, cost_usd, status, error_message, started_at, duration_ms, attributes)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR REPLACE INTO spans (span_id, trace_id, parent_span_id, session_id, agent_name, operation_name, span_type, model, input_tokens, output_tokens, cost_usd, status, error_message, started_at, duration_ms, attributes, project_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 span.span_id.0,
                 span.trace_id.0,
@@ -181,6 +182,7 @@ impl DuckDbStore {
                 span.started_at.to_rfc3339(),
                 span.duration_ms as i64,
                 span.attributes.to_string(),
+                span.project_id,
             ],
         )
         .map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -210,6 +212,19 @@ impl DuckDbStore {
                 total_input_tokens = (SELECT COALESCE(SUM(input_tokens), 0) FROM spans WHERE session_id = ?1),
                 total_output_tokens = (SELECT COALESCE(SUM(output_tokens), 0) FROM spans WHERE session_id = ?1)
              WHERE id = ?1",
+            params![session_id],
+        )
+        .map_err(|e| GctlError::Storage(e.to_string()))?;
+        // Propagate the session's project_id onto any spans that don't
+        // already carry one. Lets ingest paths (OTel push, manual span
+        // inserts) skip plumbing project_id and still have the span row
+        // line up with the cost-by-project query. Idempotent: rows whose
+        // project_id is already set are left alone.
+        conn.execute(
+            "UPDATE spans
+                SET project_id = (SELECT project_id FROM sessions WHERE id = ?1)
+              WHERE session_id = ?1
+                AND project_id IS NULL",
             params![session_id],
         )
         .map_err(|e| GctlError::Storage(e.to_string()))?;
@@ -256,7 +271,7 @@ impl DuckDbStore {
     pub fn get_session(&self, id: &SessionId) -> Result<Option<Session>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
-            .prepare("SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by FROM sessions WHERE id = ?")
+            .prepare("SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by, project_id FROM sessions WHERE id = ?")
             .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut rows = stmt
@@ -273,7 +288,7 @@ impl DuckDbStore {
     pub fn list_sessions(&self, limit: usize) -> Result<Vec<Session>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
-            .prepare("SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by FROM sessions ORDER BY started_at DESC LIMIT ?")
+            .prepare("SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by, project_id FROM sessions ORDER BY started_at DESC LIMIT ?")
             .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut rows = stmt
@@ -295,7 +310,7 @@ impl DuckDbStore {
         created_by: Option<&[gctrl_core::CreatedBy]>,
     ) -> Result<Vec<Session>> {
         let conn = self.conn.lock().unwrap();
-        let mut sql = "SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by FROM sessions WHERE 1=1".to_string();
+        let mut sql = "SELECT id, workspace_id, device_id, agent_name, started_at, ended_at, status, total_cost_usd, total_input_tokens, total_output_tokens, created_by, project_id FROM sessions WHERE 1=1".to_string();
         let mut bound_params: Vec<Box<dyn duckdb::ToSql>> = Vec::new();
 
         if let Some(agent_name) = agent {
@@ -340,7 +355,7 @@ impl DuckDbStore {
     pub fn query_spans(&self, session_id: &SessionId) -> Result<Vec<Span>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
-            .prepare("SELECT span_id, trace_id, parent_span_id, session_id, agent_name, operation_name, span_type, model, input_tokens, output_tokens, cost_usd, status, error_message, started_at, duration_ms, attributes FROM spans WHERE session_id = ? ORDER BY started_at ASC")
+            .prepare("SELECT span_id, trace_id, parent_span_id, session_id, agent_name, operation_name, span_type, model, input_tokens, output_tokens, cost_usd, status, error_message, started_at, duration_ms, attributes, project_id FROM spans WHERE session_id = ? ORDER BY started_at ASC")
             .map_err(|e| GctlError::Storage(e.to_string()))?;
 
         let mut rows = stmt
@@ -1199,6 +1214,75 @@ impl DuckDbStore {
             let cost: f64 = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
             let count: i64 = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
             results.push((agent, cost, count as u64));
+        }
+        Ok(results)
+    }
+
+    /// Cost rolled up by `project_id`. Sessions without an attributed
+    /// project surface as the bucket key `"unassigned"` so the caller
+    /// always sees the full cost ledger (no silent drop). Caller can
+    /// hide that bucket in the UI when they only want attributed work.
+    pub fn get_cost_by_project(
+        &self,
+        created_by: Option<&[CreatedBy]>,
+    ) -> Result<Vec<(String, f64, u64)>> {
+        let conn = self.conn.lock().unwrap();
+        let sessions = sessions_provenance_filter(created_by);
+        let sess_params = sessions.params();
+        let sql = format!(
+            "SELECT COALESCE(project_id, 'unassigned'), COALESCE(SUM(total_cost_usd), 0), COUNT(*) \
+             FROM sessions{} \
+             GROUP BY COALESCE(project_id, 'unassigned') ORDER BY SUM(total_cost_usd) DESC",
+            sessions.where_clause
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(sess_params.as_slice())
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut results = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
+            let project: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let cost: f64 = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let count: i64 = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
+            results.push((project, cost, count as u64));
+        }
+        Ok(results)
+    }
+
+    /// Cost rolled up by the `(agent, project)` pair — answers
+    /// "which agents are running which projects, and what does each
+    /// pair cost?". `project_id` NULL → `"unassigned"` for the same
+    /// reason as `get_cost_by_project`.
+    pub fn get_cost_by_agent_project(
+        &self,
+        created_by: Option<&[CreatedBy]>,
+    ) -> Result<Vec<(String, String, f64, u64)>> {
+        let conn = self.conn.lock().unwrap();
+        let sessions = sessions_provenance_filter(created_by);
+        let sess_params = sessions.params();
+        let sql = format!(
+            "SELECT agent_name, COALESCE(project_id, 'unassigned'), \
+                    COALESCE(SUM(total_cost_usd), 0), COUNT(*) \
+             FROM sessions{} \
+             GROUP BY agent_name, COALESCE(project_id, 'unassigned') \
+             ORDER BY SUM(total_cost_usd) DESC",
+            sessions.where_clause
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(sess_params.as_slice())
+            .map_err(|e| GctlError::Storage(e.to_string()))?;
+        let mut results = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| GctlError::Storage(e.to_string()))? {
+            let agent: String = row.get(0).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let project: String = row.get(1).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let cost: f64 = row.get(2).map_err(|e| GctlError::Storage(e.to_string()))?;
+            let count: i64 = row.get(3).map_err(|e| GctlError::Storage(e.to_string()))?;
+            results.push((agent, project, cost, count as u64));
         }
         Ok(results)
     }
@@ -2523,6 +2607,8 @@ fn row_to_session(row: &duckdb::Row<'_>) -> Result<Session> {
     // can't carry NOT NULL on DuckDB). Treat NULL as `Unknown`.
     let created_by_raw: Option<String> =
         row.get(10).map_err(|e| GctlError::Storage(e.to_string()))?;
+    let project_id: Option<String> =
+        row.get(11).map_err(|e| GctlError::Storage(e.to_string()))?;
 
     Ok(Session {
         id: gctrl_core::SessionId(id),
@@ -2549,6 +2635,7 @@ fn row_to_session(row: &duckdb::Row<'_>) -> Result<Session> {
             .as_deref()
             .and_then(gctrl_core::CreatedBy::from_str)
             .unwrap_or(gctrl_core::CreatedBy::Unknown),
+        project_id,
     })
 }
 
@@ -2571,6 +2658,8 @@ fn row_to_span(row: &duckdb::Row<'_>) -> Result<Span> {
     let started_at: String = row.get(13).map_err(|e| GctlError::Storage(e.to_string()))?;
     let duration_ms: i64 = row.get(14).map_err(|e| GctlError::Storage(e.to_string()))?;
     let attributes: String = row.get(15).map_err(|e| GctlError::Storage(e.to_string()))?;
+    let project_id: Option<String> =
+        row.get(16).map_err(|e| GctlError::Storage(e.to_string()))?;
 
     let span_status = match status.as_str() {
         "ok" => SpanStatus::Ok,
@@ -2596,6 +2685,7 @@ fn row_to_span(row: &duckdb::Row<'_>) -> Result<Span> {
             .with_timezone(&chrono::Utc),
         duration_ms: duration_ms as u64,
         attributes: serde_json::from_str(&attributes).unwrap_or(serde_json::Value::Null),
+        project_id,
     })
 }
 
@@ -2776,6 +2866,7 @@ mod tests {
             total_input_tokens: 0,
             total_output_tokens: 0,
             created_by: CreatedBy::Unknown,
+            project_id: None,
         }
     }
 
@@ -2796,6 +2887,7 @@ mod tests {
             started_at: Utc::now(),
             duration_ms: 2000,
             attributes: serde_json::json!({}),
+            project_id: None,
         }
     }
 
@@ -3089,6 +3181,94 @@ mod tests {
         let costs = store.get_cost_by_agent(None).unwrap();
         assert_eq!(costs.len(), 1);
         assert_eq!(costs[0].0, "claude");
+    }
+
+    #[test]
+    fn test_cost_by_project_groups_attributed_and_unassigned() {
+        let store = test_store();
+        // Two sessions on project alpha, one with no project attribution.
+        let mut s1 = make_session("s1");
+        s1.project_id = Some("alpha".into());
+        let mut s2 = make_session("s2");
+        s2.project_id = Some("alpha".into());
+        let s3 = make_session("s3");
+        store.insert_session(&s1).unwrap();
+        store.insert_session(&s2).unwrap();
+        store.insert_session(&s3).unwrap();
+        store.insert_spans(&[make_span("sp1", "s1")]).unwrap();
+        store.insert_spans(&[make_span("sp2", "s2")]).unwrap();
+        store.insert_spans(&[make_span("sp3", "s3")]).unwrap();
+
+        let costs = store.get_cost_by_project(None).unwrap();
+        let alpha = costs.iter().find(|(p, _, _)| p == "alpha").unwrap();
+        let unassigned = costs.iter().find(|(p, _, _)| p == "unassigned").unwrap();
+        assert!((alpha.1 - 0.10).abs() < 0.001, "alpha total = 2 * 0.05");
+        assert_eq!(alpha.2, 2);
+        assert!((unassigned.1 - 0.05).abs() < 0.001);
+        assert_eq!(unassigned.2, 1);
+    }
+
+    #[test]
+    fn test_cost_by_agent_project_pairs() {
+        let store = test_store();
+        // Two agents (`claude`, `codex`), two projects, mixed pairs.
+        let mut s1 = make_session("s1");
+        s1.project_id = Some("alpha".into());
+        let mut s2 = make_session("s2");
+        s2.project_id = Some("beta".into());
+        s2.agent_name = "codex".into();
+        let mut s3 = make_session("s3");
+        s3.project_id = Some("alpha".into());
+        s3.agent_name = "codex".into();
+        store.insert_session(&s1).unwrap();
+        store.insert_session(&s2).unwrap();
+        store.insert_session(&s3).unwrap();
+        store.insert_spans(&[make_span("sp1", "s1")]).unwrap();
+        store.insert_spans(&[make_span("sp2", "s2")]).unwrap();
+        store.insert_spans(&[make_span("sp3", "s3")]).unwrap();
+
+        let costs = store.get_cost_by_agent_project(None).unwrap();
+        // Three distinct (agent, project) pairs.
+        assert_eq!(costs.len(), 3);
+        let claude_alpha = costs
+            .iter()
+            .find(|(a, p, _, _)| a == "claude" && p == "alpha")
+            .expect("claude/alpha pair");
+        let codex_alpha = costs
+            .iter()
+            .find(|(a, p, _, _)| a == "codex" && p == "alpha")
+            .expect("codex/alpha pair");
+        let codex_beta = costs
+            .iter()
+            .find(|(a, p, _, _)| a == "codex" && p == "beta")
+            .expect("codex/beta pair");
+        assert_eq!(claude_alpha.3, 1);
+        assert_eq!(codex_alpha.3, 1);
+        assert_eq!(codex_beta.3, 1);
+    }
+
+    #[test]
+    fn test_session_round_trips_project_id() {
+        let store = test_store();
+        let mut s = make_session("s-with-proj");
+        s.project_id = Some("alpha".into());
+        store.insert_session(&s).unwrap();
+        let got = store.get_session(&s.id).unwrap().expect("session present");
+        assert_eq!(got.project_id.as_deref(), Some("alpha"));
+    }
+
+    #[test]
+    fn test_span_inherits_session_project_id_via_aggregates() {
+        let store = test_store();
+        // Session has a project; span inserted with project_id=None
+        // should have it backfilled by `update_session_aggregates`.
+        let mut s = make_session("s-proj");
+        s.project_id = Some("alpha".into());
+        store.insert_session(&s).unwrap();
+        store.insert_spans(&[make_span("sp1", "s-proj")]).unwrap();
+        let spans = store.query_spans(&s.id).unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].project_id.as_deref(), Some("alpha"));
     }
 
     #[test]

--- a/kernel/crates/gctrl-storage/src/schema.rs
+++ b/kernel/crates/gctrl-storage/src/schema.rs
@@ -14,7 +14,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- Provenance: scheduler | otel_ingest | api | unknown.
     -- See specs/architecture/apps/gctrl-analytics.md §1. `unknown`
     -- exists only for pre-migration rows; new rows must set it.
-    created_by      VARCHAR NOT NULL DEFAULT 'unknown'
+    created_by      VARCHAR NOT NULL DEFAULT 'unknown',
+    -- Optional board project attribution. NULL for legacy rows and for
+    -- sessions with no project context. Powers `cost by project` and
+    -- `cost by (agent × project)` analytics queries.
+    project_id      VARCHAR
 )
 "#;
 
@@ -27,6 +31,13 @@ CREATE TABLE IF NOT EXISTS sessions (
 /// pre-migration data.
 pub const ADD_SESSIONS_CREATED_BY: &str = r#"
 ALTER TABLE sessions ADD COLUMN IF NOT EXISTS created_by VARCHAR
+"#;
+
+/// Idempotent migration for existing DBs that predate `project_id`.
+/// Always nullable — pre-migration rows have no project context, and
+/// not every session is project-attributable (e.g. ad-hoc daemon work).
+pub const ADD_SESSIONS_PROJECT_ID: &str = r#"
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS project_id VARCHAR
 "#;
 
 pub const CREATE_SPANS_TABLE: &str = r#"
@@ -47,8 +58,17 @@ CREATE TABLE IF NOT EXISTS spans (
     started_at      VARCHAR NOT NULL,
     duration_ms     BIGINT NOT NULL,
     attributes      JSON,
-    synced          BOOLEAN DEFAULT FALSE
+    synced          BOOLEAN DEFAULT FALSE,
+    -- Denormalised from the parent session so cost-by-project queries
+    -- don't need a join. NULL for legacy rows and for spans whose
+    -- session has no project attribution.
+    project_id      VARCHAR
 )
+"#;
+
+/// Idempotent migration for existing DBs that predate `project_id` on spans.
+pub const ADD_SPANS_PROJECT_ID: &str = r#"
+ALTER TABLE spans ADD COLUMN IF NOT EXISTS project_id VARCHAR
 "#;
 
 pub const CREATE_TRAFFIC_TABLE: &str = r#"
@@ -485,6 +505,8 @@ pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_traffic_host ON traffic(host)",
     "CREATE INDEX IF NOT EXISTS idx_traffic_timestamp ON traffic(timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id)",
+    "CREATE INDEX IF NOT EXISTS idx_spans_project ON spans(project_id)",
     "CREATE INDEX IF NOT EXISTS idx_scores_target ON scores(target_type, target_id)",
     "CREATE INDEX IF NOT EXISTS idx_tags_target ON tags(target_type, target_id)",
     "CREATE INDEX IF NOT EXISTS idx_tags_key ON tags(key, value)",
@@ -537,7 +559,9 @@ pub fn all_migrations() -> Vec<&'static str> {
         // Idempotent column add for DBs that predate `created_by`. Runs
         // after CREATE so a fresh schema is also a no-op.
         ADD_SESSIONS_CREATED_BY,
+        ADD_SESSIONS_PROJECT_ID,
         CREATE_SPANS_TABLE,
+        ADD_SPANS_PROJECT_ID,
         CREATE_TRAFFIC_TABLE,
         CREATE_GUARDRAIL_EVENTS_TABLE,
         CREATE_SCORES_TABLE,

--- a/shell/gctrl-shell/src/commands/analytics.ts
+++ b/shell/gctrl-shell/src/commands/analytics.ts
@@ -21,9 +21,24 @@ const CostByAgent = Schema.Struct({
   cost: Schema.Number,
   sessions: Schema.Number,
 })
+const CostByProject = Schema.Struct({
+  project: Schema.String,
+  cost: Schema.Number,
+  sessions: Schema.Number,
+})
+const CostByAgentProject = Schema.Struct({
+  agent: Schema.String,
+  project: Schema.String,
+  cost: Schema.Number,
+  sessions: Schema.Number,
+})
+// `by_project` / `by_agent_project` are optional so the shell stays
+// compatible with older kernels that don't emit them.
 const CostAnalytics = Schema.Struct({
   by_model: Schema.Array(CostByModel),
   by_agent: Schema.Array(CostByAgent),
+  by_project: Schema.optional(Schema.Array(CostByProject)),
+  by_agent_project: Schema.optional(Schema.Array(CostByAgentProject)),
 })
 
 const LatencyByModel = Schema.Struct({
@@ -90,23 +105,87 @@ const overviewCommand = Command.make("overview", {}, () =>
   })
 )
 
-const costCommand = Command.make("cost", {}, () =>
+// `--by` selects which dimension(s) to render. Default `model,agent`
+// preserves prior CLI output. `project` and `agent,project` add the
+// new slices powered by the kernel's project_id column.
+const costBy = Options.text("by").pipe(
+  Options.withDefault("model,agent"),
+  Options.withDescription(
+    "Comma-separated dimensions to show: model, agent, project, agent,project (default: model,agent)"
+  )
+)
+
+const costCommand = Command.make("cost", { by: costBy }, ({ by }) =>
   Effect.gen(function* () {
     const kernel = yield* KernelClient
     const c = yield* kernel.get("/api/analytics/cost", CostAnalytics)
 
-    yield* Console.log("Cost by Model")
-    yield* Console.log(`${"Model".padEnd(30)} ${"Cost".padEnd(12)} Calls`)
-    yield* Console.log("-".repeat(55))
-    for (const m of c.by_model) {
-      yield* Console.log(`${m.model.padEnd(30)} $${m.cost.toFixed(4).padEnd(11)} ${m.calls}`)
+    // Parse --by into a set of canonical dimension names. The string
+    // "agent,project" (the matrix) is matched as a whole token, not
+    // split into "agent" + "project". Keep parsing tolerant: drop
+    // empties, keep order of first appearance.
+    const want = new Set<string>()
+    let raw = by.trim()
+    if (raw.includes("agent,project")) {
+      want.add("agent_project")
+      raw = raw.replaceAll("agent,project", "")
+    }
+    for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+      if (part === "model" || part === "agent" || part === "project") want.add(part)
+    }
+    if (want.size === 0) {
+      want.add("model")
+      want.add("agent")
     }
 
-    yield* Console.log("\nCost by Agent")
-    yield* Console.log(`${"Agent".padEnd(30)} ${"Cost".padEnd(12)} Sessions`)
-    yield* Console.log("-".repeat(55))
-    for (const a of c.by_agent) {
-      yield* Console.log(`${a.agent.padEnd(30)} $${a.cost.toFixed(4).padEnd(11)} ${a.sessions}`)
+    if (want.has("model")) {
+      yield* Console.log("Cost by Model")
+      yield* Console.log(`${"Model".padEnd(30)} ${"Cost".padEnd(12)} Calls`)
+      yield* Console.log("-".repeat(55))
+      for (const m of c.by_model) {
+        yield* Console.log(`${m.model.padEnd(30)} $${m.cost.toFixed(4).padEnd(11)} ${m.calls}`)
+      }
+    }
+
+    if (want.has("agent")) {
+      yield* Console.log("\nCost by Agent")
+      yield* Console.log(`${"Agent".padEnd(30)} ${"Cost".padEnd(12)} Sessions`)
+      yield* Console.log("-".repeat(55))
+      for (const a of c.by_agent) {
+        yield* Console.log(`${a.agent.padEnd(30)} $${a.cost.toFixed(4).padEnd(11)} ${a.sessions}`)
+      }
+    }
+
+    if (want.has("project")) {
+      const rows = c.by_project ?? []
+      yield* Console.log("\nCost by Project")
+      yield* Console.log(`${"Project".padEnd(30)} ${"Cost".padEnd(12)} Sessions`)
+      yield* Console.log("-".repeat(55))
+      if (rows.length === 0) {
+        yield* Console.log("(no data — kernel may predate project_id, or no sessions are project-attributed)")
+      } else {
+        for (const p of rows) {
+          yield* Console.log(`${p.project.padEnd(30)} $${p.cost.toFixed(4).padEnd(11)} ${p.sessions}`)
+        }
+      }
+    }
+
+    if (want.has("agent_project")) {
+      const rows = c.by_agent_project ?? []
+      yield* Console.log("\nCost by Agent x Project")
+      yield* Console.log(
+        `${"Agent".padEnd(22)} ${"Project".padEnd(22)} ${"Cost".padEnd(12)} Sessions`
+      )
+      yield* Console.log("-".repeat(70))
+      if (rows.length === 0) {
+        yield* Console.log("(no data — kernel may predate project_id, or no sessions are project-attributed)")
+      } else {
+        for (const r of rows) {
+          yield* Console.log(
+            `${r.agent.padEnd(22)} ${r.project.padEnd(22)} $${r.cost.toFixed(4).padEnd(11)} ${r.sessions}`
+          )
+        }
+      }
     }
   })
 )

--- a/shell/gctrl-shell/test/analytics.test.ts
+++ b/shell/gctrl-shell/test/analytics.test.ts
@@ -19,6 +19,16 @@ const mockCost = {
     { agent: "Claude Code", cost: 10.5, sessions: 30 },
     { agent: "Codex", cost: 2.0, sessions: 12 },
   ],
+  by_project: [
+    { project: "alpha", cost: 7.0, sessions: 20 },
+    { project: "beta", cost: 3.5, sessions: 10 },
+    { project: "unassigned", cost: 2.0, sessions: 12 },
+  ],
+  by_agent_project: [
+    { agent: "Claude Code", project: "alpha", cost: 7.0, sessions: 20 },
+    { agent: "Claude Code", project: "beta", cost: 3.5, sessions: 10 },
+    { agent: "Codex", project: "unassigned", cost: 2.0, sessions: 12 },
+  ],
 }
 
 const mockLatency = {
@@ -103,6 +113,43 @@ describe("Analytics commands (via KernelClient)", () => {
     expect(result.by_model).toHaveLength(2)
     expect(result.by_model[0].model).toBe("claude-opus-4")
     expect(result.by_agent[0].agent).toBe("Claude Code")
+  })
+
+  it("cost surfaces by_project and by_agent_project slices", async () => {
+    const CostAnalytics = Schema.Struct({
+      by_model: Schema.Array(Schema.Struct({ model: Schema.String, cost: Schema.Number, calls: Schema.Number })),
+      by_agent: Schema.Array(Schema.Struct({ agent: Schema.String, cost: Schema.Number, sessions: Schema.Number })),
+      by_project: Schema.optional(
+        Schema.Array(Schema.Struct({ project: Schema.String, cost: Schema.Number, sessions: Schema.Number }))
+      ),
+      by_agent_project: Schema.optional(
+        Schema.Array(
+          Schema.Struct({
+            agent: Schema.String,
+            project: Schema.String,
+            cost: Schema.Number,
+            sessions: Schema.Number,
+          })
+        )
+      ),
+    })
+
+    const program = Effect.gen(function* () {
+      const kernel = yield* KernelClient
+      return yield* kernel.get("/api/analytics/cost", CostAnalytics)
+    })
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(MockLayer)))
+    expect(result.by_project).toBeDefined()
+    expect(result.by_project!.find((r) => r.project === "alpha")?.cost).toBe(7.0)
+    expect(result.by_project!.find((r) => r.project === "unassigned")?.sessions).toBe(12)
+
+    const matrix = result.by_agent_project!
+    expect(matrix).toHaveLength(3)
+    const claudeAlpha = matrix.find((r) => r.agent === "Claude Code" && r.project === "alpha")
+    expect(claudeAlpha?.cost).toBe(7.0)
+    const codexUnassigned = matrix.find((r) => r.agent === "Codex" && r.project === "unassigned")
+    expect(codexUnassigned?.sessions).toBe(12)
   })
 
   it("latency returns percentiles", async () => {


### PR DESCRIPTION
## Summary

Adds the **project axis** to the existing usage analytics so cost can be sliced by `project` and the `(agent × project)` matrix — answering "which agents are running which projects, and what does each pair cost?". The agent axis was already supported.

- `sessions` and `spans` get a nullable `project_id` column (idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS`).
- `update_session_aggregates` propagates `sessions.project_id` onto child spans whose own `project_id` is NULL — OTel-push and other ingest paths don't need new plumbing.
- New storage queries `get_cost_by_project` and `get_cost_by_agent_project` (NULL → `"unassigned"` so totals balance).
- `/api/analytics/cost` additively returns `by_project` and `by_agent_project` alongside existing `by_model` / `by_agent`. Old clients are unaffected.
- Shell `gctrl analytics cost --by model,agent,project,agent,project` selects which dimensions to render (default `model,agent`). Schema fields are `Schema.optional` so the shell stays compatible with kernels that predate this change.
- Kernel CLI `analytics_cost` prints both new sections.

### Why

`feat/analytics-attribution` (M3) added the `created_by` provenance axis but left project unattributed in the usage tables — sessions/spans had no FK to `board_projects` and `daily_aggregates.dimension` was hardcoded `'total'`. Project attribution is the missing dimension to answer "what did project X cost this week?" without doing a manual session-id scrape.

### Design notes

- **Soft / nullable** — pre-migration rows have no project, and not every session is project-attributable (ad-hoc daemon work). NULL surfaces as the bucket key `"unassigned"` so `by_project` totals always equal `by_agent` totals.
- **Denormalised onto spans** — cost-by-project queries don't need a join. Backfilled by the existing `update_session_aggregates` path; no new write hot path.
- **Additive route** — kept `/api/analytics/cost` shape backward-compatible. Older shell builds keep parsing the response.

## Test plan

- [x] `cargo test -p gctrl-storage` — 107 unit tests (4 new: project round-trip, span-project backfill via aggregates, cost-by-project with `unassigned` bucket, cost-by-(agent,project) matrix). All pass.
- [x] `cargo test -p gctrl-otel` — 89 lib + integration tests pass. New `tests/analytics_by_project.rs` (3 tests) covers the route shape + a matrix-rows-sum-to-agent-totals integrity check.
- [x] `pnpm test` in `shell/gctrl-shell/` — 141 tests pass (1 new: cost surfaces `by_project` + `by_agent_project` slices).
- [x] `cargo check` workspace clean.
- [x] `pnpm run build` (shell) clean.
- [ ] Manual: against a populated kernel, run `gctrl analytics cost --by project` and `--by agent,project` and eyeball the output.
- [ ] Manual: confirm a fresh kernel (no DB) and an old kernel (with prior `sessions`/`spans` data) both migrate idempotently.

## Notes for reviewers

- The `update_session_aggregates` SQL uses a correlated subquery to backfill `spans.project_id` from the parent session, gated by `WHERE project_id IS NULL` so already-attributed spans aren't clobbered. Idempotent.
- I deliberately did **not** make `project_id` a foreign key to `board_projects`. That would force every kernel to know about the board's table at write time, and would break OTel ingest from non-board producers. Treating `project_id` as an opaque string (with the board as one source of values) keeps the kernel agnostic.
- Daily aggregates (`daily_aggregates.dimension`) are not yet extended for project — that can come next once we have a real consumer for the time series.
