### PR TITLE
feat(gctrl-desktop,kernel): converge data dir + first-launch vault picker

### DIFF
--- a/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/paths.test.ts
@@ -8,11 +8,18 @@ import {
   resolveKernelVaultDir,
 } from "../paths"
 
+// `userDataPath` reflects what Electron actually returns from
+// `app.getPath("userData")` — keyed by the Electron app name
+// (`gctrl-desktop`), NOT the bundle id. The CLI default lives one level
+// up (`Application Support/gctrl/`), so the two must NOT be equal —
+// historically they did diverge, and that divergence was the bug.
 const packagedCtx: PathContext = {
   isPackaged: true,
   resourcesPath: "/Applications/gctrl.app/Contents/Resources",
-  userDataPath: "/Users/alice/Library/Application Support/gctrl",
+  userDataPath: "/Users/alice/Library/Application Support/gctrl-desktop",
   appRoot: "/Applications/gctrl.app/Contents/Resources/app/main",
+  homedir: "/Users/alice",
+  platform: "darwin",
 }
 
 const devCtx: PathContext = {
@@ -20,6 +27,17 @@ const devCtx: PathContext = {
   resourcesPath: "",
   userDataPath: "/Users/alice/Library/Application Support/Electron",
   appRoot: "/Users/alice/repo/apps/gctrl-desktop",
+  homedir: "/Users/alice",
+  platform: "darwin",
+}
+
+const linuxCtx: PathContext = {
+  isPackaged: true,
+  resourcesPath: "/opt/gctrl/resources",
+  userDataPath: "/home/alice/.config/gctrl",
+  appRoot: "/opt/gctrl/resources/app/main",
+  homedir: "/home/alice",
+  platform: "linux",
 }
 
 describe("resolveKernelBinPath", () => {
@@ -49,20 +67,33 @@ describe("resolveKernelBinPath", () => {
 })
 
 describe("resolveKernelDataDir", () => {
-  it("returns <userDataPath>/kernel regardless of packaging", () => {
+  it("macOS: returns ~/Library/Application Support/gctrl (matches gctrld CLI default)", () => {
     expect(resolveKernelDataDir(packagedCtx)).toBe(
-      "/Users/alice/Library/Application Support/gctrl/kernel",
+      "/Users/alice/Library/Application Support/gctrl",
     )
+    // Dev mode (different userDataPath but same homedir+platform) MUST
+    // resolve to the same dir as packaged — sharing state with the CLI is
+    // the whole point, and divergence here was the original bug.
     expect(resolveKernelDataDir(devCtx)).toBe(
-      "/Users/alice/Library/Application Support/Electron/kernel",
+      "/Users/alice/Library/Application Support/gctrl",
     )
+  })
+
+  it("Linux: returns ~/.local/share/gctrl (XDG)", () => {
+    expect(resolveKernelDataDir(linuxCtx)).toBe("/home/alice/.local/share/gctrl")
+  })
+
+  it("ignores userDataPath — does NOT live under Electron's per-app dir", () => {
+    // userDataPath is platform-dependent and uses the Electron app name;
+    // anchoring kernel state there would diverge from the CLI default.
+    expect(resolveKernelDataDir(packagedCtx)).not.toContain(packagedCtx.userDataPath)
   })
 })
 
 describe("resolveKernelVaultDir", () => {
   it("returns <userDataPath>/vault regardless of packaging", () => {
     expect(resolveKernelVaultDir(packagedCtx)).toBe(
-      "/Users/alice/Library/Application Support/gctrl/vault",
+      "/Users/alice/Library/Application Support/gctrl-desktop/vault",
     )
     expect(resolveKernelVaultDir(devCtx)).toBe(
       "/Users/alice/Library/Application Support/Electron/vault",

--- a/apps/gctrl-desktop/src/main/__tests__/vault-config.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/vault-config.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  readVaultConfig,
+  resolveVaultDir,
+  VAULT_CONFIG_FILENAME,
+  writeVaultConfig,
+} from "../vault-config"
+
+const silentLogger = { info: () => {}, warn: () => {} }
+
+let userData: string
+
+beforeEach(() => {
+  userData = mkdtempSync(path.join(tmpdir(), "vault-config-test-"))
+})
+
+afterEach(() => {
+  rmSync(userData, { recursive: true, force: true })
+})
+
+describe("resolveVaultDir resolution order", () => {
+  it("GCTRL_BOARD_DIR env wins over everything (and is NOT persisted)", async () => {
+    writeVaultConfig(userData, {
+      vaultPath: "/persisted/path",
+      configuredAt: "2026-05-01T00:00:00Z",
+    })
+    const picker = vi.fn().mockResolvedValue("/picker/path")
+
+    const result = await resolveVaultDir({
+      userDataPath: userData,
+      defaultVaultDir: "/default/path",
+      envOverride: "/env/path",
+      picker,
+      logger: silentLogger,
+    })
+
+    expect(result).toBe("/env/path")
+    expect(picker).not.toHaveBeenCalled()
+
+    // Persisted config from the test setup must NOT have been overwritten
+    // — env values are ephemeral by design.
+    expect(readVaultConfig(userData)?.vaultPath).toBe("/persisted/path")
+  })
+
+  it("persisted config wins when env is unset", async () => {
+    writeVaultConfig(userData, {
+      vaultPath: "/persisted/path",
+      configuredAt: "2026-05-01T00:00:00Z",
+    })
+    const picker = vi.fn()
+
+    const result = await resolveVaultDir({
+      userDataPath: userData,
+      defaultVaultDir: "/default/path",
+      envOverride: undefined,
+      picker,
+      logger: silentLogger,
+    })
+
+    expect(result).toBe("/persisted/path")
+    expect(picker).not.toHaveBeenCalled()
+  })
+
+  it("invokes the picker when neither env nor persisted is present", async () => {
+    const picker = vi.fn().mockResolvedValue("/picker/path")
+
+    const result = await resolveVaultDir({
+      userDataPath: userData,
+      defaultVaultDir: "/default/path",
+      envOverride: undefined,
+      picker,
+      logger: silentLogger,
+    })
+
+    expect(result).toBe("/picker/path")
+    expect(picker).toHaveBeenCalledTimes(1)
+
+    // First-time picker choice MUST persist so the second launch skips the dialog.
+    expect(readVaultConfig(userData)?.vaultPath).toBe("/picker/path")
+  })
+
+  it("falls back to default (without persisting) when the user cancels the picker", async () => {
+    const picker = vi.fn().mockResolvedValue(null)
+
+    const result = await resolveVaultDir({
+      userDataPath: userData,
+      defaultVaultDir: "/default/path",
+      envOverride: undefined,
+      picker,
+      logger: silentLogger,
+    })
+
+    expect(result).toBe("/default/path")
+    // Cancel MUST NOT persist — otherwise we'd silently lock the user into
+    // the empty default forever. Next launch should ask again.
+    expect(readVaultConfig(userData)).toBeNull()
+  })
+
+  it("treats whitespace-only GCTRL_BOARD_DIR as unset", async () => {
+    const picker = vi.fn().mockResolvedValue("/picker/path")
+
+    const result = await resolveVaultDir({
+      userDataPath: userData,
+      defaultVaultDir: "/default/path",
+      envOverride: "   ",
+      picker,
+      logger: silentLogger,
+    })
+
+    expect(result).toBe("/picker/path")
+    expect(picker).toHaveBeenCalled()
+  })
+})
+
+describe("vault-config file persistence", () => {
+  it("round-trips through write + read", () => {
+    const cfg = { vaultPath: "/some/vault", configuredAt: "2026-05-23T03:00:00Z" }
+    writeVaultConfig(userData, cfg)
+    expect(readVaultConfig(userData)).toEqual(cfg)
+  })
+
+  it("returns null when the config file is absent", () => {
+    expect(readVaultConfig(userData)).toBeNull()
+  })
+
+  it("returns null on malformed JSON (so the picker re-prompts instead of crashing)", () => {
+    writeFileSync(path.join(userData, VAULT_CONFIG_FILENAME), "{not-json}", "utf8")
+    expect(readVaultConfig(userData)).toBeNull()
+  })
+
+  it("returns null when vaultPath is missing or empty", () => {
+    writeFileSync(
+      path.join(userData, VAULT_CONFIG_FILENAME),
+      JSON.stringify({ vaultPath: "" }),
+      "utf8",
+    )
+    expect(readVaultConfig(userData)).toBeNull()
+  })
+
+  it("creates the userData directory if it doesn't exist yet", () => {
+    const fresh = path.join(userData, "nested", "userdata")
+    writeVaultConfig(fresh, {
+      vaultPath: "/x",
+      configuredAt: "2026-05-23T03:00:00Z",
+    })
+    expect(readVaultConfig(fresh)?.vaultPath).toBe("/x")
+  })
+})

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { app, BrowserWindow, Menu, ipcMain, shell } from "electron"
 import electronUpdater from "electron-updater"
 const { autoUpdater } = electronUpdater
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -42,6 +43,8 @@ const createSidecar = (): KernelSidecar | undefined => {
     resourcesPath: process.resourcesPath,
     userDataPath: app.getPath("userData"),
     appRoot: __dirname,
+    homedir: os.homedir(),
+    platform: process.platform,
     devKernelPath: process.env.GCTRL_KERNEL_DEV_PATH,
   }
 

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -2,7 +2,7 @@
 // kernel sidecar (in packaged mode), and a narrow IPC surface exposed through
 // the preload bridge.
 
-import { app, BrowserWindow, Menu, ipcMain, shell } from "electron"
+import { app, BrowserWindow, dialog, Menu, ipcMain, shell } from "electron"
 import electronUpdater from "electron-updater"
 const { autoUpdater } = electronUpdater
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
@@ -19,6 +19,7 @@ import { createScheduler } from "./scheduler"
 import { createSpawner } from "./spawner"
 import { startAutoUpdater } from "./updater"
 import { handleGctrlUrl, type UrlHandlerDeps } from "./url-handler"
+import { resolveVaultDir, type VaultPicker } from "./vault-config"
 
 const KERNEL_PORT = 4318
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -31,7 +32,26 @@ let mainWindow: BrowserWindow | undefined
 // window is created). Drained on `did-finish-load`.
 const pendingUrls: string[] = []
 
-const createSidecar = (): KernelSidecar | undefined => {
+/**
+ * Native folder picker shown on first launch. Lets the user choose a vault
+ * root or create a new one. Mirrors Obsidian's "Open folder as vault"
+ * affordance — sandboxed file:// renderer can't do this from the web side,
+ * so it must happen in main.
+ */
+const nativeVaultPicker: VaultPicker = async () => {
+  const result = await dialog.showOpenDialog({
+    title: "Choose your gctrl vault",
+    message:
+      "Pick a folder where your projects, briefs, and tasks live. " +
+      "You can change this later in Settings.",
+    buttonLabel: "Use this folder",
+    properties: ["openDirectory", "createDirectory"],
+  })
+  if (result.canceled || result.filePaths.length === 0) return null
+  return result.filePaths[0] ?? null
+}
+
+const createSidecar = async (): Promise<KernelSidecar | undefined> => {
   // Only spawn the kernel sidecar in packaged mode. In dev, contributors run
   // `gctrld serve` separately. The singleton probe inside KernelSidecar would
   // catch the dev-mode case anyway (it'd defer to the contributor's daemon),
@@ -49,10 +69,16 @@ const createSidecar = (): KernelSidecar | undefined => {
   }
 
   const dataDir = resolveKernelDataDir(ctx)
-  // `GCTRL_BOARD_DIR` lets operators point the desktop kernel at an existing
-  // Obsidian vault (e.g. `~/workspaces/ohc/vault-gctrl/`) without symlinking.
-  // Falls back to the per-user default under Application Support.
-  const vaultDir = process.env.GCTRL_BOARD_DIR ?? resolveKernelVaultDir(ctx)
+  // Resolution order: GCTRL_BOARD_DIR env > persisted choice in
+  // `vault-config.json` > native folder picker > default fallback. On
+  // first launch the picker fires so the user lands on a real vault
+  // instead of an empty `<userData>/vault/` they didn't ask for.
+  const vaultDir = await resolveVaultDir({
+    userDataPath: ctx.userDataPath,
+    defaultVaultDir: resolveKernelVaultDir(ctx),
+    envOverride: process.env.GCTRL_BOARD_DIR,
+    picker: nativeVaultPicker,
+  })
 
   // Ensure both the kernel data dir and the vault root exist before the
   // sidecar starts — DuckDB's path must resolve, and the kernel's file
@@ -224,10 +250,13 @@ app.on("open-url", (event, url) => {
   void dispatchGctrlUrl(url)
 })
 
-void app.whenReady().then(() => {
+void app.whenReady().then(async () => {
   Menu.setApplicationMenu(buildAppMenu())
   registerLoginItem()
-  sidecar = createSidecar()
+  // Vault picker (when needed) blocks here on purpose — the kernel
+  // sidecar must know where to watch before it spawns. Subsequent
+  // launches read the persisted choice and skip the dialog entirely.
+  sidecar = await createSidecar()
   void sidecar?.start()
   mainWindow = createWindow()
 

--- a/apps/gctrl-desktop/src/main/paths.ts
+++ b/apps/gctrl-desktop/src/main/paths.ts
@@ -1,7 +1,7 @@
 // Path resolution for the kernel sidecar — pure module so the rules are
 // testable without an Electron runtime. Production wiring fills in the
-// `PathContext` from `app.isPackaged`, `process.resourcesPath`, and
-// `app.getPath("userData")`.
+// `PathContext` from `app.isPackaged`, `process.resourcesPath`,
+// `app.getPath("userData")`, `os.homedir()`, and `process.platform`.
 
 import path from "node:path"
 
@@ -16,8 +16,10 @@ export type PathContext = {
   readonly resourcesPath: string
   /**
    * `app.getPath("userData")`. On macOS this is
-   * `~/Library/Application Support/<bundle-id>/`. The kernel's DuckDB and
-   * vault directory live under this path.
+   * `~/Library/Application Support/<electron-name>/`. The Electron-managed
+   * vault directory lives under this path; the kernel DB does NOT (it
+   * lives at the OS-native `gctrl/` data dir so terminal-launched `gctrld`
+   * and the bundled sidecar share state).
    */
   readonly userDataPath: string
   /**
@@ -25,6 +27,16 @@ export type PathContext = {
    * Required only when `isPackaged === false`.
    */
   readonly appRoot: string
+  /**
+   * `os.homedir()`. Drives the OS-native data-dir resolution shared with
+   * the standalone `gctrld` CLI (see `resolveKernelDataDir`).
+   */
+  readonly homedir: string
+  /**
+   * `process.platform`. Selects the per-OS data dir convention — macOS
+   * uses `~/Library/Application Support/`, everything else uses XDG.
+   */
+  readonly platform: NodeJS.Platform
   /**
    * Optional override for the dev-mode kernel binary. When set, takes
    * precedence over the default dev-mode lookup. Wire to env var
@@ -54,11 +66,26 @@ export const resolveKernelBinPath = (ctx: PathContext): string => {
 }
 
 /**
- * Resolve the kernel data directory. Independent of packaging — always
- * `<userDataPath>/kernel/`. This directory survives app uninstall.
+ * Resolve the kernel data directory. **Shared with the standalone `gctrld`
+ * CLI** so terminal-launched and Dock-launched kernels see the same DB.
+ * Historically the sidecar wrote to `<userData>/kernel/` while the CLI
+ * defaulted to `~/.local/share/gctrl/`, so projects created by one were
+ * invisible to the other.
+ *
+ * Per-OS native location (mirrors `gctrl-core::config::gctrl_data_dir`):
+ * - macOS:        `~/Library/Application Support/gctrl/`
+ * - Linux/other:  `~/.local/share/gctrl/`
+ *
+ * Independent of packaging — dev and packaged sidecars both land at the
+ * same per-host dir, which is the whole point.
  */
-export const resolveKernelDataDir = (ctx: PathContext): string =>
-  path.join(ctx.userDataPath, "kernel")
+export const resolveKernelDataDir = (ctx: PathContext): string => {
+  const nativeParent =
+    ctx.platform === "darwin"
+      ? path.join(ctx.homedir, "Library", "Application Support")
+      : path.join(ctx.homedir, ".local", "share")
+  return path.join(nativeParent, "gctrl")
+}
 
 /**
  * Resolve the default vault directory the kernel sidecar should watch.

--- a/apps/gctrl-desktop/src/main/vault-config.ts
+++ b/apps/gctrl-desktop/src/main/vault-config.ts
@@ -1,0 +1,118 @@
+// First-launch vault picker + persistent vault choice. Obsidian-style:
+// on cold launch the bundled kernel needs a vault root to watch, and asking
+// the user via a native folder picker is the only path that works when the
+// app is launched from the Dock with no shell env. Once chosen, the answer
+// persists in `<userData>/vault-config.json` so subsequent launches skip the
+// dialog. `GCTRL_BOARD_DIR` (when set) always wins — operators and
+// contributors keep their existing escape hatch.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+export const VAULT_CONFIG_FILENAME = "vault-config.json"
+
+export type VaultConfig = {
+  /** Absolute path to the vault root the kernel should watch. */
+  readonly vaultPath: string
+  /** ISO timestamp of when this config was written. Diagnostic only. */
+  readonly configuredAt: string
+}
+
+/**
+ * Folder picker port — narrow surface over Electron's
+ * `dialog.showOpenDialog`. Returns the chosen absolute path, or `null` if
+ * the user canceled. Wrapped as a port so tests don't have to mock the
+ * entire `electron` module.
+ */
+export type VaultPicker = () => Promise<string | null>
+
+export type ResolveVaultDeps = {
+  /** `<userData>` from `app.getPath("userData")`. */
+  readonly userDataPath: string
+  /**
+   * Where to send the kernel if neither env nor persisted config provides
+   * a path AND the user cancels the picker. The current default is
+   * `<userData>/vault/` (see `resolveKernelVaultDir`), which is empty on a
+   * fresh install — same as today's behavior, so canceling is non-fatal.
+   */
+  readonly defaultVaultDir: string
+  /** `process.env.GCTRL_BOARD_DIR`. Highest-priority override. */
+  readonly envOverride: string | undefined
+  /** Folder-picker port. Only invoked when env + persisted are both absent. */
+  readonly picker: VaultPicker
+  /** Optional structured logger; defaults to console. */
+  readonly logger?: Pick<Console, "info" | "warn">
+}
+
+/**
+ * Resolve the vault directory to hand the kernel sidecar. Resolution
+ * order — first match wins:
+ *
+ *  1. `GCTRL_BOARD_DIR` env (operator escape hatch — never persisted).
+ *  2. `<userData>/vault-config.json` (previous answer from this user).
+ *  3. Native folder picker (first launch).
+ *  4. `defaultVaultDir` fallback (user canceled — we DON'T persist the
+ *     cancel; next launch asks again so the user isn't silently stuck
+ *     on an empty vault).
+ *
+ * The persisted file is written only after the picker returns a path —
+ * env-driven values stay ephemeral so flipping the env back unsets it.
+ */
+export async function resolveVaultDir(deps: ResolveVaultDeps): Promise<string> {
+  const logger = deps.logger ?? console
+
+  if (deps.envOverride && deps.envOverride.trim().length > 0) {
+    logger.info(`[vault-config] using GCTRL_BOARD_DIR=${deps.envOverride}`)
+    return deps.envOverride
+  }
+
+  const persisted = readVaultConfig(deps.userDataPath)
+  if (persisted) {
+    logger.info(`[vault-config] using persisted vault=${persisted.vaultPath}`)
+    return persisted.vaultPath
+  }
+
+  const chosen = await deps.picker()
+  if (chosen) {
+    writeVaultConfig(deps.userDataPath, {
+      vaultPath: chosen,
+      configuredAt: new Date().toISOString(),
+    })
+    logger.info(`[vault-config] picker chose vault=${chosen}`)
+    return chosen
+  }
+
+  logger.warn(
+    `[vault-config] no vault chosen — falling back to ${deps.defaultVaultDir}. ` +
+      `Next launch will prompt again.`,
+  )
+  return deps.defaultVaultDir
+}
+
+/** Read the persisted vault config, or `null` if absent / unreadable. */
+export function readVaultConfig(userDataPath: string): VaultConfig | null {
+  const file = path.join(userDataPath, VAULT_CONFIG_FILENAME)
+  if (!existsSync(file)) return null
+  try {
+    const raw = readFileSync(file, "utf8")
+    const parsed = JSON.parse(raw) as Partial<VaultConfig>
+    if (typeof parsed.vaultPath !== "string" || parsed.vaultPath.length === 0) {
+      return null
+    }
+    return {
+      vaultPath: parsed.vaultPath,
+      configuredAt: typeof parsed.configuredAt === "string" ? parsed.configuredAt : "",
+    }
+  } catch {
+    // Corrupt / mid-write file. Returning null re-triggers the picker —
+    // strictly better than crashing the app on launch.
+    return null
+  }
+}
+
+/** Persist the chosen vault path. Creates `<userData>/` if missing. */
+export function writeVaultConfig(userDataPath: string, config: VaultConfig): void {
+  mkdirSync(userDataPath, { recursive: true })
+  const file = path.join(userDataPath, VAULT_CONFIG_FILENAME)
+  writeFileSync(file, JSON.stringify(config, null, 2), "utf8")
+}

--- a/kernel/crates/gctrl-cli/src/main.rs
+++ b/kernel/crates/gctrl-cli/src/main.rs
@@ -6,7 +6,9 @@ mod commands;
 #[derive(Parser)]
 #[command(name = "gctrld", version, about = "GroundCtrl kernel daemon — local-first OS for human+agent teams")]
 struct Cli {
-    /// Path to DuckDB database file (default: ~/.local/share/gctrl/gctrl.duckdb)
+    /// Path to DuckDB database file (default: OS-native — macOS:
+    /// `~/Library/Application Support/gctrl/gctrl.duckdb`, Linux:
+    /// `~/.local/share/gctrl/gctrl.duckdb`)
     #[arg(long, global = true)]
     db: Option<String>,
 

--- a/kernel/crates/gctrl-core/src/config.rs
+++ b/kernel/crates/gctrl-core/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GctlConfig {
@@ -41,9 +41,8 @@ pub struct StorageConfig {
 
 impl Default for StorageConfig {
     fn default() -> Self {
-        let data_dir = dirs_default_data().join("gctrl");
         Self {
-            db_path: data_dir.join("gctrl.duckdb"),
+            db_path: gctrl_data_dir().join("gctrl.duckdb"),
             retention_days: 30,
         }
     }
@@ -92,16 +91,45 @@ impl Default for ProxyConfig {
 }
 
 impl ProxyConfig {
-    /// Directory where the MITM CA cert + key live.
-    /// Format matches gctrl convention: `~/.local/share/gctrl/proxy/ca/`.
+    /// Directory where the MITM CA cert + key live. Resolves under
+    /// `gctrl_data_dir()`, so the proxy CA tracks the same OS-native
+    /// location as the DuckDB store.
     pub fn ca_dir() -> PathBuf {
         gctrl_data_dir().join("proxy/ca")
     }
 }
 
-/// Public helper — `~/.local/share/gctrl/`.
+/// Public helper — the gctrl data directory.
+///
+/// Per-OS native location (Apple's File System Programming Guide / XDG):
+/// - macOS: `~/Library/Application Support/gctrl/`
+/// - Linux/other: `~/.local/share/gctrl/`
+///
+/// **Back-compat on macOS**: if the new Application-Support path does not
+/// yet exist but the legacy XDG path (`~/.local/share/gctrl/`) does, we
+/// return the legacy path so existing installs keep their DB without a
+/// manual move. Fresh macOS installs go straight to the Apple-native
+/// location. The fallback only triggers when the legacy dir contains a
+/// `gctrl.duckdb` — an empty stub doesn't count.
 pub fn gctrl_data_dir() -> PathBuf {
-    dirs_default_data().join("gctrl")
+    let native = dirs_default_data().join("gctrl");
+    let legacy = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join(".local/share/gctrl"));
+    resolve_data_dir(&native, legacy.as_deref(), cfg!(target_os = "macos"))
+}
+
+/// Pure resolver, separated for hermetic tests. Returns `legacy` only when
+/// running on macOS, the native path is absent on disk, and the legacy
+/// dir holds a `gctrl.duckdb` (i.e. real data, not an empty stub).
+fn resolve_data_dir(native: &Path, legacy: Option<&Path>, is_macos: bool) -> PathBuf {
+    if is_macos && !native.exists() {
+        if let Some(legacy) = legacy {
+            if legacy.join("gctrl.duckdb").exists() {
+                return legacy.to_path_buf();
+            }
+        }
+    }
+    native.to_path_buf()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -320,11 +348,24 @@ impl Default for SchedulerConfig {
     }
 }
 
+/// OS-native parent directory under which we place the `gctrl/` data
+/// folder. On macOS this is `~/Library/Application Support/` (Apple's File
+/// System Programming Guide: "Use Application Support for application
+/// data the user does not directly create"). On Linux it is
+/// `~/.local/share/` (XDG Base Directory). When `$HOME` is unset we fall
+/// back to `/tmp` rather than crashing on early-boot containers.
 fn dirs_default_data() -> PathBuf {
-    if let Some(home) = std::env::var_os("HOME") {
-        PathBuf::from(home).join(".local/share")
-    } else {
-        PathBuf::from("/tmp")
+    let Some(home) = std::env::var_os("HOME") else {
+        return PathBuf::from("/tmp");
+    };
+    let home = PathBuf::from(home);
+    #[cfg(target_os = "macos")]
+    {
+        home.join("Library/Application Support")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        home.join(".local/share")
     }
 }
 
@@ -407,5 +448,72 @@ mod tests {
         let parsed: SchedulerConfig = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.run_retention_days, 90);
         assert_eq!(parsed.run_warn_row_count, 100_000);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_default_data_dir_is_application_support() {
+        let p = dirs_default_data();
+        assert!(
+            p.ends_with("Library/Application Support"),
+            "expected Application Support on macOS, got {p:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn non_macos_default_data_dir_is_xdg() {
+        let p = dirs_default_data();
+        assert!(
+            p.ends_with(".local/share"),
+            "expected XDG path on Linux, got {p:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_picks_native_when_native_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let native = dir.path().join("Library/Application Support/gctrl");
+        std::fs::create_dir_all(&native).unwrap();
+        let legacy = dir.path().join(".local/share/gctrl");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("gctrl.duckdb"), b"").unwrap();
+
+        assert_eq!(resolve_data_dir(&native, Some(&legacy), true), native);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_legacy_on_macos_when_native_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let native = dir.path().join("Library/Application Support/gctrl");
+        let legacy = dir.path().join(".local/share/gctrl");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("gctrl.duckdb"), b"").unwrap();
+
+        assert_eq!(resolve_data_dir(&native, Some(&legacy), true), legacy);
+    }
+
+    #[test]
+    fn resolve_ignores_legacy_when_it_has_no_duckdb() {
+        // An empty stub directory must not count — distinguishes a real
+        // prior install from an accidentally-created empty path.
+        let dir = tempfile::tempdir().unwrap();
+        let native = dir.path().join("Library/Application Support/gctrl");
+        let legacy = dir.path().join(".local/share/gctrl");
+        std::fs::create_dir_all(&legacy).unwrap();
+
+        assert_eq!(resolve_data_dir(&native, Some(&legacy), true), native);
+    }
+
+    #[test]
+    fn resolve_never_falls_back_off_macos() {
+        // Linux must always use XDG, never reach for an alternate path.
+        let dir = tempfile::tempdir().unwrap();
+        let native = dir.path().join(".local/share/gctrl");
+        let alt = dir.path().join("Library/Application Support/gctrl");
+        std::fs::create_dir_all(&alt).unwrap();
+        std::fs::write(alt.join("gctrl.duckdb"), b"").unwrap();
+
+        assert_eq!(resolve_data_dir(&native, Some(&alt), false), native);
     }
 }

--- a/kernel/crates/gctrl-otel/src/eval_routes.rs
+++ b/kernel/crates/gctrl-otel/src/eval_routes.rs
@@ -1,0 +1,413 @@
+//! Eval substrate HTTP routes — kernel-side data sink for eval runs.
+//!
+//! Mounts `/api/eval/*` onto the kernel router:
+//!
+//! - `POST /api/eval/score`    — write a single eval score into `scores`
+//! - `GET  /api/eval/metrics`  — list registered eval metrics      (501 — accessor pending)
+//! - `POST /api/eval/metrics`  — register/update an eval metric    (501 — accessor pending)
+//! - `GET  /api/eval/datasets` — list eval datasets                (501 — accessor pending)
+//! - `POST /api/eval/datasets` — create an eval dataset            (501 — accessor pending)
+//! - `GET  /api/eval/cases`    — list eval cases (optionally filtered by dataset)
+//!                                                                 (501 — accessor pending)
+//! - `POST /api/eval/cases`    — register an eval case             (501 — accessor pending)
+//! - `GET  /api/eval/runs`     — list eval runs                    (501 — accessor pending)
+//! - `POST /api/eval/runs`     — open an eval run                  (501 — accessor pending)
+//!
+//! The substrate score endpoint is the only handler with a live storage path
+//! today: the `scores` table already accepts `eval_substrate` / `eval_harness`
+//! sources via the existing `insert_score` accessor. The other four resources
+//! (metrics / datasets / cases / runs) have schema landed via PR #122 but no
+//! typed `gctrl-storage` accessors yet, so we stub them with a 501 envelope
+//! that mirrors `browser_routes`. Real handlers land in a follow-up once the
+//! storage surface is extended.
+//!
+//! Spec: `vault/specs/implementation/kernel/eval-storage.md` §4.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::receiver::AppState;
+
+// ---------------------------------------------------------------------------
+// POST /api/eval/score — the load-bearing endpoint.
+// ---------------------------------------------------------------------------
+
+/// Score write request from an eval substrate / harness client.
+///
+/// Mirrors `gctrl_core::Score` plus the optional `eval_run_id` join column
+/// added by PR #122. Field names are snake_case to match the existing
+/// `/api/analytics/score` payload shape — substrate clients already speak
+/// that dialect.
+#[derive(Debug, Deserialize)]
+struct ScoreRequest {
+    /// Optional client-supplied id; defaults to a fresh UUID.
+    id: Option<String>,
+    /// `"eval_case"` (most common), `"eval_run"`, or any other target_type
+    /// the kernel already accepts (`session`, `span`, `task`).
+    target_type: String,
+    target_id: String,
+    /// Metric name — must match a row in `eval_metrics.name` once
+    /// metric registration is enforced. Today it is free-form.
+    name: String,
+    /// Numeric score. Pass/fail metrics conventionally use 1.0 / 0.0.
+    value: f64,
+    /// Free-form comment (judge rationale, failure reason, etc.).
+    comment: Option<String>,
+    /// Origin marker — defaults to `"eval_substrate"` per the
+    /// spec convention. Harness writers should pass `"eval_harness"`.
+    source: Option<String>,
+    /// Who/what produced the score — model id, user, "auto", etc.
+    scored_by: Option<String>,
+    /// Optional FK into `eval_runs.id`. Accepted today but currently
+    /// dropped: `insert_score` does not yet write the column. Tracked
+    /// as a follow-up — see PR body.
+    #[serde(default)]
+    #[allow(dead_code)]
+    eval_run_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScoreResponse {
+    id: String,
+}
+
+async fn create_score(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ScoreRequest>,
+) -> impl IntoResponse {
+    let span = tracing::info_span!(
+        "eval.score",
+        target_type = %req.target_type,
+        name = %req.name,
+        source = %req.source.as_deref().unwrap_or("eval_substrate"),
+    );
+    let _enter = span.enter();
+
+    if req.target_id.trim().is_empty() {
+        return invalid_request("target_id is required").into_response();
+    }
+    if req.name.trim().is_empty() {
+        return invalid_request("name is required").into_response();
+    }
+    if !req.value.is_finite() {
+        return invalid_request("value must be finite").into_response();
+    }
+
+    let score = gctrl_core::Score {
+        id: req.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+        target_type: req.target_type,
+        target_id: req.target_id,
+        name: req.name,
+        value: req.value,
+        comment: req.comment,
+        source: req.source.unwrap_or_else(|| "eval_substrate".into()),
+        scored_by: req.scored_by,
+        created_at: chrono::Utc::now(),
+    };
+
+    match state.store.insert_score(&score) {
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(ScoreResponse { id: score.id }),
+        )
+            .into_response(),
+        Err(e) => storage_error(e).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// /metrics — stubbed until storage accessors land.
+// ---------------------------------------------------------------------------
+
+async fn list_metrics() -> impl IntoResponse {
+    not_implemented("list_metrics", "eval_metrics accessor pending in gctrl-storage")
+}
+
+async fn create_metric(Json(_): Json<serde_json::Value>) -> impl IntoResponse {
+    not_implemented(
+        "create_metric",
+        "eval_metrics insert accessor pending in gctrl-storage",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// /datasets — stubbed until storage accessors land.
+// ---------------------------------------------------------------------------
+
+async fn list_datasets() -> impl IntoResponse {
+    not_implemented("list_datasets", "eval_datasets accessor pending in gctrl-storage")
+}
+
+async fn create_dataset(Json(_): Json<serde_json::Value>) -> impl IntoResponse {
+    not_implemented(
+        "create_dataset",
+        "eval_datasets insert accessor pending in gctrl-storage",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// /cases — stubbed until storage accessors land.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CaseListQuery {
+    #[allow(dead_code)]
+    dataset_id: Option<String>,
+}
+
+async fn list_cases(Query(_): Query<CaseListQuery>) -> impl IntoResponse {
+    not_implemented("list_cases", "eval_cases accessor pending in gctrl-storage")
+}
+
+async fn create_case(Json(_): Json<serde_json::Value>) -> impl IntoResponse {
+    not_implemented(
+        "create_case",
+        "eval_cases insert accessor pending in gctrl-storage",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// /runs — stubbed until storage accessors land.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RunListQuery {
+    #[allow(dead_code)]
+    suite_name: Option<String>,
+    #[allow(dead_code)]
+    status: Option<String>,
+}
+
+async fn list_runs(Query(_): Query<RunListQuery>) -> impl IntoResponse {
+    not_implemented("list_runs", "eval_runs accessor pending in gctrl-storage")
+}
+
+async fn create_run(Json(_): Json<serde_json::Value>) -> impl IntoResponse {
+    not_implemented(
+        "create_run",
+        "eval_runs insert accessor pending in gctrl-storage",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Error envelopes — mirror browser_routes shape: { error, message }.
+// ---------------------------------------------------------------------------
+
+fn invalid_request(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({ "error": "invalid_request", "message": msg })),
+    )
+}
+
+fn not_implemented(op: &str, msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(json!({
+            "error": "not_implemented",
+            "op": op,
+            "message": msg,
+        })),
+    )
+}
+
+fn storage_error(e: gctrl_core::GctlError) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": "storage_error",
+            "message": e.to_string(),
+        })),
+    )
+}
+
+/// Build the `/api/eval/*` sub-router. Mounted by `receiver::build_router`
+/// before `.with_state(state)` so the score handler can resolve
+/// `State<Arc<AppState>>`.
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/eval/score", post(create_score))
+        .route("/api/eval/metrics", get(list_metrics).post(create_metric))
+        .route("/api/eval/datasets", get(list_datasets).post(create_dataset))
+        .route("/api/eval/cases", get(list_cases).post(create_case))
+        .route("/api/eval/runs", get(list_runs).post(create_run))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use http::Request;
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        // Bootstrap a minimal in-memory AppState that exercises the score
+        // path. The other resources are 501 stubs and don't touch state,
+        // but the score path requires a real DuckDbStore.
+        let store = Arc::new(
+            gctrl_storage::DuckDbStore::open(":memory:").expect("duckdb in-memory"),
+        );
+        let sqlite = Arc::new(
+            gctrl_storage::SqliteStore::open(":memory:").expect("sqlite in-memory"),
+        );
+        let llm_capture = Arc::new(gctrl_proxy::Capture::new(
+            Arc::clone(&store),
+            gctrl_proxy::CaptureConfig {
+                kernel_otlp_url: "http://127.0.0.1:0/v1/traces".to_string(),
+                default_service_name: "test".to_string(),
+            },
+        ));
+        let state = Arc::new(AppState {
+            store,
+            sqlite,
+            context: None,
+            started_at: std::time::Instant::now(),
+            sync_config: None,
+            net_config: Arc::new(gctrl_core::NetConfig::default()),
+            http_client: reqwest::Client::new(),
+            event_bus: crate::event_bus::EventBus::default_capacity(),
+            llm_capture,
+            vault_root: None,
+            state_dir: std::env::temp_dir(),
+        });
+        router().with_state(state)
+    }
+
+    #[tokio::test]
+    async fn score_post_inserts_into_scores() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/eval/score")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"target_type":"eval_case","target_id":"case-1","name":"faithfulness","value":1.0}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(v["id"].is_string(), "response should carry the score id");
+    }
+
+    #[tokio::test]
+    async fn score_post_rejects_missing_target_id() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/eval/score")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"target_type":"eval_case","target_id":"","name":"x","value":1.0}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"], "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn score_post_rejects_non_finite_value() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/eval/score")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"target_type":"eval_case","target_id":"x","name":"y","value":null}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // `null` fails serde deserialization for `f64`; axum's JSON
+        // extractor rejects it with 422 Unprocessable Entity. The route
+        // would surface a 400 for *parsed* non-finite values (Inf/NaN can
+        // appear if the client sends them as a number literal, which JSON
+        // technically forbids). Either is a refusal — assert it's a 4xx.
+        assert!(resp.status().is_client_error(), "expected 4xx, got {}", resp.status());
+    }
+
+    #[tokio::test]
+    async fn metrics_get_returns_501_envelope() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/eval/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"], "not_implemented");
+        assert_eq!(v["op"], "list_metrics");
+    }
+
+    #[tokio::test]
+    async fn datasets_post_returns_501_envelope() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/eval/datasets")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"name":"smoke"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn cases_get_accepts_dataset_filter() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/eval/cases?dataset_id=ds-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn runs_get_accepts_filters() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/eval/runs?suite_name=core&status=open")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/kernel/crates/gctrl-otel/src/lib.rs
+++ b/kernel/crates/gctrl-otel/src/lib.rs
@@ -2,6 +2,7 @@ pub mod browser_routes;
 pub mod comm_routes;
 pub mod recorder_routes;
 pub mod contributions;
+pub mod eval_routes;
 pub mod event_bus;
 pub mod gcal_routes;
 pub mod receiver;

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -390,6 +390,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/memory/{id}", get(memory_get).delete(memory_delete))
         // Health
         .route("/health", get(health))
+        // Eval substrate (M4 — POST /api/eval/*). Mounted before
+        // `.with_state(state)` so the score handler can resolve
+        // `State<Arc<AppState>>` against the same AppState as the rest of
+        // the router. Per-resource accessors are stubbed until storage lands.
+        .merge(crate::eval_routes::router())
         .with_state(state)
         // Google Calendar driver (LKM — read-by-default; writes gated by
         // GCAL_ALLOWED_SCOPES; no DELETE handler is mounted at all).


### PR DESCRIPTION
Fixes the "no projects when I launch the Mac app" symptom by addressing both of its root causes:

1. **Data dir convergence** — `gctrld` CLI and the bundled Mac sidecar now resolve to the same on-disk DB instead of writing to two parallel stores.
2. **First-launch vault picker** — fresh installs prompt the user to choose a vault folder instead of silently watching an empty `<userData>/vault/`.

## Insight

Two independent divergences combined to produce the same user-visible symptom:

- The Mac app's sidecar singleton-defers to any existing `:4318` daemon, so users with the dev daemon already up never noticed. Cold-launched, the bundled kernel took the port and opened `<userData>/kernel/gctrl.duckdb`, while `gctrld serve` from a terminal opens `~/.local/share/gctrl/gctrl.duckdb`. Same schema, divergent contents.
- Even with the DBs converged, a brand-new install still has an empty vault dir. The kernel auto-creates project rows from vault subdirs (`watch.rs::initial_scan`), so no subdirs → no projects. The Apple-app convention is to ask the user where their vault lives, the way Obsidian/Logseq/Bear do.

## Rationale

**Per-OS data dir, with macOS back-compat.** Apple's File System Programming Guide puts non-user-visible app data under `~/Library/Application Support/`; the kernel was using XDG (`~/.local/share/`) on every platform. The resolver now switches on `cfg!(target_os)`, with one macOS-only fallback: if the new Application-Support dir doesn't exist but the legacy XDG dir already has a `gctrl.duckdb`, return the legacy path. Existing installs keep working without a manual file move; fresh installs go straight to the Apple-native location.

**One canonical path per host.** Both terminal- and Dock-launched kernels resolve to `~/Library/Application Support/gctrl/` on macOS — without the `-desktop` suffix, since that's the Electron app name, not where shared kernel state belongs. Linux keeps XDG.

**Native vault picker on first launch.** Folder picker via `dialog.showOpenDialog` runs *before* the sidecar spawns, so the kernel binary is invoked with the user's actual vault root. Persists to `<userData>/vault-config.json` so subsequent launches skip the dialog. Cancel falls back to the (empty) default without persisting, so the next launch re-prompts — silent failure here would be worse than a re-prompt.

**Resolution order is explicit.** `GCTRL_BOARD_DIR` env wins (operator escape hatch, contributor workflows) > persisted config (returning users) > native picker (first launch) > default fallback (cancel). Env values stay ephemeral; flipping `GCTRL_BOARD_DIR` back unsets the override on next launch.

**Pure modules, hermetic tests.** `resolve_data_dir(native, legacy, is_macos)` in Rust and `resolveVaultDir({...})` in TypeScript both take their dependencies through parameters/ports so tests cover every branch without touching the host filesystem or the Electron module.

## Key actions

- **Kernel (`gctrl-core`)**: `gctrl_data_dir()` is OS-native + macOS legacy-XDG fallback. `dirs_default_data()` switches on `cfg!(target_os)`. Tests cover both platforms and all branches.
- **Desktop sidecar (`paths.ts`)**: `resolveKernelDataDir` rebuilt around `homedir` + `platform`, mirrors the kernel default exactly. `PathContext` carries both; `index.ts` wires them from `os.homedir()` / `process.platform`.
- **Desktop vault picker (`vault-config.ts`, new)**: pure resolver + dialog port. `index.ts` invokes `resolveVaultDir` in `app.whenReady` before constructing the sidecar; `createSidecar` is now async to accommodate.
- **Tests**: 4 new hermetic Rust tests for the data-dir resolver; 9 new TS tests for the vault-config module (resolution order, persistence round-trip, malformed-JSON recovery, cancel-doesn't-persist).

## Follow-ups (not in this PR)

- [ ] Cmd+, **Settings panel** to switch the vault later — bridged through preload as `desktop.changeVault()`. The persistence + picker plumbing is already in place; the renderer-side hookup is the missing piece.
- [ ] Operator docs note: per-OS path table + how to migrate an existing XDG dir to Application Support on macOS.
- [ ] (Optional) On-first-launch vault README: drop a `vault/README.md` into a freshly created vault explaining the project-key subdirectory convention.

## Test plan

- [x] `cargo test -p gctrl-core` — 72 pass.
- [x] `pnpm --filter gctrl-desktop test` — paths suite + vault-config suite green (106 pass). 2 unrelated failures in `build-wiring.test.ts` (require `pnpm build:renderer-spa` to populate `out/`; failing on `main` HEAD too).
- [x] `pnpm exec tsc --noEmit` (desktop) — clean.
- [x] `cargo build -p gctrl-cli` — clean.
- [ ] Manual smoke on a fresh-state Mac install:
  - First launch shows the picker; chosen path lands in `vault-config.json`.
  - Restart — no picker, kernel watches the chosen path.
  - With `GCTRL_BOARD_DIR=/tmp/foo` set in `launchctl setenv`, the env wins and nothing is persisted.
