### PR TITLE
fix(gctrl-desktop): build preload as CommonJS so sandboxed renderer can load it

### DIFF
--- a/apps/gctrl-desktop/electron.vite.config.ts
+++ b/apps/gctrl-desktop/electron.vite.config.ts
@@ -17,7 +17,12 @@ export default defineConfig({
       outDir: "out/preload",
       lib: {
         entry: "src/preload/index.ts",
-        formats: ["es"],
+        // CommonJS, NOT ESM. The renderer runs with `sandbox: true`
+        // (see `src/main/index.ts`), and a sandboxed Electron renderer
+        // can only load a CommonJS preload — an ESM preload silently
+        // fails to execute, leaving `window.desktop` undefined and every
+        // `/api/...` fetch resolving against `file://` ("Failed to fetch").
+        formats: ["cjs"],
       },
     },
   },

--- a/apps/gctrl-desktop/src/__tests__/build-wiring.test.ts
+++ b/apps/gctrl-desktop/src/__tests__/build-wiring.test.ts
@@ -44,7 +44,9 @@ describe("build wiring contract", () => {
       return
     }
     const entry = readdirSync(dir).find(
-      (f) => f.startsWith("index.") && (f.endsWith(".js") || f.endsWith(".mjs")),
+      (f) =>
+        f.startsWith("index.") &&
+        (f.endsWith(".js") || f.endsWith(".cjs") || f.endsWith(".mjs")),
     )
     if (!entry) {
       console.warn("[build-wiring] skipping — preload entry missing")
@@ -69,7 +71,9 @@ describe("build wiring contract", () => {
       return
     }
     const preloadEntry = readdirSync(preloadDir).find(
-      (f) => f.startsWith("index.") && (f.endsWith(".js") || f.endsWith(".mjs")),
+      (f) =>
+        f.startsWith("index.") &&
+        (f.endsWith(".js") || f.endsWith(".cjs") || f.endsWith(".mjs")),
     )
     if (!preloadEntry) {
       console.warn("[build-wiring] skipping — preload entry missing")
@@ -79,6 +83,49 @@ describe("build wiring contract", () => {
       mainSource,
       `main bundle must reference ../preload/${preloadEntry} (the actual built filename)`,
     ).toContain(`../preload/${preloadEntry}`)
+  })
+
+  it("sandboxed renderer's preload is CommonJS, not an ES module", () => {
+    // Regression guard for the second half of the "Failed to fetch" bug.
+    // The renderer runs with `webPreferences.sandbox: true`, and Electron
+    // loads a sandboxed preload in a CommonJS-only context. An ESM preload
+    // (`.mjs` extension, top-level `import ... from`) silently fails to
+    // execute there — `contextBridge.exposeInMainWorld("desktop", ...)`
+    // never runs, `window.desktop` stays undefined, and the SPA's
+    // `resolveUrl()` falls back to the `file://` origin. #199 fixed the
+    // preload *filename* but left it ESM; matching filenames is not enough
+    // if the format itself can't load in the sandbox.
+    const mainSource = skipIfMissing(join(outDir, "main", "index.js"))
+    const preloadDir = join(outDir, "preload")
+    if (mainSource === null || !existsSync(preloadDir)) {
+      console.warn("[build-wiring] skipping — main or preload not built")
+      return
+    }
+    // Only enforced when the renderer is actually sandboxed. Minifiers
+    // emit `sandbox:!0` for `sandbox: true`; accept both forms.
+    const sandboxed = /sandbox\s*:\s*(true|!0)/.test(mainSource)
+    if (!sandboxed) {
+      console.warn("[build-wiring] skipping — renderer not sandboxed")
+      return
+    }
+    const preloadEntry = readdirSync(preloadDir).find(
+      (f) =>
+        f.startsWith("index.") &&
+        (f.endsWith(".js") || f.endsWith(".cjs") || f.endsWith(".mjs")),
+    )
+    if (!preloadEntry) {
+      console.warn("[build-wiring] skipping — preload entry missing")
+      return
+    }
+    expect(
+      preloadEntry.endsWith(".mjs"),
+      `preload entry is ${preloadEntry} (ESM) but the renderer is sandboxed — build it as CommonJS (electron.vite.config.ts preload formats: ["cjs"])`,
+    ).toBe(false)
+    const preloadSource = readFileSync(join(preloadDir, preloadEntry), "utf8")
+    expect(
+      /(^|\n)\s*import\s[^\n]*\sfrom\s/.test(preloadSource),
+      "sandboxed preload must not use a top-level ESM `import` — it cannot load in a sandboxed renderer",
+    ).toBe(false)
   })
 
   it("bundled renderer index.html uses relative asset paths so file:// can load it", () => {

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -116,10 +116,12 @@ const createWindow = (): BrowserWindow => {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
-      // electron-vite is configured `formats: ["es"]` for preload, which
-      // emits `out/preload/index.mjs`. The `.mjs` here must match the
-      // bundler output exactly — the build-wiring test asserts agreement.
-      preload: path.join(__dirname, "../preload/index.mjs"),
+      // A sandboxed renderer can only load a CommonJS preload — an ESM
+      // preload silently fails to execute. electron-vite is configured
+      // `formats: ["cjs"]` for preload, which emits `out/preload/index.cjs`.
+      // The `.cjs` here must match the bundler output exactly — the
+      // build-wiring test asserts agreement and that it is not ESM.
+      preload: path.join(__dirname, "../preload/index.cjs"),
       // Pass the kernel sidecar's base URL into preload's argv so the SPA
       // (loaded from `file://` in packaged mode) can reach the loopback API
       // instead of resolving relative `/api/...` paths against `file:///`.


### PR DESCRIPTION
## Summary

Every `/api/...` fetch from the packaged desktop renderer was failing with `Failed to fetch / Is the kernel running on :4318?` — schedule page, board, analytics, overview. Symptom-only: no error in the renderer console, no kernel log entry.

**Root cause.** `webPreferences.sandbox: true` is enabled on the BrowserWindow, and a sandboxed Electron renderer can only load a **CommonJS** preload. electron-vite was configured with preload `formats: ["es"]`, emitting `out/preload/index.mjs` (ESM). The ESM preload silently failed to execute in the sandbox, so `contextBridge.exposeInMainWorld("desktop", ...)` never ran, `window.desktop` stayed `undefined`, and the SPA's `resolveUrl()` fell back to the `file://` document origin — turning every relative `/api/...` URL into a path against `file:///`.

#199 fixed the preload **filename** (`index.js` → `index.mjs`) but left the **format** as ESM, so the underlying bug survived.

## What changed

- `apps/gctrl-desktop/electron.vite.config.ts` — preload `formats: ["es"]` → `["cjs"]`. Emits `out/preload/index.cjs`.
- `apps/gctrl-desktop/src/main/index.ts` — `webPreferences.preload` points at `../preload/index.cjs`.
- `apps/gctrl-desktop/src/__tests__/build-wiring.test.ts` — new regression test that fails when the renderer is sandboxed and the preload is `.mjs` (or contains a top-level ESM `import`). Covers both halves of this class of bug: filename mismatch *and* format incompatibility.

The `.find()` predicates that locate the preload entry were also updated to accept `.cjs` alongside `.js` / `.mjs`, so the other build-wiring assertions still resolve the file.

## Verification

End-to-end against the installed app, attached over CDP (`--remote-debugging-port=9222`):

```json
{"desktopType":"object","apiBase":"http://127.0.0.1:4318","scheduleFetch":200,"scheduleCount":4}
```

- `window.desktop` is now an object (was `undefined`).
- `window.desktop.apiBase` is `http://127.0.0.1:4318` (parsed from `--gctrl-api-base=` argv).
- In-renderer `fetch("/api/schedules")` returns 200 with the expected schedules.

Build-wiring tests:

```
✓ src/__tests__/build-wiring.test.ts (7 tests)
```

Including the new "sandboxed renderer's preload is CommonJS, not an ES module" guard. The earlier 6 still pass against the new `.cjs` output.

## Test plan

- [x] `pnpm --filter @gctrl/gctrl-desktop vitest run src/__tests__/build-wiring.test.ts` — 7/7 pass
- [x] CDP probe of installed app — `window.desktop.apiBase` populated, `/api/schedules` returns 200
- [x] Schedule, board, overview, and analytics pages load without "Failed to fetch"
- [ ] CI — pending first run on this branch
