### PR TITLE
fix(shell): tolerate JSON null in BoardIssue nullable fields

### DIFF
--- a/shell/gctrl-shell/src/commands/board.ts
+++ b/shell/gctrl-shell/src/commands/board.ts
@@ -10,27 +10,36 @@ const BoardProject = Schema.Struct({
   name: Schema.String,
   key: Schema.String,
   counter: Schema.Number,
-  github_repo: Schema.optional(Schema.String),
+  github_repo: Schema.optional(Schema.NullOr(Schema.String)),
 })
 const BoardProjectList = Schema.Array(BoardProject)
 
-const BoardIssue = Schema.Struct({
+// Kernel serializes `Option<T>` fields as JSON `null` (not omitted), so every
+// nullable field needs `Schema.NullOr` — `Schema.optional` alone rejects null
+// and fails the entire `Schema.Array(BoardIssue)` decode. That regression
+// surfaced as `gctrl board issues list` showing zero issues despite the
+// kernel holding 32+. Match the wire shape: present-with-null OR present-
+// with-value OR (for `created_by_*`, kernel guarantees the value) absent.
+//
+// Exported so tests can decode a real wire payload through the production
+// schema rather than a test-local copy that drifts.
+export const BoardIssue = Schema.Struct({
   id: Schema.String,
   project_id: Schema.String,
   title: Schema.String,
-  description: Schema.optional(Schema.String),
+  description: Schema.optional(Schema.NullOr(Schema.String)),
   status: Schema.String,
   priority: Schema.String,
-  assignee_id: Schema.optional(Schema.String),
-  assignee_name: Schema.optional(Schema.String),
+  assignee_id: Schema.optional(Schema.NullOr(Schema.String)),
+  assignee_name: Schema.optional(Schema.NullOr(Schema.String)),
   labels: Schema.Array(Schema.String),
   created_at: Schema.String,
   updated_at: Schema.String,
-  created_by_id: Schema.optional(Schema.String),
-  created_by_name: Schema.optional(Schema.String),
-  created_by_type: Schema.optional(Schema.String),
-  github_issue_number: Schema.optional(Schema.Number),
-  github_url: Schema.optional(Schema.String),
+  created_by_id: Schema.optional(Schema.NullOr(Schema.String)),
+  created_by_name: Schema.optional(Schema.NullOr(Schema.String)),
+  created_by_type: Schema.optional(Schema.NullOr(Schema.String)),
+  github_issue_number: Schema.optional(Schema.NullOr(Schema.Number)),
+  github_url: Schema.optional(Schema.NullOr(Schema.String)),
 })
 const BoardIssueList = Schema.Array(BoardIssue)
 

--- a/shell/gctrl-shell/test/board-schema-null.test.ts
+++ b/shell/gctrl-shell/test/board-schema-null.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest"
+import { Effect, Schema } from "effect"
+import { BoardIssue } from "../src/commands/board"
+
+// Regression: kernel `Option<T>` fields land on the wire as JSON `null`
+// (not omitted). `Schema.optional(Schema.String)` rejects null and fails
+// the entire `Schema.Array(BoardIssue)` decode, which manifested as
+// `gctrl board issues list` showing zero issues against a kernel that
+// held 32+. Lock in null-tolerance against the real exported schema so
+// a future "tighten the schema" refactor can't silently re-break it.
+
+describe("BoardIssue schema null tolerance", () => {
+  it("decodes a wire payload with null assignee/description/github fields", async () => {
+    const wire = [
+      {
+        id: "iss-1",
+        project_id: "proj-1",
+        title: "Test issue",
+        description: null,
+        status: "backlog",
+        priority: "high",
+        // Every Option<String> field on the kernel side serializes null:
+        assignee_id: null,
+        assignee_name: null,
+        assignee_type: null,
+        labels: [],
+        created_at: "2026-05-06T00:00:00Z",
+        updated_at: "2026-05-06T00:00:00Z",
+        created_by_id: "debuggingfuture",
+        created_by_name: "debuggingfuture",
+        created_by_type: "human",
+        github_issue_number: null,
+        github_url: null,
+      },
+    ]
+
+    const decoded = await Effect.runPromise(
+      Schema.decodeUnknown(Schema.Array(BoardIssue))(wire)
+    )
+
+    expect(decoded).toHaveLength(1)
+    expect(decoded[0].id).toBe("iss-1")
+    // Null-flavored fields should round-trip as null (not undefined) so
+    // downstream `!= null` checks behave the same way they do in prod.
+    expect(decoded[0].assignee_id).toBeNull()
+    expect(decoded[0].github_issue_number).toBeNull()
+  })
+
+  it("still decodes when nullable fields are simply absent", async () => {
+    // Older kernel builds and our own POST handlers may omit fields entirely
+    // rather than emit explicit nulls. Both shapes must work.
+    const wire = [
+      {
+        id: "iss-2",
+        project_id: "proj-1",
+        title: "Minimal issue",
+        status: "todo",
+        priority: "none",
+        labels: [],
+        created_at: "2026-05-06T00:00:00Z",
+        updated_at: "2026-05-06T00:00:00Z",
+      },
+    ]
+
+    const decoded = await Effect.runPromise(
+      Schema.decodeUnknown(Schema.Array(BoardIssue))(wire)
+    )
+
+    expect(decoded).toHaveLength(1)
+    expect(decoded[0].assignee_id).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

`gctrl board issues list` showed zero issues despite the kernel holding 32+
across BOARD/INBOX/UBER projects, with a Schema decode error pointing at
`assignee_id` being `null`. Cause: the kernel serializes `Option<T>` fields
to JSON `null` (not omitted), but `BoardIssue` declared them as
`Schema.optional(Schema.String)` — that variant rejects `null`, so a single
field on a single issue tanked the entire `Schema.Array(BoardIssue)` decode.

Switch every nullable field to `Schema.optional(Schema.NullOr(...))`, which
accepts `string | null | undefined`. That's already the project convention
in `inbox.ts`, `vault.ts`, `wrangler.ts`, and `app.ts`; `board.ts` was the
outlier.

## Why this kept slipping past CI

The existing `board.test.ts` declared its own local `BoardIssue` schema
rather than importing the production one, so refactors to the source schema
weren't exercised. Export the production schema and add a regression test
(`board-schema-null.test.ts`) that decodes a wire-shaped payload through
the real schema.

## Test plan

- [x] Unit: 2 new tests in `board-schema-null.test.ts`
  - decodes a payload with explicit `null` on assignee/description/github_*
    fields and asserts the values round-trip as `null` (not silently mapped
    to `undefined`) so downstream `!= null` checks behave as in prod
  - decodes a payload with the same fields entirely omitted (older kernel
    builds + our own POST handlers may emit either shape)
- [x] Full shell suite: `pnpm test` — 162 passing (was 160).
- [x] End-to-end against the running kernel: `gctrl board issues list`
      now prints all 32+ rows across BOARD/INBOX/UBER. Same shell against
      the same kernel was returning the schema-decode error before.

## Companion PR

Independent of #189 (`fix(storage): keep daemon alive when CREATE INDEX
hits a missing column`) — that one keeps the daemon binding `:4318`
through schema drift; this one fixes the shell client's decode of issues
that the daemon serves. Together they unblock the `gctrl board` workflow
on stale local state.
