### PR TITLE
fix(kernel): initial vault scan so desktop shows preexisting projects

### DIFF
--- a/kernel/crates/gctrl-cli/src/commands/watch.rs
+++ b/kernel/crates/gctrl-cli/src/commands/watch.rs
@@ -139,6 +139,13 @@ pub async fn watch_vault_mount(store: Arc<SqliteStore>, mount: VaultMount) {
         return;
     }
 
+    // Initial scan: notify only fires on Create/Modify, so a vault that
+    // already contains `{root}/PROJECT/*.md` at daemon startup would never
+    // trigger `import_subdir` and the projects table would stay empty.
+    // Walk direct children once so the desktop sidecar shows projects on
+    // first launch against an existing vault.
+    initial_scan(&store, &root, &mount.name);
+
     // Debounce: collect events for 500ms before processing
     loop {
         let Some(first_path) = rx.recv().await else {
@@ -167,6 +174,39 @@ pub async fn watch_vault_mount(store: Arc<SqliteStore>, mount: VaultMount) {
 
     // Keep watcher alive — dropping it stops watching
     drop(watcher);
+}
+
+/// One-shot scan of a mount root's direct children. Each subdirectory is
+/// fed through `import_subdir`, which auto-creates the project row and
+/// upserts any markdown issues. Errors are logged and skipped per-entry —
+/// a single unreadable subdirectory must not stop the watcher from booting.
+fn initial_scan(store: &SqliteStore, root: &Path, mount_name: &str) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(it) => it,
+        Err(e) => {
+            tracing::warn!(
+                mount = %mount_name,
+                path = %root.display(),
+                error = %e,
+                "initial vault scan: read_dir failed"
+            );
+            return;
+        }
+    };
+    let mut scanned = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            import_subdir(store, &path, root, mount_name);
+            scanned += 1;
+        }
+    }
+    tracing::info!(
+        mount = %mount_name,
+        path = %root.display(),
+        subdirs = scanned,
+        "initial vault scan complete"
+    );
 }
 
 /// Import a single project subdirectory (e.g. `{mount_root}/BOARD/`).
@@ -374,6 +414,45 @@ mod tests {
         let bbb_issues = store.list_board_issues(&bbb_filter).unwrap();
         assert!(!aaa_issues.is_empty(), "AAA issues should be imported");
         assert!(!bbb_issues.is_empty(), "BBB issues should be imported");
+    }
+
+    /// Vault that already contains projects + markdown at daemon startup
+    /// must be imported by the initial scan — notify won't emit Create
+    /// events for files that exist before `watcher.watch` is called.
+    #[tokio::test]
+    async fn watch_imports_preexisting_projects_via_initial_scan() {
+        let store = Arc::new(SqliteStore::open(":memory:").unwrap());
+
+        let tmp = TempDir::new().unwrap();
+        let proj_dir = tmp.path().join("BOARD");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        // Write the markdown BEFORE the watcher starts so notify sees no events.
+        std::fs::write(proj_dir.join("BOARD-1.md"), issue_md("BOARD", "BOARD", 1)).unwrap();
+
+        store
+            .create_vault_mount(&make_mount("m-pre", "preexisting", tmp.path()))
+            .unwrap();
+
+        watch_all_vault_mounts(Arc::clone(&store)).await;
+        // Initial scan runs synchronously during watcher startup; a brief
+        // sleep gives the spawned task time to reach it.
+        sleep(Duration::from_millis(300)).await;
+
+        let projects = store.list_board_projects().unwrap();
+        let keys: std::collections::HashSet<_> =
+            projects.iter().map(|p| p.key.as_str()).collect();
+        assert!(
+            keys.contains("BOARD"),
+            "initial scan must auto-create BOARD project for preexisting vault content; got {keys:?}"
+        );
+        let board = projects.iter().find(|p| p.key == "BOARD").unwrap();
+        let issues = store
+            .list_board_issues(&gctrl_core::BoardIssueFilter {
+                project_id: Some(board.id.clone()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(!issues.is_empty(), "initial scan must import preexisting markdown");
     }
 
     /// `App`-kind mounts (registered by `gctrl app install`) belong to the


### PR DESCRIPTION
## Summary

The desktop app shows **0 projects** on first launch even when `--board-dir` points at a vault that already contains `BOARD/`, `INBOX/`, etc. on disk. Cause: the kernel's vault watcher in `gctrl-cli` only reacts to `notify` `Create`/`Modify` events, and `notify` does not emit events for files that exist *before* `watcher.watch()` is called. So `import_subdir` never ran for pre-existing content and `board_projects` stayed empty — `GET /api/board/projects` correctly returned `[]`.

This PR adds a one-shot **initial scan** that runs as soon as each vault watcher boots: it walks the direct children of the mount root and feeds every subdirectory through the existing `import_subdir` (auto-create project + upsert markdown). After that the live `notify` loop continues to handle subsequent edits as before.

The scan is resilient — per-entry errors log and continue; an unreadable subdirectory must not stop the watcher from booting. App-kind mounts still skip kernel-side import (unchanged).

## Test plan

- [x] `cargo test -p gctrl-cli watch` — all 4 watcher tests pass, including the new `watch_imports_preexisting_projects_via_initial_scan` which writes `BOARD/BOARD-1.md` *before* the watcher starts and asserts the project + issue land
- [ ] Manual: launch the desktop app against a vault that already has `BOARD/BOARD-1.md` on disk and confirm projects render in the SPA on first launch
