### PR TITLE
fix(sync): enable R2 from env + sign with AWS sigv4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2043,6 +2044,8 @@ dependencies = [
  "duckdb",
  "gctrl-core",
  "gctrl-storage",
+ "hex",
+ "hmac",
  "parquet",
  "reqwest 0.12.28",
  "serde",
@@ -2243,6 +2246,21 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "htmd"

--- a/kernel/crates/gctrl-cli/src/commands/serve.rs
+++ b/kernel/crates/gctrl-cli/src/commands/serve.rs
@@ -69,8 +69,16 @@ pub async fn run(
     tokio::spawn(watch::watch_all_vault_mounts(watcher_store));
 
     let sync_config = SyncConfig::from_env();
-    let sync_config = if sync_config.d1_enabled() {
-        tracing::info!("D1 sync enabled: database_id={}", sync_config.d1_database_id);
+    let sync_config = if sync_config.d1_enabled() || sync_config.r2_enabled() {
+        if sync_config.d1_enabled() {
+            tracing::info!("D1 sync enabled: database_id={}", sync_config.d1_database_id);
+        }
+        if sync_config.r2_enabled() {
+            tracing::info!(
+                "R2 vault sync enabled: bucket={} endpoint={}",
+                sync_config.r2_bucket, sync_config.r2_endpoint
+            );
+        }
         Some(Arc::new(sync_config))
     } else {
         None

--- a/kernel/crates/gctrl-core/src/config.rs
+++ b/kernel/crates/gctrl-core/src/config.rs
@@ -155,9 +155,17 @@ impl SyncConfig {
             && !self.d1_api_token.is_empty()
     }
 
-    /// Populate D1 credentials from env vars (GCTRL_D1_DATABASE_ID,
-    /// GCTRL_D1_ACCOUNT_ID, GCTRL_D1_API_TOKEN). Returns a config with
-    /// `enabled=true` iff all three are set.
+    /// Returns true if R2 vault sync is configured (all four fields non-empty).
+    pub fn r2_enabled(&self) -> bool {
+        !self.r2_endpoint.is_empty()
+            && !self.r2_bucket.is_empty()
+            && !self.r2_access_key_id.is_empty()
+            && !self.r2_secret_access_key.is_empty()
+    }
+
+    /// Populate D1 + R2 credentials from env vars. Returns a config with
+    /// `enabled=true` iff either D1 or R2 is fully configured. Vault sync
+    /// (`/api/sync/vault/*`) only needs R2; DuckDB telemetry sync needs D1.
     pub fn from_env() -> Self {
         let mut cfg = Self::default();
         if let Ok(v) = std::env::var("GCTRL_D1_DATABASE_ID") {
@@ -169,10 +177,22 @@ impl SyncConfig {
         if let Ok(v) = std::env::var("GCTRL_D1_API_TOKEN") {
             cfg.d1_api_token = v;
         }
+        if let Ok(v) = std::env::var("GCTRL_R2_ENDPOINT") {
+            cfg.r2_endpoint = v;
+        }
+        if let Ok(v) = std::env::var("GCTRL_R2_BUCKET") {
+            cfg.r2_bucket = v;
+        }
+        if let Ok(v) = std::env::var("GCTRL_R2_ACCESS_KEY_ID") {
+            cfg.r2_access_key_id = v;
+        }
+        if let Ok(v) = std::env::var("GCTRL_R2_SECRET_ACCESS_KEY") {
+            cfg.r2_secret_access_key = v;
+        }
         if let Ok(v) = std::env::var("GCTRL_DEVICE_ID") {
             cfg.device_id = v;
         }
-        cfg.enabled = cfg.d1_enabled();
+        cfg.enabled = cfg.d1_enabled() || cfg.r2_enabled();
         cfg
     }
 }

--- a/kernel/crates/gctrl-sync/Cargo.toml
+++ b/kernel/crates/gctrl-sync/Cargo.toml
@@ -19,6 +19,8 @@ parquet = { workspace = true }
 reqwest = { workspace = true }
 duckdb = { workspace = true }
 sha2 = { workspace = true }
+hmac = "0.12"
+hex = "0.4"
 walkdir = "2"
 
 [dev-dependencies]

--- a/kernel/crates/gctrl-sync/src/r2.rs
+++ b/kernel/crates/gctrl-sync/src/r2.rs
@@ -1,15 +1,26 @@
 //! R2 client — S3-compatible upload/download to Cloudflare R2.
 //!
-//! Uses reqwest with AWS Signature V4 style auth headers.
+//! Uses reqwest with proper AWS Signature V4 (AWS4-HMAC-SHA256) signing.
+//! Cloudflare R2 strictly requires sigv4 — earlier `basic_auth + x-amz-*`
+//! header form returns `400 InvalidRequest "Please use AWS4-HMAC-SHA256"`.
+//!
 //! R2 supports the S3 PutObject/GetObject/ListObjectsV2 API subset.
 
 use chrono::Utc;
-use reqwest::Client;
+use hmac::{Hmac, Mac};
+use reqwest::{Client, Url};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 use tokio::fs;
 use tracing::{debug, warn};
 
 use crate::SyncError;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// R2 region tag — Cloudflare uses literal "auto" for sigv4 scope.
+const R2_REGION: &str = "auto";
+const R2_SERVICE: &str = "s3";
 
 /// S3-compatible client for Cloudflare R2.
 #[derive(Debug, Clone)]
@@ -47,12 +58,16 @@ impl R2Client {
         let url = self.object_url(key);
         debug!(key, url, size = body.len(), "R2 PUT");
 
+        let body_sha = sha256_hex(&body);
+        let auth = self.signed_headers("PUT", &url, &body_sha)?;
+
         let resp = self
             .client
             .put(&url)
-            .header("x-amz-date", Utc::now().format("%Y%m%dT%H%M%SZ").to_string())
-            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
-            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .header("host", auth.host)
+            .header("x-amz-date", auth.amz_date)
+            .header("x-amz-content-sha256", body_sha)
+            .header("authorization", auth.authorization)
             .body(body)
             .send()
             .await
@@ -79,12 +94,16 @@ impl R2Client {
         let url = self.object_url(key);
         debug!(key, url, "R2 GET");
 
+        let body_sha = sha256_hex(&[]);
+        let auth = self.signed_headers("GET", &url, &body_sha)?;
+
         let resp = self
             .client
             .get(&url)
-            .header("x-amz-date", Utc::now().format("%Y%m%dT%H%M%SZ").to_string())
-            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
-            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .header("host", auth.host)
+            .header("x-amz-date", auth.amz_date)
+            .header("x-amz-content-sha256", body_sha)
+            .header("authorization", auth.authorization)
             .send()
             .await
             .map_err(|e| SyncError::R2(format!("GET {key}: {e}")))?;
@@ -118,9 +137,21 @@ impl R2Client {
     /// Check if R2 is reachable by issuing a HEAD on the bucket.
     pub async fn health_check(&self) -> bool {
         let url = format!("{}/{}", self.endpoint, self.bucket);
-        match self.client
+        let body_sha = sha256_hex(&[]);
+        let auth = match self.signed_headers("HEAD", &url, &body_sha) {
+            Ok(a) => a,
+            Err(e) => {
+                warn!(error = %e, "R2 health check sign failed");
+                return false;
+            }
+        };
+        match self
+            .client
             .head(&url)
-            .basic_auth(&self.access_key_id, Some(&self.secret_access_key))
+            .header("host", auth.host)
+            .header("x-amz-date", auth.amz_date)
+            .header("x-amz-content-sha256", body_sha)
+            .header("authorization", auth.authorization)
             .send()
             .await
         {
@@ -137,6 +168,108 @@ impl R2Client {
             }
         }
     }
+
+    /// Build sigv4 signed headers for a request. Signs `host`, `x-amz-date`,
+    /// `x-amz-content-sha256`. R2 region is `auto`, service is `s3`.
+    fn signed_headers(
+        &self,
+        method: &str,
+        url_str: &str,
+        payload_sha_hex: &str,
+    ) -> Result<SignedHeaders, SyncError> {
+        let url: Url = url_str
+            .parse()
+            .map_err(|e| SyncError::R2(format!("parse url {url_str}: {e}")))?;
+        let host = url
+            .host_str()
+            .ok_or_else(|| SyncError::R2(format!("no host in url {url_str}")))?
+            .to_string();
+        let path = url.path();
+        let canonical_path = aws_uri_encode_path(path);
+
+        let now = Utc::now();
+        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date_stamp = now.format("%Y%m%d").to_string();
+        let scope = format!("{date_stamp}/{R2_REGION}/{R2_SERVICE}/aws4_request");
+
+        // Canonical request — headers must be sorted lowercase, trimmed, no dup whitespace.
+        let canonical_headers = format!(
+            "host:{host}\nx-amz-content-sha256:{payload_sha_hex}\nx-amz-date:{amz_date}\n"
+        );
+        let signed_header_names = "host;x-amz-content-sha256;x-amz-date";
+        let canonical_request = format!(
+            "{method}\n{canonical_path}\n\n{canonical_headers}\n{signed_header_names}\n{payload_sha_hex}"
+        );
+
+        // String to sign.
+        let cr_hash = sha256_hex(canonical_request.as_bytes());
+        let string_to_sign = format!("AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{cr_hash}");
+
+        // Derived signing key: HMAC chain date → region → service → "aws4_request".
+        let k_date = hmac_sha256(
+            format!("AWS4{}", self.secret_access_key).as_bytes(),
+            date_stamp.as_bytes(),
+        )?;
+        let k_region = hmac_sha256(&k_date, R2_REGION.as_bytes())?;
+        let k_service = hmac_sha256(&k_region, R2_SERVICE.as_bytes())?;
+        let k_signing = hmac_sha256(&k_service, b"aws4_request")?;
+
+        // Signature.
+        let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes())?);
+
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={}/{scope}, SignedHeaders={signed_header_names}, Signature={signature}",
+            self.access_key_id
+        );
+
+        Ok(SignedHeaders {
+            host,
+            amz_date,
+            authorization,
+        })
+    }
+}
+
+struct SignedHeaders {
+    host: String,
+    amz_date: String,
+    authorization: String,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Result<Vec<u8>, SyncError> {
+    let mut mac = HmacSha256::new_from_slice(key)
+        .map_err(|e| SyncError::R2(format!("hmac key: {e}")))?;
+    mac.update(data);
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+/// AWS canonical URI encoding for the path. Each path segment is URL-encoded
+/// (RFC 3986 unreserved set kept verbatim, everything else percent-encoded),
+/// but `/` between segments is preserved.
+fn aws_uri_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for (i, seg) in path.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        for b in seg.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    out.push(b as char);
+                }
+                _ => {
+                    out.push_str(&format!("%{b:02X}"));
+                }
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -169,5 +302,31 @@ mod tests {
             client.object_url("test.parquet"),
             "https://abc.r2.cloudflarestorage.com/gctrl-sync/test.parquet"
         );
+    }
+
+    #[test]
+    fn aws_uri_encode_keeps_slashes_encodes_spaces() {
+        assert_eq!(
+            aws_uri_encode_path("/foo/bar baz/2026-W19.md"),
+            "/foo/bar%20baz/2026-W19.md"
+        );
+    }
+
+    #[test]
+    fn signed_headers_have_aws4_prefix() {
+        let client = R2Client::new(
+            "https://abc.r2.cloudflarestorage.com",
+            "gctrl-vault",
+            "AKIATEST",
+            "secret-key-test",
+        );
+        let h = client
+            .signed_headers("PUT", "https://abc.r2.cloudflarestorage.com/gctrl-vault/x.md", &sha256_hex(b"hi"))
+            .expect("sign");
+        assert!(h.authorization.starts_with("AWS4-HMAC-SHA256 "));
+        assert!(h.authorization.contains("Credential=AKIATEST/"));
+        assert!(h.authorization.contains("/auto/s3/aws4_request"));
+        assert!(h.authorization.contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date"));
+        assert!(h.host == "abc.r2.cloudflarestorage.com");
     }
 }


### PR DESCRIPTION
## Summary

Makes R2 vault sync actually work end-to-end. Two bugs were preventing the kernel from talking to Cloudflare R2 even when credentials were present:

1. **R2 env vars were never read.** `SyncConfig::from_env()` only populated D1 fields, so `GCTRL_R2_ENDPOINT` / `GCTRL_R2_BUCKET` / `GCTRL_R2_ACCESS_KEY_ID` / `GCTRL_R2_SECRET_ACCESS_KEY` set in the daemon's environment were dropped on the floor. `enabled` only flipped on when D1 was configured, so a vault-only deployment silently ran without sync.
2. **R2 rejected our auth.** The R2 client signed requests with `basic_auth` plus `x-amz-date` / `x-amz-content-sha256: UNSIGNED-PAYLOAD`. Cloudflare R2 strictly requires sigv4 and returns `400 InvalidRequest "Please use AWS4-HMAC-SHA256"` for that shape.

## How it works

- `SyncConfig::from_env` reads the four `GCTRL_R2_*` vars in addition to the D1 trio. `r2_enabled()` mirrors `d1_enabled()`; the master `enabled` flag is now `d1_enabled() || r2_enabled()`, so vault-only or telemetry-only deployments both light up sync.
- `serve` logs the R2 bucket/endpoint at startup whenever sync is enabled by R2 alone (mirroring the existing D1 startup log).
- `R2Client` now builds proper AWS4-HMAC-SHA256 signed headers for PUT / GET / HEAD: canonical request → string-to-sign → derived signing key chain (`AWS4{secret} → date → "auto" → "s3" → "aws4_request"`) → signature. Region scope is the literal `"auto"` Cloudflare uses. Path encoding follows AWS's RFC-3986 unreserved-set rule (slashes preserved between segments).

## Test plan
- [x] `cargo test -p gctrl-sync` — existing tests still pass; new tests cover `aws_uri_encode_path` (slashes preserved, spaces percent-encoded) and the authorization header shape (prefix, credential scope, signed-header list, host).
- [ ] Live sanity: run the daemon with `GCTRL_R2_*` set and confirm `health_check()` no longer returns `400 InvalidRequest` against a real R2 bucket.