### PR TITLE
fix(scheduler): add missing app_id + health fields on Schedule literals

### DIFF
--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -5109,6 +5109,7 @@ fn install_app_inner(
                 app_id: Some(manifest.app.name.clone()),
                 created_at: now_str.clone(),
                 updated_at: now_str,
+                health: None,
             },
             "http" => gctrl_core::Schedule {
                 id: uuid::Uuid::new_v4().to_string(),
@@ -5138,6 +5139,7 @@ fn install_app_inner(
                 app_id: Some(manifest.app.name.clone()),
                 created_at: now_str.clone(),
                 updated_at: now_str,
+                health: None,
             },
             other => {
                 return Err((

--- a/kernel/crates/gctrl-scheduler/src/bootstrap.rs
+++ b/kernel/crates/gctrl-scheduler/src/bootstrap.rs
@@ -94,6 +94,7 @@ pub fn build_gc_row(cfg: &SchedulerConfig) -> Schedule {
     Schedule {
         id: uuid::Uuid::new_v4().to_string(),
         name: GC_SCHEDULE_NAME.into(),
+        app_id: None,
         cron: GC_CRON.into(),
         target_kind: TARGET_KIND_HTTP.into(),
         target_url: target,


### PR DESCRIPTION
## Summary

Main has been red since #174 — two `Schedule { ... }` literal sites were missed when the struct grew `app_id: Option<String>` (#174) and `health: Option<ScheduleHealth>` (earlier).

- `kernel/crates/gctrl-scheduler/src/bootstrap.rs:94` — GC bootstrap row, missing `app_id`
- `kernel/crates/gctrl-otel/src/receiver.rs:5087,5113` — manifest install exec/http handlers, missing `health`

Both fields are `Option<_>`. The correct value at construction time (no app association for the bootstrap row; no derived health on freshly-inserted rows) is `None`.

## Test plan

- [x] `cargo check --workspace` — clean, no errors
- [ ] CI green on this PR before merge
