### PR TITLE
feat(kernel): /api/sync/vault/{push,status} HTTP routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "async-stream",
  "axum",
  "chrono",
+ "dirs",
  "duckdb",
  "feed-rs",
  "futures-core",
@@ -1889,6 +1890,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -59,7 +59,9 @@ pub async fn run(
 
     // Spawn board directory file watcher (if configured). Watcher writes to
     // SQLite (the source of truth for board data, and the origin side of
-    // the SQLite → D1 sync).
+    // the SQLite → D1 sync). Stash a clone of the path so the kernel router
+    // can serve `/api/sync/vault/*` against the same root.
+    let vault_root = board_dir.clone();
     if let Some(dir) = board_dir {
         let watcher_store = Arc::clone(&sqlite);
         tokio::spawn(watch::watch_board_dir(watcher_store, dir));
@@ -160,12 +162,14 @@ pub async fn run(
         tracing::info!("LLM relay disabled (--no-relay)");
     }
 
-    let router = gctrl_otel::create_router_full_with_scheduler(
+    let router = gctrl_otel::create_router_full_with_vault(
         Arc::clone(&store),
         Arc::clone(&sqlite),
         sync_config,
         Arc::new(net_config),
         Arc::clone(&scheduler_config_arc),
+        vault_root,
+        None, // honor GCTRL_STATE_DIR or platform default
     );
     let router = host_allowlist_middleware::apply(router);
     let addr = format!("{host}:{port}");

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -34,9 +34,11 @@ http = { workspace = true }
 feed-rs = { workspace = true }
 sha2 = { workspace = true }
 url = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }
 http-body-util = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
+wiremock = "0.6"

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -7,4 +7,4 @@ pub mod rss;
 pub mod span_processor;
 
 pub use event_bus::{EventBus, ReplayResult, SessionEvent};
-pub use receiver::{create_router, create_router_dual, create_router_dual_with_sync, create_router_from_arc, create_router_full, create_router_full_with_scheduler};
+pub use receiver::{create_router, create_router_dual, create_router_dual_with_sync, create_router_from_arc, create_router_full, create_router_full_with_scheduler, create_router_full_with_vault};

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -46,6 +46,17 @@ pub struct AppState {
     /// See vault/specs/implementation/llm-relay.md § "Convergence with
     /// driver-llm".
     pub llm_capture: Arc<gctrl_proxy::Capture>,
+    /// Kernel-owned vault root — resolved at daemon startup from
+    /// `--board-dir` → `GCTRL_BOARD_DIR` → `./gctrl/`, per #163. Used by
+    /// the vault sync routes (`/api/sync/vault/*`) to walk
+    /// `<vault_root>/<project_key>/`. `None` when the daemon was not
+    /// configured with a board dir — sync routes return 503.
+    pub vault_root: Option<std::path::PathBuf>,
+    /// Kernel-owned state dir for vault sync manifests. Defaults to
+    /// `~/.local/share/gctrl/`; tests inject a `TempDir` to avoid
+    /// touching the operator's real state. Daemon startup honors
+    /// `GCTRL_STATE_DIR` for sandboxed deployments.
+    pub state_dir: std::path::PathBuf,
 }
 
 pub fn create_router(store: DuckDbStore) -> Router {
@@ -66,6 +77,8 @@ pub fn create_router_from_arc(store: Arc<DuckDbStore>) -> Router {
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
         llm_capture,
+        vault_root: None,
+        state_dir: default_state_dir(),
     });
     build_router(state)
 }
@@ -116,6 +129,31 @@ pub fn create_router_full_with_scheduler(
     net_config: Arc<NetConfig>,
     scheduler_config: Arc<SchedulerConfig>,
 ) -> Router {
+    create_router_full_with_vault(
+        store,
+        sqlite,
+        sync_config,
+        net_config,
+        scheduler_config,
+        None,
+        None,
+    )
+}
+
+/// Same as `create_router_full_with_scheduler` but accepts the kernel-owned
+/// vault root. Pass the same path used by `watch_board_dir` so the vault
+/// sync routes (`/api/sync/vault/*`) operate on the same on-disk tree the
+/// watcher indexes. `state_dir` defaults to `~/.local/share/gctrl/`; tests
+/// pass `Some(TempDir.path())` for isolation.
+pub fn create_router_full_with_vault(
+    store: Arc<DuckDbStore>,
+    sqlite: Arc<SqliteStore>,
+    sync_config: Option<Arc<SyncConfig>>,
+    net_config: Arc<NetConfig>,
+    scheduler_config: Arc<SchedulerConfig>,
+    vault_root: Option<std::path::PathBuf>,
+    state_dir: Option<std::path::PathBuf>,
+) -> Router {
     let llm_capture = build_llm_capture(Arc::clone(&store));
     let state = Arc::new(AppState {
         store,
@@ -127,6 +165,8 @@ pub fn create_router_full_with_scheduler(
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
         llm_capture,
+        vault_root,
+        state_dir: state_dir.unwrap_or_else(default_state_dir),
     });
     build_router(state).merge(gctrl_scheduler::http::router(sqlite, scheduler_config))
 }
@@ -145,6 +185,8 @@ pub fn create_router_with_context(store: DuckDbStore, context: Option<ContextMan
         http_client: reqwest::Client::new(),
         event_bus: EventBus::default_capacity(),
         llm_capture,
+        vault_root: None,
+        state_dir: default_state_dir(),
     });
     build_router(state)
 }
@@ -278,6 +320,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/vault/mounts/{name}", delete(vault_mounts_delete))
         .route("/api/vault/page", get(vault_page_get).post(vault_page_put))
+        // Vault file sync (kernel sync vault extension — replaces in-app
+        // R2Sync adapters per app-decoupling.md). Spec: sync.md § 2.4 and
+        // implementation/kernel/sync-vault.md.
+        .route("/api/sync/vault/push", post(vault_sync_push))
+        .route("/api/sync/vault/status", get(vault_sync_status))
         // Uebermensch briefs index — `(date, kind)` keyed; vault file is the
         // source of truth, this is the queryable index for listing/filtering.
         .route(
@@ -3865,6 +3912,165 @@ async fn sync_push(
     use gctrl_sync::SyncEngine;
     match engine.push(&defaulted).await {
         Ok(result) => Json(result).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// =============================================================================
+// Vault file sync — POST /api/sync/vault/push, GET /api/sync/vault/status.
+//
+// Walks `<vault_root>/<project_key>/`, hashes each file, uploads changed
+// files to R2 at `vaults/<project_key>/<rel_path>`. Per-project manifest
+// (`<state_dir>/sync/vaults/<project_key>.json`) persists what's been
+// pushed so subsequent calls dedup against content hashes.
+//
+// Pre-conditions enforced before any R2 call:
+//   1. `state.vault_root` is set (daemon was started with --board-dir).
+//   2. `state.sync_config` has the R2 credentials.
+//   3. `project_key` is registered in `gctrl_vault_mounts` (some app owns
+//      it via `[[vault-projects]] key = "..."` in its manifest).
+//
+// Spec: vault/specs/architecture/kernel/sync.md § 2.4 +
+//        vault/specs/implementation/kernel/sync-vault.md.
+// =============================================================================
+
+#[derive(Deserialize)]
+struct VaultSyncPushBody {
+    project_key: String,
+    #[serde(default)]
+    prefixes: Vec<String>,
+    #[serde(default)]
+    dry_run: bool,
+    #[serde(default)]
+    force: bool,
+}
+
+#[derive(Deserialize)]
+struct VaultSyncStatusQuery {
+    project_key: String,
+}
+
+/// Default state dir for daemon startup — `~/.local/share/gctrl/` overridable
+/// via `GCTRL_STATE_DIR`. Tests inject their own path via `AppState.state_dir`
+/// so no env-var race.
+pub fn default_state_dir() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("GCTRL_STATE_DIR") {
+        return std::path::PathBuf::from(p);
+    }
+    dirs::data_local_dir()
+        .map(|d: std::path::PathBuf| d.join("gctrl"))
+        .unwrap_or_else(|| std::path::PathBuf::from(".gctrl-state"))
+}
+
+fn resolve_r2_client(
+    state: &Arc<AppState>,
+) -> Result<gctrl_sync::r2::R2Client, (StatusCode, String)> {
+    let cfg = state.sync_config.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "R2 sync not configured — set GCTRL_R2_ENDPOINT, GCTRL_R2_BUCKET, \
+             GCTRL_R2_ACCESS_KEY_ID, GCTRL_R2_SECRET_ACCESS_KEY"
+                .to_string(),
+        )
+    })?;
+    if cfg.r2_endpoint.is_empty() || cfg.r2_bucket.is_empty() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "R2 sync not configured — endpoint or bucket missing".to_string(),
+        ));
+    }
+    Ok(gctrl_sync::r2::R2Client::new(
+        &cfg.r2_endpoint,
+        &cfg.r2_bucket,
+        &cfg.r2_access_key_id,
+        &cfg.r2_secret_access_key,
+    ))
+}
+
+fn resolve_vault_root(
+    state: &Arc<AppState>,
+) -> Result<std::path::PathBuf, (StatusCode, String)> {
+    state.vault_root.clone().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "vault root not configured — start gctrld with --board-dir or set GCTRL_BOARD_DIR"
+                .to_string(),
+        )
+    })
+}
+
+/// 404 if `project_key` is not registered as an app vault mount. Without
+/// this check, an HTTP caller could push to any path under the vault root,
+/// including subtrees no installed app owns. This is also where future
+/// per-app authorisation would land (today: any caller can push any
+/// registered key).
+fn require_registered_project_key(
+    state: &Arc<AppState>,
+    project_key: &str,
+) -> Result<(), (StatusCode, String)> {
+    let mounts = state.sqlite.list_vault_mounts().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    if mounts.iter().any(|m| m.name == project_key) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "project key `{project_key}` is not a registered vault mount — \
+                 install an app whose manifest declares `[[vault-projects]] key = \"{project_key}\"`"
+            ),
+        ))
+    }
+}
+
+async fn vault_sync_push(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<VaultSyncPushBody>,
+) -> impl IntoResponse {
+    let r2 = match resolve_r2_client(&state) {
+        Ok(c) => c,
+        Err((s, m)) => return (s, m).into_response(),
+    };
+    let vault_root = match resolve_vault_root(&state) {
+        Ok(p) => p,
+        Err((s, m)) => return (s, m).into_response(),
+    };
+    if let Err((s, m)) = require_registered_project_key(&state, &body.project_key) {
+        return (s, m).into_response();
+    }
+    let state_dir = state.state_dir.clone();
+    let prefixes: Vec<&str> = body.prefixes.iter().map(String::as_str).collect();
+    let opts = gctrl_sync::vault::VaultSyncOpts {
+        dry_run: body.dry_run,
+        force: body.force,
+        concurrency: 8,
+    };
+    match gctrl_sync::vault::push_to_r2(
+        &r2,
+        &vault_root,
+        &state_dir,
+        &body.project_key,
+        &prefixes,
+        opts,
+    )
+    .await
+    {
+        Ok(result) => Json(result).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn vault_sync_status(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<VaultSyncStatusQuery>,
+) -> impl IntoResponse {
+    if let Err((s, m)) = require_registered_project_key(&state, &q.project_key) {
+        return (s, m).into_response();
+    }
+    let state_dir = state.state_dir.clone();
+    match gctrl_sync::vault::VaultManifest::load(&state_dir, &q.project_key) {
+        Ok(manifest) => Json(manifest).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/kernel/crates/gctrl-otel/tests/sync_vault_routes.rs
+++ b/kernel/crates/gctrl-otel/tests/sync_vault_routes.rs
@@ -1,0 +1,330 @@
+//! HTTP contract tests for `/api/sync/vault/{push,status}`.
+//!
+//! Wires the kernel router with a `TempDir` vault root + a `TempDir`
+//! state dir + an R2Client pointed at a `wiremock` PUT endpoint. Asserts
+//! the routes correctly:
+//!   - 503 when sync isn't configured / vault root not set
+//!   - 404 when the project_key isn't a registered vault mount
+//!   - 200 happy-path push that uploads files + writes manifest
+//!   - 200 status returns the persisted manifest
+//!   - dry_run skips R2 + manifest write
+//!   - per-file R2 failures are counted, not fatal
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use chrono::Utc;
+use gctrl_otel::create_router_full_with_vault;
+use gctrl_storage::{DuckDbStore, SqliteStore};
+use http::Request;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::ServiceExt;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn write(dir: &std::path::Path, rel: &str, content: &[u8]) {
+    let abs = dir.join(rel);
+    if let Some(parent) = abs.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(abs, content).unwrap();
+}
+
+fn register_mount(sqlite: &Arc<SqliteStore>, project_key: &str) {
+    let now = Utc::now();
+    sqlite
+        .create_vault_mount(&gctrl_core::VaultMount {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: project_key.to_string(),
+            root_path: project_key.to_string(),
+            kind: gctrl_core::VaultMountKind::App,
+            git_url: None,
+            app_id: Some("test-app".into()),
+            last_commit_sha: None,
+            last_synced_at: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .unwrap();
+}
+
+struct Fixtures {
+    router: axum::Router,
+    vault: TempDir,
+    /// Held to keep the state-dir TempDir alive for the duration of the test
+    /// (the router's `state_dir` points inside it). Read elsewhere via
+    /// `f.router`'s captured Arc<AppState>.
+    #[allow(dead_code)]
+    state: TempDir,
+}
+
+fn build_app(server_uri: &str, register: &[&str]) -> Fixtures {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    for k in register {
+        register_mount(&sqlite, k);
+    }
+    let mut sync_config = gctrl_core::SyncConfig::default();
+    sync_config.r2_endpoint = server_uri.to_string();
+    sync_config.r2_bucket = "test-bucket".into();
+    sync_config.r2_access_key_id = "test-key".into();
+    sync_config.r2_secret_access_key = "test-secret".into();
+    sync_config.device_id = "test-device".into();
+
+    let vault = TempDir::new().unwrap();
+    let state = TempDir::new().unwrap();
+    let router = create_router_full_with_vault(
+        store,
+        sqlite,
+        Some(Arc::new(sync_config)),
+        Arc::new(gctrl_core::NetConfig::default()),
+        Arc::new(gctrl_core::SchedulerConfig::default()),
+        Some(vault.path().to_path_buf()),
+        Some(state.path().to_path_buf()),
+    );
+    Fixtures { router, vault, state }
+}
+
+async fn post_push(
+    router: &axum::Router,
+    body: Value,
+) -> http::Response<Body> {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/sync/vault/push")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    router.clone().oneshot(req).await.unwrap()
+}
+
+#[tokio::test]
+async fn push_503_when_sync_not_configured() {
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    register_mount(&sqlite, "UBER");
+    let vault = TempDir::new().unwrap();
+    let state = TempDir::new().unwrap();
+    // No sync_config — route must fail closed.
+    let router = create_router_full_with_vault(
+        store,
+        sqlite,
+        None,
+        Arc::new(gctrl_core::NetConfig::default()),
+        Arc::new(gctrl_core::SchedulerConfig::default()),
+        Some(vault.path().to_path_buf()),
+        Some(state.path().to_path_buf()),
+    );
+
+    let resp = post_push(
+        &router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let msg = String::from_utf8_lossy(&body);
+    assert!(msg.contains("R2 sync not configured"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn push_503_when_vault_root_not_set() {
+    let server = MockServer::start().await;
+    let store = Arc::new(DuckDbStore::open(":memory:").unwrap());
+    let sqlite = Arc::new(SqliteStore::open(":memory:").unwrap());
+    register_mount(&sqlite, "UBER");
+    let mut sync_config = gctrl_core::SyncConfig::default();
+    sync_config.r2_endpoint = server.uri();
+    sync_config.r2_bucket = "test-bucket".into();
+    sync_config.r2_access_key_id = "k".into();
+    sync_config.r2_secret_access_key = "s".into();
+    let state = TempDir::new().unwrap();
+
+    let router = create_router_full_with_vault(
+        store,
+        sqlite,
+        Some(Arc::new(sync_config)),
+        Arc::new(gctrl_core::NetConfig::default()),
+        Arc::new(gctrl_core::SchedulerConfig::default()),
+        None, // no vault root
+        Some(state.path().to_path_buf()),
+    );
+    let resp = post_push(
+        &router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let msg = String::from_utf8_lossy(&body);
+    assert!(msg.contains("vault root not configured"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn push_404_when_project_key_unregistered() {
+    let server = MockServer::start().await;
+    // No mounts registered.
+    let f = build_app(&server.uri(), &[]);
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "GHOST" }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let msg = String::from_utf8_lossy(&body);
+    assert!(msg.contains("GHOST"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn push_uploads_files_and_persists_manifest() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/test-bucket/vaults/UBER/.*$"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let f = build_app(&server.uri(), &["UBER"]);
+    write(f.vault.path(), "UBER/input/briefs/2026-05-03.md", b"# Daily brief\n");
+    write(f.vault.path(), "UBER/input/raw/foo.md", b"# Foo");
+
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["project_key"], "UBER");
+    assert_eq!(v["uploaded"], 2);
+    assert_eq!(v["failed"], 0);
+    assert!(v["bytes_uploaded"].as_u64().unwrap() > 0);
+    let plan = v["plan"].as_array().unwrap();
+    assert_eq!(plan.len(), 2);
+
+    // Status route now returns the manifest with the two entries.
+    let req = Request::builder()
+        .uri("/api/sync/vault/status?project_key=UBER")
+        .body(Body::empty())
+        .unwrap();
+    let resp = f.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let m: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(m["project_key"], "UBER");
+    let entries = m["entries"].as_object().unwrap();
+    assert_eq!(entries.len(), 2);
+    assert!(entries.contains_key("input/briefs/2026-05-03.md"));
+    assert!(entries.contains_key("input/raw/foo.md"));
+}
+
+#[tokio::test]
+async fn dry_run_does_not_write_manifest() {
+    let server = MockServer::start().await;
+    // No PUT handlers — if dry_run leaks through, wiremock 404s and `failed`
+    // bumps. The test asserts `failed == 0` to catch that.
+    let f = build_app(&server.uri(), &["UBER"]);
+    write(f.vault.path(), "UBER/x.md", b"hello");
+
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "UBER", "dry_run": true }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["uploaded"], 0);
+    assert_eq!(v["failed"], 0);
+    let plan = v["plan"].as_array().unwrap();
+    assert_eq!(plan.len(), 1);
+
+    // Status should still be empty — manifest never persisted.
+    let req = Request::builder()
+        .uri("/api/sync/vault/status?project_key=UBER")
+        .body(Body::empty())
+        .unwrap();
+    let resp = f.router.clone().oneshot(req).await.unwrap();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let m: Value = serde_json::from_slice(&body).unwrap();
+    let entries = m["entries"].as_object().unwrap();
+    assert!(entries.is_empty(), "dry-run must not write manifest entries");
+}
+
+#[tokio::test]
+async fn second_push_dedups_via_manifest() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/test-bucket/vaults/UBER/.*$"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let f = build_app(&server.uri(), &["UBER"]);
+    write(f.vault.path(), "UBER/x.md", b"unchanged");
+
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(serde_json::from_slice::<Value>(&body).unwrap()["uploaded"], 1);
+
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["uploaded"], 0, "second push should dedup");
+    assert_eq!(v["skipped"], 1);
+}
+
+#[tokio::test]
+async fn r2_failure_per_file_is_counted_not_fatal() {
+    let server = MockServer::start().await;
+    // x.md → 503; y.md → 200.
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/test-bucket/vaults/UBER/x\.md$"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/test-bucket/vaults/UBER/y\.md$"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let f = build_app(&server.uri(), &["UBER"]);
+    write(f.vault.path(), "UBER/x.md", b"x");
+    write(f.vault.path(), "UBER/y.md", b"y");
+
+    let resp = post_push(
+        &f.router,
+        serde_json::json!({ "project_key": "UBER" }),
+    )
+    .await;
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["uploaded"], 1);
+    assert_eq!(v["failed"], 1);
+}
+
+#[tokio::test]
+async fn status_404_for_unregistered_project_key() {
+    let server = MockServer::start().await;
+    let f = build_app(&server.uri(), &[]);
+    let req = Request::builder()
+        .uri("/api/sync/vault/status?project_key=GHOST")
+        .body(Body::empty())
+        .unwrap();
+    let resp = f.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+}

--- a/kernel/crates/gctrl-sync/src/engine.rs
+++ b/kernel/crates/gctrl-sync/src/engine.rs
@@ -493,6 +493,12 @@ impl R2SyncEngine {
     /// uploaded, so the next plan picks up where this one left off).
     ///
     /// Spec: `vault/specs/implementation/kernel/sync-vault.md`.
+    ///
+    /// Thin wrapper around [`crate::vault::push_to_r2`] that uses the
+    /// engine's already-configured R2 client. The HTTP route layer
+    /// (PR-β.2) calls `push_to_r2` directly without the engine, since
+    /// vault sync needs neither the DuckDB connection nor the rest of
+    /// the engine's surface.
     pub async fn push_vault(
         &self,
         vault_root: &std::path::Path,
@@ -501,106 +507,15 @@ impl R2SyncEngine {
         prefixes: &[&str],
         opts: crate::vault::VaultSyncOpts,
     ) -> Result<crate::vault::VaultSyncResult, SyncError> {
-        let mut manifest =
-            crate::vault::VaultManifest::load(state_dir, project_key)?;
-        let plan = crate::vault::plan_push(
+        crate::vault::push_to_r2(
+            &self.r2,
             vault_root,
+            state_dir,
             project_key,
             prefixes,
-            &manifest,
-            opts.force,
-        )?;
-
-        let mut uploaded = 0u64;
-        let mut skipped = 0u64;
-        let mut failed = 0u64;
-        let mut bytes_uploaded = 0u64;
-
-        if opts.dry_run {
-            for entry in &plan {
-                if matches!(entry.action, crate::vault::VaultSyncAction::Upload) {
-                    // dry-run treats Upload entries as "would upload"; counts
-                    // stay at 0 so callers can distinguish "nothing changed"
-                    // from "would change N".
-                } else {
-                    skipped += 1;
-                }
-            }
-            return Ok(crate::vault::VaultSyncResult {
-                project_key: project_key.to_string(),
-                plan,
-                uploaded,
-                skipped,
-                failed,
-                bytes_uploaded,
-            });
-        }
-
-        for entry in &plan {
-            match entry.action {
-                crate::vault::VaultSyncAction::Upload => {
-                    let abs = vault_root.join(project_key).join(&entry.rel_path);
-                    let key = crate::vault::r2_key(project_key, &entry.rel_path);
-                    match tokio::fs::read(&abs).await {
-                        Ok(body) => {
-                            let n = body.len() as u64;
-                            match self.r2.put_object(&key, body).await {
-                                Ok(()) => {
-                                    uploaded += 1;
-                                    bytes_uploaded += n;
-                                    manifest.entries.insert(
-                                        entry.rel_path.clone(),
-                                        crate::vault::VaultManifestEntry {
-                                            sha256: entry.sha256.clone(),
-                                            size_bytes: entry.size_bytes,
-                                            uploaded_at: chrono::Utc::now().to_rfc3339(),
-                                            etag: None,
-                                        },
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        ?key,
-                                        error = %e,
-                                        "vault sync: R2 upload failed"
-                                    );
-                                    failed += 1;
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                path = %abs.display(),
-                                error = %e,
-                                "vault sync: file read failed"
-                            );
-                            failed += 1;
-                        }
-                    }
-                }
-                crate::vault::VaultSyncAction::SkipHashMatch
-                | crate::vault::VaultSyncAction::SkipOutsidePrefix => {
-                    skipped += 1;
-                }
-            }
-        }
-
-        if uploaded > 0 {
-            manifest.updated_at = Some(chrono::Utc::now().to_rfc3339());
-            // Manifest save errors are surfaced — losing manifest state means
-            // the next sync re-uploads everything from scratch. That's
-            // wasteful but not corrupting; still worth the explicit error.
-            manifest.save(state_dir)?;
-        }
-
-        Ok(crate::vault::VaultSyncResult {
-            project_key: project_key.to_string(),
-            plan,
-            uploaded,
-            skipped,
-            failed,
-            bytes_uploaded,
-        })
+            opts,
+        )
+        .await
     }
 }
 

--- a/kernel/crates/gctrl-sync/src/vault.rs
+++ b/kernel/crates/gctrl-sync/src/vault.rs
@@ -286,6 +286,123 @@ pub fn r2_key(project_key: &str, rel_path: &str) -> String {
     format!("vaults/{project_key}/{rel_path}")
 }
 
+// ───────────────────────── Push (engine-free) ─────────────────────────
+
+/// Push every file under `<vault_root>/<project_key>/` to R2 at
+/// `vaults/<project_key>/<rel_path>`. Honors content-hash dedup against the
+/// per-project manifest at `<state_dir>/sync/vaults/<project_key>.json`.
+///
+/// `prefixes` narrows to subtrees (e.g. `["input/briefs", "input/raw"]`).
+///
+/// On `dry_run = true`, skips R2 entirely and returns the plan only — the
+/// manifest is NOT touched. On per-file upload failure, increments `failed`
+/// and continues so a flaky network doesn't lose a whole sync — the next
+/// call retries since the manifest only records what actually uploaded.
+///
+/// Decoupled from `R2SyncEngine` so the HTTP route can call it with just an
+/// `R2Client`, no DuckDB connection. `R2SyncEngine::push_vault` is a thin
+/// wrapper for the engine consumer side.
+pub async fn push_to_r2(
+    r2: &crate::r2::R2Client,
+    vault_root: &Path,
+    state_dir: &Path,
+    project_key: &str,
+    prefixes: &[&str],
+    opts: VaultSyncOpts,
+) -> Result<VaultSyncResult, SyncError> {
+    let mut manifest = VaultManifest::load(state_dir, project_key)?;
+    let plan = plan_push(vault_root, project_key, prefixes, &manifest, opts.force)?;
+
+    let mut uploaded = 0u64;
+    let mut skipped = 0u64;
+    let mut failed = 0u64;
+    let mut bytes_uploaded = 0u64;
+
+    if opts.dry_run {
+        for entry in &plan {
+            if !matches!(entry.action, VaultSyncAction::Upload) {
+                skipped += 1;
+            }
+            // Upload entries in dry-run stay at uploaded=0; callers can
+            // distinguish "nothing changed" from "would change N" by
+            // counting plan entries with action=Upload.
+        }
+        return Ok(VaultSyncResult {
+            project_key: project_key.to_string(),
+            plan,
+            uploaded,
+            skipped,
+            failed,
+            bytes_uploaded,
+        });
+    }
+
+    for entry in &plan {
+        match entry.action {
+            VaultSyncAction::Upload => {
+                let abs = vault_root.join(project_key).join(&entry.rel_path);
+                let key = r2_key(project_key, &entry.rel_path);
+                match tokio::fs::read(&abs).await {
+                    Ok(body) => {
+                        let n = body.len() as u64;
+                        match r2.put_object(&key, body).await {
+                            Ok(()) => {
+                                uploaded += 1;
+                                bytes_uploaded += n;
+                                manifest.entries.insert(
+                                    entry.rel_path.clone(),
+                                    VaultManifestEntry {
+                                        sha256: entry.sha256.clone(),
+                                        size_bytes: entry.size_bytes,
+                                        uploaded_at: chrono::Utc::now().to_rfc3339(),
+                                        etag: None,
+                                    },
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    ?key,
+                                    error = %e,
+                                    "vault sync: R2 upload failed"
+                                );
+                                failed += 1;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            path = %abs.display(),
+                            error = %e,
+                            "vault sync: file read failed"
+                        );
+                        failed += 1;
+                    }
+                }
+            }
+            VaultSyncAction::SkipHashMatch | VaultSyncAction::SkipOutsidePrefix => {
+                skipped += 1;
+            }
+        }
+    }
+
+    if uploaded > 0 {
+        manifest.updated_at = Some(chrono::Utc::now().to_rfc3339());
+        // Manifest save errors are surfaced — losing manifest state means
+        // the next sync re-uploads everything from scratch. That's wasteful
+        // but not corrupting; still worth the explicit error.
+        manifest.save(state_dir)?;
+    }
+
+    Ok(VaultSyncResult {
+        project_key: project_key.to_string(),
+        plan,
+        uploaded,
+        skipped,
+        failed,
+        bytes_uploaded,
+    })
+}
+
 fn is_under_any_prefix(rel_path: &str, prefixes: &[&str]) -> bool {
     if prefixes.is_empty() {
         return true;


### PR DESCRIPTION
## Summary

PR-β.2 of the kernel sync vault extension. **Stacks on #176** (PR-β.1: vault module).

Mounts the kernel HTTP surface for vault file sync that uebermensch (and any future app with a vault) calls instead of shelling out to wrangler. Routes are 503/404-checked before touching R2 so an unconfigured daemon or unregistered project key fails fast with a useful error.

## What lands

### `gctrl-sync::vault::push_to_r2` (free function)

Refactor of PR-β.1's `R2SyncEngine::push_vault` — the heavy lifting now lives as a free function that takes only an `R2Client` (no DuckDB connection required), so the HTTP route can call it without spinning up the full engine. `R2SyncEngine::push_vault` becomes a thin wrapper for the engine consumer side.

### `AppState` extension

| Field | Purpose |
|---|---|
| `vault_root: Option<PathBuf>` | Kernel-owned vault root from `--board-dir` / `GCTRL_BOARD_DIR` (per #163). `None` → sync routes return 503. |
| `state_dir: PathBuf` | Kernel-owned state dir for vault sync manifests. Defaults to `~/.local/share/gctrl/`; tests inject a `TempDir` so no env-var race. |

### Router constructor

New `create_router_full_with_vault(...)` accepts both `vault_root` and `state_dir` as optional overrides. `serve.rs` plumbs the existing `--board-dir` argument straight through; defaults to env resolution otherwise. Old `create_router_full_with_scheduler` stays as a thin wrapper passing `None` for both, for back-compat with existing tests.

### Routes

| Route | Verb | Behavior |
|---|---|---|
| `/api/sync/vault/push` | POST | Body: `{ project_key, prefixes?, dry_run?, force? }`. Returns the `VaultSyncResult` (plan + uploaded/skipped/failed counts). |
| `/api/sync/vault/status` | GET | Query: `?project_key=X`. Returns the persisted `VaultManifest` (empty manifest for first-time keys). |

Pre-conditions enforced before any R2 call:

1. `state.vault_root` is set (else **503**).
2. `state.sync_config` has R2 endpoint + bucket (else **503**).
3. `project_key` is a registered row in `gctrl_vault_mounts` (else **404**). This is also where future per-app authorisation will land — today any caller can push to any registered key.

## Test plan

- `cargo build --workspace --tests` clean (`RUSTFLAGS=-D warnings`)
- `cargo test --workspace` — **637 passing** (8 new sync_vault route tests; no regressions)

8 integration tests in `tests/sync_vault_routes.rs` against `wiremock` for R2:

- `push_503_when_sync_not_configured`
- `push_503_when_vault_root_not_set`
- `push_404_when_project_key_unregistered`
- `push_uploads_files_and_persists_manifest` — happy path; status route reflects the manifest after push
- `dry_run_does_not_write_manifest`
- `second_push_dedups_via_manifest` — replay returns uploaded=0
- `r2_failure_per_file_is_counted_not_fatal`
- `status_404_for_unregistered_project_key`

## Stack

- ✅ #166 — capability registry + manifest parser **(merged)**
- ✅ #147, #159, #165, #173 — unrelated **(merged this week)**
- 🟡 #167, #168, #171 — install machinery (rebased earlier)
- 🟡 #174 — schedule registration (likely conflicts with #165's `health` field; deferred rebase)
- 🟡 #176 — PR-β.1 vault sync engine
- **This PR** — PR-β.2 vault sync HTTP routes ← *you are here*

## Out of scope (deferred)

- **`pull_vault`** (cross-device sync) — will land alongside `R2Client::list_objects` when a real use case appears.
- **Per-app authorisation** — route validates `project_key` is registered but doesn't yet check that the caller is the owning app. v1 trusts any caller behind the daemon's auth gate.
- **Watcher-driven incremental pushes** — still a separate slice.
