### PR TITLE
fix(gctrl-desktop): wire preload to .mjs + fail-loud renderer placeholder

### DIFF
--- a/apps/gctrl-desktop/src/__tests__/build-wiring.test.ts
+++ b/apps/gctrl-desktop/src/__tests__/build-wiring.test.ts
@@ -55,6 +55,32 @@ describe("build wiring contract", () => {
     expect(source).toContain("--gctrl-api-base=")
   })
 
+  it("main bundle's preload path matches the actual preload entry filename", () => {
+    // Regression guard: electron-vite emits `out/preload/index.mjs` (ES
+    // module format). When `src/main/index.ts` referenced
+    // `../preload/index.js` instead, Electron silently failed to load the
+    // preload, `window.desktop` was never defined, the SPA's `resolveUrl()`
+    // fell back to the document origin (`file://`), and every `/api/...`
+    // fetch turned into "Failed to fetch". Symptom-only — no error logged.
+    const mainSource = skipIfMissing(join(outDir, "main", "index.js"))
+    const preloadDir = join(outDir, "preload")
+    if (mainSource === null || !existsSync(preloadDir)) {
+      console.warn("[build-wiring] skipping — main or preload not built")
+      return
+    }
+    const preloadEntry = readdirSync(preloadDir).find(
+      (f) => f.startsWith("index.") && (f.endsWith(".js") || f.endsWith(".mjs")),
+    )
+    if (!preloadEntry) {
+      console.warn("[build-wiring] skipping — preload entry missing")
+      return
+    }
+    expect(
+      mainSource,
+      `main bundle must reference ../preload/${preloadEntry} (the actual built filename)`,
+    ).toContain(`../preload/${preloadEntry}`)
+  })
+
   it("bundled renderer index.html uses relative asset paths so file:// can load it", () => {
     const indexPath = join(outDir, "renderer", "index.html")
     const html = skipIfMissing(indexPath)
@@ -72,6 +98,28 @@ describe("build wiring contract", () => {
     for (const ref of assetRefs) {
       expect(ref, `asset ref must be relative (not /...) for file:// loading: ${ref}`).not.toMatch(/^\//)
     }
+  })
+
+  it("bundled renderer is the SPA, not the placeholder fallback", () => {
+    // `pnpm build` writes `out/renderer/index.html` as a placeholder
+    // ("Renderer not bundled."). The real SPA only lands when
+    // `pnpm build:renderer-spa` runs after — it RM's `out/renderer/` and
+    // copies `apps/gctrl-board/dist-web/` in. If someone packages with
+    // just `pnpm build`, the asar ships the placeholder and users see
+    // "Renderer not bundled" on launch instead of the dashboard.
+    //
+    // Hard-fail instead of skipping: if `out/renderer/` exists but is the
+    // placeholder, packaging is broken and CI must see it.
+    const indexPath = join(outDir, "renderer", "index.html")
+    const indexHtml = skipIfMissing(indexPath)
+    if (indexHtml === null) {
+      console.warn("[build-wiring] skipping — out/renderer/index.html not built")
+      return
+    }
+    expect(
+      indexHtml,
+      "out/renderer/index.html is the fallback placeholder — `pnpm build:renderer-spa` did not run",
+    ).not.toContain("Renderer not bundled")
   })
 
   it("bundled renderer SPA reads window.desktop.apiBase before fetching", () => {

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -116,7 +116,10 @@ const createWindow = (): BrowserWindow => {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
-      preload: path.join(__dirname, "../preload/index.js"),
+      // electron-vite is configured `formats: ["es"]` for preload, which
+      // emits `out/preload/index.mjs`. The `.mjs` here must match the
+      // bundler output exactly — the build-wiring test asserts agreement.
+      preload: path.join(__dirname, "../preload/index.mjs"),
       // Pass the kernel sidecar's base URL into preload's argv so the SPA
       // (loaded from `file://` in packaged mode) can reach the loopback API
       // instead of resolving relative `/api/...` paths against `file:///`.


### PR DESCRIPTION
## Summary

Two related build-wiring regressions in `gctrl-desktop` that both ship as silent runtime breakage rather than build-time failures:

1. **Preload bridge never loaded.** Main referenced `../preload/index.js`, but electron-vite is configured `formats: ["es"]` and emits `out/preload/index.mjs`. Electron silently dropped the preload, `window.desktop` was undefined, the SPA's `resolveUrl()` fell back to the `file://` document origin, and every `/api/...` fetch turned into "Failed to fetch". Nothing in any log.
2. **Packaged renderer was the placeholder.** The "renderer reads `window.desktop.apiBase`" test skipped silently when `out/renderer/assets/` was missing — exactly the regression case where `pnpm build` writes the placeholder `index.html` ("Renderer not bundled") and a package run that omits `build:renderer-spa` ships it.

Both bugs are fixed and the wiring contract is tightened so the next time someone changes the preload format or skips the SPA copy, CI catches it before ship.

## Changes

- `apps/gctrl-desktop/src/main/index.ts`: point `BrowserWindow.webPreferences.preload` at `../preload/index.mjs`.
- `apps/gctrl-desktop/src/__tests__/build-wiring.test.ts`:
  - Add `main bundle's preload path matches the actual preload entry filename` — fails when main and preload disagree on the entry name.
  - Add `bundled renderer is the SPA, not the placeholder fallback` — hard-fails if `out/renderer/index.html` still contains "Renderer not bundled" (replaces the previous skip-on-missing-assets behavior, which was the loophole).

## How it was caught

`/reinstall-mac-app` rebuilt and replaced `/Applications/gctrl.app`; the in-place validation phase passed (`/api/board/projects` 200, etc., from curl) but the renderer surfaced "Failed to load overview: Failed to fetch / Is the kernel running on :4318?". Confirmed via `asar extract` that the installed bundle's `out/main/index.js` referenced the wrong preload filename, then that the renderer was the placeholder shell.

## Test plan

- [x] `pnpm --filter gctrl-desktop test` — 95/95 pass on the rebuilt artifacts.
- [x] Repackaged + reinstalled `/Applications/gctrl.app`; asar inspection confirms `preload/index.mjs` and SPA `assets/` present.
- [x] App launches, kernel sidecar healthy on :4318, bootstrap endpoints (`/api/macos/health`, `/api/analytics`, `/api/board/projects`) return 200.
- [ ] CI green.
- [ ] Branch up to date with `main` before promoting out of draft.
