### PR TITLE
feat(kernel): generalize watcher to walk gctrl_vault_mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
  "notify",
  "reqwest 0.12.28",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tracing",

--- a/kernel/crates/gctrl-cli/Cargo.toml
+++ b/kernel/crates/gctrl-cli/Cargo.toml
@@ -42,3 +42,4 @@ notify = "7"
 
 [dev-dependencies]
 tower = { workspace = true }
+tempfile = { workspace = true }

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -57,15 +57,15 @@ pub async fn run(
     let sqlite = Arc::new(SqliteStore::open(&sqlite_path)?);
     tracing::info!("sqlite (board/inbox): {sqlite_path}");
 
-    // Spawn board directory file watcher (if configured). Watcher writes to
-    // SQLite (the source of truth for board data, and the origin side of
-    // the SQLite → D1 sync). Stash a clone of the path so the kernel router
-    // can serve `/api/sync/vault/*` against the same root.
+    // Spawn one file watcher per row in `gctrl_vault_mounts`. Each watcher
+    // writes to SQLite (the source of truth for board data, and the origin
+    // side of the SQLite → D1 sync). The legacy single `board_dir` arg is
+    // kept only so the kernel router can serve `/api/sync/vault/*` against
+    // the same root the operator configured on the CLI; mounts are now the
+    // exclusive source for *which* directories get watched.
     let vault_root = board_dir.clone();
-    if let Some(dir) = board_dir {
-        let watcher_store = Arc::clone(&sqlite);
-        tokio::spawn(watch::watch_board_dir(watcher_store, dir));
-    }
+    let watcher_store = Arc::clone(&sqlite);
+    tokio::spawn(watch::watch_all_vault_mounts(watcher_store));
 
     let sync_config = SyncConfig::from_env();
     let sync_config = if sync_config.d1_enabled() {

--- a/kernel/crates/gctrl-cli/src/commands/watch.rs
+++ b/kernel/crates/gctrl-cli/src/commands/watch.rs
@@ -1,37 +1,91 @@
-//! File watcher for board markdown directories.
+//! File watcher for vault markdown directories.
 //!
-//! Watches `gctrl/{PROJECT_KEY}/*.md` and auto-imports on create/modify into
-//! the SQLite board store (the source of truth for board data, and the
-//! origin side of the SQLite → D1 sync).
+//! Walks every row in `gctrl_vault_mounts` and spawns one watcher per mount.
+//! Each mount's `root_path` is treated like the legacy board dir: subdirectories
+//! become project keys, and `.md` files inside them are auto-imported via
+//! `gctrl_storage::import_markdown_dir` with content_hash dedup.
+//!
+//! Layout for a single mount:
+//!   {mount.root_path}/
+//!     BOARD/
+//!       BOARD-1.md
+//!     INBOX/
+//!       INBOX-1.md
+//!
 //! Uses native OS file events (FSEvents on macOS, inotify on Linux).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use gctrl_core::VaultMount;
 use gctrl_storage::SqliteStore;
 use notify::{Event, EventKind, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
 
-/// Spawn a file watcher on `board_dir` that auto-imports markdown issues.
+/// List every registered vault mount and spawn one watcher per row.
 ///
-/// Expected layout:
-///   board_dir/
-///     BOARD/
-///       BOARD-1.md
-///       BOARD-2.md
-///     INBOX/
-///       INBOX-1.md
-///
-/// Each subdirectory name is a project key. Files are imported using
-/// `gctrl_storage::import_markdown_dir` with content_hash dedup.
-pub async fn watch_board_dir(store: Arc<SqliteStore>, board_dir: PathBuf) {
-    if !board_dir.is_dir() {
-        tracing::warn!("board dir not found: {} — file watcher disabled", board_dir.display());
+/// Resilient: a launch failure on one mount logs and skips that mount;
+/// the others keep running. Empty list logs and returns (no panic).
+pub async fn watch_all_vault_mounts(store: Arc<SqliteStore>) {
+    let mounts = match store.list_vault_mounts() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to list vault mounts — file watcher disabled");
+            return;
+        }
+    };
+
+    if mounts.is_empty() {
+        tracing::info!("no vault mounts registered — file watcher idle");
         return;
     }
 
-    tracing::info!("watching board dir: {}", board_dir.display());
+    tracing::info!("starting file watchers for {} vault mount(s)", mounts.len());
+    for mount in mounts {
+        let mount_store = Arc::clone(&store);
+        tokio::spawn(async move {
+            watch_vault_mount(mount_store, mount).await;
+        });
+    }
+}
+
+/// Spawn a file watcher rooted at `mount.root_path`. Each direct subdirectory
+/// of the root is treated as a project key (same semantics as the legacy
+/// board-dir watcher). Failures log and exit this task only — sibling
+/// watchers keep running.
+pub async fn watch_vault_mount(store: Arc<SqliteStore>, mount: VaultMount) {
+    let root_input = PathBuf::from(&mount.root_path);
+    if !root_input.is_dir() {
+        tracing::warn!(
+            mount = %mount.name,
+            path = %root_input.display(),
+            "vault mount root not found — watcher disabled for this mount"
+        );
+        return;
+    }
+
+    // Canonicalize so that path comparisons against events from notify (which
+    // on macOS resolves `/var` → `/private/var` via FSEvents) line up with
+    // the watcher's root.
+    let root = match std::fs::canonicalize(&root_input) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                mount = %mount.name,
+                path = %root_input.display(),
+                error = %e,
+                "failed to canonicalize vault mount root"
+            );
+            return;
+        }
+    };
+
+    tracing::info!(
+        mount = %mount.name,
+        path = %root.display(),
+        "watching vault mount"
+    );
 
     // Channel to receive file events from the sync watcher callback
     let (tx, mut rx) = mpsc::channel::<PathBuf>(64);
@@ -52,13 +106,22 @@ pub async fn watch_board_dir(store: Arc<SqliteStore>, board_dir: PathBuf) {
     }) {
         Ok(w) => w,
         Err(e) => {
-            tracing::error!("failed to create file watcher: {e}");
+            tracing::error!(
+                mount = %mount.name,
+                error = %e,
+                "failed to create file watcher"
+            );
             return;
         }
     };
 
-    if let Err(e) = watcher.watch(&board_dir, RecursiveMode::Recursive) {
-        tracing::error!("failed to watch {}: {e}", board_dir.display());
+    if let Err(e) = watcher.watch(&root, RecursiveMode::Recursive) {
+        tracing::error!(
+            mount = %mount.name,
+            path = %root.display(),
+            error = %e,
+            "failed to watch vault mount root"
+        );
         return;
     }
 
@@ -84,7 +147,7 @@ pub async fn watch_board_dir(store: Arc<SqliteStore>, board_dir: PathBuf) {
 
         // Import each changed subdirectory
         for dir in &changed_dirs {
-            import_subdir(&store, dir, &board_dir);
+            import_subdir(&store, dir, &root, &mount.name);
         }
     }
 
@@ -92,16 +155,21 @@ pub async fn watch_board_dir(store: Arc<SqliteStore>, board_dir: PathBuf) {
     drop(watcher);
 }
 
-/// Import a single project subdirectory (e.g. `apps/gctrl-board/vault/BOARD/`).
-fn import_subdir(store: &SqliteStore, dir: &std::path::Path, board_dir: &std::path::Path) {
+/// Import a single project subdirectory (e.g. `{mount_root}/BOARD/`).
+fn import_subdir(
+    store: &SqliteStore,
+    dir: &Path,
+    mount_root: &Path,
+    mount_name: &str,
+) {
     // Derive project key from directory name
     let project_key = match dir.file_name().and_then(|n| n.to_str()) {
         Some(key) => key.to_uppercase(),
         None => return,
     };
 
-    // Skip if this isn't a direct child of board_dir
-    if dir.parent() != Some(board_dir) {
+    // Skip if this isn't a direct child of the mount root
+    if dir.parent() != Some(mount_root) {
         return;
     }
 
@@ -109,7 +177,7 @@ fn import_subdir(store: &SqliteStore, dir: &std::path::Path, board_dir: &std::pa
     let projects = match store.list_board_projects() {
         Ok(p) => p,
         Err(e) => {
-            tracing::error!("failed to list projects: {e}");
+            tracing::error!(mount = %mount_name, error = %e, "failed to list projects");
             return;
         }
     };
@@ -124,17 +192,22 @@ fn import_subdir(store: &SqliteStore, dir: &std::path::Path, board_dir: &std::pa
             github_repo: None,
         };
         if let Err(e) = store.create_board_project(&project) {
-            tracing::error!("failed to auto-create project {project_key}: {e}");
+            tracing::error!(
+                mount = %mount_name,
+                project = %project_key,
+                error = %e,
+                "failed to auto-create project"
+            );
             return;
         }
-        tracing::info!("auto-created project: {project_key}");
+        tracing::info!(mount = %mount_name, project = %project_key, "auto-created project");
     }
 
     // Re-fetch projects (may have just created one)
     let projects = match store.list_board_projects() {
         Ok(p) => p,
         Err(e) => {
-            tracing::error!("failed to list projects: {e}");
+            tracing::error!(mount = %mount_name, error = %e, "failed to list projects");
             return;
         }
     };
@@ -143,7 +216,12 @@ fn import_subdir(store: &SqliteStore, dir: &std::path::Path, board_dir: &std::pa
     let parsed = match gctrl_storage::import_markdown_dir(dir, &projects) {
         Ok(p) => p,
         Err(e) => {
-            tracing::warn!("import error in {}: {e}", dir.display());
+            tracing::warn!(
+                mount = %mount_name,
+                dir = %dir.display(),
+                error = %e,
+                "import error"
+            );
             return;
         }
     };
@@ -154,14 +232,129 @@ fn import_subdir(store: &SqliteStore, dir: &std::path::Path, board_dir: &std::pa
         match store.upsert_board_issue(issue) {
             Ok(true) => imported += 1,
             Ok(false) => skipped += 1,
-            Err(e) => tracing::error!("upsert failed for {}: {e}", issue.id),
+            Err(e) => tracing::error!(
+                mount = %mount_name,
+                issue = %issue.id,
+                error = %e,
+                "upsert failed"
+            ),
         }
     }
 
     if imported > 0 {
         tracing::info!(
-            "board watch: {project_key}/ — {imported} imported, {skipped} skipped (total: {})",
-            parsed.len()
+            mount = %mount_name,
+            project = %project_key,
+            imported,
+            skipped,
+            total = parsed.len(),
+            "vault watch imported issues"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use gctrl_core::VaultMountKind;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use tokio::time::sleep;
+
+    fn make_mount(id: &str, name: &str, root: &Path) -> VaultMount {
+        let now = Utc::now();
+        VaultMount {
+            id: id.into(),
+            name: name.into(),
+            root_path: root.to_string_lossy().into_owned(),
+            kind: VaultMountKind::App,
+            git_url: None,
+            app_id: None,
+            last_commit_sha: None,
+            last_synced_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn issue_md(key: &str, project: &str, n: u32) -> String {
+        format!(
+            "---\nid: {key}-{n}\nproject: {project}\ntitle: Issue {n}\nstatus: todo\n---\n\n# Issue {n}\n\nbody\n",
+            key = key,
+            n = n,
+            project = project
+        )
+    }
+
+    #[tokio::test]
+    async fn watch_all_vault_mounts_empty_list_no_panic() {
+        let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+        // No mounts registered — should log and return cleanly
+        watch_all_vault_mounts(store).await;
+    }
+
+    #[tokio::test]
+    async fn watch_all_vault_mounts_imports_under_each_mount() {
+        // Two mounts, each with one project subdir; write a .md file in each
+        // and assert both get imported under their respective project keys.
+        let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+
+        let tmp_a = TempDir::new().unwrap();
+        let tmp_b = TempDir::new().unwrap();
+
+        // Pre-create the project subdirs (mount A → AAA, mount B → BBB)
+        let proj_a_dir = tmp_a.path().join("AAA");
+        let proj_b_dir = tmp_b.path().join("BBB");
+        std::fs::create_dir_all(&proj_a_dir).unwrap();
+        std::fs::create_dir_all(&proj_b_dir).unwrap();
+
+        store
+            .create_vault_mount(&make_mount("m-a", "mount-a", tmp_a.path()))
+            .unwrap();
+        store
+            .create_vault_mount(&make_mount("m-b", "mount-b", tmp_b.path()))
+            .unwrap();
+
+        // Spawn the watcher orchestrator
+        watch_all_vault_mounts(Arc::clone(&store)).await;
+
+        // Give the watchers a moment to register with the OS
+        sleep(Duration::from_millis(300)).await;
+
+        // Write a file in each mount
+        std::fs::write(proj_a_dir.join("AAA-1.md"), issue_md("AAA", "AAA", 1)).unwrap();
+        std::fs::write(proj_b_dir.join("BBB-1.md"), issue_md("BBB", "BBB", 1)).unwrap();
+
+        // Wait for debounce + import: 500ms debounce + slack
+        sleep(Duration::from_millis(2000)).await;
+
+        let projects = store.list_board_projects().unwrap();
+        let project_keys: std::collections::HashSet<_> =
+            projects.iter().map(|p| p.key.as_str()).collect();
+        assert!(
+            project_keys.contains("AAA"),
+            "expected AAA project to be auto-created, got {project_keys:?}"
+        );
+        assert!(
+            project_keys.contains("BBB"),
+            "expected BBB project to be auto-created, got {project_keys:?}"
+        );
+
+        // Assert at least one issue exists per project
+        let aaa = projects.iter().find(|p| p.key == "AAA").unwrap();
+        let bbb = projects.iter().find(|p| p.key == "BBB").unwrap();
+        let aaa_filter = gctrl_core::BoardIssueFilter {
+            project_id: Some(aaa.id.clone()),
+            ..Default::default()
+        };
+        let bbb_filter = gctrl_core::BoardIssueFilter {
+            project_id: Some(bbb.id.clone()),
+            ..Default::default()
+        };
+        let aaa_issues = store.list_board_issues(&aaa_filter).unwrap();
+        let bbb_issues = store.list_board_issues(&bbb_filter).unwrap();
+        assert!(!aaa_issues.is_empty(), "AAA issues should be imported");
+        assert!(!bbb_issues.is_empty(), "BBB issues should be imported");
     }
 }


### PR DESCRIPTION
## Summary

Generalizes the kernel's markdown file watcher from a single hardcoded `board_dir` to one watcher per row in `gctrl_vault_mounts`. This unblocks per-app vault indexing — each app (e.g. uebermensch's UBER project at `${GCTRL_BOARD_DIR}/UBER/`) can register its vault root as a mount and the kernel will watch and index it the same way it always watched the legacy board directory.

This is slice 2 of 3 on the vault-sync work, stacked on top of [#178](https://github.com/OpenHackersClub/gctrl/pull/178) (the parent `feat/kernel-sync-vault-routes` branch).

### How it works

- `watch_all_vault_mounts(store)` reads `gctrl_vault_mounts` at startup and spawns one task per row. Empty list logs and returns; per-mount setup failures (missing root, notify error, canonicalize error) log and exit only that task — sibling mounts keep running.
- `watch_vault_mount(store, mount)` is the per-mount task: same notify-based debounced import path as before, rooted at `mount.root_path`. Each direct subdirectory of the root is a project key, matching the legacy board-dir semantics.
- Mount roots are canonicalized before watching so FSEvents events on macOS (which resolve `/var` → `/private/var`) line up with the watcher root used for the `dir.parent() == mount_root` filter.
- `serve.rs` now spawns `watch_all_vault_mounts` unconditionally. The `board_dir` CLI arg survives only as the `vault_root` passed to the otel router for `/api/sync/vault/*` — operators who want their old `${BOARD_DIR}` watched need to register it as a workspace vault mount.

### New public functions (in `kernel/crates/gctrl-cli/src/commands/watch.rs`)

- `pub async fn watch_all_vault_mounts(store: Arc<SqliteStore>)`
- `pub async fn watch_vault_mount(store: Arc<SqliteStore>, mount: VaultMount)`

The legacy `watch_board_dir` was deleted (only caller was `serve.rs`).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p gctrl-cli -p gctrl-storage` — 6 + 107 + 5 + 5 + 14 tests passing
- [x] New tokio test `watch_all_vault_mounts_imports_under_each_mount` registers two mounts at temp dirs, writes `.md` files under each, asserts both projects auto-create and issues import
- [x] Empty-mount-list test (`watch_all_vault_mounts_empty_list_no_panic`) confirms no panic
