### PR TITLE
fix(kernel): permissive loopback CORS for the desktop renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -5175,6 +5176,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ which = "7"
 
 # Testing
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.6", features = ["trace", "cors"] }
 http = "1"
 http-body-util = "0.1"
 tempfile = "3"

--- a/kernel/crates/gctrl-cli/Cargo.toml
+++ b/kernel/crates/gctrl-cli/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 axum = { workspace = true }
+tower-http = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 notify = "7"

--- a/kernel/crates/gctrl-cli/src/commands/cors_middleware.rs
+++ b/kernel/crates/gctrl-cli/src/commands/cors_middleware.rs
@@ -1,0 +1,109 @@
+//! CORS layer for the kernel HTTP API.
+//!
+//! The Electron renderer (gctrl-desktop) loads its bundled SPA from `file://`
+//! and fetches `http://127.0.0.1:4318/api/...`. That is a cross-origin request,
+//! and the SPA's `request()` helper sends `Content-Type: application/json` —
+//! which is *not* a CORS-safelisted Content-Type, so every call (including
+//! plain GETs) triggers a CORS preflight. Without an OPTIONS handler the
+//! preflight returns 405 and the browser surfaces `TypeError: Failed to fetch`.
+//!
+//! `host_allowlist_middleware` already blocks DNS-rebinding, so the CORS
+//! policy here is intentionally permissive for loopback / file origins:
+//! the *attack* surface is gated on Host, not Origin.
+//!
+//! Allowed origins:
+//!   - `null` (file:// renders, as sent by Chromium)
+//!   - `file://...`
+//!   - `http://localhost[:port]` and `https://localhost[:port]`
+//!   - `http://127.0.0.1[:port]`, `http://[::1][:port]` and https equivalents
+//!   - `app://...` (reserved for a future Electron custom protocol)
+//!
+//! Anything else falls through unhandled, the layer omits the
+//! `Access-Control-Allow-Origin` header, and the browser blocks the response.
+
+use std::time::Duration;
+
+use axum::{
+    http::{header, HeaderName, HeaderValue, Method},
+    Router,
+};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+pub fn apply(router: Router) -> Router {
+    router.layer(layer())
+}
+
+fn layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(|origin, _| is_allowed_origin(origin)))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::PATCH,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            header::ACCEPT,
+            HeaderName::from_static("x-session-id"),
+            HeaderName::from_static("x-service-name"),
+        ])
+        .max_age(Duration::from_secs(600))
+}
+
+fn is_allowed_origin(origin: &HeaderValue) -> bool {
+    let Ok(s) = origin.to_str() else { return false };
+    if s == "null" || s.starts_with("file://") || s.starts_with("app://") {
+        return true;
+    }
+    is_loopback_http(s)
+}
+
+fn is_loopback_http(origin: &str) -> bool {
+    let rest = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"));
+    let Some(rest) = rest else { return false };
+    let host = rest.rsplit_once(':').map(|(h, _)| h).unwrap_or(rest);
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header(s: &str) -> HeaderValue {
+        HeaderValue::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn allows_file_protocol() {
+        assert!(is_allowed_origin(&header("null")));
+        assert!(is_allowed_origin(&header("file://")));
+        assert!(is_allowed_origin(&header("file:///Users/me/index.html")));
+    }
+
+    #[test]
+    fn allows_app_protocol() {
+        assert!(is_allowed_origin(&header("app://gctrl-board.local")));
+    }
+
+    #[test]
+    fn allows_loopback_http() {
+        assert!(is_allowed_origin(&header("http://localhost")));
+        assert!(is_allowed_origin(&header("http://localhost:4200")));
+        assert!(is_allowed_origin(&header("http://127.0.0.1:4318")));
+        assert!(is_allowed_origin(&header("https://localhost:5173")));
+        assert!(is_allowed_origin(&header("http://[::1]:4318")));
+    }
+
+    #[test]
+    fn rejects_public_origins() {
+        assert!(!is_allowed_origin(&header("http://attacker.example.com")));
+        assert!(!is_allowed_origin(&header("https://example.com:4318")));
+        assert!(!is_allowed_origin(&header("http://127.0.0.1.evil.com")));
+    }
+}

--- a/kernel/crates/gctrl-cli/src/commands/mod.rs
+++ b/kernel/crates/gctrl-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod alert;
 pub mod analytics;
 pub mod board;
 pub mod context;
+pub mod cors_middleware;
 pub mod analytics_cost;
 pub mod analytics_cost_breakdown;
 pub mod analytics_daily;

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -7,6 +7,7 @@ use gctrl_proxy::{Capture, CaptureConfig, LlmRelay, RelayConfig};
 use gctrl_scheduler::ScheduleRunner;
 use gctrl_storage::{DuckDbStore, SqliteStore};
 
+use super::cors_middleware;
 use super::host_allowlist_middleware;
 use super::watch;
 
@@ -172,6 +173,9 @@ pub async fn run(
         None, // honor GCTRL_STATE_DIR or platform default
     );
     let router = host_allowlist_middleware::apply(router);
+    // CORS sits outside the Host check so the browser preflight is answered
+    // before the rebinding guard rejects requests with mismatched Host.
+    let router = cors_middleware::apply(router);
     let addr = format!("{host}:{port}");
     tracing::info!("gctrl OTel receiver listening on {addr}");
     tracing::info!("database: {db_path}");


### PR DESCRIPTION
## Summary

Unblocks the desktop renderer's `fetch` calls to the kernel by adding a
loopback-permissive CORS layer to the kernel HTTP API.

### Problem

The Electron renderer loads its bundled SPA from `file://` and calls
`http://127.0.0.1:4318/api/...`. The SPA's `request()` helper always
sends `Content-Type: application/json`, which is **not** a
CORS-safelisted Content-Type — so every call (including plain GETs)
triggers a CORS preflight. The kernel had no `OPTIONS` handler and emitted
no `Access-Control-Allow-Origin`, so preflight returned `405` and the
browser surfaced `TypeError: Failed to fetch`. Settings → macOS Spaces is
the most reliable repro because it polls `/api/macos/health` every 5s on
mount.

`curl` from the terminal worked fine because no `Origin` header was sent —
which is exactly why this latent bug went unnoticed.

### Approach

Wire a `tower_http::cors::CorsLayer` outside the existing host-allowlist
middleware so the preflight is answered before the DNS-rebinding guard
rejects requests with a mismatched `Host`. The allowlist remains the
structural defense against rebinding; CORS here is purely about
unblocking the legitimate desktop renderer.

**Allowed origins** (origin-mirror via `AllowOrigin::predicate`):
- `null` (file:// renders, as Chromium reports them)
- `file://...`
- `app://...` (reserved for a future Electron custom protocol)
- any-port `http(s)://localhost`, `http(s)://127.0.0.1`, `http(s)://[::1]`

Anything else falls through unhandled — no `Access-Control-Allow-Origin`
is emitted, so the browser blocks the response.

**Allowed methods**: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`.
**Allowed headers**: `content-type`, `authorization`, `accept`,
`x-session-id`, `x-service-name` (LLM relay headers).
**Max-age**: 600s, to keep preflight chatter low.

## Test plan

- [x] `cors_middleware::tests` (4 unit tests) cover file/app/loopback
      acceptance and public-origin rejection.
- [x] Live verification on `127.0.0.1:4318`:
      - preflight `Origin: null` → `200` with
        `access-control-allow-origin: null`, methods, headers, max-age.
      - public origin (`https://attacker.example.com`) → preflight `200`
        but no `access-control-allow-origin` → browser blocks.
      - GET with `Origin` header → ACAO mirrored on the response.
- [x] Settings → macOS Spaces in the desktop app now polls
      `/api/macos/health` and `/api/macos/spaces` cleanly (no "Failed to
      fetch").
- [ ] `cargo test -p gctrl-cli --bin gctrld cors` in CI.