### PR TITLE
chore(rust): support shared target dir and smaller releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/debuggingfuture/gctrl"
 
+[profile.release]
+strip = "debuginfo"
+lto = "thin"
+
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ cargo run -- status          # health check
 cargo run -- sessions        # list agent sessions
 ```
 
+To keep Rust build artifacts outside the checkout, set a local shared target
+directory before running Cargo:
+
+```sh
+export CARGO_TARGET_DIR="$HOME/Library/Caches/gctrl/cargo-target"
+```
+
+Do not commit this as repo config; the path is machine-specific. The desktop
+kernel build script honors `CARGO_TARGET_DIR` when staging its universal2
+release binary.
+
 ## Architecture
 
 ```mermaid

--- a/apps/gctrl-desktop/scripts/build-kernel-universal.sh
+++ b/apps/gctrl-desktop/scripts/build-kernel-universal.sh
@@ -22,6 +22,7 @@ PACKAGE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 WORKSPACE_ROOT="$(cd "${PACKAGE_ROOT}/../.." && pwd)"
 
 OUT_DIR="${PACKAGE_ROOT}/resources/kernel"
+CARGO_OUT_DIR="${CARGO_TARGET_DIR:-target}"
 # Source binary defined in `kernel/crates/gctrl-cli/Cargo.toml`. The kernel
 # daemon binary is `gctrld` (with the `d` suffix); we bundle it under a
 # friendlier `gctrl-kernel` name so the desktop's path resolver doesn't have
@@ -30,6 +31,7 @@ BIN_NAME="gctrld"
 DEST_NAME="gctrl-kernel"
 
 echo "[build-kernel] workspace: ${WORKSPACE_ROOT}"
+echo "[build-kernel] cargo target dir: ${CARGO_OUT_DIR}"
 
 # Sanity-check toolchain so failures surface at the top of the log instead
 # of mid-cargo.
@@ -55,8 +57,8 @@ cargo build \
 echo "[build-kernel] fusing into universal2 with lipo..."
 mkdir -p "${OUT_DIR}"
 lipo -create -output "${OUT_DIR}/${DEST_NAME}" \
-  "target/aarch64-apple-darwin/release/${BIN_NAME}" \
-  "target/x86_64-apple-darwin/release/${BIN_NAME}"
+  "${CARGO_OUT_DIR}/aarch64-apple-darwin/release/${BIN_NAME}" \
+  "${CARGO_OUT_DIR}/x86_64-apple-darwin/release/${BIN_NAME}"
 
 echo "[build-kernel] staged ${OUT_DIR}/${DEST_NAME}"
 file "${OUT_DIR}/${DEST_NAME}"


### PR DESCRIPTION
## Summary
- make the desktop universal kernel build honor CARGO_TARGET_DIR when locating release artifacts for lipo
- document a safe local shared Cargo target dir workflow in the README
- add conservative release profile size tuning with debuginfo stripping and thin LTO

## Verification
- bash -n apps/gctrl-desktop/scripts/build-kernel-universal.sh
- git diff --check
- cargo metadata --no-deps --format-version 1
- env CARGO_TARGET_DIR=/private/tmp/gctrl-release-check cargo build --release -p gctrl-core --locked

## Note
- env CARGO_TARGET_DIR=/private/tmp/gctrl-release-check cargo build --release --bin gctrld --locked is currently blocked by an existing compile error in gctrl-scheduler: Schedule initializer in kernel/crates/gctrl-scheduler/src/bootstrap.rs is missing app_id.