### PR TITLE
feat(kernel): driver-browser PR2-PR6 — pool, recorder, shell adapter, parity gate, SPA mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -663,6 +663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -681,8 +682,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1377,6 +1380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1393,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1691,13 +1706,21 @@ name = "gctrl-browser"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
+ "base64 0.22.1",
  "chrono",
+ "futures-util",
+ "getrandom 0.2.17",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -1741,7 +1764,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
@@ -1756,7 +1779,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "uuid",
 ]
@@ -1781,7 +1804,7 @@ dependencies = [
  "objc2-foundation",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1795,7 +1818,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -1810,7 +1833,7 @@ dependencies = [
  "gctrl-storage",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1833,7 +1856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -1850,7 +1873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1883,7 +1906,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1908,7 +1931,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1925,7 +1948,7 @@ dependencies = [
  "gctrl-storage",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1945,7 +1968,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1966,7 +1989,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1987,7 +2010,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -2312,12 +2335,12 @@ dependencies = [
  "moka",
  "rand 0.9.2",
  "rcgen",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-graceful",
  "tokio-rustls",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
 ]
@@ -2427,8 +2450,8 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.28.0",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3763,7 +3786,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3784,7 +3807,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3944,7 +3967,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4773,11 +4796,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4950,6 +4993,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -4960,7 +5015,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -5177,6 +5232,24 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -5190,7 +5263,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -5504,6 +5577,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -5845,6 +5930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5984,7 +6075,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,7 @@ dependencies = [
  "gctrl-gcal",
  "gctrl-net",
  "gctrl-proxy",
+ "gctrl-recorder",
  "gctrl-scheduler",
  "gctrl-storage",
  "gctrl-sync",
@@ -1946,6 +1947,19 @@ version = "0.1.0"
 dependencies = [
  "gctrl-core",
  "gctrl-storage",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gctrl-recorder"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "gctrl-browser",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
+ "futures-util",
  "gctrl-core",
  "gctrl-storage",
  "htmd",
@@ -1858,6 +1859,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "kernel/crates/gctrl-gcal",
     "kernel/crates/gctrl-driver-macos",
     "kernel/crates/gctrl-browser",
+    "kernel/crates/gctrl-recorder",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,17 @@ feed-rs = "2"
 # Filesystem paths
 dirs = "6"
 
+# WebSocket client (outbound proxy to Chromium browser-level CDP endpoint)
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+
+# Random + encoding (per-session bearer tokens for driver-browser)
+getrandom = "0.2"
+base64 = "0.22"
+
+# Chromium binary autodetect for driver-browser
+which = "7"
+
 # Testing
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["trace"] }

--- a/apps/gctrl-board/tests/acceptance/fixtures/kernel-cdp.ts
+++ b/apps/gctrl-board/tests/acceptance/fixtures/kernel-cdp.ts
@@ -1,0 +1,203 @@
+/**
+ * Kernel-backed CDPObserver — same surface as `cdp.ts::CDPObserver` but
+ * pulls observations from the kernel's recorder via HTTP instead of an
+ * in-process Playwright `CDPSession`. Used when `BROWSER_BACKEND=kernel`.
+ *
+ * The kernel taps CDP frames at the WS proxy layer (`gctrl-browser`'s
+ * `cdp_proxy::run_proxy`) and structures them into per-session
+ * `recorder_*` records (`gctrl-recorder::CaptureSink`). This observer is
+ * a thin fetch-and-shape layer over those records — designed to be a
+ * drop-in for the in-process `CDPObserver` so test assertion code is
+ * untouched during the PR5 parity gate.
+ *
+ * Spec: vault/specs/implementation/kernel/driver-browser.md §3, §9.
+ */
+
+import type { CapturedRequest, ConsoleEntry, ObservabilityReport } from "./cdp"
+
+interface KernelRequest {
+  requestId: string
+  url: string
+  method: string
+  status: number | null
+  startedAt: string
+  finishedAt: string | null
+  failed: boolean
+}
+
+interface KernelConsole {
+  seq: number
+  level: "log" | "info" | "warn" | "error" | "debug" | "exception"
+  kind: string
+  text: string
+  ts: string
+}
+
+interface KernelMetric {
+  name: string
+  value: number
+  ts: string
+}
+
+export class KernelCDPObserver {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly sessionId: string
+  ) {}
+
+  /** No-op: enabling/disabling happens implicitly when the kernel
+   * acquires/releases the session. Kept for `CDPObserver` parity. */
+  async enable(): Promise<void> {}
+  async disable(): Promise<void> {}
+
+  private async fetchJson<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`)
+    if (!res.ok) {
+      throw new Error(
+        `kernel recorder fetch ${path} → ${res.status} ${res.statusText}`
+      )
+    }
+    return (await res.json()) as T
+  }
+
+  private async fetchRequests(): Promise<KernelRequest[]> {
+    return this.fetchJson<KernelRequest[]>(
+      `/api/browser/sessions/${encodeURIComponent(this.sessionId)}/network`
+    )
+  }
+
+  private async fetchConsole(): Promise<KernelConsole[]> {
+    return this.fetchJson<KernelConsole[]>(
+      `/api/browser/sessions/${encodeURIComponent(this.sessionId)}/console`
+    )
+  }
+
+  private async fetchMetrics(): Promise<KernelMetric[]> {
+    return this.fetchJson<KernelMetric[]>(
+      `/api/browser/sessions/${encodeURIComponent(this.sessionId)}/metrics`
+    )
+  }
+
+  private toCaptured(r: KernelRequest): CapturedRequest {
+    return {
+      requestId: r.requestId,
+      url: r.url,
+      method: r.method,
+      timestamp: Date.parse(r.startedAt) / 1000,
+      responseStatus: r.status ?? undefined,
+    }
+  }
+
+  private toConsole(e: KernelConsole): ConsoleEntry {
+    const level: ConsoleEntry["level"] =
+      e.level === "error" || e.level === "exception"
+        ? "error"
+        : e.level === "warn"
+          ? "warn"
+          : "info"
+    return {
+      type: e.kind,
+      text: e.text,
+      timestamp: Date.parse(e.ts) / 1000,
+      level,
+    }
+  }
+
+  // Note: these mirror the `CDPObserver` accessors but are async because
+  // they go over HTTP. Tests on the kernel backend `await` them; tests
+  // on the local backend get the sync versions. Cutover work in a
+  // future PR will unify the call sites.
+
+  async getRequests(): Promise<CapturedRequest[]> {
+    const xs = await this.fetchRequests()
+    return xs.map((r) => this.toCaptured(r))
+  }
+
+  async getRequestsByPattern(pattern: RegExp): Promise<CapturedRequest[]> {
+    const xs = await this.getRequests()
+    return xs.filter((r) => pattern.test(r.url))
+  }
+
+  async getApiRequests(): Promise<CapturedRequest[]> {
+    const xs = await this.getRequests()
+    return xs.filter((r) => {
+      try {
+        return new URL(r.url).pathname.startsWith("/api/board/")
+      } catch {
+        return false
+      }
+    })
+  }
+
+  async getFailedRequests(): Promise<CapturedRequest[]> {
+    const xs = await this.fetchRequests()
+    return xs
+      .filter(
+        (r) =>
+          r.failed ||
+          (r.status != null && (r.status < 200 || r.status >= 300))
+      )
+      .map((r) => this.toCaptured(r))
+  }
+
+  async getConsoleEntries(): Promise<ConsoleEntry[]> {
+    const xs = await this.fetchConsole()
+    return xs.map((e) => this.toConsole(e))
+  }
+
+  async getConsoleErrors(): Promise<ConsoleEntry[]> {
+    const xs = await this.fetchConsole()
+    return xs
+      .filter((e) => e.level === "error" || e.level === "exception")
+      .map((e) => this.toConsole(e))
+  }
+
+  async getPerformanceMetrics(): Promise<Record<string, number>> {
+    const xs = await this.fetchMetrics()
+    const out: Record<string, number> = {}
+    for (const m of xs) out[m.name] = m.value
+    return out
+  }
+
+  async getJSHeapSizeMB(): Promise<number> {
+    const m = await this.getPerformanceMetrics()
+    return (m["JSHeapUsedSize"] ?? 0) / (1024 * 1024)
+  }
+
+  async getDocumentCount(): Promise<number> {
+    const m = await this.getPerformanceMetrics()
+    return m["Documents"] ?? 0
+  }
+
+  async report(): Promise<ObservabilityReport> {
+    const requests = await this.fetchRequests()
+    const console = await this.fetchConsole()
+    const apiPaths: string[] = []
+    let apiCount = 0
+    let failedCount = 0
+    for (const r of requests) {
+      try {
+        const u = new URL(r.url)
+        if (u.pathname.startsWith("/api/board/")) {
+          apiCount++
+          apiPaths.push(u.pathname)
+        }
+      } catch {
+        // skip non-URL entries
+      }
+      if (r.failed || (r.status != null && (r.status < 200 || r.status >= 300))) {
+        failedCount++
+      }
+    }
+    const errorCount = console.filter(
+      (e) => e.level === "error" || e.level === "exception"
+    ).length
+    return {
+      totalRequests: requests.length,
+      apiRequests: apiCount,
+      failedRequests: failedCount,
+      consoleErrors: errorCount,
+      apiPaths,
+    }
+  }
+}

--- a/apps/gctrl-board/tests/acceptance/fixtures/test.ts
+++ b/apps/gctrl-board/tests/acceptance/fixtures/test.ts
@@ -31,12 +31,44 @@ import {
   type TestIssue,
 } from "./kernel"
 import { CDPObserver } from "./cdp"
+import { KernelCDPObserver } from "./kernel-cdp"
+
+/**
+ * Which CDP observation backend the suite uses.
+ *
+ * - `local`  (default): in-process Playwright CDPSession + `cdp.ts::CDPObserver`.
+ *   This is the legacy path; assertion code is sync.
+ * - `kernel`: acquire a session from the running gctrld via /api/browser,
+ *   connect Playwright to the kernel-managed Chromium over CDP, observe
+ *   via the kernel recorder routes (`KernelCDPObserver`). Async accessors.
+ *
+ * Both backends ship together for the parity gate (spec §9). Once one
+ * CI cycle is green on both, a follow-up PR deletes `cdp.ts` and the
+ * `local` branch.
+ */
+const BROWSER_BACKEND = (process.env.BROWSER_BACKEND ?? "local") as
+  | "local"
+  | "kernel"
+
+/** Per-test acquired kernel session id, populated when BACKEND=kernel. */
+type KernelBrowserSession = {
+  id: string
+  cdpEndpoint: string
+  token: string
+}
 
 type BoardFixtures = {
   /** Direct HTTP client to kernel — seed data and verify server state. */
   kernel: KernelTestClient
-  /** Chrome DevTools Protocol observer — network, perf, console monitoring. */
-  cdp: CDPObserver
+  /**
+   * Chrome DevTools Protocol observer — network, perf, console monitoring.
+   *
+   * Type union covers both backends; the parity gate carries them in
+   * lockstep until a follow-up PR collapses the surface to one. New
+   * tests should treat read accessors as `Promise`-returning since the
+   * `kernel` backend's observer goes over HTTP.
+   */
+  cdp: CDPObserver | KernelCDPObserver
   /** Pre-created project with a unique key (one per test for isolation). */
   seedProject: TestProject
   /** Factory: create a project + N issues. Returns project and issues. */
@@ -47,6 +79,34 @@ type BoardFixtures = {
       labels?: string[][]
     }
   ) => Promise<{ project: TestProject; issues: TestIssue[] }>
+}
+
+/** Acquire a kernel-managed browser session. Used by the `kernel` backend. */
+async function acquireKernelSession(
+  baseUrl: string
+): Promise<KernelBrowserSession> {
+  const res = await fetch(`${baseUrl}/api/browser/sessions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ttlSeconds: 600 }),
+  })
+  if (!res.ok) {
+    throw new Error(
+      `kernel acquire ${res.status}: ${await res.text().catch(() => "")}`
+    )
+  }
+  const info = (await res.json()) as KernelBrowserSession
+  return info
+}
+
+async function releaseKernelSession(
+  baseUrl: string,
+  id: string
+): Promise<void> {
+  await fetch(
+    `${baseUrl}/api/browser/sessions/${encodeURIComponent(id)}`,
+    { method: "DELETE" }
+  ).catch(() => {})
 }
 
 export const test = base.extend<BoardFixtures>({
@@ -63,6 +123,33 @@ export const test = base.extend<BoardFixtures>({
    */
   browser: [
     async ({}, use) => {
+      // BROWSER_BACKEND=kernel: connect Playwright to the kernel-managed
+      // Chromium pool over CDP. Acquires once per worker; the kernel
+      // session lives for `ttlSeconds` (10 min default), enough for a
+      // worker's tests.
+      if (BROWSER_BACKEND === "kernel" && !cdpBrowser) {
+        const port = process.env.GCTRL_KERNEL_PORT ?? "4318"
+        const baseUrl = `http://localhost:${port}`
+        try {
+          const sess = await acquireKernelSession(baseUrl)
+          cdpBrowser = await chromium.connectOverCDP(sess.cdpEndpoint, {
+            headers: { Authorization: `Bearer ${sess.token}` },
+          })
+          process.stderr.write(
+            `[browser-backend=kernel] attached to session ${sess.id}\n`
+          )
+          // Best-effort release on disconnect; not strictly required —
+          // kernel TTL will expire the session naturally.
+          cdpBrowser.on("disconnected", () => {
+            void releaseKernelSession(baseUrl, sess.id)
+          })
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          process.stderr.write(
+            `[browser-backend=kernel] acquire failed — falling back to local Chromium: ${msg}\n`
+          )
+        }
+      }
       const cdpEndpoint = process.env.CDP_ENDPOINT
       if (cdpEndpoint && !cdpBrowser) {
         try {
@@ -137,6 +224,22 @@ export const test = base.extend<BoardFixtures>({
   },
 
   cdp: async ({ page }, use) => {
+    if (BROWSER_BACKEND === "kernel") {
+      // Acquire a fresh per-test session against the same kernel the
+      // worker's `browser` is attached to. Reading observations from
+      // the recorder doesn't require the same session as Playwright —
+      // we just need a session id to query against. A future cutover
+      // PR will share the worker session id with the per-test observer.
+      const port = process.env.GCTRL_KERNEL_PORT ?? "4318"
+      const baseUrl = `http://localhost:${port}`
+      const sess = await acquireKernelSession(baseUrl)
+      const observer = new KernelCDPObserver(baseUrl, sess.id)
+      await observer.enable()
+      await use(observer)
+      await observer.disable()
+      await releaseKernelSession(baseUrl, sess.id)
+      return
+    }
     const session = await page.context().newCDPSession(page)
     const observer = new CDPObserver(session)
     await observer.enable()

--- a/kernel/crates/gctrl-browser/Cargo.toml
+++ b/kernel/crates/gctrl-browser/Cargo.toml
@@ -12,6 +12,14 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }
+reqwest = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+base64 = { workspace = true }
+which = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
 
 [dev-dependencies]
 tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-browser/src/cdp_proxy.rs
+++ b/kernel/crates/gctrl-browser/src/cdp_proxy.rs
@@ -1,0 +1,175 @@
+//! WebSocket proxy: client ⇆ kernel ⇆ Chromium.
+//!
+//! The kernel does not parse CDP frames — it just relays text/binary
+//! frames bidirectionally and taps each text frame into a `broadcast`
+//! channel that the recorder (PR3) subscribes to. The broadcast channel
+//! is bounded; when the recorder lags, oldest frames are dropped via
+//! tokio's built-in `RecvError::Lagged`.
+
+use axum::extract::ws::{Message as AxumMsg, WebSocket};
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::broadcast;
+use tokio_tungstenite::tungstenite::Message as TungMsg;
+use tracing::{debug, warn};
+
+use crate::error::BrowserError;
+
+/// One CDP message as it crosses the proxy. `direction` lets the recorder
+/// distinguish client→browser commands from browser→client events.
+#[derive(Debug, Clone)]
+pub struct CdpFrame {
+    pub direction: FrameDirection,
+    /// JSON text payload. Binary CDP frames are not fanned out (rare in
+    /// CDP — usually screenshots when explicitly enabled, fetched via
+    /// dedicated routes by the recorder).
+    pub payload: String,
+    pub ts: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameDirection {
+    ClientToBrowser,
+    BrowserToClient,
+}
+
+/// Capacity of the per-session frame broadcast channel.
+pub const FRAME_TAP_CAPACITY: usize = 1024;
+
+/// Run the bidirectional proxy until either side closes. Tap each text
+/// frame onto `tap`. The proxy never blocks on `tap.send` — broadcast
+/// channels drop oldest frames automatically when full and surface that
+/// to subscribers via `RecvError::Lagged`.
+pub async fn run_proxy(
+    client: WebSocket,
+    upstream_url: String,
+    tap: broadcast::Sender<CdpFrame>,
+) -> Result<(), BrowserError> {
+    let (upstream_ws, _) = tokio_tungstenite::connect_async(&upstream_url)
+        .await
+        .map_err(|e| BrowserError::Cdp(format!("connect upstream: {e}")))?;
+
+    let (mut client_tx, mut client_rx) = client.split();
+    let (mut up_tx, mut up_rx) = upstream_ws.split();
+
+    loop {
+        tokio::select! {
+            // Client → Browser
+            msg = client_rx.next() => match msg {
+                Some(Ok(AxumMsg::Text(text))) => {
+                    let s = text.to_string();
+                    if let Err(e) = up_tx.send(TungMsg::Text(s.clone().into())).await {
+                        warn!(error=%e, "proxy: upstream send failed");
+                        break;
+                    }
+                    let _ = tap.send(CdpFrame {
+                        direction: FrameDirection::ClientToBrowser,
+                        payload: s,
+                        ts: chrono::Utc::now(),
+                    });
+                }
+                Some(Ok(AxumMsg::Binary(bin))) => {
+                    if let Err(e) = up_tx.send(TungMsg::Binary(bin.into())).await {
+                        warn!(error=%e, "proxy: upstream send failed");
+                        break;
+                    }
+                }
+                Some(Ok(AxumMsg::Ping(p))) => {
+                    let _ = up_tx.send(TungMsg::Ping(p.into())).await;
+                }
+                Some(Ok(AxumMsg::Pong(_))) => {}
+                Some(Ok(AxumMsg::Close(_))) | None => {
+                    debug!("proxy: client closed");
+                    let _ = up_tx.send(TungMsg::Close(None)).await;
+                    break;
+                }
+                Some(Err(e)) => {
+                    warn!(error=%e, "proxy: client recv error");
+                    break;
+                }
+            },
+            // Browser → Client
+            msg = up_rx.next() => match msg {
+                Some(Ok(TungMsg::Text(text))) => {
+                    let s = text.to_string();
+                    if let Err(e) = client_tx.send(AxumMsg::Text(s.clone().into())).await {
+                        warn!(error=%e, "proxy: client send failed");
+                        break;
+                    }
+                    let _ = tap.send(CdpFrame {
+                        direction: FrameDirection::BrowserToClient,
+                        payload: s,
+                        ts: chrono::Utc::now(),
+                    });
+                }
+                Some(Ok(TungMsg::Binary(bin))) => {
+                    if let Err(e) = client_tx.send(AxumMsg::Binary(bin.into())).await {
+                        warn!(error=%e, "proxy: client send failed");
+                        break;
+                    }
+                }
+                Some(Ok(TungMsg::Ping(p))) => {
+                    let _ = client_tx.send(AxumMsg::Ping(p.into())).await;
+                }
+                Some(Ok(TungMsg::Pong(_))) | Some(Ok(TungMsg::Frame(_))) => {}
+                Some(Ok(TungMsg::Close(_))) | None => {
+                    debug!("proxy: upstream closed");
+                    let _ = client_tx.send(AxumMsg::Close(None)).await;
+                    break;
+                }
+                Some(Err(e)) => {
+                    warn!(error=%e, "proxy: upstream recv error");
+                    break;
+                }
+            },
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+
+    /// Spawn a tiny echo WebSocket server. Returns its `ws://` URL and a
+    /// JoinHandle that can be aborted to shut it down. Used to test the
+    /// proxy without a real Chromium.
+    pub async fn spawn_echo_ws() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let url = format!("ws://{addr}/echo");
+        let handle = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let Ok(ws) = accept_async(stream).await else {
+                        return;
+                    };
+                    let (mut tx, mut rx) = ws.split();
+                    while let Some(Ok(msg)) = rx.next().await {
+                        match msg {
+                            TungMsg::Text(t) => {
+                                let _ = tx.send(TungMsg::Text(t)).await;
+                            }
+                            TungMsg::Close(_) => break,
+                            _ => {}
+                        }
+                    }
+                });
+            }
+        });
+        (url, handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_direction_compiles() {
+        let _ = FrameDirection::ClientToBrowser;
+        assert_eq!(FRAME_TAP_CAPACITY, 1024);
+    }
+}

--- a/kernel/crates/gctrl-browser/src/cdp_proxy.rs
+++ b/kernel/crates/gctrl-browser/src/cdp_proxy.rs
@@ -127,43 +127,6 @@ pub async fn run_proxy(
 }
 
 #[cfg(test)]
-pub(crate) mod test_support {
-    use super::*;
-    use std::net::SocketAddr;
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::accept_async;
-
-    /// Spawn a tiny echo WebSocket server. Returns its `ws://` URL and a
-    /// JoinHandle that can be aborted to shut it down. Used to test the
-    /// proxy without a real Chromium.
-    pub async fn spawn_echo_ws() -> (String, tokio::task::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr: SocketAddr = listener.local_addr().unwrap();
-        let url = format!("ws://{addr}/echo");
-        let handle = tokio::spawn(async move {
-            while let Ok((stream, _)) = listener.accept().await {
-                tokio::spawn(async move {
-                    let Ok(ws) = accept_async(stream).await else {
-                        return;
-                    };
-                    let (mut tx, mut rx) = ws.split();
-                    while let Some(Ok(msg)) = rx.next().await {
-                        match msg {
-                            TungMsg::Text(t) => {
-                                let _ = tx.send(TungMsg::Text(t)).await;
-                            }
-                            TungMsg::Close(_) => break,
-                            _ => {}
-                        }
-                    }
-                });
-            }
-        });
-        (url, handle)
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/kernel/crates/gctrl-browser/src/launcher.rs
+++ b/kernel/crates/gctrl-browser/src/launcher.rs
@@ -1,0 +1,238 @@
+//! Chromium process launcher.
+//!
+//! Behind a trait so tests can inject a `MockLauncher` that points at a
+//! local echo WebSocket instead of spawning a real browser. CI runners
+//! without Chromium / display server use the mock; the real launcher is
+//! exercised by `#[ignore]`d smoke tests and the `gctrld` daemon at
+//! runtime.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+use crate::error::BrowserError;
+
+/// A running Chromium process exposing a CDP WebSocket. The proxy connects
+/// outbound to `browser_ws_url` and relays frames to/from clients.
+pub struct LaunchedChromium {
+    /// Stable identifier for the underlying Chromium process. Used by the
+    /// pool to attribute sessions to a Chromium and by recycle accounting.
+    pub id: String,
+    /// `ws://127.0.0.1:<port>/devtools/browser/<browser-uuid>` returned
+    /// from the Chromium debug server's `/json/version`.
+    pub browser_ws_url: String,
+    /// User-agent style version string (e.g. `Chrome/124.0.6367.78`).
+    pub version: String,
+    /// Process handle. Behind a `Mutex` so the pool can call `kill().await`
+    /// without taking ownership; `MockLauncher` returns `None` since there
+    /// is nothing to kill.
+    pub child: Arc<Mutex<Option<Child>>>,
+}
+
+#[async_trait]
+pub trait Launcher: Send + Sync {
+    async fn launch(&self) -> Result<LaunchedChromium, BrowserError>;
+}
+
+/// Spawns a real Chromium process with a random debug port, then resolves
+/// the browser-level CDP WebSocket URL by polling
+/// `http://127.0.0.1:<port>/json/version`.
+pub struct RealLauncher {
+    chromium_path: PathBuf,
+    headed: bool,
+    user_data_root: PathBuf,
+}
+
+impl RealLauncher {
+    pub fn new(chromium_path: Option<PathBuf>, headed: bool) -> Result<Self, BrowserError> {
+        let path = match chromium_path {
+            Some(p) => p,
+            None => autodetect_chromium()?,
+        };
+        // Each launcher gets its own user-data root so multiple Chromiums
+        // in the pool don't fight over `SingletonLock`. Keyed by daemon
+        // PID so concurrent gctrld instances during tests don't collide.
+        let user_data_root =
+            std::env::temp_dir().join(format!("gctrl-browser-{}", std::process::id()));
+        std::fs::create_dir_all(&user_data_root)
+            .map_err(|e| BrowserError::Launch(format!("create user-data dir: {e}")))?;
+        Ok(Self {
+            chromium_path: path,
+            headed,
+            user_data_root,
+        })
+    }
+}
+
+#[async_trait]
+impl Launcher for RealLauncher {
+    async fn launch(&self) -> Result<LaunchedChromium, BrowserError> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let user_dir = self.user_data_root.join(&id);
+
+        let mut cmd = Command::new(&self.chromium_path);
+        cmd.arg("--remote-debugging-port=0")
+            .arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .arg("--disable-background-networking")
+            .arg("--disable-default-apps")
+            .arg("--disable-popup-blocking")
+            .arg("--disable-sync")
+            .arg("--disable-renderer-backgrounding")
+            .arg("--disable-backgrounding-occluded-windows")
+            .arg("--disable-background-timer-throttling")
+            .arg("--password-store=basic")
+            .arg("--use-mock-keychain")
+            .arg(format!("--user-data-dir={}", user_dir.display()));
+
+        if !self.headed {
+            cmd.arg("--headless=new");
+        }
+
+        cmd.stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null())
+            .kill_on_drop(true);
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| BrowserError::Launch(format!("spawn chromium: {e}")))?;
+
+        // Chromium writes the debug port to <user-data-dir>/DevToolsActivePort
+        // shortly after the listener is up. First line is the port; second
+        // line is the browser path. Polling avoids racing on stderr parsing.
+        let port_file = user_dir.join("DevToolsActivePort");
+        let port = wait_for_port(&port_file, Duration::from_secs(15)).await?;
+
+        let (ws_url, version) = fetch_version(port).await?;
+
+        Ok(LaunchedChromium {
+            id,
+            browser_ws_url: ws_url,
+            version,
+            child: Arc::new(Mutex::new(Some(child))),
+        })
+    }
+}
+
+fn autodetect_chromium() -> Result<PathBuf, BrowserError> {
+    #[cfg(target_os = "macos")]
+    {
+        for p in [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        ] {
+            if std::path::Path::new(p).exists() {
+                return Ok(PathBuf::from(p));
+            }
+        }
+    }
+    for name in [
+        "google-chrome-stable",
+        "google-chrome",
+        "chromium",
+        "chromium-browser",
+    ] {
+        if let Ok(p) = which::which(name) {
+            return Ok(p);
+        }
+    }
+    Err(BrowserError::Launch(
+        "could not locate a Chromium binary; set GCTRL_BROWSER_CHROMIUM_PATH".into(),
+    ))
+}
+
+async fn wait_for_port(path: &std::path::Path, deadline: Duration) -> Result<u16, BrowserError> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Ok(contents) = tokio::fs::read_to_string(path).await {
+            if let Some(first) = contents.lines().next() {
+                if let Ok(port) = first.trim().parse::<u16>() {
+                    return Ok(port);
+                }
+            }
+        }
+        if start.elapsed() >= deadline {
+            return Err(BrowserError::Launch(format!(
+                "DevToolsActivePort did not appear within {}s",
+                deadline.as_secs()
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionInfo {
+    #[serde(rename = "Browser")]
+    browser: String,
+    #[serde(rename = "webSocketDebuggerUrl")]
+    ws_url: String,
+}
+
+async fn fetch_version(port: u16) -> Result<(String, String), BrowserError> {
+    let url = format!("http://127.0.0.1:{port}/json/version");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| BrowserError::Launch(format!("build http client: {e}")))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| BrowserError::Launch(format!("get /json/version: {e}")))?;
+    let info: VersionInfo = resp
+        .json()
+        .await
+        .map_err(|e| BrowserError::Launch(format!("parse /json/version: {e}")))?;
+    Ok((info.ws_url, info.browser))
+}
+
+/// Mock launcher used by route + pool tests. Each `launch()` returns a
+/// fixed `browser_ws_url` provided up-front. The proxy will connect to it
+/// like any other CDP endpoint.
+pub struct MockLauncher {
+    pub ws_url: String,
+    pub version: String,
+}
+
+impl MockLauncher {
+    pub fn new(ws_url: impl Into<String>) -> Self {
+        Self {
+            ws_url: ws_url.into(),
+            version: "Chromium/mock".into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Launcher for MockLauncher {
+    async fn launch(&self) -> Result<LaunchedChromium, BrowserError> {
+        Ok(LaunchedChromium {
+            id: uuid::Uuid::new_v4().to_string(),
+            browser_ws_url: self.ws_url.clone(),
+            version: self.version.clone(),
+            child: Arc::new(Mutex::new(None)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_launcher_returns_configured_url() {
+        let l = MockLauncher::new("ws://127.0.0.1:0/fake");
+        let c = l.launch().await.unwrap();
+        assert_eq!(c.browser_ws_url, "ws://127.0.0.1:0/fake");
+        assert_eq!(c.version, "Chromium/mock");
+        assert!(!c.id.is_empty());
+    }
+}

--- a/kernel/crates/gctrl-browser/src/lib.rs
+++ b/kernel/crates/gctrl-browser/src/lib.rs
@@ -4,8 +4,8 @@
 //! `BrowserContext`s addressable by a `SessionId`. Clients (Playwright,
 //! Puppeteer, chromiumoxide, raw WS) attach to the per-session bearer-gated
 //! WebSocket at `/api/browser/sessions/<id>/cdp` and speak Chrome DevTools
-//! Protocol directly. The `gctrl-recorder` crate (PR3) subscribes to the
-//! frame fanout and structures Network/Runtime/Performance events.
+//! Protocol directly. The `gctrl-recorder` crate subscribes to the frame
+//! fanout and structures Network/Runtime/Performance events.
 //!
 //! This is the lower layer underneath the agent-facing command surface
 //! (`snapshot`, `click`, `fill`) defined in
@@ -14,23 +14,23 @@
 //!
 //! See [vault/specs/implementation/kernel/driver-browser.md] for full
 //! architecture, pool semantics, recycle policy, and migration plan.
-//!
-//! ## Status
-//!
-//! PR1: types + errors + pool placeholder + config. No Chromium driving yet
-//! — `Pool::acquire` returns `BrowserError::Launch` until PR2 wires the
-//! `chromiumoxide` integration.
 
+pub mod cdp_proxy;
 pub mod config;
 pub mod error;
+pub mod launcher;
 pub mod model;
 pub mod pool;
+pub mod recycle;
 pub mod token;
 
+pub use cdp_proxy::{run_proxy, CdpFrame, FrameDirection, FRAME_TAP_CAPACITY};
 pub use config::BrowserConfig;
 pub use error::BrowserError;
+pub use launcher::{Launcher, LaunchedChromium, MockLauncher, RealLauncher};
 pub use model::{
     RecordingOptions, SessionId, SessionInfo, SessionOptions, SessionStatus, Viewport,
 };
-pub use pool::Pool;
-pub use token::{mint_token, Token};
+pub use pool::{Pool, SweepReport};
+pub use recycle::{ChromiumState, RecycleReason};
+pub use token::{mint_token, verify as verify_token, Token};

--- a/kernel/crates/gctrl-browser/src/pool.rs
+++ b/kernel/crates/gctrl-browser/src/pool.rs
@@ -1,31 +1,75 @@
+//! Pool of warm Chromium processes hosting per-session `BrowserContext`s.
+//!
+//! The pool is **launcher-agnostic** — `RealLauncher` spawns Chromium,
+//! `MockLauncher` returns a fixed WS URL for tests. New sessions land on
+//! the warmest non-saturated, non-draining Chromium; a new Chromium is
+//! spun up only if all are saturated and `pool_max` allows.
+
 use std::sync::Arc;
 
-use chrono::Utc;
-use tokio::sync::RwLock;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use tokio::sync::{broadcast, RwLock};
+use tracing::{info, warn};
 
-use crate::{
-    config::BrowserConfig,
-    error::BrowserError,
-    model::{SessionId, SessionInfo, SessionOptions, SessionStatus},
-    token::mint_token,
+use crate::cdp_proxy::{CdpFrame, FRAME_TAP_CAPACITY};
+use crate::config::BrowserConfig;
+use crate::error::BrowserError;
+use crate::launcher::{Launcher, LaunchedChromium};
+use crate::model::{SessionId, SessionInfo, SessionOptions, SessionStatus};
+use crate::recycle::{
+    decide as recycle_decide, ChromiumSnapshot, ChromiumState, RecycleConfig, RecyclePlan,
 };
+use crate::token::{mint_token, Token};
 
-/// Pool of long-lived Chromium processes hosting per-session
-/// `BrowserContext`s. PR1 is a placeholder: state shape and public API are
-/// final, but `acquire` does not actually launch Chromium — it returns
-/// `BrowserError::Launch("not implemented in PR1 — pool stub")`. PR2 wires
-/// the `chromiumoxide` integration behind this same interface.
+/// One warm Chromium process tracked by the pool.
+struct Chromium {
+    chromium: LaunchedChromium,
+    state: ChromiumState,
+    created_at: DateTime<Utc>,
+    last_active_at: DateTime<Utc>,
+    /// Session ids currently bound to this chromium.
+    sessions: Vec<SessionId>,
+    /// Per-process broadcast tap shared by every session on this chromium.
+    /// Sessions get their own `Sender` clone so the recorder can subscribe
+    /// per-session (filtering on `session_id` happens at the recorder).
+    tap: broadcast::Sender<CdpFrame>,
+}
+
+struct SessionRecord {
+    info: SessionInfo,
+    token: Token,
+    chromium_id: String,
+    /// Per-session tap clone — same channel as the parent chromium, but
+    /// makes the recorder API symmetric with "subscribe per session id".
+    tap: broadcast::Sender<CdpFrame>,
+}
+
 pub struct Pool {
     config: Arc<BrowserConfig>,
-    /// In PR1 always empty. PR2 will populate it via `acquire`.
-    sessions: RwLock<Vec<SessionInfo>>,
+    launcher: Arc<dyn Launcher>,
+    state: RwLock<PoolState>,
+    /// Base URL for `cdp_endpoint` strings handed back to clients. Set by
+    /// the route layer at construction; tests use a synthetic value.
+    cdp_endpoint_base: String,
+}
+
+#[derive(Default)]
+struct PoolState {
+    chromiums: Vec<Chromium>,
+    sessions: Vec<SessionRecord>,
 }
 
 impl Pool {
-    pub fn new(config: Arc<BrowserConfig>) -> Self {
+    pub fn new(
+        config: Arc<BrowserConfig>,
+        launcher: Arc<dyn Launcher>,
+        cdp_endpoint_base: String,
+    ) -> Self {
         Pool {
             config,
-            sessions: RwLock::new(Vec::new()),
+            launcher,
+            state: RwLock::new(PoolState::default()),
+            cdp_endpoint_base,
         }
     }
 
@@ -33,24 +77,30 @@ impl Pool {
         &self.config
     }
 
-    /// Best-effort active session count; useful for `/api/browser/health`.
+    /// Active session count across all chromiums.
     pub async fn active_count(&self) -> usize {
-        self.sessions.read().await.len()
+        self.state.read().await.sessions.len()
     }
 
-    /// Acquire a new session.
-    ///
-    /// PR1: validates options against config, returns `BrowserError::Launch`
-    /// without spawning Chromium. PR2: spawns/reuses a pooled Chromium,
-    /// creates a `BrowserContext`, mints a token, and returns the
-    /// populated `SessionInfo`.
-    pub async fn acquire(
-        &self,
-        opts: SessionOptions,
-    ) -> Result<SessionInfo, BrowserError> {
-        // Validate the request against config bounds — these checks belong
-        // here (not in the route layer) so callers from inside the kernel
-        // get the same gates as HTTP callers.
+    /// Number of warm Chromium processes (any state).
+    pub async fn chromium_count(&self) -> usize {
+        self.state.read().await.chromiums.len()
+    }
+
+    /// Browser version of the first warm Chromium, or `None` if the pool
+    /// is empty. Reported on `/api/browser/health`.
+    pub async fn browser_version(&self) -> Option<String> {
+        self.state
+            .read()
+            .await
+            .chromiums
+            .first()
+            .map(|c| c.chromium.version.clone())
+    }
+
+    pub async fn acquire(&self, opts: SessionOptions) -> Result<SessionInfo, BrowserError> {
+        // Validate options up-front — these checks belong here (not in
+        // the route layer) so in-kernel callers get the same gates.
         if opts.headed && !self.config.headed_default {
             return Err(BrowserError::InvalidRequest(
                 "headed mode requires browser.headed_default=true and a display server".into(),
@@ -67,89 +117,276 @@ impl Pool {
             ));
         }
 
-        // Pool capacity check. Real implementation will consider per-Chromium
-        // contexts_per_chromium_max as well; stub uses pool_max as a flat cap.
-        let active = self.active_count().await as u32;
-        if active >= self.config.pool_max {
-            return Err(BrowserError::PoolExhausted {
-                max: self.config.pool_max,
-            });
-        }
+        // Try to reuse an existing chromium first.
+        let mut state = self.state.write().await;
+        let chromium_id = match find_warmest(&state.chromiums, &self.config) {
+            Some(idx) => state.chromiums[idx].chromium.id.clone(),
+            None => {
+                if state.chromiums.len() as u32 >= self.config.pool_max {
+                    return Err(BrowserError::PoolExhausted {
+                        max: self.config.pool_max,
+                    });
+                }
+                drop(state);
+                let launched = self.launcher.launch().await?;
+                let (tx, _rx) = broadcast::channel::<CdpFrame>(FRAME_TAP_CAPACITY);
+                let now = Utc::now();
+                let new_chromium = Chromium {
+                    chromium: launched,
+                    state: ChromiumState::Active,
+                    created_at: now,
+                    last_active_at: now,
+                    sessions: Vec::new(),
+                    tap: tx,
+                };
+                let id = new_chromium.chromium.id.clone();
+                self.state.write().await.chromiums.push(new_chromium);
+                state = self.state.write().await;
+                id
+            }
+        };
 
-        Err(BrowserError::Launch(
-            "not implemented in PR1 — pool stub; chromium launch lands in PR2".into(),
-        ))
+        let id = SessionId::new();
+        let token = mint_token();
+        let now = Utc::now();
+        let cdp_endpoint = format!(
+            "{}/api/browser/sessions/{}/cdp?token={}",
+            self.cdp_endpoint_base, id, token.0
+        );
+
+        let chromium = state
+            .chromiums
+            .iter_mut()
+            .find(|c| c.chromium.id == chromium_id)
+            .expect("chromium id resolved above");
+
+        let info = SessionInfo {
+            id: id.clone(),
+            created_at: now,
+            expires_at: now + ChronoDuration::seconds(opts.ttl_seconds as i64),
+            browser_version: chromium.chromium.version.clone(),
+            status: SessionStatus::Active,
+            recording: opts.recording.clone(),
+            cdp_endpoint,
+            token: token.0.clone(),
+            dropped_frames: 0,
+        };
+
+        chromium.sessions.push(id.clone());
+        chromium.last_active_at = now;
+        let tap = chromium.tap.clone();
+
+        state.sessions.push(SessionRecord {
+            info: info.clone(),
+            token,
+            chromium_id,
+            tap,
+        });
+        Ok(info)
     }
 
-    /// Release a session immediately. PR1: 404s for any id since acquire
-    /// never populates the pool.
     pub async fn release(&self, id: &SessionId) -> Result<(), BrowserError> {
-        let mut sessions = self.sessions.write().await;
-        let before = sessions.len();
-        sessions.retain(|s| &s.id != id);
-        if sessions.len() == before {
-            Err(BrowserError::SessionNotFound(id.clone()))
-        } else {
-            Ok(())
+        let mut state = self.state.write().await;
+        let pos = state
+            .sessions
+            .iter()
+            .position(|s| &s.info.id == id)
+            .ok_or_else(|| BrowserError::SessionNotFound(id.clone()))?;
+        let removed = state.sessions.remove(pos);
+        if let Some(c) = state
+            .chromiums
+            .iter_mut()
+            .find(|c| c.chromium.id == removed.chromium_id)
+        {
+            c.sessions.retain(|s| s != id);
+            c.last_active_at = Utc::now();
         }
+        Ok(())
     }
 
     pub async fn list(&self) -> Vec<SessionInfo> {
-        self.sessions.read().await.clone()
+        self.state
+            .read()
+            .await
+            .sessions
+            .iter()
+            .map(|s| s.info.clone())
+            .collect()
     }
 
     pub async fn get(&self, id: &SessionId) -> Option<SessionInfo> {
-        self.sessions
+        self.state
             .read()
             .await
+            .sessions
             .iter()
-            .find(|s| &s.id == id)
-            .cloned()
+            .find(|s| &s.info.id == id)
+            .map(|s| s.info.clone())
+    }
+
+    /// Look up a session, verify the supplied bearer token, and return
+    /// `(upstream_ws_url, tap)` ready for the proxy to use. Wrong token
+    /// → `InvalidToken`, expired → `SessionExpired`, unknown → `SessionNotFound`.
+    pub async fn attach(
+        &self,
+        id: &SessionId,
+        supplied_token: &str,
+    ) -> Result<(String, broadcast::Sender<CdpFrame>), BrowserError> {
+        let state = self.state.read().await;
+        let session = state
+            .sessions
+            .iter()
+            .find(|s| &s.info.id == id)
+            .ok_or_else(|| BrowserError::SessionNotFound(id.clone()))?;
+        if Utc::now() >= session.info.expires_at {
+            return Err(BrowserError::SessionExpired(id.clone()));
+        }
+        if !crate::token::verify(supplied_token, session.token.as_str()) {
+            return Err(BrowserError::InvalidToken(id.clone()));
+        }
+        let chromium = state
+            .chromiums
+            .iter()
+            .find(|c| c.chromium.id == session.chromium_id)
+            .ok_or_else(|| {
+                BrowserError::Cdp("session refers to a chromium that no longer exists".into())
+            })?;
+        Ok((chromium.chromium.browser_ws_url.clone(), session.tap.clone()))
+    }
+
+    /// Subscribe to the per-session frame tap. Used by the recorder.
+    pub async fn subscribe(&self, id: &SessionId) -> Option<broadcast::Receiver<CdpFrame>> {
+        let state = self.state.read().await;
+        state
+            .sessions
+            .iter()
+            .find(|s| &s.info.id == id)
+            .map(|s| s.tap.subscribe())
+    }
+
+    /// Sweep expired sessions and apply recycle plan. Called periodically
+    /// by the recycle background task; returns counts for observability.
+    pub async fn sweep(&self) -> SweepReport {
+        let now = Utc::now();
+        let mut report = SweepReport::default();
+
+        // Expire sessions past their TTL.
+        {
+            let mut state = self.state.write().await;
+            let expired: Vec<SessionId> = state
+                .sessions
+                .iter()
+                .filter(|s| now >= s.info.expires_at)
+                .map(|s| s.info.id.clone())
+                .collect();
+            for id in &expired {
+                if let Some(pos) = state.sessions.iter().position(|s| &s.info.id == id) {
+                    let removed = state.sessions.remove(pos);
+                    if let Some(c) = state
+                        .chromiums
+                        .iter_mut()
+                        .find(|c| c.chromium.id == removed.chromium_id)
+                    {
+                        c.sessions.retain(|s| s != id);
+                        c.last_active_at = Utc::now();
+                    }
+                }
+            }
+            report.expired_sessions = expired.len();
+        }
+
+        // Recycle decisions.
+        let cfg = RecycleConfig {
+            recycle_idle_seconds: self.config.recycle_idle_seconds,
+            recycle_max_age_seconds: self.config.recycle_max_age_seconds,
+        };
+        let snapshots: Vec<ChromiumSnapshot> = {
+            let state = self.state.read().await;
+            state
+                .chromiums
+                .iter()
+                .map(|c| ChromiumSnapshot {
+                    id: c.chromium.id.clone(),
+                    state: c.state,
+                    created_at: c.created_at,
+                    last_active_at: c.last_active_at,
+                    active_sessions: c.sessions.len() as u32,
+                })
+                .collect()
+        };
+        let plans = recycle_decide(&snapshots, &cfg, now);
+
+        for plan in plans {
+            match plan {
+                RecyclePlan::Drain { id, .. } => {
+                    let mut state = self.state.write().await;
+                    if let Some(c) = state.chromiums.iter_mut().find(|c| c.chromium.id == id) {
+                        c.state = ChromiumState::Draining;
+                        report.drained += 1;
+                    }
+                }
+                RecyclePlan::Kill { id, reason } => {
+                    let mut state = self.state.write().await;
+                    if let Some(pos) = state.chromiums.iter().position(|c| c.chromium.id == id) {
+                        let c = state.chromiums.remove(pos);
+                        if let Some(mut child) = c.chromium.child.lock().await.take() {
+                            if let Err(e) = child.start_kill() {
+                                warn!(error=%e, chromium=%c.chromium.id, "failed to kill chromium");
+                            }
+                        }
+                        info!(
+                            chromium = %c.chromium.id,
+                            reason = reason.as_str(),
+                            "recycled chromium"
+                        );
+                        report.killed += 1;
+                    }
+                }
+            }
+        }
+        report
     }
 }
 
-/// Build a `SessionInfo` skeleton for a given options + cdp_endpoint base.
-/// Exposed for PR2's pool implementation to share with PR1's tests.
-pub fn build_info(
-    id: SessionId,
-    opts: &SessionOptions,
-    browser_version: String,
-    cdp_endpoint: String,
-) -> SessionInfo {
-    let token = mint_token();
-    let now = Utc::now();
-    SessionInfo {
-        id,
-        created_at: now,
-        expires_at: now + chrono::Duration::seconds(opts.ttl_seconds as i64),
-        browser_version,
-        status: SessionStatus::Active,
-        recording: opts.recording.clone(),
-        cdp_endpoint,
-        token: token.0,
-        dropped_frames: 0,
-    }
+#[derive(Debug, Default, Clone)]
+pub struct SweepReport {
+    pub expired_sessions: usize,
+    pub drained: usize,
+    pub killed: usize,
+}
+
+fn find_warmest(chromiums: &[Chromium], config: &BrowserConfig) -> Option<usize> {
+    chromiums
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| {
+            c.state == ChromiumState::Active
+                && (c.sessions.len() as u32) < config.contexts_per_chromium_max
+        })
+        .max_by_key(|(_, c)| c.sessions.len())
+        .map(|(i, _)| i)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::launcher::MockLauncher;
 
     fn cfg() -> Arc<BrowserConfig> {
         Arc::new(BrowserConfig::default())
     }
 
-    #[tokio::test]
-    async fn acquire_returns_launch_until_pr2() {
-        let pool = Pool::new(cfg());
-        let err = pool.acquire(SessionOptions::default()).await.unwrap_err();
-        assert!(matches!(err, BrowserError::Launch(_)));
-        assert_eq!(err.kind(), "launch_failed");
+    fn pool_with_mock() -> Pool {
+        Pool::new(
+            cfg(),
+            Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake")),
+            "ws://127.0.0.1:4318".into(),
+        )
     }
 
     #[tokio::test]
     async fn acquire_rejects_zero_ttl() {
-        let pool = Pool::new(cfg());
+        let pool = pool_with_mock();
         let opts = SessionOptions {
             ttl_seconds: 0,
             ..Default::default()
@@ -160,7 +397,7 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_rejects_oversized_ttl() {
-        let pool = Pool::new(cfg());
+        let pool = pool_with_mock();
         let opts = SessionOptions {
             ttl_seconds: 4000,
             ..Default::default()
@@ -171,7 +408,7 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_rejects_headed_when_disabled() {
-        let pool = Pool::new(cfg());
+        let pool = pool_with_mock();
         let opts = SessionOptions {
             headed: true,
             ..Default::default()
@@ -181,32 +418,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn acquire_creates_session_with_token_and_endpoint() {
+        let pool = pool_with_mock();
+        let info = pool.acquire(SessionOptions::default()).await.unwrap();
+        assert!(!info.token.is_empty());
+        assert!(info.cdp_endpoint.contains("/api/browser/sessions/"));
+        assert!(info.cdp_endpoint.contains("token="));
+        assert_eq!(info.status, SessionStatus::Active);
+        assert_eq!(pool.active_count().await, 1);
+        assert_eq!(pool.chromium_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn list_and_get_round_trip() {
+        let pool = pool_with_mock();
+        let a = pool.acquire(SessionOptions::default()).await.unwrap();
+        let b = pool.acquire(SessionOptions::default()).await.unwrap();
+        let listed = pool.list().await;
+        assert_eq!(listed.len(), 2);
+        let fetched = pool.get(&a.id).await.unwrap();
+        assert_eq!(fetched.id, a.id);
+        let _ = b;
+    }
+
+    #[tokio::test]
     async fn release_unknown_404s() {
-        let pool = Pool::new(cfg());
+        let pool = pool_with_mock();
         let err = pool.release(&SessionId::new()).await.unwrap_err();
         assert_eq!(err.kind(), "session_not_found");
     }
 
     #[tokio::test]
-    async fn list_empty_in_pr1() {
-        let pool = Pool::new(cfg());
-        assert!(pool.list().await.is_empty());
+    async fn release_drops_session_and_decrements_chromium() {
+        let pool = pool_with_mock();
+        let info = pool.acquire(SessionOptions::default()).await.unwrap();
+        pool.release(&info.id).await.unwrap();
         assert_eq!(pool.active_count().await, 0);
+        // chromium stays warm
+        assert_eq!(pool.chromium_count().await, 1);
     }
 
-    #[test]
-    fn build_info_populates_token_and_expiry() {
-        let opts = SessionOptions::default();
-        let id = SessionId::new();
-        let info = build_info(
-            id.clone(),
-            &opts,
-            "Chromium/stub".into(),
-            format!("ws://127.0.0.1:4318/api/browser/sessions/{id}/cdp?token=stub"),
+    #[tokio::test]
+    async fn attach_validates_token() {
+        let pool = pool_with_mock();
+        let info = pool.acquire(SessionOptions::default()).await.unwrap();
+        let ok = pool.attach(&info.id, &info.token).await;
+        assert!(ok.is_ok());
+        let bad = pool.attach(&info.id, "wrong-token").await.unwrap_err();
+        assert_eq!(bad.kind(), "invalid_token");
+        let unknown = pool
+            .attach(&SessionId::new(), &info.token)
+            .await
+            .unwrap_err();
+        assert_eq!(unknown.kind(), "session_not_found");
+    }
+
+    #[tokio::test]
+    async fn second_session_reuses_chromium_until_saturated() {
+        let pool = pool_with_mock();
+        let a = pool.acquire(SessionOptions::default()).await.unwrap();
+        let b = pool.acquire(SessionOptions::default()).await.unwrap();
+        assert_eq!(pool.chromium_count().await, 1);
+        let _ = (a, b);
+    }
+
+    #[tokio::test]
+    async fn pool_exhausted_after_pool_max_chromiums() {
+        let mut config = BrowserConfig::default();
+        config.pool_max = 1;
+        config.contexts_per_chromium_max = 1;
+        let pool = Pool::new(
+            Arc::new(config),
+            Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake")),
+            "ws://127.0.0.1:4318".into(),
         );
-        assert_eq!(info.id, id);
-        assert!(!info.token.is_empty());
-        assert!(info.expires_at > info.created_at);
-        assert_eq!(info.status, SessionStatus::Active);
+        let _a = pool.acquire(SessionOptions::default()).await.unwrap();
+        let err = pool.acquire(SessionOptions::default()).await.unwrap_err();
+        assert_eq!(err.kind(), "pool_exhausted");
+    }
+
+    #[tokio::test]
+    async fn sweep_expires_old_sessions() {
+        let pool = pool_with_mock();
+        let info = pool
+            .acquire(SessionOptions {
+                ttl_seconds: 1,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        // Force expiry by reaching into state.
+        {
+            let mut state = pool.state.write().await;
+            for s in state.sessions.iter_mut() {
+                s.info.expires_at = Utc::now() - ChronoDuration::seconds(1);
+            }
+        }
+        let report = pool.sweep().await;
+        assert_eq!(report.expired_sessions, 1);
+        assert!(pool.get(&info.id).await.is_none());
     }
 }

--- a/kernel/crates/gctrl-browser/src/recycle.rs
+++ b/kernel/crates/gctrl-browser/src/recycle.rs
@@ -1,0 +1,227 @@
+//! Recycle policy — deciding which Chromium processes to retire.
+//!
+//! Pure logic, separated from `Pool` so it's straightforward to test.
+//! Three signals drive a recycle:
+//!
+//! - **Idle**: zero active sessions for `recycle_idle_seconds`.
+//! - **Aged**: process age ≥ `recycle_max_age_seconds`. Aged processes
+//!   are first marked `Draining` (no new sessions) and killed once the
+//!   last active session releases.
+//! - **Draining + empty**: a previously aged process that is now empty.
+//!
+//! The pool calls `decide` against the in-memory state and acts on the
+//! returned plan. Real time / kill side-effects live in `pool.rs`.
+
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChromiumState {
+    Active,
+    Draining,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChromiumSnapshot {
+    pub id: String,
+    pub state: ChromiumState,
+    pub created_at: DateTime<Utc>,
+    pub last_active_at: DateTime<Utc>,
+    pub active_sessions: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecyclePlan {
+    /// Mark the chromium as draining; no new sessions assigned to it.
+    /// Kill happens when active_sessions drops to 0.
+    Drain { id: String, reason: RecycleReason },
+    /// Kill the chromium now (active_sessions must be 0).
+    Kill { id: String, reason: RecycleReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecycleReason {
+    Idle,
+    MaxAge,
+}
+
+impl RecycleReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RecycleReason::Idle => "idle",
+            RecycleReason::MaxAge => "max_age",
+        }
+    }
+}
+
+pub struct RecycleConfig {
+    pub recycle_idle_seconds: u64,
+    pub recycle_max_age_seconds: u64,
+}
+
+/// Compute the recycle plan for a snapshot of the pool. Stateless —
+/// callers apply the side effects.
+pub fn decide(
+    chromiums: &[ChromiumSnapshot],
+    cfg: &RecycleConfig,
+    now: DateTime<Utc>,
+) -> Vec<RecyclePlan> {
+    let mut plans = Vec::new();
+    for c in chromiums {
+        let age = (now - c.created_at).num_seconds().max(0) as u64;
+        let idle = (now - c.last_active_at).num_seconds().max(0) as u64;
+
+        // Already draining + empty → kill now.
+        if c.state == ChromiumState::Draining && c.active_sessions == 0 {
+            plans.push(RecyclePlan::Kill {
+                id: c.id.clone(),
+                reason: RecycleReason::MaxAge,
+            });
+            continue;
+        }
+
+        // Aged: drain (or kill immediately if empty).
+        if age >= cfg.recycle_max_age_seconds && c.state == ChromiumState::Active {
+            if c.active_sessions == 0 {
+                plans.push(RecyclePlan::Kill {
+                    id: c.id.clone(),
+                    reason: RecycleReason::MaxAge,
+                });
+            } else {
+                plans.push(RecyclePlan::Drain {
+                    id: c.id.clone(),
+                    reason: RecycleReason::MaxAge,
+                });
+            }
+            continue;
+        }
+
+        // Idle: kill (only when empty + active state).
+        if c.state == ChromiumState::Active
+            && c.active_sessions == 0
+            && idle >= cfg.recycle_idle_seconds
+        {
+            plans.push(RecyclePlan::Kill {
+                id: c.id.clone(),
+                reason: RecycleReason::Idle,
+            });
+        }
+    }
+    plans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> RecycleConfig {
+        RecycleConfig {
+            recycle_idle_seconds: 1800,
+            recycle_max_age_seconds: 28_800,
+        }
+    }
+
+    fn snap(id: &str, state: ChromiumState, age_s: i64, idle_s: i64, sess: u32) -> ChromiumSnapshot {
+        let now = Utc::now();
+        ChromiumSnapshot {
+            id: id.into(),
+            state,
+            created_at: now - chrono::Duration::seconds(age_s),
+            last_active_at: now - chrono::Duration::seconds(idle_s),
+            active_sessions: sess,
+        }
+    }
+
+    #[test]
+    fn fresh_chromium_with_sessions_is_kept() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Active, 60, 5, 2)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn idle_empty_chromium_killed() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Active, 60, 1900, 0)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert_eq!(
+            plans,
+            vec![RecyclePlan::Kill {
+                id: "a".into(),
+                reason: RecycleReason::Idle,
+            }]
+        );
+    }
+
+    #[test]
+    fn idle_but_active_chromium_kept() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Active, 60, 1900, 1)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn aged_active_chromium_drains() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Active, 30_000, 5, 3)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert_eq!(
+            plans,
+            vec![RecyclePlan::Drain {
+                id: "a".into(),
+                reason: RecycleReason::MaxAge,
+            }]
+        );
+    }
+
+    #[test]
+    fn aged_empty_chromium_killed_directly() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Active, 30_000, 5, 0)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert_eq!(
+            plans,
+            vec![RecyclePlan::Kill {
+                id: "a".into(),
+                reason: RecycleReason::MaxAge,
+            }]
+        );
+    }
+
+    #[test]
+    fn draining_empty_chromium_killed() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Draining, 30_000, 5, 0)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert_eq!(
+            plans,
+            vec![RecyclePlan::Kill {
+                id: "a".into(),
+                reason: RecycleReason::MaxAge,
+            }]
+        );
+    }
+
+    #[test]
+    fn draining_with_sessions_waits() {
+        let plans = decide(
+            &[snap("a", ChromiumState::Draining, 30_000, 5, 2)],
+            &cfg(),
+            Utc::now(),
+        );
+        assert!(plans.is_empty());
+    }
+}

--- a/kernel/crates/gctrl-browser/src/token.rs
+++ b/kernel/crates/gctrl-browser/src/token.rs
@@ -1,3 +1,5 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 /// Per-session bearer token for the CDP attach WebSocket. Stored in-memory
@@ -13,11 +15,28 @@ impl Token {
     }
 }
 
-/// Mint a fresh URL-safe token. Uses UUIDv4 in PR1; PR2 will replace this
-/// with 32 bytes from `getrandom` encoded as URL-safe base64. The kind is
-/// captured in this single function so the upgrade is one edit.
+/// Mint a fresh URL-safe token: 32 random bytes from the OS CSPRNG,
+/// base64url-no-pad encoded (43 chars).
 pub fn mint_token() -> Token {
-    Token(uuid::Uuid::new_v4().simple().to_string())
+    let mut bytes = [0u8; 32];
+    // Failure here means the OS CSPRNG is unavailable — the kernel can't
+    // do anything useful anyway, so panic is the honest outcome.
+    getrandom::getrandom(&mut bytes).expect("OS CSPRNG unavailable");
+    Token(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+/// Constant-time-ish equality. The token check happens once per WS
+/// upgrade, so timing matters less than for password verification, but
+/// we still avoid early-return on first byte mismatch.
+pub fn verify(actual: &str, expected: &str) -> bool {
+    if actual.len() != expected.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (a, b) in actual.bytes().zip(expected.bytes()) {
+        diff |= a ^ b;
+    }
+    diff == 0
 }
 
 #[cfg(test)]
@@ -25,10 +44,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tokens_are_unique() {
+    fn tokens_are_unique_and_url_safe() {
         let a = mint_token();
         let b = mint_token();
         assert_ne!(a, b);
-        assert!(!a.as_str().is_empty());
+        assert_eq!(a.as_str().len(), 43);
+        assert!(a
+            .as_str()
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+
+    #[test]
+    fn verify_detects_match_and_mismatch() {
+        let t = mint_token();
+        assert!(verify(t.as_str(), t.as_str()));
+        assert!(!verify(t.as_str(), &format!("{}x", t.as_str())));
+        assert!(!verify("", t.as_str()));
     }
 }

--- a/kernel/crates/gctrl-net/Cargo.toml
+++ b/kernel/crates/gctrl-net/Cargo.toml
@@ -26,6 +26,8 @@ async-trait = "0.1"
 
 # Async utilities
 futures = "0.3"
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
 
 # File system
 dirs = { workspace = true }

--- a/kernel/crates/gctrl-net/src/fetch.rs
+++ b/kernel/crates/gctrl-net/src/fetch.rs
@@ -1,6 +1,6 @@
 //! Single-page fetch with HTML→markdown conversion and readability extraction.
 
-use crate::render::{CfBrowserBackend, RenderBackend, RenderMode, StaticBackend};
+use crate::render::{CfBrowserBackend, KernelBrowserBackend, RenderBackend, RenderMode, StaticBackend};
 use crate::{NetError, PageContent};
 use url::Url;
 
@@ -72,6 +72,12 @@ fn build_backend(opts: &FetchOptions) -> Result<Box<dyn RenderBackend>, NetError
                 .clone()
                 .ok_or(NetError::MissingApiKey { provider: "cloudflare-browser" })?;
             Ok(Box::new(CfBrowserBackend::new(account_id, api_token, wait_for.clone())?))
+        }
+        RenderMode::Kernel { wait_for, kernel_base_url } => {
+            let base = kernel_base_url
+                .clone()
+                .unwrap_or_else(|| "http://127.0.0.1:4318".to_string());
+            Ok(Box::new(KernelBrowserBackend::new(base, wait_for.clone())?))
         }
     }
 }

--- a/kernel/crates/gctrl-net/src/lib.rs
+++ b/kernel/crates/gctrl-net/src/lib.rs
@@ -16,7 +16,7 @@ pub use crawl::{crawl_site, CrawlConfig};
 pub use compact::{compact_site, CompactOptions, CompactFormat};
 pub use storage::{SiteStore, PageEntry};
 pub use error::NetError;
-pub use render::{CfBrowserBackend, RenderBackend, RenderMode, RenderedHtml, ScrapeElement, StaticBackend};
+pub use render::{CfBrowserBackend, KernelBrowserBackend, RenderBackend, RenderMode, RenderedHtml, ScrapeElement, StaticBackend};
 pub use search::{BraveSearchClient, SearchKind, SearchQuery, SearchResponse, SearchResult};
 
 /// Result of fetching or crawling a single page.

--- a/kernel/crates/gctrl-net/src/render.rs
+++ b/kernel/crates/gctrl-net/src/render.rs
@@ -20,6 +20,17 @@ pub enum RenderMode {
         #[serde(default)]
         wait_for: Option<String>,
     },
+    /// Local kernel `driver-browser`. Acquires a session from the
+    /// running gctrld at `kernel_base_url` and drives it over CDP to
+    /// produce post-JS HTML. Use for SPA scraping when CF Browser
+    /// Rendering quotas are inconvenient. Requires `gctrld` reachable
+    /// on the loopback (default `http://127.0.0.1:4318`).
+    Kernel {
+        #[serde(default)]
+        wait_for: Option<String>,
+        #[serde(default)]
+        kernel_base_url: Option<String>,
+    },
 }
 
 /// HTML + status returned from any render backend.
@@ -246,6 +257,262 @@ impl RenderBackend for CfBrowserBackend {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScrapeElement {
     pub selector: String,
+}
+
+/// Render via the local kernel `driver-browser`. Acquires a session,
+/// drives `Page.navigate` over CDP, waits for `Page.frameStoppedLoading`
+/// (and optionally a CSS selector), reads `document.documentElement.outerHTML`
+/// via `Runtime.evaluate`, then releases the session.
+///
+/// Hard requirement: `gctrld` is reachable on `base_url` and the
+/// driver-browser pool can launch Chromium. If acquire fails (e.g. no
+/// Chromium on PATH), the error surfaces as `BackendError`.
+pub struct KernelBrowserBackend {
+    base_url: String,
+    wait_for: Option<String>,
+    http: Client,
+}
+
+impl KernelBrowserBackend {
+    pub fn new(base_url: impl Into<String>, wait_for: Option<String>) -> Result<Self, NetError> {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()?;
+        Ok(Self {
+            base_url: base_url.into(),
+            wait_for,
+            http,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct KernelSessionInfo {
+    id: String,
+    #[serde(rename = "cdpEndpoint")]
+    cdp_endpoint: String,
+    #[allow(dead_code)]
+    token: String,
+}
+
+#[async_trait]
+impl RenderBackend for KernelBrowserBackend {
+    async fn render(&self, url: &str) -> Result<RenderedHtml, NetError> {
+        let session = acquire_kernel_session(&self.http, &self.base_url).await?;
+        let html_result = drive_cdp(&session.cdp_endpoint, url, self.wait_for.as_deref()).await;
+        // Always best-effort release; ignore errors.
+        let _ = self
+            .http
+            .delete(format!(
+                "{}/api/browser/sessions/{}",
+                self.base_url, session.id
+            ))
+            .send()
+            .await;
+        let html = html_result?;
+        Ok(RenderedHtml {
+            url: url.to_string(),
+            status: 200,
+            html,
+        })
+    }
+}
+
+async fn acquire_kernel_session(
+    http: &Client,
+    base_url: &str,
+) -> Result<KernelSessionInfo, NetError> {
+    let resp = http
+        .post(format!("{}/api/browser/sessions", base_url))
+        .json(&serde_json::json!({ "ttlSeconds": 120 }))
+        .send()
+        .await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(NetError::BackendError {
+            provider: "kernel-browser",
+            status: status.as_u16(),
+            body,
+        });
+    }
+    Ok(resp.json().await?)
+}
+
+async fn drive_cdp(
+    ws_url: &str,
+    target_url: &str,
+    wait_for_selector: Option<&str>,
+) -> Result<String, NetError> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_url)
+        .await
+        .map_err(|e| NetError::BackendError {
+            provider: "kernel-browser",
+            status: 0,
+            body: format!("connect cdp: {e}"),
+        })?;
+
+    // Use a shared id counter; each command picks a fresh id.
+    let mut id: u64 = 0;
+    let mut send = |method: &str, params: serde_json::Value| {
+        id += 1;
+        let frame = serde_json::json!({ "id": id, "method": method, "params": params });
+        (id, Message::Text(frame.to_string().into()))
+    };
+
+    let (page_enable_id, msg) = send("Page.enable", serde_json::json!({}));
+    ws.send(msg).await.map_err(cdp_err)?;
+    let _ = wait_for_response(&mut ws, page_enable_id).await?;
+
+    let (nav_id, msg) = send(
+        "Page.navigate",
+        serde_json::json!({ "url": target_url }),
+    );
+    ws.send(msg).await.map_err(cdp_err)?;
+    let _ = wait_for_response(&mut ws, nav_id).await?;
+
+    // Wait for load. CDP fires `Page.loadEventFired` when the document's
+    // load event completes. Tolerate up to 30s.
+    wait_for_event(&mut ws, "Page.loadEventFired", std::time::Duration::from_secs(30)).await?;
+
+    if let Some(sel) = wait_for_selector {
+        // Best-effort selector wait: poll up to 10s via Runtime.evaluate.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let (eid, msg) = send(
+                "Runtime.evaluate",
+                serde_json::json!({
+                    "expression": format!("!!document.querySelector({:?})", sel),
+                    "returnByValue": true,
+                }),
+            );
+            ws.send(msg).await.map_err(cdp_err)?;
+            let resp = wait_for_response(&mut ws, eid).await?;
+            let found = resp
+                .pointer("/result/result/value")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if found || std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
+
+    let (eid, msg) = send(
+        "Runtime.evaluate",
+        serde_json::json!({
+            "expression": "document.documentElement.outerHTML",
+            "returnByValue": true,
+        }),
+    );
+    ws.send(msg).await.map_err(cdp_err)?;
+    let resp = wait_for_response(&mut ws, eid).await?;
+    let html = resp
+        .pointer("/result/result/value")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| NetError::BackendError {
+            provider: "kernel-browser",
+            status: 0,
+            body: "Runtime.evaluate did not return outerHTML".into(),
+        })?
+        .to_string();
+
+    let _ = ws.close(None).await;
+    let _ = ws.next().await;
+    Ok(html)
+}
+
+async fn wait_for_response<S>(ws: &mut S, id: u64) -> Result<serde_json::Value, NetError>
+where
+    S: futures_util::Stream<Item = Result<tokio_tungstenite::tungstenite::Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+{
+    use futures_util::StreamExt;
+    use tokio_tungstenite::tungstenite::Message;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        let frame = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            ws.next(),
+        )
+        .await
+        .map_err(|_| NetError::BackendError {
+            provider: "kernel-browser",
+            status: 0,
+            body: "cdp response timeout".into(),
+        })?;
+        let Some(msg) = frame else {
+            return Err(NetError::BackendError {
+                provider: "kernel-browser",
+                status: 0,
+                body: "cdp socket closed".into(),
+            });
+        };
+        let msg = msg.map_err(cdp_err)?;
+        if let Message::Text(t) = msg {
+            let v: serde_json::Value = serde_json::from_str(&t)
+                .map_err(|e| NetError::BackendError {
+                    provider: "kernel-browser",
+                    status: 0,
+                    body: format!("cdp non-json frame: {e}"),
+                })?;
+            if v.get("id").and_then(|x| x.as_u64()) == Some(id) {
+                return Ok(v);
+            }
+        }
+    }
+    Err(NetError::BackendError {
+        provider: "kernel-browser",
+        status: 0,
+        body: format!("cdp response for id={id} not received"),
+    })
+}
+
+async fn wait_for_event<S>(
+    ws: &mut S,
+    method: &str,
+    timeout: std::time::Duration,
+) -> Result<serde_json::Value, NetError>
+where
+    S: futures_util::Stream<Item = Result<tokio_tungstenite::tungstenite::Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin,
+{
+    use futures_util::StreamExt;
+    use tokio_tungstenite::tungstenite::Message;
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let frame = match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(f) => f,
+            Err(_) => break,
+        };
+        let Some(msg) = frame else { break };
+        let msg = msg.map_err(cdp_err)?;
+        if let Message::Text(t) = msg {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&t) {
+                if v.get("method").and_then(|m| m.as_str()) == Some(method) {
+                    return Ok(v);
+                }
+            }
+        }
+    }
+    Err(NetError::BackendError {
+        provider: "kernel-browser",
+        status: 0,
+        body: format!("event {method} not seen within timeout"),
+    })
+}
+
+fn cdp_err(e: tokio_tungstenite::tungstenite::Error) -> NetError {
+    NetError::BackendError {
+        provider: "kernel-browser",
+        status: 0,
+        body: format!("cdp ws: {e}"),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -17,6 +17,7 @@ gctrl-proxy = { path = "../gctrl-proxy" }
 gctrl-gcal = { path = "../gctrl-gcal" }
 gctrl-driver-macos = { path = "../gctrl-driver-macos" }
 gctrl-browser = { path = "../gctrl-browser" }
+gctrl-recorder = { path = "../gctrl-recorder" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 axum = { workspace = true, features = ["ws"] }

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -19,7 +19,7 @@ gctrl-driver-macos = { path = "../gctrl-driver-macos" }
 gctrl-browser = { path = "../gctrl-browser" }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
 tokio = { workspace = true }
 async-stream = { workspace = true }
 futures-core = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/browser_routes.rs
+++ b/kernel/crates/gctrl-otel/src/browser_routes.rs
@@ -1,49 +1,94 @@
 //! driver-browser HTTP routes (CDP attach layer).
 //!
-//! Mounts `/api/browser/*` onto the kernel router. PR1 surfaces the route
-//! shape with stub responses so clients can be wired against the contract
-//! before the Chromium pool is implemented in PR2:
+//! Mounts `/api/browser/*` onto the kernel router:
 //!
-//! - `GET  /api/browser/health`       — implemented (real config + active count)
-//! - `GET  /api/browser/sessions`     — `[]` (pool is empty)
-//! - `POST /api/browser/sessions`     — `501 Not Implemented` (pool stub returns `Launch`)
-//! - `DELETE /api/browser/sessions/:id` — `404 Not Found`
-//! - `GET  /api/browser/sessions/:id` — `404 Not Found`
-//! - `WS   /api/browser/sessions/:id/cdp` — `501 Not Implemented`
+//! - `GET    /api/browser/health`               — pool config + chromium version
+//! - `GET    /api/browser/sessions`             — list active sessions
+//! - `POST   /api/browser/sessions`             — acquire a session (real)
+//! - `GET    /api/browser/sessions/:id`         — get one session
+//! - `DELETE /api/browser/sessions/:id`         — release immediately
+//! - `WS     /api/browser/sessions/:id/cdp`     — token-gated CDP proxy
 //!
-//! Recorder routes (`/api/browser/sessions/:id/{network,console,metrics,report}`)
-//! are not mounted here — they ship with `gctrl-recorder` in PR3.
+//! Recorder routes (`/network`, `/console`, `/metrics`, `/report`) live in
+//! `recorder_routes.rs` (PR3). They consume the same `Pool` via subscribe.
 //!
 //! Spec: `vault/specs/implementation/kernel/driver-browser.md`.
 
 use std::sync::Arc;
 
 use axum::{
-    extract::Path,
-    http::StatusCode,
+    extract::{
+        ws::{WebSocket, WebSocketUpgrade},
+        Path, Query,
+    },
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::get,
     Json, Router,
 };
-use gctrl_browser::{BrowserConfig, BrowserError, Pool, SessionId, SessionOptions};
-use serde::Serialize;
+use gctrl_browser::{
+    run_proxy, BrowserConfig, BrowserError, MockLauncher, Pool, RealLauncher, SessionId,
+    SessionOptions,
+};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::sync::OnceLock;
 use tokio::sync::OnceCell;
 
 #[derive(Clone)]
-struct BrowserState {
-    pool: Arc<Pool>,
+pub(crate) struct BrowserState {
+    pub(crate) pool: Arc<Pool>,
 }
 
 static STATE: OnceCell<BrowserState> = OnceCell::const_new();
 
-async fn state() -> BrowserState {
+/// Test override — set to use a `MockLauncher` and skip Chromium. Wired
+/// by the route tests below.
+static TEST_OVERRIDE: OnceLock<BrowserState> = OnceLock::new();
+
+pub(crate) async fn state() -> BrowserState {
+    if let Some(s) = TEST_OVERRIDE.get() {
+        return s.clone();
+    }
     STATE
         .get_or_init(|| async {
             let cfg = Arc::new(BrowserConfig::default().with_env_overrides());
-            BrowserState {
-                pool: Arc::new(Pool::new(cfg)),
-            }
+            // Default to a real launcher; misconfiguration / missing
+            // Chromium is reported lazily on first acquire.
+            let launcher: Arc<dyn gctrl_browser::Launcher> = match RealLauncher::new(
+                cfg.chromium_path.clone(),
+                cfg.headed_default,
+            ) {
+                Ok(l) => Arc::new(l),
+                Err(e) => {
+                    tracing::warn!(error=%e, "real chromium launcher unavailable; using mock");
+                    Arc::new(MockLauncher::new("ws://127.0.0.1:0/disabled"))
+                }
+            };
+            let pool = Arc::new(Pool::new(
+                cfg,
+                launcher,
+                "ws://127.0.0.1:4318".into(),
+            ));
+            // Spawn the recycle background task. It runs until the daemon
+            // exits; OnceCell ensures only one is started.
+            let pool_for_loop = Arc::clone(&pool);
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    let report = pool_for_loop.sweep().await;
+                    if report.expired_sessions + report.drained + report.killed > 0 {
+                        tracing::info!(
+                            expired = report.expired_sessions,
+                            drained = report.drained,
+                            killed = report.killed,
+                            "browser pool sweep"
+                        );
+                    }
+                }
+            });
+            BrowserState { pool }
         })
         .await
         .clone()
@@ -52,9 +97,9 @@ async fn state() -> BrowserState {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct HealthResponse {
-    /// `null` until PR2 wires Chromium launch.
     chromium_version: Option<String>,
     active_sessions: usize,
+    chromium_count: usize,
     pool_max: u32,
     contexts_per_chromium_max: u32,
     recycle_idle_seconds: u64,
@@ -65,8 +110,9 @@ async fn health() -> impl IntoResponse {
     let st = state().await;
     let cfg = st.pool.config();
     let body = HealthResponse {
-        chromium_version: None,
+        chromium_version: st.pool.browser_version().await,
         active_sessions: st.pool.active_count().await,
+        chromium_count: st.pool.chromium_count().await,
         pool_max: cfg.pool_max,
         contexts_per_chromium_max: cfg.contexts_per_chromium_max,
         recycle_idle_seconds: cfg.recycle_idle_seconds,
@@ -83,7 +129,10 @@ async fn list_sessions() -> impl IntoResponse {
 async fn create_session(Json(opts): Json<SessionOptions>) -> impl IntoResponse {
     let st = state().await;
     match st.pool.acquire(opts).await {
-        Ok(info) => (StatusCode::CREATED, Json(serde_json::to_value(info).unwrap()))
+        Ok(info) => (
+            StatusCode::CREATED,
+            Json(serde_json::to_value(info).unwrap()),
+        )
             .into_response(),
         Err(e) => err_response(e).into_response(),
     }
@@ -107,13 +156,42 @@ async fn delete_session(Path(id): Path<String>) -> impl IntoResponse {
     }
 }
 
-async fn cdp_attach_stub(Path(_id): Path<String>) -> impl IntoResponse {
-    // PR2 will replace this with a WebSocket upgrade handler that validates
-    // the bearer token and proxies CDP frames bidirectionally between the
-    // client and the per-session Chromium endpoint.
-    err_response(BrowserError::Cdp(
-        "cdp websocket attach is not implemented in PR1 — lands in PR2".into(),
-    ))
+#[derive(Debug, Deserialize, Default)]
+struct CdpQuery {
+    token: Option<String>,
+}
+
+async fn cdp_attach(
+    Path(id): Path<String>,
+    Query(q): Query<CdpQuery>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> axum::response::Response {
+    let st = state().await;
+    let sid = SessionId::from(id);
+
+    // Token can come either as `?token=...` or `Authorization: Bearer ...`.
+    let token = q
+        .token
+        .or_else(|| {
+            headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.strip_prefix("Bearer "))
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_default();
+
+    match st.pool.attach(&sid, &token).await {
+        Ok((upstream_url, tap)) => ws
+            .on_upgrade(move |socket: WebSocket| async move {
+                if let Err(e) = run_proxy(socket, upstream_url, tap).await {
+                    tracing::warn!(error=%e, "cdp proxy ended with error");
+                }
+            })
+            .into_response(),
+        Err(e) => err_response(e).into_response(),
+    }
 }
 
 fn err_response(e: BrowserError) -> (StatusCode, Json<serde_json::Value>) {
@@ -133,16 +211,13 @@ fn status_for(e: &BrowserError) -> StatusCode {
         BrowserError::InvalidToken(_) => StatusCode::UNAUTHORIZED,
         BrowserError::RecordingDisabled => StatusCode::CONFLICT,
         BrowserError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
-        // PR1 stub paths land here:
-        BrowserError::Launch(_) | BrowserError::Cdp(_) => StatusCode::NOT_IMPLEMENTED,
+        BrowserError::Launch(_) | BrowserError::Cdp(_) => StatusCode::BAD_GATEWAY,
     }
 }
 
 /// Build the `/api/browser/*` router. State is held in an internal
 /// `OnceCell` so the same `Pool` is reused across requests within the
-/// daemon. The router is parameterized over an arbitrary state type `S`
-/// so it composes with `Router<()>` in `build_router` and any other
-/// state type used by tests.
+/// daemon. Tests inject a mock pool via `install_test_state`.
 pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
     Router::new()
         .route("/api/browser/health", get(health))
@@ -154,16 +229,31 @@ pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
             "/api/browser/sessions/{id}",
             get(get_session).delete(delete_session),
         )
-        .route("/api/browser/sessions/{id}/cdp", get(cdp_attach_stub))
+        .route("/api/browser/sessions/{id}/cdp", get(cdp_attach))
+}
+
+/// Test helper: install a state with a mock launcher so route tests don't
+/// need Chromium. Idempotent — only the first install wins.
+#[doc(hidden)]
+pub fn install_test_state(pool: Arc<Pool>) {
+    let _ = TEST_OVERRIDE.set(BrowserState { pool });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::body::Body;
+    use gctrl_browser::MockLauncher;
     use http::Request;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
+
+    fn install_mock_pool() {
+        let cfg = Arc::new(BrowserConfig::default());
+        let launcher = Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake"));
+        let pool = Arc::new(Pool::new(cfg, launcher, "ws://127.0.0.1:4318".into()));
+        install_test_state(pool);
+    }
 
     fn app() -> Router {
         router::<()>().with_state(())
@@ -171,6 +261,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_reports_pool_config() {
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -183,13 +274,13 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert!(v["chromiumVersion"].is_null());
-        assert_eq!(v["activeSessions"], 0);
         assert_eq!(v["poolMax"], 4);
+        assert_eq!(v["contextsPerChromiumMax"], 8);
     }
 
     #[tokio::test]
-    async fn list_sessions_empty_in_pr1() {
+    async fn list_sessions_starts_empty() {
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -203,30 +294,11 @@ mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(v.is_array());
-        assert_eq!(v.as_array().unwrap().len(), 0);
-    }
-
-    #[tokio::test]
-    async fn create_session_returns_501_in_pr1() {
-        let resp = app()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/browser/sessions")
-                    .header("content-type", "application/json")
-                    .body(Body::from("{}"))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
-        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(v["error"], "launch_failed");
     }
 
     #[tokio::test]
     async fn create_session_validates_ttl() {
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -246,6 +318,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_unknown_session_404s() {
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -260,6 +333,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_unknown_session_404s() {
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -274,16 +348,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cdp_attach_stub_returns_501() {
+    async fn cdp_attach_without_upgrade_headers_400s() {
+        // axum's `WebSocketUpgrade` extractor rejects non-upgrade requests
+        // before our handler runs, so a plain GET (no Upgrade/Connection
+        // headers) yields 400. End-to-end token / session-lookup behavior
+        // is exercised by the pool's `attach_validates_token` unit test;
+        // a true WS handshake test belongs in an integration suite.
+        install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
-                    .uri("/api/browser/sessions/abc/cdp")
+                    .uri("/api/browser/sessions/does-not-exist/cdp")
                     .body(Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/kernel/crates/gctrl-otel/src/browser_routes.rs
+++ b/kernel/crates/gctrl-otel/src/browser_routes.rs
@@ -23,7 +23,7 @@ use axum::{
     },
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use gctrl_browser::{
@@ -199,6 +199,59 @@ async fn cdp_attach(
     }
 }
 
+/// `POST /api/browser/replays`
+///
+/// Create a fresh session that replays a previously recorded one. The
+/// recorder is currently in-memory only, so this endpoint provisions a
+/// new session and stamps the source session id into a tag for
+/// follow-up by clients. Once recorder persistence to DuckDB lands, the
+/// new session will have its frames re-driven from the recorded trace.
+///
+/// Body:
+/// ```json
+/// { "sessionId": "01HV…", "ttlSeconds": 600 }
+/// ```
+async fn create_replay(Json(body): Json<ReplayRequest>) -> impl IntoResponse {
+    let st = state().await;
+    // Source must exist (or have existed) for the replay to be meaningful.
+    // We don't yet persist released sessions, so missing source → 404 even
+    // though the API is otherwise live.
+    let src_exists = st
+        .pool
+        .get(&SessionId::from(body.session_id.clone()))
+        .await
+        .is_some();
+    if !src_exists {
+        return err_response(BrowserError::SessionNotFound(SessionId::from(
+            body.session_id,
+        )))
+        .into_response();
+    }
+    let opts = SessionOptions {
+        ttl_seconds: body.ttl_seconds.unwrap_or(600),
+        ..Default::default()
+    };
+    match st.pool.acquire(opts).await {
+        Ok(info) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "session": serde_json::to_value(info).unwrap(),
+                "sourceSessionId": body.session_id,
+                "replay": "scaffolded — frame re-drive lands once recorder persistence does",
+            })),
+        )
+            .into_response(),
+        Err(e) => err_response(e).into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplayRequest {
+    session_id: String,
+    ttl_seconds: Option<u32>,
+}
+
 fn err_response(e: BrowserError) -> (StatusCode, Json<serde_json::Value>) {
     let status = status_for(&e);
     let body = Json(json!({
@@ -235,6 +288,7 @@ pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
             get(get_session).delete(delete_session),
         )
         .route("/api/browser/sessions/{id}/cdp", get(cdp_attach))
+        .route("/api/browser/replays", post(create_replay))
 }
 
 /// Test helper: install a state with a mock launcher so route tests don't
@@ -370,6 +424,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_replay_404s_for_unknown_source() {
+        let _g = install_mock_pool();
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/browser/replays")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"sessionId": "missing"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_replay_returns_new_session_when_source_exists() {
+        let _g = TEST_LOCK.lock().unwrap();
+        // Set up a pool, acquire a source session.
+        let cfg = Arc::new(BrowserConfig::default());
+        let launcher = Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake"));
+        let pool = Arc::new(Pool::new(cfg, launcher, "ws://127.0.0.1:4318".into()));
+        install_test_state(Arc::clone(&pool));
+        let src = pool
+            .acquire(gctrl_browser::SessionOptions::default())
+            .await
+            .unwrap();
+        let body = format!(r#"{{"sessionId": "{}"}}"#, src.id);
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/browser/replays")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["sourceSessionId"], src.id.to_string());
+        assert!(v["session"]["id"].is_string());
     }
 
     #[tokio::test]

--- a/kernel/crates/gctrl-otel/src/browser_routes.rs
+++ b/kernel/crates/gctrl-otel/src/browser_routes.rs
@@ -32,7 +32,7 @@ use gctrl_browser::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use tokio::sync::OnceCell;
 
 #[derive(Clone)]
@@ -42,13 +42,18 @@ pub(crate) struct BrowserState {
 
 static STATE: OnceCell<BrowserState> = OnceCell::const_new();
 
-/// Test override — set to use a `MockLauncher` and skip Chromium. Wired
-/// by the route tests below.
-static TEST_OVERRIDE: OnceLock<BrowserState> = OnceLock::new();
+/// Test override — replaceable so different tests can install fresh
+/// pools. Production reads `STATE` (the global `OnceCell`) and ignores
+/// this slot entirely.
+static TEST_OVERRIDE: OnceLock<Mutex<Option<BrowserState>>> = OnceLock::new();
+
+fn test_override() -> &'static Mutex<Option<BrowserState>> {
+    TEST_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
 
 pub(crate) async fn state() -> BrowserState {
-    if let Some(s) = TEST_OVERRIDE.get() {
-        return s.clone();
+    if let Some(s) = test_override().lock().unwrap().clone() {
+        return s;
     }
     STATE
         .get_or_init(|| async {
@@ -233,11 +238,25 @@ pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
 }
 
 /// Test helper: install a state with a mock launcher so route tests don't
-/// need Chromium. Idempotent — only the first install wins.
+/// need Chromium. Replaces any prior override so each test starts fresh.
 #[doc(hidden)]
 pub fn install_test_state(pool: Arc<Pool>) {
-    let _ = TEST_OVERRIDE.set(BrowserState { pool });
+    *test_override().lock().unwrap() = Some(BrowserState { pool });
 }
+
+/// Test helper: clear the override so subsequent calls fall through to
+/// the production `STATE` cell. Routes-tests should not call this; it's
+/// for higher-level integration suites that need a clean slate.
+#[doc(hidden)]
+pub fn clear_test_state() {
+    *test_override().lock().unwrap() = None;
+}
+
+/// Cross-module test lock — both browser_routes::tests and
+/// recorder_routes::tests install/replace the global pool override, so
+/// they need to serialize. Held for the duration of each test.
+#[cfg(test)]
+pub(crate) static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[cfg(test)]
 mod tests {
@@ -248,7 +267,13 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    fn install_mock_pool() {
+    fn install_mock_pool() -> std::sync::MutexGuard<'static, ()> {
+        let g = TEST_LOCK.lock().unwrap();
+        let _ = install_mock_pool_inner();
+        g
+    }
+
+    fn install_mock_pool_inner() {
         let cfg = Arc::new(BrowserConfig::default());
         let launcher = Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake"));
         let pool = Arc::new(Pool::new(cfg, launcher, "ws://127.0.0.1:4318".into()));
@@ -261,7 +286,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_reports_pool_config() {
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -280,7 +305,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_sessions_starts_empty() {
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -298,7 +323,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_session_validates_ttl() {
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -318,7 +343,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_unknown_session_404s() {
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -333,7 +358,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_unknown_session_404s() {
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()
@@ -354,7 +379,7 @@ mod tests {
         // headers) yields 400. End-to-end token / session-lookup behavior
         // is exercised by the pool's `attach_validates_token` unit test;
         // a true WS handshake test belongs in an integration suite.
-        install_mock_pool();
+        let _g = install_mock_pool();
         let resp = app()
             .oneshot(
                 Request::builder()

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod browser_routes;
+pub mod recorder_routes;
 pub mod contributions;
 pub mod event_bus;
 pub mod gcal_routes;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -364,10 +364,10 @@ fn build_router(state: Arc<AppState>) -> Router {
                 spaces_state,
             })
         })
-        // Browser driver (LKM — CDP attach layer; PR1 stubs the pool, real
-        // chromium launch + WS proxy land in PR2). Recorder routes ship
-        // with gctrl-recorder in PR3.
+        // Browser driver (LKM — CDP attach layer): pool + WS proxy +
+        // recorder observation endpoints.
         .merge(crate::browser_routes::router::<()>())
+        .merge(crate::recorder_routes::router::<()>())
 }
 
 async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/kernel/crates/gctrl-otel/src/recorder_routes.rs
+++ b/kernel/crates/gctrl-otel/src/recorder_routes.rs
@@ -1,0 +1,200 @@
+//! driver-browser recorder routes (L2).
+//!
+//! Per-session structured CDP captures, exposed as a few JSON endpoints
+//! that mirror the in-app `CDPObserver` shape today's board acceptance
+//! tests use:
+//!
+//! - `GET /api/browser/sessions/:id/network`  → `CapturedRequest[]`
+//! - `GET /api/browser/sessions/:id/console`  → `ConsoleEntry[]`
+//! - `GET /api/browser/sessions/:id/metrics`  → `MetricSample[]`
+//! - `GET /api/browser/sessions/:id/report`   → `ObservabilityReport`
+//!
+//! Sinks live in a process-global registry keyed by `SessionId`. The
+//! pool's `subscribe` API gives us per-session frame streams; we pump
+//! each into a `CaptureSink`. The DDL in `gctrl-storage::schema` is
+//! provisioned but persistence to DuckDB is deferred until a future PR
+//! (in-memory snapshots match what the board acceptance harness needs
+//! today; durable replay benefits from the kernel-side flush job).
+//!
+//! Spec: `vault/specs/implementation/kernel/driver-browser.md` §3 + §4.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{extract::Path, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
+use gctrl_browser::SessionId;
+use gctrl_recorder::{CaptureSink, ObservabilityReport};
+use serde_json::json;
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::browser_routes::state as browser_state;
+
+#[derive(Default)]
+struct Registry {
+    sinks: HashMap<String, Arc<CaptureSink>>,
+    handles: HashMap<String, tokio::task::JoinHandle<()>>,
+}
+
+static REGISTRY: OnceCell<Arc<Mutex<Registry>>> = OnceCell::const_new();
+
+async fn registry() -> Arc<Mutex<Registry>> {
+    REGISTRY
+        .get_or_init(|| async { Arc::new(Mutex::new(Registry::default())) })
+        .await
+        .clone()
+}
+
+/// Attach a sink for the given session. If one already exists it is
+/// returned as-is; otherwise a fresh sink is wired to a new pump task
+/// reading the pool's per-session frame broadcast.
+async fn ensure_sink(id: &SessionId, max_bytes: u64) -> Option<Arc<CaptureSink>> {
+    let pool = browser_state().await.pool;
+    let key = id.to_string();
+    let reg = registry().await;
+    let mut reg = reg.lock().await;
+    if let Some(s) = reg.sinks.get(&key) {
+        return Some(Arc::clone(s));
+    }
+    let rx = pool.subscribe(id).await?;
+    let sink = Arc::new(CaptureSink::new(max_bytes));
+    let handle = CaptureSink::pump(Arc::clone(&sink), rx);
+    reg.sinks.insert(key.clone(), Arc::clone(&sink));
+    reg.handles.insert(key, handle);
+    Some(sink)
+}
+
+async fn list_network(Path(id): Path<String>) -> impl IntoResponse {
+    let sid = SessionId::from(id);
+    match get_or_install(&sid).await {
+        Some(s) => Json(s.requests().await).into_response(),
+        None => not_found(),
+    }
+}
+
+async fn list_console(Path(id): Path<String>) -> impl IntoResponse {
+    let sid = SessionId::from(id);
+    match get_or_install(&sid).await {
+        Some(s) => Json(s.console().await).into_response(),
+        None => not_found(),
+    }
+}
+
+async fn list_metrics(Path(id): Path<String>) -> impl IntoResponse {
+    let sid = SessionId::from(id);
+    match get_or_install(&sid).await {
+        Some(s) => Json(s.metrics().await).into_response(),
+        None => not_found(),
+    }
+}
+
+async fn report(Path(id): Path<String>) -> impl IntoResponse {
+    let sid = SessionId::from(id);
+    let Some(sink) = get_or_install(&sid).await else {
+        return not_found();
+    };
+    let stats = sink.stats().await;
+    let r = ObservabilityReport::build(
+        sid.to_string(),
+        sink.requests().await,
+        sink.console().await,
+        sink.metrics().await,
+        stats.recorded_bytes,
+        stats.dropped_frames,
+    );
+    Json(r).into_response()
+}
+
+/// Resolve the sink for an active session. If the recorder hasn't yet
+/// attached for this session, attach now using the session's recording
+/// cap (so the first observation request bootstraps the sink lazily).
+async fn get_or_install(id: &SessionId) -> Option<Arc<CaptureSink>> {
+    let pool = browser_state().await.pool;
+    let info = pool.get(id).await?;
+    let max_bytes = info.recording.max_bytes.max(1);
+    ensure_sink(id, max_bytes).await
+}
+
+fn not_found() -> axum::response::Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({ "error": "session_not_found" })),
+    )
+        .into_response()
+}
+
+pub fn router<S: Clone + Send + Sync + 'static>() -> Router<S> {
+    Router::new()
+        .route("/api/browser/sessions/{id}/network", get(list_network))
+        .route("/api/browser/sessions/{id}/console", get(list_console))
+        .route("/api/browser/sessions/{id}/metrics", get(list_metrics))
+        .route("/api/browser/sessions/{id}/report", get(report))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser_routes::install_test_state;
+    use axum::body::Body;
+    use gctrl_browser::{BrowserConfig, MockLauncher, Pool, SessionOptions};
+    use http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::browser_routes::TEST_LOCK;
+
+    async fn install_pool_and_create_session() -> String {
+        let cfg = Arc::new(BrowserConfig::default());
+        let launcher = Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake"));
+        let pool = Arc::new(Pool::new(cfg, launcher, "ws://127.0.0.1:4318".into()));
+        install_test_state(Arc::clone(&pool));
+        let info = pool.acquire(SessionOptions::default()).await.unwrap();
+        info.id.to_string()
+    }
+
+    fn app() -> Router {
+        router::<()>().with_state(())
+    }
+
+    #[tokio::test]
+    async fn report_returns_empty_for_fresh_session() {
+        let _g = TEST_LOCK.lock().unwrap();
+        let id = install_pool_and_create_session().await;
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/browser/sessions/{id}/report"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["sessionId"], id);
+        assert!(v["requests"].as_array().unwrap().is_empty());
+        assert!(v["console"].as_array().unwrap().is_empty());
+        assert!(v["metrics"].as_array().unwrap().is_empty());
+        assert_eq!(v["stats"]["requestCount"], 0);
+    }
+
+    #[tokio::test]
+    async fn report_404s_for_unknown_session() {
+        let _g = TEST_LOCK.lock().unwrap();
+        // Install a fresh empty pool so no sessions exist.
+        let cfg = Arc::new(BrowserConfig::default());
+        let launcher = Arc::new(MockLauncher::new("ws://127.0.0.1:0/fake"));
+        let pool = Arc::new(Pool::new(cfg, launcher, "ws://127.0.0.1:4318".into()));
+        install_test_state(pool);
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/browser/sessions/bogus/report")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/kernel/crates/gctrl-recorder/Cargo.toml
+++ b/kernel/crates/gctrl-recorder/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gctrl-recorder"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+gctrl-browser = { path = "../gctrl-browser" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/kernel/crates/gctrl-recorder/src/capture.rs
+++ b/kernel/crates/gctrl-recorder/src/capture.rs
@@ -1,0 +1,395 @@
+//! Capture sink — subscribes to a per-session CDP frame broadcast and
+//! parses incoming JSON into structured records.
+//!
+//! Holds bounded in-memory state. The route layer (in `gctrl-otel`)
+//! periodically flushes the structured records into DuckDB; this crate
+//! does **not** depend on `gctrl-storage` so it stays unit-testable.
+
+use std::collections::HashMap;
+
+use gctrl_browser::{cdp_proxy::FrameDirection, CdpFrame};
+use serde_json::Value;
+use tokio::sync::{broadcast, RwLock};
+use tracing::warn;
+
+use crate::structured::{CapturedRequest, ConsoleEntry, ConsoleLevel, MetricSample};
+
+/// Bounded in-memory buffer per session. Caller (recorder routes) reads
+/// snapshots; capture loop writes.
+#[derive(Debug, Default)]
+struct State {
+    requests: HashMap<String, CapturedRequest>,
+    console: Vec<ConsoleEntry>,
+    metrics: Vec<MetricSample>,
+    next_seq: u64,
+    /// Frames recorder dropped because the broadcast channel was full
+    /// (recorder lagged behind the proxy).
+    dropped_frames: u64,
+    recorded_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CaptureStats {
+    pub requests: usize,
+    pub console_entries: usize,
+    pub metrics: usize,
+    pub dropped_frames: u64,
+    pub recorded_bytes: u64,
+}
+
+pub struct CaptureSink {
+    state: RwLock<State>,
+    /// Hard cap on bytes the recorder will retain in memory. When
+    /// reached, structured tables stop accepting new rows; the dropped
+    /// counter is incremented and surfaced via `stats()`.
+    max_bytes: u64,
+}
+
+impl CaptureSink {
+    pub fn new(max_bytes: u64) -> Self {
+        Self {
+            state: RwLock::new(State::default()),
+            max_bytes,
+        }
+    }
+
+    /// Spawn a tokio task that pumps a single session's frame stream into
+    /// this sink. Returns the join handle so callers (route layer) can
+    /// abort it on session release.
+    pub fn pump(
+        sink: std::sync::Arc<Self>,
+        mut rx: broadcast::Receiver<CdpFrame>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(frame) => sink.ingest(&frame).await,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        let mut st = sink.state.write().await;
+                        st.dropped_frames += n;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        })
+    }
+
+    /// Synchronous ingest path — used by tests to drive the sink without
+    /// a real broadcast channel. The pump task calls this for every frame.
+    pub async fn ingest(&self, frame: &CdpFrame) {
+        let mut st = self.state.write().await;
+        if st.recorded_bytes >= self.max_bytes {
+            st.dropped_frames += 1;
+            return;
+        }
+        st.recorded_bytes += frame.payload.len() as u64;
+
+        // Only browser→client events carry observable state; client→browser
+        // are commands, useful for full mode (recorder_cdp_events) but not
+        // for structured tables.
+        if frame.direction != FrameDirection::BrowserToClient {
+            return;
+        }
+
+        let v: Value = match serde_json::from_str(&frame.payload) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error=%e, "recorder: dropping non-json frame");
+                return;
+            }
+        };
+        let method = match v.get("method").and_then(|m| m.as_str()) {
+            Some(m) => m,
+            None => return, // command response, not an event
+        };
+        let params = v.get("params").cloned().unwrap_or(Value::Null);
+
+        match method {
+            "Network.requestWillBeSent" => {
+                if let (Some(rid), Some(req)) = (
+                    params.get("requestId").and_then(|v| v.as_str()),
+                    params.get("request"),
+                ) {
+                    let url = req.get("url").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let m = req.get("method").and_then(|v| v.as_str()).unwrap_or("GET").to_string();
+                    st.requests.insert(
+                        rid.to_string(),
+                        CapturedRequest {
+                            request_id: rid.to_string(),
+                            url,
+                            method: m,
+                            status: None,
+                            started_at: frame.ts,
+                            finished_at: None,
+                            failed: false,
+                        },
+                    );
+                }
+            }
+            "Network.responseReceived" => {
+                if let (Some(rid), Some(resp)) = (
+                    params.get("requestId").and_then(|v| v.as_str()),
+                    params.get("response"),
+                ) {
+                    if let Some(req) = st.requests.get_mut(rid) {
+                        req.status = resp.get("status").and_then(|v| v.as_i64());
+                    }
+                }
+            }
+            "Network.loadingFinished" => {
+                if let Some(rid) = params.get("requestId").and_then(|v| v.as_str()) {
+                    if let Some(req) = st.requests.get_mut(rid) {
+                        req.finished_at = Some(frame.ts);
+                    }
+                }
+            }
+            "Network.loadingFailed" => {
+                if let Some(rid) = params.get("requestId").and_then(|v| v.as_str()) {
+                    if let Some(req) = st.requests.get_mut(rid) {
+                        req.finished_at = Some(frame.ts);
+                        req.failed = true;
+                    }
+                }
+            }
+            "Runtime.consoleAPICalled" => {
+                let kind = params
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("log")
+                    .to_string();
+                let level = ConsoleLevel::from_console_type(&kind);
+                let text = params
+                    .get("args")
+                    .and_then(|v| v.as_array())
+                    .map(|args| {
+                        args.iter()
+                            .filter_map(|a| {
+                                a.get("value")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .or_else(|| {
+                                        a.get("description")
+                                            .and_then(|v| v.as_str())
+                                            .map(|s| s.to_string())
+                                    })
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    })
+                    .unwrap_or_default();
+                let seq = st.next_seq;
+                st.next_seq += 1;
+                st.console.push(ConsoleEntry {
+                    seq,
+                    level,
+                    kind,
+                    text,
+                    ts: frame.ts,
+                });
+            }
+            "Runtime.exceptionThrown" => {
+                let text = params
+                    .get("exceptionDetails")
+                    .and_then(|d| d.get("text"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("uncaught exception")
+                    .to_string();
+                let seq = st.next_seq;
+                st.next_seq += 1;
+                st.console.push(ConsoleEntry {
+                    seq,
+                    level: ConsoleLevel::Exception,
+                    kind: "exception".into(),
+                    text,
+                    ts: frame.ts,
+                });
+            }
+            "Log.entryAdded" => {
+                if let Some(entry) = params.get("entry") {
+                    let level_str =
+                        entry.get("level").and_then(|v| v.as_str()).unwrap_or("info");
+                    let level = match level_str {
+                        "error" => ConsoleLevel::Error,
+                        "warning" => ConsoleLevel::Warn,
+                        "info" => ConsoleLevel::Info,
+                        _ => ConsoleLevel::Log,
+                    };
+                    let text =
+                        entry.get("text").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let kind =
+                        entry.get("source").and_then(|v| v.as_str()).unwrap_or("log").to_string();
+                    let seq = st.next_seq;
+                    st.next_seq += 1;
+                    st.console.push(ConsoleEntry {
+                        seq,
+                        level,
+                        kind,
+                        text,
+                        ts: frame.ts,
+                    });
+                }
+            }
+            "Performance.metrics" => {
+                if let Some(metrics) = params.get("metrics").and_then(|v| v.as_array()) {
+                    for m in metrics {
+                        if let (Some(name), Some(value)) = (
+                            m.get("name").and_then(|v| v.as_str()),
+                            m.get("value").and_then(|v| v.as_f64()),
+                        ) {
+                            st.metrics.push(MetricSample {
+                                name: name.to_string(),
+                                value,
+                                ts: frame.ts,
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub async fn requests(&self) -> Vec<CapturedRequest> {
+        self.state.read().await.requests.values().cloned().collect()
+    }
+
+    pub async fn console(&self) -> Vec<ConsoleEntry> {
+        self.state.read().await.console.clone()
+    }
+
+    pub async fn metrics(&self) -> Vec<MetricSample> {
+        self.state.read().await.metrics.clone()
+    }
+
+    pub async fn stats(&self) -> CaptureStats {
+        let st = self.state.read().await;
+        CaptureStats {
+            requests: st.requests.len(),
+            console_entries: st.console.len(),
+            metrics: st.metrics.len(),
+            dropped_frames: st.dropped_frames,
+            recorded_bytes: st.recorded_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use gctrl_browser::cdp_proxy::FrameDirection;
+
+    fn frame(payload: &str) -> CdpFrame {
+        CdpFrame {
+            direction: FrameDirection::BrowserToClient,
+            payload: payload.into(),
+            ts: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn captures_request_lifecycle() {
+        let sink = CaptureSink::new(1024 * 1024);
+        sink.ingest(&frame(
+            r#"{"method":"Network.requestWillBeSent","params":{"requestId":"r1","request":{"url":"https://example.com/x","method":"GET"}}}"#,
+        ))
+        .await;
+        sink.ingest(&frame(
+            r#"{"method":"Network.responseReceived","params":{"requestId":"r1","response":{"status":200}}}"#,
+        ))
+        .await;
+        sink.ingest(&frame(
+            r#"{"method":"Network.loadingFinished","params":{"requestId":"r1"}}"#,
+        ))
+        .await;
+        let reqs = sink.requests().await;
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].url, "https://example.com/x");
+        assert_eq!(reqs[0].status, Some(200));
+        assert!(reqs[0].finished_at.is_some());
+        assert!(!reqs[0].failed);
+    }
+
+    #[tokio::test]
+    async fn captures_failed_request() {
+        let sink = CaptureSink::new(1024 * 1024);
+        sink.ingest(&frame(
+            r#"{"method":"Network.requestWillBeSent","params":{"requestId":"r2","request":{"url":"https://example.com","method":"GET"}}}"#,
+        ))
+        .await;
+        sink.ingest(&frame(
+            r#"{"method":"Network.loadingFailed","params":{"requestId":"r2"}}"#,
+        ))
+        .await;
+        let reqs = sink.requests().await;
+        assert!(reqs[0].failed);
+    }
+
+    #[tokio::test]
+    async fn captures_console_entries() {
+        let sink = CaptureSink::new(1024 * 1024);
+        sink.ingest(&frame(
+            r#"{"method":"Runtime.consoleAPICalled","params":{"type":"warning","args":[{"value":"low memory"}]}}"#,
+        ))
+        .await;
+        sink.ingest(&frame(
+            r#"{"method":"Runtime.exceptionThrown","params":{"exceptionDetails":{"text":"boom"}}}"#,
+        ))
+        .await;
+        let log = sink.console().await;
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0].level, ConsoleLevel::Warn);
+        assert_eq!(log[0].text, "low memory");
+        assert_eq!(log[1].level, ConsoleLevel::Exception);
+    }
+
+    #[tokio::test]
+    async fn captures_performance_metrics() {
+        let sink = CaptureSink::new(1024 * 1024);
+        sink.ingest(&frame(
+            r#"{"method":"Performance.metrics","params":{"metrics":[{"name":"JSHeapUsedSize","value":12345.0}]}}"#,
+        ))
+        .await;
+        let m = sink.metrics().await;
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].name, "JSHeapUsedSize");
+        assert_eq!(m[0].value, 12345.0);
+    }
+
+    #[tokio::test]
+    async fn ignores_client_to_browser_frames() {
+        let sink = CaptureSink::new(1024 * 1024);
+        sink.ingest(&CdpFrame {
+            direction: FrameDirection::ClientToBrowser,
+            payload: r#"{"id":1,"method":"Network.enable"}"#.into(),
+            ts: Utc::now(),
+        })
+        .await;
+        let stats = sink.stats().await;
+        // bytes counted, but no structured rows produced for the command.
+        assert!(stats.recorded_bytes > 0);
+        assert_eq!(stats.requests, 0);
+    }
+
+    #[tokio::test]
+    async fn ignores_command_responses() {
+        let sink = CaptureSink::new(1024 * 1024);
+        // Browser → client but no `method` field == response to a command.
+        sink.ingest(&frame(r#"{"id":1,"result":{}}"#)).await;
+        assert!(sink.requests().await.is_empty());
+        assert!(sink.console().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cap_drops_frames_after_max_bytes() {
+        let sink = CaptureSink::new(50);
+        for i in 0..10 {
+            sink.ingest(&frame(&format!(
+                r#"{{"method":"Network.requestWillBeSent","params":{{"requestId":"r{i}","request":{{"url":"u","method":"GET"}}}}}}"#,
+            )))
+            .await;
+        }
+        let stats = sink.stats().await;
+        assert!(stats.dropped_frames > 0);
+    }
+}

--- a/kernel/crates/gctrl-recorder/src/lib.rs
+++ b/kernel/crates/gctrl-recorder/src/lib.rs
@@ -1,0 +1,29 @@
+//! gctrl-recorder — L2 of driver-browser.
+//!
+//! Subscribes to a `gctrl-browser::Pool`'s per-session `CdpFrame`
+//! broadcast and structures the relevant CDP messages into typed records:
+//!
+//! - `Network.requestWillBeSent` / `responseReceived` / `loadingFinished`
+//!   → `CapturedRequest`
+//! - `Runtime.consoleAPICalled` / `Log.entryAdded` / `Runtime.exceptionThrown`
+//!   → `ConsoleEntry`
+//! - `Performance.metrics` → `MetricSample`
+//!
+//! The `ObservabilityReport` shape mirrors the in-app `CDPObserver`
+//! fixture being replaced (`apps/gctrl-board/tests/acceptance/fixtures/cdp.ts`)
+//! so PR5's migration can swap an HTTP fetch for an in-process method
+//! call with no assertion changes.
+//!
+//! DDL lives in `gctrl-storage::schema` per the Crate Ownership rule
+//! (`browser_sessions`, `recorder_requests`, `recorder_console`,
+//! `recorder_metrics`, `recorder_cdp_events`). Persistence happens in
+//! `gctrl-otel` so the recorder itself stays storage-agnostic and
+//! testable without DuckDB.
+
+pub mod capture;
+pub mod report;
+pub mod structured;
+
+pub use capture::{CaptureSink, CaptureStats};
+pub use report::ObservabilityReport;
+pub use structured::{CapturedRequest, ConsoleEntry, ConsoleLevel, MetricSample};

--- a/kernel/crates/gctrl-recorder/src/report.rs
+++ b/kernel/crates/gctrl-recorder/src/report.rs
@@ -1,0 +1,120 @@
+//! `ObservabilityReport` — a single JSON blob the test harness can fetch
+//! with one request after a scenario completes. Mirrors the shape that
+//! `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts::CDPObserver.report`
+//! returns today.
+
+use serde::{Deserialize, Serialize};
+
+use crate::structured::{CapturedRequest, ConsoleEntry, MetricSample};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObservabilityReport {
+    pub session_id: String,
+    pub requests: Vec<CapturedRequest>,
+    pub console: Vec<ConsoleEntry>,
+    pub metrics: Vec<MetricSample>,
+    pub stats: ReportStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportStats {
+    pub recorded_bytes: u64,
+    pub dropped_frames: u64,
+    pub request_count: usize,
+    pub console_count: usize,
+    pub metric_count: usize,
+    pub error_console_count: usize,
+    pub failed_request_count: usize,
+}
+
+impl ObservabilityReport {
+    pub fn build(
+        session_id: String,
+        requests: Vec<CapturedRequest>,
+        console: Vec<ConsoleEntry>,
+        metrics: Vec<MetricSample>,
+        recorded_bytes: u64,
+        dropped_frames: u64,
+    ) -> Self {
+        let error_console_count = console
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c.level,
+                    crate::structured::ConsoleLevel::Error
+                        | crate::structured::ConsoleLevel::Exception
+                )
+            })
+            .count();
+        let failed_request_count = requests.iter().filter(|r| r.failed).count();
+        let stats = ReportStats {
+            recorded_bytes,
+            dropped_frames,
+            request_count: requests.len(),
+            console_count: console.len(),
+            metric_count: metrics.len(),
+            error_console_count,
+            failed_request_count,
+        };
+        ObservabilityReport {
+            session_id,
+            requests,
+            console,
+            metrics,
+            stats,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::structured::ConsoleLevel;
+    use chrono::Utc;
+
+    #[test]
+    fn report_summarises_counts() {
+        let now = Utc::now();
+        let req = CapturedRequest {
+            request_id: "r".into(),
+            url: "u".into(),
+            method: "GET".into(),
+            status: Some(500),
+            started_at: now,
+            finished_at: Some(now),
+            failed: true,
+        };
+        let console = vec![
+            ConsoleEntry {
+                seq: 0,
+                level: ConsoleLevel::Error,
+                kind: "error".into(),
+                text: "boom".into(),
+                ts: now,
+            },
+            ConsoleEntry {
+                seq: 1,
+                level: ConsoleLevel::Info,
+                kind: "info".into(),
+                text: "ok".into(),
+                ts: now,
+            },
+        ];
+        let r = ObservabilityReport::build(
+            "sess1".into(),
+            vec![req],
+            console,
+            vec![],
+            42,
+            7,
+        );
+        assert_eq!(r.stats.recorded_bytes, 42);
+        assert_eq!(r.stats.dropped_frames, 7);
+        assert_eq!(r.stats.request_count, 1);
+        assert_eq!(r.stats.console_count, 2);
+        assert_eq!(r.stats.error_console_count, 1);
+        assert_eq!(r.stats.failed_request_count, 1);
+    }
+}

--- a/kernel/crates/gctrl-recorder/src/structured.rs
+++ b/kernel/crates/gctrl-recorder/src/structured.rs
@@ -1,0 +1,91 @@
+//! Structured records derived from CDP frames. Field names mirror the
+//! TypeScript shapes in `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts`
+//! so the PR5 migration can swap the HTTP fetch in for the in-process
+//! call without touching assertion code.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CapturedRequest {
+    pub request_id: String,
+    pub url: String,
+    pub method: String,
+    /// Populated once `Network.responseReceived` arrives. `None` for
+    /// in-flight requests at the moment the report is generated.
+    pub status: Option<i64>,
+    /// Wall-clock timestamp of `Network.requestWillBeSent`.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Populated by `Network.loadingFinished` / `loadingFailed`.
+    pub finished_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub failed: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsoleLevel {
+    Log,
+    Info,
+    Warn,
+    Error,
+    Debug,
+    Exception,
+}
+
+impl ConsoleLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConsoleLevel::Log => "log",
+            ConsoleLevel::Info => "info",
+            ConsoleLevel::Warn => "warn",
+            ConsoleLevel::Error => "error",
+            ConsoleLevel::Debug => "debug",
+            ConsoleLevel::Exception => "exception",
+        }
+    }
+
+    /// Map a CDP `Runtime.consoleAPICalled` `type` field to a level.
+    pub fn from_console_type(t: &str) -> Self {
+        match t {
+            "warning" | "warn" => ConsoleLevel::Warn,
+            "error" => ConsoleLevel::Error,
+            "info" => ConsoleLevel::Info,
+            "debug" | "trace" => ConsoleLevel::Debug,
+            _ => ConsoleLevel::Log,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsoleEntry {
+    pub seq: u64,
+    pub level: ConsoleLevel,
+    /// Original CDP type/source (`consoleAPICalled.type`, `Log.entryAdded.source`,
+    /// or literal `"exception"`).
+    pub kind: String,
+    pub text: String,
+    pub ts: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricSample {
+    pub name: String,
+    pub value: f64,
+    pub ts: chrono::DateTime<chrono::Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn console_level_maps_known_types() {
+        assert_eq!(ConsoleLevel::from_console_type("warning"), ConsoleLevel::Warn);
+        assert_eq!(ConsoleLevel::from_console_type("error"), ConsoleLevel::Error);
+        assert_eq!(ConsoleLevel::from_console_type("info"), ConsoleLevel::Info);
+        assert_eq!(ConsoleLevel::from_console_type("trace"), ConsoleLevel::Debug);
+        assert_eq!(ConsoleLevel::from_console_type("anything-else"), ConsoleLevel::Log);
+    }
+}

--- a/kernel/crates/gctrl-storage/src/schema.rs
+++ b/kernel/crates/gctrl-storage/src/schema.rs
@@ -479,6 +479,68 @@ CREATE TABLE IF NOT EXISTS macos_space_labels (
 )
 "#;
 
+// driver-browser recorder: one row per session that the daemon ever created,
+// plus per-session structured CDP-event tables. See
+// vault/specs/implementation/kernel/driver-browser.md §3.
+pub const CREATE_BROWSER_SESSIONS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS browser_sessions (
+    id              VARCHAR PRIMARY KEY,
+    created_at      VARCHAR NOT NULL,
+    released_at     VARCHAR,
+    browser_version VARCHAR NOT NULL,
+    options_json    VARCHAR NOT NULL,
+    status          VARCHAR NOT NULL,
+    recorded_bytes  BIGINT NOT NULL DEFAULT 0,
+    dropped_frames  BIGINT NOT NULL DEFAULT 0
+)
+"#;
+
+pub const CREATE_RECORDER_REQUESTS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS recorder_requests (
+    session_id    VARCHAR NOT NULL,
+    request_id    VARCHAR NOT NULL,
+    url           VARCHAR NOT NULL,
+    method        VARCHAR NOT NULL,
+    status        INTEGER,
+    headers_json  VARCHAR,
+    timings_json  VARCHAR,
+    ts            VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, request_id)
+)
+"#;
+
+pub const CREATE_RECORDER_CONSOLE_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS recorder_console (
+    session_id  VARCHAR NOT NULL,
+    seq         BIGINT NOT NULL,
+    level       VARCHAR NOT NULL,
+    type        VARCHAR NOT NULL,
+    text        VARCHAR NOT NULL,
+    ts          VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, seq)
+)
+"#;
+
+pub const CREATE_RECORDER_METRICS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS recorder_metrics (
+    session_id  VARCHAR NOT NULL,
+    name        VARCHAR NOT NULL,
+    value       DOUBLE NOT NULL,
+    ts          VARCHAR NOT NULL
+)
+"#;
+
+pub const CREATE_RECORDER_CDP_EVENTS_TABLE: &str = r#"
+CREATE TABLE IF NOT EXISTS recorder_cdp_events (
+    session_id  VARCHAR NOT NULL,
+    seq         BIGINT NOT NULL,
+    method      VARCHAR NOT NULL,
+    params_json VARCHAR NOT NULL,
+    ts          VARCHAR NOT NULL,
+    PRIMARY KEY (session_id, seq)
+)
+"#;
+
 pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_spans_session ON spans(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_spans_trace ON spans(trace_id)",
@@ -529,6 +591,11 @@ pub const CREATE_INDEXES: &[&str] = &[
     "CREATE INDEX IF NOT EXISTS idx_eval_metrics_kind ON eval_metrics(kind)",
     // driver-macos
     "CREATE INDEX IF NOT EXISTS idx_macos_space_labels_label ON macos_space_labels(label)",
+    // driver-browser recorder
+    "CREATE INDEX IF NOT EXISTS idx_recorder_requests_session ON recorder_requests(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_recorder_console_session ON recorder_console(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_recorder_metrics_session ON recorder_metrics(session_id, name)",
+    "CREATE INDEX IF NOT EXISTS idx_recorder_cdp_events_session ON recorder_cdp_events(session_id)",
 ];
 
 pub fn all_migrations() -> Vec<&'static str> {
@@ -570,6 +637,12 @@ pub fn all_migrations() -> Vec<&'static str> {
         ADD_SCORES_EVAL_RUN_ID,
         // driver-macos
         CREATE_MACOS_SPACE_LABELS_TABLE,
+        // driver-browser recorder
+        CREATE_BROWSER_SESSIONS_TABLE,
+        CREATE_RECORDER_REQUESTS_TABLE,
+        CREATE_RECORDER_CONSOLE_TABLE,
+        CREATE_RECORDER_METRICS_TABLE,
+        CREATE_RECORDER_CDP_EVENTS_TABLE,
     ];
     stmts.extend(CREATE_INDEXES.iter());
     stmts

--- a/shell/gctrl-shell/src/adapters/HttpBrowserClient.ts
+++ b/shell/gctrl-shell/src/adapters/HttpBrowserClient.ts
@@ -1,0 +1,62 @@
+/**
+ * HttpBrowserClient — KernelClient-backed adapter for `BrowserClient`.
+ *
+ * Translates the typed BrowserClient port into kernel HTTP calls
+ * against `/api/browser/*`. Schemas live in the port file; this adapter
+ * just wires routes.
+ */
+import { Effect, Layer } from "effect"
+import { KernelClient } from "../services/KernelClient"
+import {
+  BrowserClient,
+  CapturedRequest,
+  ConsoleEntry,
+  HealthInfo,
+  MetricSample,
+  ObservabilityReport,
+  SessionInfo,
+  SessionList,
+  type SessionOptions,
+} from "../services/BrowserClient"
+import { Schema } from "effect"
+
+const CapturedRequestList = Schema.Array(CapturedRequest)
+const ConsoleEntryList = Schema.Array(ConsoleEntry)
+const MetricSampleList = Schema.Array(MetricSample)
+
+export const HttpBrowserClientLive = Layer.effect(
+  BrowserClient,
+  Effect.gen(function* () {
+    const kernel = yield* KernelClient
+    return BrowserClient.of({
+      health: () => kernel.get("/api/browser/health", HealthInfo),
+      acquire: (opts?: SessionOptions) =>
+        kernel.post("/api/browser/sessions", opts ?? {}, SessionInfo),
+      list: () => kernel.get("/api/browser/sessions", SessionList),
+      get: (id) =>
+        kernel.get(`/api/browser/sessions/${encodeURIComponent(id)}`, SessionInfo),
+      release: (id) =>
+        kernel.delete(`/api/browser/sessions/${encodeURIComponent(id)}`),
+      network: (id) =>
+        kernel.get(
+          `/api/browser/sessions/${encodeURIComponent(id)}/network`,
+          CapturedRequestList
+        ),
+      console: (id) =>
+        kernel.get(
+          `/api/browser/sessions/${encodeURIComponent(id)}/console`,
+          ConsoleEntryList
+        ),
+      metrics: (id) =>
+        kernel.get(
+          `/api/browser/sessions/${encodeURIComponent(id)}/metrics`,
+          MetricSampleList
+        ),
+      report: (id) =>
+        kernel.get(
+          `/api/browser/sessions/${encodeURIComponent(id)}/report`,
+          ObservabilityReport
+        ),
+    })
+  })
+)

--- a/shell/gctrl-shell/src/commands/browser.ts
+++ b/shell/gctrl-shell/src/commands/browser.ts
@@ -1,0 +1,64 @@
+/**
+ * `gctrl browser` — drive the kernel `driver-browser` from the CLI.
+ *
+ * Subcommands:
+ *   - health           kernel browser health
+ *   - sessions         list active sessions
+ *   - acquire [--ttl]  acquire a session, print info
+ *   - release <id>     release a session
+ *   - report <id>      print observability report (network/console/metrics)
+ */
+import { Args, Command, Options } from "@effect/cli"
+import { Console, Effect } from "effect"
+import { BrowserClient } from "../services/BrowserClient"
+
+const idArg = Args.text({ name: "id" })
+
+const healthCmd = Command.make("health", {}, () =>
+  Effect.gen(function* () {
+    const browser = yield* BrowserClient
+    const h = yield* browser.health()
+    yield* Console.log(JSON.stringify(h, null, 2))
+  })
+)
+
+const sessionsCmd = Command.make("sessions", {}, () =>
+  Effect.gen(function* () {
+    const browser = yield* BrowserClient
+    const list = yield* browser.list()
+    yield* Console.log(JSON.stringify(list, null, 2))
+  })
+)
+
+const ttlOpt = Options.integer("ttl").pipe(
+  Options.withDefault(600),
+  Options.withDescription("session TTL in seconds (max 3600)")
+)
+
+const acquireCmd = Command.make("acquire", { ttl: ttlOpt }, ({ ttl }) =>
+  Effect.gen(function* () {
+    const browser = yield* BrowserClient
+    const info = yield* browser.acquire({ ttlSeconds: ttl })
+    yield* Console.log(JSON.stringify(info, null, 2))
+  })
+)
+
+const releaseCmd = Command.make("release", { id: idArg }, ({ id }) =>
+  Effect.gen(function* () {
+    const browser = yield* BrowserClient
+    yield* browser.release(id)
+    yield* Console.log(`released ${id}`)
+  })
+)
+
+const reportCmd = Command.make("report", { id: idArg }, ({ id }) =>
+  Effect.gen(function* () {
+    const browser = yield* BrowserClient
+    const r = yield* browser.report(id)
+    yield* Console.log(JSON.stringify(r, null, 2))
+  })
+)
+
+export const browserCommand = Command.make("browser").pipe(
+  Command.withSubcommands([healthCmd, sessionsCmd, acquireCmd, releaseCmd, reportCmd])
+)

--- a/shell/gctrl-shell/src/main.ts
+++ b/shell/gctrl-shell/src/main.ts
@@ -24,7 +24,9 @@ import { inboxCommand } from "./commands/inbox"
 import { vaultCommand } from "./commands/vault"
 import { wranglerCommand } from "./commands/wrangler"
 import { appCommand } from "./commands/app"
+import { browserCommand } from "./commands/browser"
 import { HttpKernelClientLive } from "./adapters/HttpKernelClient"
+import { HttpBrowserClientLive } from "./adapters/HttpBrowserClient"
 
 const command = Command.make("gctrl").pipe(
   Command.withSubcommands([
@@ -43,6 +45,7 @@ const command = Command.make("gctrl").pipe(
     vaultCommand,
     wranglerCommand,
     appCommand,
+    browserCommand,
   ])
 )
 
@@ -51,7 +54,9 @@ const cli = Command.run(command, {
   version: "0.1.0",
 })
 
-const ShellLive = HttpKernelClientLive().pipe(Layer.provide(FetchHttpClient.layer))
+const KernelLive = HttpKernelClientLive().pipe(Layer.provide(FetchHttpClient.layer))
+const BrowserLive = HttpBrowserClientLive.pipe(Layer.provide(KernelLive))
+const ShellLive = Layer.mergeAll(KernelLive, BrowserLive)
 
 cli(process.argv).pipe(
   Effect.provide(ShellLive),

--- a/shell/gctrl-shell/src/services/BrowserClient.ts
+++ b/shell/gctrl-shell/src/services/BrowserClient.ts
@@ -1,0 +1,165 @@
+/**
+ * BrowserClient — port for driving the kernel's `driver-browser` (CDP
+ * attach layer + recorder) over its HTTP API.
+ *
+ * Apps and acceptance tests acquire a session here, then connect their
+ * own Playwright / Puppeteer / chromiumoxide client to `cdpEndpoint`
+ * over WebSocket. After the scenario finishes, `report(id)` returns the
+ * structured `ObservabilityReport` derived from the CDP frame stream.
+ *
+ * Spec: `vault/specs/implementation/kernel/driver-browser.md`.
+ */
+import { Context, type Effect, Schema } from "effect"
+import type { KernelError, KernelUnavailableError } from "../errors"
+
+// --- schemas ---
+
+export const RecordingOptions = Schema.Struct({
+  network: Schema.optional(Schema.Boolean),
+  console: Schema.optional(Schema.Boolean),
+  performance: Schema.optional(Schema.Boolean),
+  screenshots: Schema.optional(Schema.Boolean),
+  full: Schema.optional(Schema.Boolean),
+  maxBytes: Schema.optional(Schema.Number),
+})
+export type RecordingOptions = Schema.Schema.Type<typeof RecordingOptions>
+
+export const Viewport = Schema.Struct({
+  width: Schema.Number,
+  height: Schema.Number,
+})
+export type Viewport = Schema.Schema.Type<typeof Viewport>
+
+export const SessionOptions = Schema.Struct({
+  viewport: Schema.optional(Viewport),
+  headed: Schema.optional(Schema.Boolean),
+  recording: Schema.optional(RecordingOptions),
+  ttlSeconds: Schema.optional(Schema.Number),
+})
+export type SessionOptions = Schema.Schema.Type<typeof SessionOptions>
+
+export const SessionInfo = Schema.Struct({
+  id: Schema.String,
+  createdAt: Schema.String,
+  expiresAt: Schema.String,
+  browserVersion: Schema.String,
+  status: Schema.Literal("active", "releasing", "expired"),
+  recording: Schema.Struct({
+    network: Schema.Boolean,
+    console: Schema.Boolean,
+    performance: Schema.Boolean,
+    screenshots: Schema.Boolean,
+    full: Schema.Boolean,
+    maxBytes: Schema.Number,
+  }),
+  cdpEndpoint: Schema.String,
+  token: Schema.String,
+  droppedFrames: Schema.optional(Schema.Number),
+})
+export type SessionInfo = Schema.Schema.Type<typeof SessionInfo>
+
+export const SessionList = Schema.Array(SessionInfo)
+
+export const HealthInfo = Schema.Struct({
+  chromiumVersion: Schema.NullOr(Schema.String),
+  activeSessions: Schema.Number,
+  chromiumCount: Schema.optional(Schema.Number),
+  poolMax: Schema.Number,
+  contextsPerChromiumMax: Schema.Number,
+  recycleIdleSeconds: Schema.Number,
+  recycleMaxAgeSeconds: Schema.Number,
+})
+export type HealthInfo = Schema.Schema.Type<typeof HealthInfo>
+
+export const CapturedRequest = Schema.Struct({
+  requestId: Schema.String,
+  url: Schema.String,
+  method: Schema.String,
+  status: Schema.NullOr(Schema.Number),
+  startedAt: Schema.String,
+  finishedAt: Schema.NullOr(Schema.String),
+  failed: Schema.Boolean,
+})
+export type CapturedRequest = Schema.Schema.Type<typeof CapturedRequest>
+
+export const ConsoleEntry = Schema.Struct({
+  seq: Schema.Number,
+  level: Schema.Literal("log", "info", "warn", "error", "debug", "exception"),
+  kind: Schema.String,
+  text: Schema.String,
+  ts: Schema.String,
+})
+export type ConsoleEntry = Schema.Schema.Type<typeof ConsoleEntry>
+
+export const MetricSample = Schema.Struct({
+  name: Schema.String,
+  value: Schema.Number,
+  ts: Schema.String,
+})
+export type MetricSample = Schema.Schema.Type<typeof MetricSample>
+
+export const ObservabilityReport = Schema.Struct({
+  sessionId: Schema.String,
+  requests: Schema.Array(CapturedRequest),
+  console: Schema.Array(ConsoleEntry),
+  metrics: Schema.Array(MetricSample),
+  stats: Schema.Struct({
+    recordedBytes: Schema.Number,
+    droppedFrames: Schema.Number,
+    requestCount: Schema.Number,
+    consoleCount: Schema.Number,
+    metricCount: Schema.Number,
+    errorConsoleCount: Schema.Number,
+    failedRequestCount: Schema.Number,
+  }),
+})
+export type ObservabilityReport = Schema.Schema.Type<typeof ObservabilityReport>
+
+// --- service tag ---
+
+export class BrowserClient extends Context.Tag("BrowserClient")<
+  BrowserClient,
+  {
+    readonly health: () => Effect.Effect<
+      HealthInfo,
+      KernelError | KernelUnavailableError
+    >
+    readonly acquire: (
+      opts?: SessionOptions
+    ) => Effect.Effect<SessionInfo, KernelError | KernelUnavailableError>
+    readonly list: () => Effect.Effect<
+      ReadonlyArray<SessionInfo>,
+      KernelError | KernelUnavailableError
+    >
+    readonly get: (
+      id: string
+    ) => Effect.Effect<SessionInfo, KernelError | KernelUnavailableError>
+    readonly release: (
+      id: string
+    ) => Effect.Effect<void, KernelError | KernelUnavailableError>
+    readonly network: (
+      id: string
+    ) => Effect.Effect<
+      ReadonlyArray<CapturedRequest>,
+      KernelError | KernelUnavailableError
+    >
+    readonly console: (
+      id: string
+    ) => Effect.Effect<
+      ReadonlyArray<ConsoleEntry>,
+      KernelError | KernelUnavailableError
+    >
+    readonly metrics: (
+      id: string
+    ) => Effect.Effect<
+      ReadonlyArray<MetricSample>,
+      KernelError | KernelUnavailableError
+    >
+    readonly report: (
+      id: string
+    ) => Effect.Effect<
+      ObservabilityReport,
+      KernelError | KernelUnavailableError
+    >
+  }
+>() {}

--- a/shell/gctrl-shell/test/browser.test.ts
+++ b/shell/gctrl-shell/test/browser.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+import { Effect, Layer } from "effect"
+import { BrowserClient } from "../src/services/BrowserClient"
+import { HttpBrowserClientLive } from "../src/adapters/HttpBrowserClient"
+import { createMockKernelClient } from "./helpers/mock-kernel"
+
+const mockHealth = {
+  chromiumVersion: "Chrome/124.0.6367.78",
+  activeSessions: 0,
+  chromiumCount: 1,
+  poolMax: 4,
+  contextsPerChromiumMax: 8,
+  recycleIdleSeconds: 1800,
+  recycleMaxAgeSeconds: 28800,
+}
+
+const mockSession = {
+  id: "01HV-fake",
+  createdAt: "2026-05-02T10:00:00Z",
+  expiresAt: "2026-05-02T10:10:00Z",
+  browserVersion: "Chrome/124.0.6367.78",
+  status: "active" as const,
+  recording: {
+    network: true,
+    console: true,
+    performance: true,
+    screenshots: false,
+    full: false,
+    maxBytes: 52428800,
+  },
+  cdpEndpoint:
+    "ws://127.0.0.1:4318/api/browser/sessions/01HV-fake/cdp?token=t",
+  token: "t",
+  droppedFrames: 0,
+}
+
+const mockReport = {
+  sessionId: "01HV-fake",
+  requests: [
+    {
+      requestId: "r1",
+      url: "https://example.com",
+      method: "GET",
+      status: 200,
+      startedAt: "2026-05-02T10:00:01Z",
+      finishedAt: "2026-05-02T10:00:02Z",
+      failed: false,
+    },
+  ],
+  console: [],
+  metrics: [],
+  stats: {
+    recordedBytes: 4096,
+    droppedFrames: 0,
+    requestCount: 1,
+    consoleCount: 0,
+    metricCount: 0,
+    errorConsoleCount: 0,
+    failedRequestCount: 0,
+  },
+}
+
+const TestLayer = HttpBrowserClientLive.pipe(
+  Layer.provide(
+    createMockKernelClient(
+      {
+        "/api/browser/health": mockHealth,
+        "/api/browser/sessions/01HV-fake/report": mockReport,
+        "/api/browser/sessions/01HV-fake": mockSession,
+        "/api/browser/sessions": [mockSession],
+      },
+      {
+        "/api/browser/sessions": mockSession,
+      }
+    )
+  )
+)
+
+describe("BrowserClient", () => {
+  it("health() returns parsed pool info", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const browser = yield* BrowserClient
+        return yield* browser.health()
+      }).pipe(Effect.provide(TestLayer))
+    )
+    expect(result.poolMax).toBe(4)
+    expect(result.chromiumVersion).toBe("Chrome/124.0.6367.78")
+    expect(result.activeSessions).toBe(0)
+  })
+
+  it("acquire() returns the new session info", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const browser = yield* BrowserClient
+        return yield* browser.acquire({ ttlSeconds: 600 })
+      }).pipe(Effect.provide(TestLayer))
+    )
+    expect(result.id).toBe("01HV-fake")
+    expect(result.cdpEndpoint).toContain("token=")
+    expect(result.status).toBe("active")
+  })
+
+  it("list() returns the session array", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const browser = yield* BrowserClient
+        return yield* browser.list()
+      }).pipe(Effect.provide(TestLayer))
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].id).toBe("01HV-fake")
+  })
+
+  it("get() fetches a single session", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const browser = yield* BrowserClient
+        return yield* browser.get("01HV-fake")
+      }).pipe(Effect.provide(TestLayer))
+    )
+    expect(result.token).toBe("t")
+  })
+
+  it("report() returns the structured ObservabilityReport", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const browser = yield* BrowserClient
+        return yield* browser.report("01HV-fake")
+      }).pipe(Effect.provide(TestLayer))
+    )
+    expect(result.sessionId).toBe("01HV-fake")
+    expect(result.requests.length).toBe(1)
+    expect(result.requests[0].status).toBe(200)
+    expect(result.stats.requestCount).toBe(1)
+  })
+})

--- a/vault/specs/implementation/kernel/driver-browser.md
+++ b/vault/specs/implementation/kernel/driver-browser.md
@@ -356,14 +356,14 @@ CDP frame proxy itself is **not** spanned per-frame (volume too high). Top-level
 
 ## 8. Migration plan
 
-| PR | Scope | This PR? |
+| PR | Scope | Status |
 |---|---|---|
-| 1 | Spec + scaffold `gctrl-browser` (types, errors, pool stub, route stubs returning 501) + workspace registration + light update to `architecture/kernel/browser.md` | **yes** |
-| 2 | Implement L1: real Chromium pool via `chromiumoxide`, WS proxy, token mint/verify, OTel spans, recycle loop | no |
-| 3 | Add `gctrl-recorder` crate; subscribe to L1 broadcast; DuckDB tables; observation routes + tests | no |
-| 4 | `KernelBrowserClient` Effect-TS adapter in `shell/gctrl-shell/src/services/`; mock-layer tests | no |
-| 5 | Migrate `apps/gctrl-board/tests/acceptance/`: introduce `BROWSER_BACKEND={kernel,local}` env flag; require both green for one CI cycle; then delete `apps/gctrl-board/tests/acceptance/fixtures/cdp.ts` and the local-backend code path | no |
-| 6 | (Additive) `gctrl-net` SPA mode using kernel browser; replay endpoint | no |
+| 1 | Spec + scaffold `gctrl-browser` (types, errors, pool stub, route stubs returning 501) + workspace registration + light update to `architecture/kernel/browser.md` | merged ([#148](https://github.com/OpenHackersClub/gctrl/pull/148)) |
+| 2 | Implement L1: real Chromium pool, WS proxy, token mint/verify, recycle loop. Uses raw `tokio::process` + `tokio-tungstenite` (not `chromiumoxide`) since the kernel only proxies CDP frames and never drives them from Rust | **landed in this PR** |
+| 3 | Add `gctrl-recorder` crate; subscribe to L1 broadcast; DDL in `gctrl-storage`; observation routes (`/network`, `/console`, `/metrics`, `/report`) + tests | **landed in this PR** |
+| 4 | `BrowserClient` Effect-TS port + `HttpBrowserClient` adapter in `shell/gctrl-shell/src/`; `gctrl browser` CLI; mock-layer tests | **landed in this PR** |
+| 5 | Introduce `BROWSER_BACKEND={kernel,local}` env flag in `apps/gctrl-board/tests/acceptance/`; both backends ship together for the parity gate (spec §9). **Deletion of `cdp.ts` is deferred** until one CI cycle is green on both | **gate landed; deletion follow-up TBD** |
+| 6 | (Additive) `gctrl-net` SPA mode using kernel browser; replay endpoint | **landed in this PR** |
 
 Each PR is independently mergeable: PR2 turns the stubs into real behavior; PR3 starts populating the recorder tables that PR2 wrote nothing to; PR4/5 are pure consumer changes.
 


### PR DESCRIPTION
## Summary

Turns the `driver-browser` route surface from PR1 stubs into a working CDP attach layer end-to-end: kernel pool, recorder, shell client, and a parity-gated migration path for the board acceptance suite. Spec: [vault/specs/implementation/kernel/driver-browser.md](vault/specs/implementation/kernel/driver-browser.md).

## What works after this lands

- `POST /api/browser/sessions` actually launches a Chromium and returns a token-gated CDP WS endpoint.
- `WS /api/browser/sessions/:id/cdp` proxies frames bidirectionally between the client (Playwright/Puppeteer/raw WS) and Chromium, tapping each frame for the recorder.
- `GET /api/browser/sessions/:id/{network,console,metrics,report}` returns structured observations matching the in-app `CDPObserver` shape — drop-in for board acceptance.
- A pool sweep loop expires sessions and recycles Chromiums on idle/age thresholds.
- Shell consumers can `gctrl browser {health,sessions,acquire,release,report}` or import the `BrowserClient` Effect-TS service.
- `gctrl-net` gains a `RenderMode::Kernel` so SPA scrapes go through the local kernel instead of Cloudflare Browser Rendering.
- Board acceptance can be flipped to the kernel backend with `BROWSER_BACKEND=kernel`; the legacy in-app `cdp.ts` path remains the default.

## Notable decisions

- **No `chromiumoxide`.** The kernel proxies CDP frames; it never speaks CDP from Rust. Raw `tokio::process` + `tokio-tungstenite` is the right primitive — chromiumoxide would add a framing layer we'd just be proxying around.
- **PR5 is the gate, not the cutover.** Spec §9 requires both backends to run green for one CI cycle before deleting the in-app `cdp.ts`. Flag introduced here; deletion is a follow-up PR.
- **Recorder persistence is in-memory.** DDL is provisioned in `gctrl-storage::schema` (`browser_sessions`, `recorder_*`) but the capture sink keeps observations in memory — the only consumer today reads via `/report` after each test. `POST /api/browser/replays` is scaffolded; real frame re-drive lands when the DuckDB flush job does.

## Test plan

- [x] `cargo test -p gctrl-browser` (23) / `gctrl-recorder` (9) / `gctrl-otel --lib` (92) / `gctrl-net` (27)
- [x] `pnpm --filter gctrl-shell test` — 145 pass; `tsup` build clean
- [x] `tsc --noEmit` in `apps/gctrl-board/`
- [ ] Real-Chromium smoke runs against `gctrld` at runtime; not in CI without xvfb (deferred per spec §10)
- [ ] Board acceptance under `BROWSER_BACKEND=kernel` for one CI cycle before opening the `cdp.ts` deletion PR

## Follow-ups

1. Recorder DuckDB flush job → enables real `/replays` and durable observations across daemon restarts.
2. Headed-mode CI image (xvfb) → real-Chromium smoke gate.
3. `cdp.ts` deletion PR after the parity cycle is green.
4. `Network.requestWillBeSent` cancellation hook for the future `gctrl-guardrails::BrowserDomainAllowlist`.

Commits are split per spec PR (PR2 → PR6) so reviewers can read them in order.
