### PR TITLE
fix(desktop): wire sidecar to a vault dir + auto-bootstrap default mount

### DIFF
--- a/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
@@ -1,7 +1,12 @@
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
-import { type PathContext, resolveKernelBinPath, resolveKernelDataDir } from "../paths"
+import {
+  type PathContext,
+  resolveKernelBinPath,
+  resolveKernelDataDir,
+  resolveKernelVaultDir,
+} from "../paths"
 
 const packagedCtx: PathContext = {
   isPackaged: true,
@@ -51,5 +56,20 @@ describe("resolveKernelDataDir", () => {
     expect(resolveKernelDataDir(devCtx)).toBe(
       "/Users/alice/Library/Application Support/Electron/kernel",
     )
+  })
+})
+
+describe("resolveKernelVaultDir", () => {
+  it("returns <userDataPath>/vault regardless of packaging", () => {
+    expect(resolveKernelVaultDir(packagedCtx)).toBe(
+      "/Users/alice/Library/Application Support/gctrl/vault",
+    )
+    expect(resolveKernelVaultDir(devCtx)).toBe(
+      "/Users/alice/Library/Application Support/Electron/vault",
+    )
+  })
+
+  it("never collides with the kernel data dir (kept on a sibling path)", () => {
+    expect(resolveKernelVaultDir(packagedCtx)).not.toBe(resolveKernelDataDir(packagedCtx))
   })
 })

--- a/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
@@ -22,6 +22,17 @@ describe("buildKernelArgs", () => {
     ])
   })
 
+  it("appends --board-dir when vaultDir is configured", () => {
+    const args = buildKernelArgs({ ...baseConfig, vaultDir: "/abs/vault" })
+    const idx = args.indexOf("--board-dir")
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(args[idx + 1]).toBe("/abs/vault")
+  })
+
+  it("omits --board-dir when vaultDir is not set", () => {
+    expect(buildKernelArgs(baseConfig)).not.toContain("--board-dir")
+  })
+
   it("always binds 127.0.0.1, never 0.0.0.0", () => {
     const args = buildKernelArgs({ ...baseConfig, port: 5555 })
     const hostIdx = args.indexOf("--host")

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -5,12 +5,13 @@
 import { app, BrowserWindow, Menu, ipcMain, shell } from "electron"
 import electronUpdater from "electron-updater"
 const { autoUpdater } = electronUpdater
+import { mkdirSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { KernelSidecar } from "./kernel-sidecar"
 import { buildAppMenu } from "./menu"
-import { resolveKernelBinPath, resolveKernelDataDir } from "./paths"
+import { resolveKernelBinPath, resolveKernelDataDir, resolveKernelVaultDir } from "./paths"
 import { createScheduler } from "./scheduler"
 import { createSpawner } from "./spawner"
 import { startAutoUpdater } from "./updater"
@@ -41,11 +42,25 @@ const createSidecar = (): KernelSidecar | undefined => {
     devKernelPath: process.env.GCTRL_KERNEL_DEV_PATH,
   }
 
+  const dataDir = resolveKernelDataDir(ctx)
+  // `GCTRL_BOARD_DIR` lets operators point the desktop kernel at an existing
+  // Obsidian vault (e.g. `~/workspaces/ohc/vault-gctrl/`) without symlinking.
+  // Falls back to the per-user default under Application Support.
+  const vaultDir = process.env.GCTRL_BOARD_DIR ?? resolveKernelVaultDir(ctx)
+
+  // Ensure both the kernel data dir and the vault root exist before the
+  // sidecar starts — DuckDB's path must resolve, and the kernel's file
+  // watcher canonicalizes the vault root (silent skip if missing).
+  // `recursive: true` is idempotent; safe to run on every launch.
+  mkdirSync(dataDir, { recursive: true })
+  mkdirSync(vaultDir, { recursive: true })
+
   return new KernelSidecar(
     {
       binPath: resolveKernelBinPath(ctx),
       port: KERNEL_PORT,
-      dataDir: resolveKernelDataDir(ctx),
+      dataDir,
+      vaultDir,
     },
     {
       spawner: createSpawner(),

--- a/apps/gctrl-desktop/src/main/kernel-sidecar.ts
+++ b/apps/gctrl-desktop/src/main/kernel-sidecar.ts
@@ -23,6 +23,13 @@ export type SidecarConfig = {
   readonly binPath: string
   readonly port: number
   readonly dataDir: string
+  /**
+   * Vault root the kernel watches for `*.md` issue files. Forwarded as
+   * `--board-dir`; the kernel auto-registers a `default` mount here on
+   * first boot when `gctrl_vault_mounts` is empty so the file watcher
+   * starts indexing without any UI flow.
+   */
+  readonly vaultDir?: string
   readonly env?: Readonly<Record<string, string>>
 }
 

--- a/apps/gctrl-desktop/src/main/paths.ts
+++ b/apps/gctrl-desktop/src/main/paths.ts
@@ -59,3 +59,19 @@ export const resolveKernelBinPath = (ctx: PathContext): string => {
  */
 export const resolveKernelDataDir = (ctx: PathContext): string =>
   path.join(ctx.userDataPath, "kernel")
+
+/**
+ * Resolve the default vault directory the kernel sidecar should watch.
+ *
+ * Layout under this root follows the existing kernel convention — one
+ * subdirectory per project key holding `*.md` files (e.g. `vault/BOARD/BOARD-1.md`,
+ * `vault/INBOX/INBOX-1.md`). The kernel auto-registers a `default`
+ * `gctrl_vault_mounts` row at this path on first boot when the table is
+ * empty so the file watcher starts indexing immediately.
+ *
+ * Always `<userDataPath>/vault/`; operators who want to watch an existing
+ * Obsidian vault elsewhere can override at the kernel level via
+ * `GCTRL_BOARD_DIR` (consumed by the bundled binary directly).
+ */
+export const resolveKernelVaultDir = (ctx: PathContext): string =>
+  path.join(ctx.userDataPath, "vault")

--- a/apps/gctrl-desktop/src/main/spawner.ts
+++ b/apps/gctrl-desktop/src/main/spawner.ts
@@ -10,18 +10,24 @@ import { spawn, type ChildProcess } from "node:child_process"
 import type { SidecarConfig, SpawnedProcess, Spawner } from "./kernel-sidecar"
 
 /** CLI args passed to the kernel binary. Pure for testability. */
-export const buildKernelArgs = (config: SidecarConfig): readonly string[] => [
-  "serve",
-  "--port",
-  String(config.port),
-  "--db",
-  `${config.dataDir}/gctrl.duckdb`,
-  // Always bind loopback. Never `0.0.0.0` — the desktop kernel must not be
-  // reachable from the network, both for security and to avoid Apple App
-  // Store review pushback on inbound connections.
-  "--host",
-  "127.0.0.1",
-]
+export const buildKernelArgs = (config: SidecarConfig): readonly string[] => {
+  const args: string[] = [
+    "serve",
+    "--port",
+    String(config.port),
+    "--db",
+    `${config.dataDir}/gctrl.duckdb`,
+    // Always bind loopback. Never `0.0.0.0` — the desktop kernel must not be
+    // reachable from the network, both for security and to avoid Apple App
+    // Store review pushback on inbound connections.
+    "--host",
+    "127.0.0.1",
+  ]
+  if (config.vaultDir) {
+    args.push("--board-dir", config.vaultDir)
+  }
+  return args
+}
 
 /**
  * Wrap a `ChildProcess` as a `SpawnedProcess`. Single-fire `onExit` per the

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -64,6 +64,17 @@ pub async fn run(
     // the same root the operator configured on the CLI; mounts are now the
     // exclusive source for *which* directories get watched.
     let vault_root = board_dir.clone();
+
+    // Bootstrap a `default` mount when the operator passed a vault root and
+    // the mounts table is empty. Without this the desktop sidecar — which has
+    // no UI to register a mount yet — silently idles its watcher and the
+    // board surface stays empty even when `<vault>/BOARD/*.md` exists on
+    // disk. CLI users who already curate mounts via `/api/vault/mounts` are
+    // unaffected (the empty-table guard skips the bootstrap).
+    if let Some(ref root) = vault_root {
+        bootstrap_default_vault_mount(&sqlite, root);
+    }
+
     let watcher_store = Arc::clone(&sqlite);
     tokio::spawn(watch::watch_all_vault_mounts(watcher_store));
 
@@ -205,4 +216,93 @@ pub async fn run(
 
     axum_fut.await?;
     Ok(())
+}
+
+/// Insert a `default` Workspace mount pointing at `root` if and only if
+/// `gctrl_vault_mounts` is empty. Idempotent across daemon restarts: once
+/// the mount exists (or any other mount has been registered) this is a
+/// no-op and the operator's curated mounts win. Failure is non-fatal —
+/// the daemon still serves everything else; the file watcher just stays
+/// idle until a mount is registered manually.
+fn bootstrap_default_vault_mount(sqlite: &SqliteStore, root: &std::path::Path) {
+    let mounts = match sqlite.list_vault_mounts() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "vault bootstrap: failed to list mounts");
+            return;
+        }
+    };
+    if !mounts.is_empty() {
+        return;
+    }
+    let now = chrono::Utc::now();
+    let mount = gctrl_core::VaultMount {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: "default".into(),
+        root_path: root.to_string_lossy().into_owned(),
+        kind: gctrl_core::VaultMountKind::Workspace,
+        git_url: None,
+        app_id: None,
+        last_commit_sha: None,
+        last_synced_at: None,
+        created_at: now,
+        updated_at: now,
+    };
+    match sqlite.create_vault_mount(&mount) {
+        Ok(()) => tracing::info!(
+            path = %root.display(),
+            "vault bootstrap: registered `default` mount"
+        ),
+        Err(e) => tracing::warn!(
+            path = %root.display(),
+            error = %e,
+            "vault bootstrap: create_vault_mount failed"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_creates_default_mount_when_table_empty() {
+        let sqlite = SqliteStore::open(":memory:").unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        bootstrap_default_vault_mount(&sqlite, tmp.path());
+
+        let mounts = sqlite.list_vault_mounts().unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].name, "default");
+        assert_eq!(mounts[0].root_path, tmp.path().to_string_lossy());
+        assert_eq!(mounts[0].kind, gctrl_core::VaultMountKind::Workspace);
+    }
+
+    #[test]
+    fn bootstrap_is_noop_when_any_mount_already_exists() {
+        let sqlite = SqliteStore::open(":memory:").unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let now = chrono::Utc::now();
+        sqlite
+            .create_vault_mount(&gctrl_core::VaultMount {
+                id: "preexisting".into(),
+                name: "curated".into(),
+                root_path: "/elsewhere".into(),
+                kind: gctrl_core::VaultMountKind::App,
+                git_url: None,
+                app_id: None,
+                last_commit_sha: None,
+                last_synced_at: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .unwrap();
+
+        bootstrap_default_vault_mount(&sqlite, tmp.path());
+
+        let mounts = sqlite.list_vault_mounts().unwrap();
+        assert_eq!(mounts.len(), 1, "operator's curated mount must be preserved");
+        assert_eq!(mounts[0].name, "curated");
+    }
 }


### PR DESCRIPTION
## Summary

Closes the gap that left the desktop sidecar's file watcher rootless on a fresh
install: the bundled kernel now boots with a vault directory, auto-registers a
`default` mount on first run, and the operator-override path stays open via
`GCTRL_BOARD_DIR`.

### Behavior

- The Electron main process resolves `<userDataPath>/vault/` as the default
  vault root (override via `GCTRL_BOARD_DIR`), `mkdir -p`s it next to the
  kernel data dir, and forwards it as `--board-dir` to `gctrld serve`.
- When `serve` receives a `--board-dir` and `gctrl_vault_mounts` is empty,
  it auto-inserts a `default` Workspace mount pointing at that path. Any
  pre-existing mount short-circuits the bootstrap, so CLI users who curate
  mounts via `/api/vault/mounts` are unaffected.

Net effect: a fresh install starts indexing `<vault>/BOARD/*.md`,
`<vault>/INBOX/*.md`, etc. without any manual mount-registration UI flow.

## Test plan

- [x] `apps/gctrl-desktop` unit tests cover `buildKernelArgs` with/without
      `vaultDir` and the new `resolveKernelVaultDir` resolver.
- [x] `kernel/crates/gctrl-cli` unit tests cover `bootstrap_default_vault_mount`:
      empty-table seeds the default; pre-existing mount is preserved.
- [x] Live install verified end-to-end via `/reinstall-mac-app`: app launches,
      sidecar binary is built with the change, kernel health responds.
- [ ] Smoke-test on a clean machine (fresh `Application Support/gctrl-desktop/`)
      to confirm the default mount appears and watcher fires on a new
      `<vault>/BOARD/test.md`.