### PR TITLE
docs(specs): Centaur learnings — extension-tier gap, credential proxy, topology ADR

### DIFF
--- a/vault/specs/architecture/adr-deployment-topology.md
+++ b/vault/specs/architecture/adr-deployment-topology.md
@@ -1,0 +1,99 @@
+# ADR: Deployment topology + the durability ceiling
+
+**Status**: proposed (names two tensions; commits to a direction, defers the build)
+**Scope**: kernel daemon, sync, scheduler, orchestrator
+**Drives**: future `vault/specs/architecture/kernel/*` work; `gctrl/ROADMAP.md`
+
+## Context
+
+Analysis of Centaur (Paradigm / Tempo, May 2026 — a self-hosted *team* agent
+runtime) surfaced two architectural tensions in gctrl that the "AI-native team
+OS" pivot (`gctrl/PRD.md`) had left implicit. Both are foundational, not
+incidental — they follow from early, deliberate choices and deserve to be named
+rather than papered over.
+
+### Tension 1 — Stateful singleton kernel vs. the multiplayer vision
+
+Centaur's architecture: **every service is stateless; Postgres is the single
+source of truth.** Any service restarts freely; writers scale horizontally;
+Postgres arbitrates concurrency.
+
+gctrl's architecture is the inverse: **a stateful singleton daemon.** One
+`gctrld` process holds the DuckDB single-writer lock, owns the file watchers,
+the event bus, and the projection writers. This is *correct* and differentiating
+for local-first single-user / small-team-on-one-box — it is why gctrl runs
+offline with zero infra.
+
+But the pivot's headline is "3 humans + 30 agents." Centaur shows what *team*
+demands structurally: a deployed server, a shared DB the writers contend on,
+per-user isolation, org-level secrets. gctrl's current answer to "team" is the
+**sync layer** (D1/R2 edge replicas) — but that is read-scale-out. The *write
+path still funnels through one daemon holding one lock.* Thirty concurrent
+sessions all projecting inbox messages and board mutations contend on a single
+SQLite writer on one machine.
+
+The honest question: **is gctrl a personal agent-OS that syncs, or a team
+agent-server?** Those are different products with different kernels. Today's
+desktop-sidecar topology is the former; the marketing is the latter.
+
+### Tension 2 — Agent-agnosticism caps durability at the orchestration layer
+
+Centaur **owns the agent runtime**, so it checkpoints every workflow step to
+Postgres and resumes after a crash without redoing work.
+
+gctrl is **agent-agnostic** — it observes any agent via OTel spans and does not
+own the agent's internal loop. Therefore gctrl *cannot* checkpoint the agent's
+reasoning/conversation state the way Centaur can. A crash 90 minutes into a long
+autonomous session loses the in-flight work; the scheduler only reaps the run as
+failed (`gctrl-scheduler/src/runner.rs:70`).
+
+This bites precisely because the pivot says sessions run "minutes to hours+" and
+agents work "like employees." An employee does not restart their whole day on a
+power blip. Agent-agnosticism buys portability (any agent that emits spans) at
+the cost of resumability.
+
+## Decision
+
+1. **Name two topologies; do not pretend one covers both.**
+   - **Personal (local-first):** the current desktop-sidecar singleton. Default.
+     Sync is for the *same user's* devices and edge read replicas.
+   - **Team (deployed server):** a deployed multi-tenant kernel where the
+     singleton-lock assumption is replaced. Postgres (or a server-grade store)
+     as source of truth; stateless shell/app services; per-user auth and thread
+     isolation. **Not built yet** — this ADR commits to treating it as a
+     first-class second topology rather than assuming D1/R2 sync papers over the
+     single-writer bottleneck.
+
+   Sync remains the bridge (a personal kernel can sync into a team kernel), but
+   the team write path must not funnel through one SQLite writer.
+
+2. **Durability is bounded at the orchestration layer — say so.** gctrl will
+   checkpoint **orchestration** state (which task, which retry, which sub-goal
+   completed) so a crash resumes at the last task boundary. gctrl will **not**
+   attempt to checkpoint agent-internal reasoning — that is the runtime's job.
+   Where an agent provides its own resume (e.g. Claude Code session resume),
+   gctrl re-attaches to it at the orchestration boundary rather than
+   reconstructing it. "Agent-agnostic" and "resumes the agent's train of
+   thought" are mutually exclusive; we keep agnosticism and accept the ceiling.
+
+## Consequences
+
+- **Positive:** the local-first differentiator is protected; the team story gets
+  an honest architecture instead of an implicit scaling cliff; the durability
+  contract is explicit, so nobody designs a 3-hour autonomous workflow assuming
+  mid-session resume that cannot exist.
+- **Negative / cost:** a second topology is real engineering (auth, multi-tenant
+  store, stateless services). It is deferred, not free. Until it exists, "team"
+  at scale means "one beefy shared host running the singleton," with the
+  single-writer lock as the known ceiling.
+- **Follow-ups:** orchestration-layer checkpointing slice in `gctrl/ROADMAP.md`;
+  a `kernel/server-topology.md` design when the team topology is scheduled.
+
+## References
+
+- `gctrl/PRD.md` — "3 humans + 30 agents"; the team operating model.
+- `gctrl-scheduler/src/runner.rs:70` — current crash handling (reap, not resume).
+- `vault/specs/architecture/kernel/sync.md` — D1/R2 sync (the current "team" answer).
+- `vault/specs/comparison.md § gctrl vs. Centaur` — stateless-services contrast.
+- Centaur (Paradigm / Tempo, May 2026) — stateless services + Postgres source of
+  truth; runtime-owned durable workflow checkpointing.

--- a/vault/specs/architecture/extension-tiers.md
+++ b/vault/specs/architecture/extension-tiers.md
@@ -1,0 +1,134 @@
+# Extension Tiers — The Capability-Growth System
+
+> gctrl's extension model has a missing tier. Skills carry *knowledge* but no
+> new I/O; drivers carry *capability* but require a kernel rebuild and a human.
+> The gap between them — **userspace capability an agent can author itself** —
+> is what makes a self-improvement loop actually grow capability instead of
+> just retuning existing capability.
+
+**Status:** design analysis + decision. Implementation tracked in `gctrl/ROADMAP.md`.
+
+This spec extends the layer model in [os.md](os.md) (§4 Utilities, §5 Drivers)
+with a cross-cutting view: not "what layer does X live in" but "**who can add a
+new capability, and how fast does it land**." Prompted by analysis of Centaur
+(Paradigm / Tempo, May 2026) — see [comparison.md § gctrl vs. Centaur](../comparison.md).
+
+---
+
+## 1. The tiers, viewed by capability and authorship
+
+| Tier | New I/O capability? | Author | Lands live by | Trust model |
+|---|---|---|---|---|
+| **Skill** | No — procedural knowledge only | Agent or human | Drop `SKILL.md` | Read-only instructions; safe by construction |
+| **Skill + `scripts/`** | *Latent* — a bundled script can call out | Agent or human | Drop file | **Currently blocked** — guardrails don't grant agent-authored scripts network access |
+| **Driver (LKM)** | Yes | **Human only** | Rust crate → compile → ship kernel | Kernel-integrated; full secret access |
+| **App** | Yes (owns domain data) | **Human only** | TS package → deploy | Owns namespaced tables |
+
+The two tiers an agent can author (Skill, Skill+scripts) **cannot grant a new
+external capability today.** The two tiers that *can* (Driver, App) are
+**human-only and slow** (compile/deploy). So an agent's self-improvement is
+structurally capped: it can change *how it uses what it already has* (prompts,
+skill selection, scope) but cannot give itself a new integration.
+
+Centaur's "tool" (a Python class dropped in `tools/`, auto-discovered,
+hot-reloaded, declaring its required hosts/creds) sits exactly in the empty
+cell: **userspace capability the agent can author.** That single tier is *why*
+Centaur's nightly reflection can ship a genuinely new integration while gctrl's
+outer loop can only retune.
+
+## 2. gctrl is three connectors away, not a subsystem away
+
+The pieces for the missing tier already exist; they are simply not wired
+together:
+
+1. **Skills already bundle executables.** `SKILL.md` permits `scripts/` and
+   `assets/` ([skills.md §1](skills.md)). A skill with a `scripts/fetch_foo.sh`
+   *is* a userspace tool in embryo.
+2. **The proxy can make agent-authored network calls safe.** A script the agent
+   wrote is untrusted — you cannot hand it `GITHUB_TOKEN`. But if its egress
+   routes through the credential-injecting proxy
+   ([proxy-credential-injection.md](kernel/proxy-credential-injection.md)), the
+   script never sees a secret, and response bodies are scanned for leaks. The
+   proxy is not merely a security feature — **it is the enabling substrate for
+   agent-authored tools.**
+3. **The outer loop already promotes patterns.**
+   [outer-improvement-loop.md](outer-improvement-loop.md) defines the
+   auto-apply / propose-to-human boundary that decides when an agent-authored
+   tool graduates to a first-class, reviewed capability.
+
+The three connectors needed:
+
+| # | Connector | Where |
+|---|---|---|
+| C1 | A guardrail capability that permits an agent-authored script to make **proxied** network calls (and *only* proxied — direct egress stays denied) | `gctrl-guardrails` + `allowed-tools` grammar |
+| C2 | A manifest convention for a skill/script to declare `required_hosts` (Centaur's `pyproject.toml` field, directly portable) so the proxy knows which secret rules apply and the kernel can warn on missing creds | `SKILL.md` frontmatter |
+| C3 | Hot-reload of the skill catalog on FS events so an agent-authored tool is live without a daemon restart | orchestrator dispatch path ([skills.md §3.2](skills.md)) |
+
+## 3. The composed system
+
+These are not four features. They are one **capability-growth loop**:
+
+```mermaid
+flowchart LR
+  A[Agent authors a skill+script\nin .agents/skills/] --> G{Guardrails\nC1: proxied net only?}
+  G -->|allowed| PX[Proxy injects creds\nscans responses]
+  PX --> EX[External API]
+  G -->|hot-reload C3| CAT[Skill catalog\nlive without restart]
+  A -->|C2 required_hosts| PX
+  USE[High-value pattern\nused across sessions] --> OL{Outer loop\nblast radius?}
+  OL -->|low| PROMOTE[Promote to first-class skill\nor propose driver]
+  OL -->|high| HUMAN[Propose to human\nvia inbox]
+```
+
+Read it as a lifecycle: an agent writes a tool → guardrails permit it under a
+constrained (proxy-only) network policy → the proxy makes it safe → it
+hot-reloads → if it proves valuable across sessions, the outer loop promotes it
+(or proposes a human-authored driver when it needs deeper kernel integration).
+Capability *grows* — and the kernel-invariant boundary
+([outer-improvement-loop.md § kernel-invariant surface](outer-improvement-loop.md))
+still holds, because the agent never writes a driver, never touches guardrail
+*policy code*, never sees a secret.
+
+## 4. Why keep the human-only driver tier at all
+
+The missing tier does not abolish drivers. The two coexist by design:
+
+- **Userspace tool (agent-authored):** ad-hoc, fast, sandboxed, proxy-mediated,
+  no kernel state. The agent's REPL for capability. Cheap to create, cheap to
+  discard. No OTel-deep integration, no typed error channel.
+- **Driver (human-authored LKM):** durable, typed, kernel-integrated, OTel
+  spans, secret injection at the kernel boundary, caching. The capability worth
+  hardening.
+
+The promotion path *is* the relationship: a userspace tool that proves its
+worth across many sessions is the **evidence** that a driver should be written.
+The outer loop surfaces "this proxied-script pattern appears in N sessions →
+propose a `driver-foo`." Agents discover capability cheaply in userspace; humans
+harden the winners into the kernel. This mirrors the Unix path from a shell
+script to a compiled coreutil.
+
+## 5. Non-goals / boundaries
+
+- **No arbitrary agent code execution outside the sandbox.** Userspace tools run
+  in the per-session compute sandbox
+  ([compute-cf-containers.md](../implementation/kernel/compute-cf-containers.md)),
+  not on the host. Filesystem isolation is the container's job; network
+  isolation is the proxy's.
+- **No direct egress for agent-authored scripts — ever.** C1 grants *proxied*
+  network access only. A script attempting direct egress is denied. This is what
+  keeps "the agent wrote this code" compatible with "secrets are never exposed."
+- **Agents never author drivers, apps, guardrail policy, or secret rules.** Those
+  remain human-only (see [outer-improvement-loop.md](outer-improvement-loop.md)).
+- **No tool marketplace.** Same stance as skills ([skills.md § Non-goals](skills.md)).
+
+## 6. References
+
+- [os.md](os.md) — the layer model this extends (§4 Utilities, §5 Drivers).
+- [skills.md](skills.md) — skill format; `scripts/` bundling; hot-reload (C3).
+- [kernel/proxy-credential-injection.md](kernel/proxy-credential-injection.md) —
+  the substrate that makes agent-authored network calls safe (C2 maps to its
+  secret rules).
+- [outer-improvement-loop.md](outer-improvement-loop.md) — promotion path and
+  kernel-invariant boundary.
+- [comparison.md § gctrl vs. Centaur](../comparison.md) — Centaur's `tools/`
+  tier that prompted this analysis.

--- a/vault/specs/architecture/kernel/proxy-credential-injection.md
+++ b/vault/specs/architecture/kernel/proxy-credential-injection.md
@@ -7,6 +7,15 @@
 **Status:** design decision locked, implementation pending.
 See `gctrl/ROADMAP.md` for the issue tracking implementation slices.
 
+> **This is more than a security feature.** Credential injection is the
+> enabling substrate for **agent-authored userspace tools** — the missing
+> extension tier. A tool the agent wrote is untrusted code you cannot hand a
+> raw token; routing its egress through this proxy (creds injected, responses
+> scanned) is what makes "the agent wrote this code" compatible with "secrets
+> are never exposed." See
+> [extension-tiers.md](../extension-tiers.md) for the composed capability-growth
+> system this unlocks.
+
 ---
 
 ## Problem

--- a/vault/specs/architecture/kernel/proxy-credential-injection.md
+++ b/vault/specs/architecture/kernel/proxy-credential-injection.md
@@ -1,0 +1,187 @@
+# Proxy Credential Injection
+
+> **Design decision** — agents MUST NOT hold API secrets. The kernel proxy
+> is the credential plane. Secrets live in the kernel secrets store; the
+> MITM proxy injects them into outbound requests in-flight.
+
+**Status:** design decision locked, implementation pending.
+See `gctrl/ROADMAP.md` for the issue tracking implementation slices.
+
+---
+
+## Problem
+
+Today gctrl drivers receive secrets via environment variables (`GITHUB_TOKEN`,
+`ANTHROPIC_API_KEY`, etc.) that are visible inside the agent's execution
+context. A successful prompt injection attack against any agent session can
+exfiltrate every secret in its environment — the agent knows the secret before
+the request leaves the machine.
+
+This is the standard weak model for agentic tooling. It is acceptable when the
+agent's execution environment is fully trusted and isolated. It is not
+acceptable when:
+
+1. Agents run user-supplied or LLM-generated code (jailbreak surface).
+2. Multiple agents with different authorization levels share a host.
+3. An external model's output is piped directly back to the agent
+   (response-poisoning surface).
+
+Centaur's open-sourcing (May 2026) independently validated this threat model
+and ships a production solution: a network-level firewall ("iron-proxy") that
+intercepts agent egress and injects credentials without exposing them inside
+the sandbox. Their findings: "credentials exist only inside an isolated secrets
+manager, and a network-level firewall injects them into outbound requests
+in-flight." LLM response bodies are scanned for leaked secrets and redacted
+before the agent sees them.
+
+gctrl already has the right primitives (`gctrl-proxy`, `hudsucker`-based MITM,
+`handler.rs` in the egress path). The proxy is currently a **traffic logger**.
+This spec elevates it to the **credential plane**.
+
+---
+
+## Design
+
+### 1. Secrets store in the kernel
+
+A new `kernel_secrets` SQLite table (isolated from DuckDB — never queryable via
+the analytics API):
+
+```sql
+CREATE TABLE IF NOT EXISTS kernel_secrets (
+    id         VARCHAR PRIMARY KEY,
+    name       VARCHAR NOT NULL UNIQUE,  -- human-readable: "github", "anthropic"
+    api_host   VARCHAR NOT NULL,         -- e.g. "api.github.com"
+    header     VARCHAR NOT NULL DEFAULT 'Authorization',
+    value      TEXT NOT NULL,            -- encrypted at rest via OS keychain or SOPS
+    scope      VARCHAR NOT NULL DEFAULT 'global',  -- 'global' | 'persona:<id>'
+    created_at VARCHAR NOT NULL,
+    updated_at VARCHAR NOT NULL
+)
+```
+
+Secrets are registered via `POST /api/secrets` (kernel-local endpoint, not
+proxied to the edge — never appears in D1 sync). The kernel CLI gains:
+
+```sh
+gctrld secrets add --name github --host api.github.com --value "$GITHUB_TOKEN"
+gctrld secrets list
+gctrld secrets remove github
+```
+
+### 2. Proxy injection in the request path
+
+`gctrl-proxy/handler.rs` gains a `secrets` field: `Arc<Vec<SecretRule>>` where
+`SecretRule` carries `(api_host, header_name, header_value)`. At
+`handle_request` time:
+
+```
+incoming request
+  → match req.host against secret rules
+  → if matched: inject/replace Authorization (or custom) header in-place
+  → forward to upstream (agent never sees the value it sent; the proxy replaced it)
+```
+
+**Agents route external API calls through the proxy.** This is enforced at the
+driver level: `driver-github`, `driver-llm`, etc. set
+`HTTP_PROXY=http://127.0.0.1:<proxy_port>` in the child process's env (or
+configure their HTTP client to use the proxy transport). The proxy port itself
+is kernel-internal and not exposed to agents.
+
+Drivers declare required API hosts in their crate `Cargo.toml` metadata (or a
+sidecar `driver.toml`):
+
+```toml
+[package.metadata.gctrl-driver]
+required_hosts = ["api.github.com"]
+```
+
+On driver load the kernel ensures at least one matching secret rule exists and
+warns if not.
+
+### 3. LLM response body scanning
+
+The LLM relay (`relay.rs`) already sits in the response path for
+`/llm/v1/chat/completions`. It gains a scanning pass before the response is
+forwarded to the agent:
+
+- Regex patterns for common secret formats: GitHub tokens (`gh[ps]_[A-Za-z0-9]{36}`),
+  Anthropic keys (`sk-ant-[a-zA-Z0-9\-_]{93}`), generic `Bearer \S{20,}` tokens.
+- Pattern list is configurable via `kernel_secrets` — each registered secret
+  also contributes a `detect_pattern` field so the scanner knows what the
+  leaked form looks like.
+- On match: replace the secret value with `[REDACTED]` in the response body
+  before forwarding. Log a `guardrail.secret_leak_detected` span with
+  `secret.name` attribute (not the value).
+
+This defends against the response-poisoning vector: a compromised upstream API
+returning a payload that contains secrets from a previous request or from the
+model's training data.
+
+### 4. Scope isolation (future)
+
+`scope: 'persona:<id>'` rules are only injected when the session's active
+persona matches. This allows:
+
+- A `deployer` persona to have access to production credentials.
+- A `reviewer` persona to have read-only access to the same API.
+- Untrusted/sandboxed sessions to have no credentials injected at all.
+
+Scope enforcement requires the proxy to receive the active `session_id` (and
+from that, the active persona). The relay already propagates
+`x-session-id` headers; the MITM proxy gains the same awareness.
+
+---
+
+## What this does NOT do
+
+- **Does not replace env vars for non-proxied local tools** (e.g. `git`
+  running in a subprocess). Those need a separate credential isolation story
+  (OS keychain credential helpers, short-lived tokens via `git credential`).
+- **Does not encrypt secrets at rest today** — the `value` column stores
+  plaintext in the SQLite file. Encryption via OS keychain integration or SOPS
+  is a follow-up. The schema reserves space for an `encrypted` flag.
+- **Does not isolate file-system access** — the proxy closes the network
+  exfiltration vector; a sandboxed execution environment (see
+  `vault/specs/implementation/kernel/compute-cf-containers.md`) closes the
+  file-system vector.
+
+---
+
+## Security boundary summary
+
+```mermaid
+flowchart LR
+    AG[Agent session] -->|HTTP via proxy| PR[gctrl-proxy\nCredential Injector]
+    PR -->|injects Authorization| API[External API\napi.github.com etc.]
+    PR -->|scans response body| SC[Secret Scanner]
+    SC -->|redacted response| AG
+    KS[kernel_secrets\nSQLite isolated] -->|rules at startup| PR
+    AG -.->|cannot reach| KS
+    AG -.->|never sees| TK[actual token]
+```
+
+---
+
+## Relationship to other specs
+
+- `vault/specs/implementation/kernel/compute-cf-containers.md` — container
+  isolation per session. Complementary: proxy closes network exfiltration;
+  containers close file-system exfiltration.
+- `vault/specs/architecture/kernel/driver-macos.md` — macOS capabilities
+  bridge. Driver declarations (`required_hosts`) originate here.
+- `vault/specs/principles.md` — "the kernel provides mechanisms, not policy":
+  the proxy provides the injection mechanism; the `kernel_secrets` table and
+  per-persona scope is policy.
+
+---
+
+## References
+
+- Centaur open-source release (Paradigm / Tempo, May 2026) — production
+  implementation of the credential injection + response scanning pattern.
+  Architecture: iron-proxy (network firewall), isolated secrets manager.
+- `gctrl-proxy/src/handler.rs` — existing `TrafficLogger`; injection hooks go here.
+- `gctrl-proxy/src/relay.rs` — existing LLM relay; response scanning goes here.
+- `gctrl-proxy/src/redact.rs` — existing URL query-param redaction; pattern
+  extended to response body scanning.

--- a/vault/specs/architecture/outer-improvement-loop.md
+++ b/vault/specs/architecture/outer-improvement-loop.md
@@ -10,6 +10,15 @@ This document specifies the outer loop's scope, auto-apply boundary, and
 structural safeguards. For the inner loop (per-session harness update) see
 `vault/specs/gctrl/PRD.md § inner loop`.
 
+> **The outer loop is the promotion stage of the capability-growth system.** An
+> agent can cheaply author a userspace tool (see
+> [extension-tiers.md](extension-tiers.md)); the outer loop is what observes
+> which agent-authored tools prove valuable across sessions and either promotes
+> them to first-class skills (auto-apply) or proposes hardening them into a
+> human-authored driver (propose-to-human). Without the missing userspace tier,
+> the outer loop can only *retune* existing capability; with it, the loop
+> actually *grows* capability while keeping the kernel-invariant boundary intact.
+
 ---
 
 ## Two loops, two cadences
@@ -60,6 +69,7 @@ vault diff).
 |---|---|
 | The same review-feedback constraint appears ≥ 3 times against one persona | Append constraint to that persona's `system_prompt` in `vault/specs/team/personas.md` |
 | A sequence of tool calls appears in ≥ 5 high-scoring sessions and has no corresponding skill | Create a new `SKILL.md` in `apps/utils/skills/<name>/` with the pattern extracted |
+| An agent-authored userspace tool (skill + proxied `scripts/`) is reused across ≥ 5 sessions with a high score | Promote it to a first-class shipped skill under `apps/utils/skills/` (see [extension-tiers.md](extension-tiers.md)) |
 | Sessions tagged with a given direction label consistently over-run cost budget | Raise the `cost_limit_usd` for that direction's label in `vault/specs/team/personas.md` |
 | A direction template (`WORKFLOW.md`) is stale (last used > 60 days, no active sessions) | Mark it `status: archived` in frontmatter |
 | A skill's `allowed-tools` is consistently broader than what the sessions actually used | Narrow `allowed-tools` in the skill's `SKILL.md` |
@@ -84,6 +94,7 @@ Changes in this zone are: **wide in scope**, **affect security posture**, or
 | A prompt pattern from a high-scoring session looks like a good default starter | `review_request` — "add to default starter prompt?" | Starter prompts affect every future session for that persona |
 | New direction type appears frequently with no matching WORKFLOW template | `review_request` — "create direction template for X?" | Requires human to validate the pattern is intentional |
 | A driver or tool is called by ≥ 3 personas but has no skill wrapping it | `review_request` — "extract into a first-class skill?" | Promotes something to the skill registry; others may disagree |
+| A proxied agent-authored script pattern recurs across ≥ N sessions and would benefit from typed/kernel integration | `review_request` — "harden into a human-authored `driver-foo`?" | A driver is kernel-integrated and human-only ([extension-tiers.md § 4](extension-tiers.md)); the userspace tool is the *evidence* a driver is warranted |
 | Any change to a guardrail rule, persona capability grant, or cost quota | Blocked entirely — outer agent must not auto-apply | Security/cost posture is always human-gated |
 
 Inbox messages from the outer loop use:

--- a/vault/specs/architecture/outer-improvement-loop.md
+++ b/vault/specs/architecture/outer-improvement-loop.md
@@ -1,0 +1,162 @@
+# Outer Improvement Loop
+
+> The outer loop is a scheduled agent that observes *the team using the team*
+> and proposes or applies system-level improvements. It operates at the level
+> no single session can reach.
+
+**Status:** design decision locked. Implementation tracked in `gctrl/ROADMAP.md`.
+
+This document specifies the outer loop's scope, auto-apply boundary, and
+structural safeguards. For the inner loop (per-session harness update) see
+`vault/specs/gctrl/PRD.md § inner loop`.
+
+---
+
+## Two loops, two cadences
+
+```mermaid
+flowchart TB
+    subgraph inner["Inner loop (per session)"]
+        S[session ends] --> E[eval scores + review feedback]
+        E --> P[update this persona's harness\nprompts, skill selection, retry policy]
+        P --> N[next run of this persona]
+    end
+    subgraph outer["Outer loop (cross-session, scheduled)"]
+        O[outer agent wakes up\nnightly or on trigger] --> OB[observe: sessions, feedback,\ncost trends, drift, recurring mistakes]
+        OB --> OA{blast radius?}
+        OA -->|low| AA[auto-apply]
+        OA -->|high| PH[propose to human\nvia inbox review_request]
+    end
+    inner --> outer
+```
+
+The inner loop is narrow: one session's signal → one persona's harness, applied
+immediately. The outer loop is wide: all sessions, all personas, all directions
+→ system-level changes, gated by blast radius.
+
+---
+
+## Why a blast radius boundary matters
+
+Centaur (Paradigm / Tempo, May 2026) ships the same structural insight with a
+production deployment: "the agent reviews its own performance, identifies gaps,
+and ships fixes to its own skills and tools **without touching the kernel**."
+The kernel is the invariant. Skills and tools are the patchable surface.
+
+For gctrl, "kernel" means more than the Rust binary — it means any artifact
+whose change could affect multiple personas, all sessions, or the team's shared
+security posture. The boundary is drawn by asking: *if this change is wrong,
+how bad is the worst case, and how reversible is it?*
+
+---
+
+## Auto-apply zone (outer agent acts unilaterally)
+
+All changes in this zone are: **reversible via git**, **narrow in scope** (one
+skill, one persona's config), and **observable** (the change appears in the
+vault diff).
+
+| Signal the agent observes | Change applied |
+|---|---|
+| The same review-feedback constraint appears ≥ 3 times against one persona | Append constraint to that persona's `system_prompt` in `vault/specs/team/personas.md` |
+| A sequence of tool calls appears in ≥ 5 high-scoring sessions and has no corresponding skill | Create a new `SKILL.md` in `apps/utils/skills/<name>/` with the pattern extracted |
+| Sessions tagged with a given direction label consistently over-run cost budget | Raise the `cost_limit_usd` for that direction's label in `vault/specs/team/personas.md` |
+| A direction template (`WORKFLOW.md`) is stale (last used > 60 days, no active sessions) | Mark it `status: archived` in frontmatter |
+| A skill's `allowed-tools` is consistently broader than what the sessions actually used | Narrow `allowed-tools` in the skill's `SKILL.md` |
+
+**Structural constraint:** the outer agent commits changes to a branch and
+opens a PR tagged `outer-loop-auto`. It does **not** self-merge. The PR is
+auto-merged by CI after a configurable hold period (default: 24h) unless a
+human marks `hold` or closes it. This keeps the auto-apply loop auditable and
+trivially revertible.
+
+---
+
+## Propose-to-human zone (outer agent posts inbox message)
+
+Changes in this zone are: **wide in scope**, **affect security posture**, or
+**require human judgment** about team intent.
+
+| Signal | Inbox message kind | Why human gating |
+|---|---|---|
+| The same guardrail denial pattern appears across ≥ 5 distinct personas | `review_request` — "promote to global guardrail?" | Affects all personas; wrong guardrail could block legitimate work |
+| A persona's cost trend is > 2× the team average with no clear output correlation | `review_request` — "review BACK-42 persona scope?" | Scoping down a persona is a strategic call |
+| A prompt pattern from a high-scoring session looks like a good default starter | `review_request` — "add to default starter prompt?" | Starter prompts affect every future session for that persona |
+| New direction type appears frequently with no matching WORKFLOW template | `review_request` — "create direction template for X?" | Requires human to validate the pattern is intentional |
+| A driver or tool is called by ≥ 3 personas but has no skill wrapping it | `review_request` — "extract into a first-class skill?" | Promotes something to the skill registry; others may disagree |
+| Any change to a guardrail rule, persona capability grant, or cost quota | Blocked entirely — outer agent must not auto-apply | Security/cost posture is always human-gated |
+
+Inbox messages from the outer loop use:
+- `source: outer-loop`
+- `kind: review_request`
+- `context_type: session` or `context_type: project`
+- `requires_action: true` for proposals requiring an explicit decision
+
+---
+
+## What the outer agent cannot touch (kernel-invariant surface)
+
+Even with explicit human proposal + approval, some changes require a
+code-review PR rather than a vault edit. The outer agent MUST NOT:
+
+- Modify guardrail policy code (`gctrl-guardrails`).
+- Add or remove drivers (`driver-github`, etc.).
+- Change the kernel HTTP API surface.
+- Modify the secrets store or credential injection rules.
+- Change the scheduler's execution model.
+- Edit other agents' session history or eval scores retroactively.
+
+These require human authorship + CI + code review. The outer loop's job is to
+surface *that* a change is warranted, not to make it.
+
+---
+
+## Outer agent persona
+
+The outer agent runs as a dedicated persona:
+
+```yaml
+# vault/specs/team/personas.md addition
+- id: outer-loop
+  name: System Improvement Agent
+  description: >
+    Observes the team's operation across sessions and proposes or applies
+    bounded system improvements — skill creation, persona tuning, direction
+    archiving. Cannot modify guardrails, drivers, or the kernel.
+  allowed-tools:
+    - Read
+    - Bash(gctrl sessions:*)
+    - Bash(gctrl inbox post)
+    - Bash(git checkout -b outer-loop/*)
+    - Bash(git commit)
+    - Bash(gh pr create)
+    - Write(apps/utils/skills/**/SKILL.md)
+    - Write(vault/specs/team/personas.md)
+  cost_limit_usd: 2.00   # per nightly run
+  schedule: "0 3 * * *"  # 3 AM daily
+```
+
+The `allowed-tools` list is the structural boundary. The guardrails engine
+enforces it at every tool call — the outer agent cannot call tools it isn't
+granted, including any `Write` to paths outside its declared scope.
+
+---
+
+## Relationship to the inner loop
+
+The outer loop *reads* inner-loop outputs (eval scores, review feedback stored
+as `board_events` and `inbox_actions`) but does not modify them. The inner loop
+operates within a session; the outer loop is a separate session that treats
+inner-loop outputs as immutable read-only signal.
+
+---
+
+## References
+
+- `vault/specs/gctrl/PRD.md § outer loop` — goals and motivation.
+- `vault/specs/architecture/skills.md` — skill format the outer loop creates.
+- `vault/specs/team/personas.md` — persona definitions the outer loop may update.
+- `vault/specs/architecture/kernel/proxy-credential-injection.md` — why the
+  outer agent cannot touch the kernel's security model unilaterally.
+- Centaur (Paradigm / Tempo, May 2026) — "nightly reflection; bounded blast
+  radius; kernel is immutable." Production validation of this design.

--- a/vault/specs/architecture/skills.md
+++ b/vault/specs/architecture/skills.md
@@ -6,6 +6,15 @@ This document covers the skill format, discovery, enforcement, and how skills co
 
 ---
 
+> **External validation (May 2026):** Centaur (Paradigm / Tempo) independently
+> arrived at `.agents/skills/` markdown files with the same progressive-disclosure
+> structure and auto-discovery convention. Centaur's API server additionally
+> **hot-reloads** skills on file-system changes. The orchestrator dispatch path
+> (§ 3.2) should adopt the same: flush the skill catalog cache when a file-system
+> event fires on a skill directory, so an in-progress session gets updated skill
+> listings without restarting the daemon. See also `vault/specs/comparison.md §
+> gctrl vs. Centaur`.
+
 ## Goals
 
 1. Let agents (and humans) extend gctrl's procedural knowledge without changing code.

--- a/vault/specs/architecture/skills.md
+++ b/vault/specs/architecture/skills.md
@@ -12,8 +12,11 @@ This document covers the skill format, discovery, enforcement, and how skills co
 > **hot-reloads** skills on file-system changes. The orchestrator dispatch path
 > (§ 3.2) should adopt the same: flush the skill catalog cache when a file-system
 > event fires on a skill directory, so an in-progress session gets updated skill
-> listings without restarting the daemon. See also `vault/specs/comparison.md §
-> gctrl vs. Centaur`.
+> listings without restarting the daemon. This hot-reload is connector **C3** of
+> the capability-growth system in [extension-tiers.md](extension-tiers.md): a
+> skill bundling proxied `scripts/` is an agent-authorable *userspace tool*, and
+> hot-reload is what lets an agent-authored tool go live without a daemon
+> restart. See also `vault/specs/comparison.md § gctrl vs. Centaur`.
 
 ## Goals
 

--- a/vault/specs/comparison.md
+++ b/vault/specs/comparison.md
@@ -1,6 +1,6 @@
-# Competitive Landscape: gctrl vs. Ruflo, oh-my-claudecode, Symphony
+# Competitive Landscape: gctrl vs. Ruflo, oh-my-claudecode, Symphony, Centaur
 
-> Comparison as of 2026-03-30. Sources: public GitHub READMEs, SPEC.md, and documentation.
+> Comparison as of 2026-05-28. Sources: public GitHub READMEs, SPEC.md, documentation, and open-source releases.
 
 ## One-Line Summaries
 
@@ -10,6 +10,7 @@
 | **Ruflo** (ruvnet/ruflo) | Enterprise multi-agent orchestration platform — 100+ specialized agents in coordinated swarms with self-learning, consensus protocols, and multi-LLM routing. |
 | **oh-my-claudecode** (OMC) | Claude Code plugin adding multi-agent orchestration, natural-language task dispatch, and persistent execution modes on top of the existing Claude Code runtime. |
 | **Symphony** (openai/symphony) | Issue-tracker-driven daemon that polls Linear for work, creates isolated workspaces, and dispatches coding agents (Codex) — spec-first, language-agnostic. |
+| **Centaur** (Paradigm / Tempo) | Self-hosted multiplayer agent runtime — one Slack thread = one isolated sandbox, credentials injected at the network layer (never held by the agent), nightly self-improvement that patches skills/tools without touching the kernel. Apache 2.0. |
 
 ---
 
@@ -189,17 +190,92 @@ graph TB
 
 ---
 
+## gctrl vs. Centaur: Self-hosted Team Agents (May 2026)
+
+Centaur was open-sourced by Paradigm and Tempo in May 2026 under Apache 2.0.
+It is the closest published architectural peer to gctrl: self-hosted, team-scoped,
+with a small auditable kernel and an extensible userspace. Key comparison:
+
+### Where Centaur is ahead of gctrl today
+
+**1. Credential injection at the network layer (iron-proxy)**
+
+Centaur's most novel design: API secrets live in an isolated secrets manager.
+A network-level firewall (iron-proxy) intercepts all agent egress and injects
+credentials into outbound requests in-flight. The agent never holds the secret —
+it routes through the proxy to reach external APIs. LLM API response bodies are
+also scanned for leaked secrets and redacted before reaching the agent.
+
+gctrl's proxy (`gctrl-proxy`) is today a traffic logger. **Design update:**
+elevate it to the credential injection plane. See
+`vault/specs/architecture/kernel/proxy-credential-injection.md`.
+
+**2. Warm container pool**
+
+Centaur pre-spawns sandbox containers so agent sessions start without cold-start
+delays. gctrl's compute spec (`compute-cf-containers.md`) is a stub. The warm
+pool principle (keep N containers ready; replenish after claim) belongs there.
+
+### Where gctrl and Centaur independently converged
+
+**Skills as `.agents/skills/` markdown** — Centaur's skills are markdown files
+in `.agents/skills/`, hot-reloaded on change. gctrl's skills spec
+(`vault/specs/architecture/skills.md`) reached the same path convention and
+progressive-disclosure protocol independently. Convergent external validation.
+Difference: gctrl's orchestrator does lazy scan on dispatch; Centaur's API
+server watches for file changes and hot-reloads. Hot-reload consideration added
+to skills.md.
+
+**Bounded kernel + extensible userspace** — both projects explicitly protect the
+kernel from agent modification. Centaur: "the agent reviews its own performance,
+identifies gaps, and ships fixes to its own skills and tools without touching the
+kernel." gctrl's outer improvement loop (PRD § outer loop) has the same
+principle but doesn't yet specify the structural boundary. See
+`vault/specs/architecture/outer-improvement-loop.md`.
+
+**Durable workflow checkpointing** — Centaur checkpoints every workflow step to
+Postgres so the agent can resume after a crash. gctrl's scheduler already reaps
+interrupted runs on restart (`runner.rs:70`) but doesn't checkpoint mid-workflow
+step state. A follow-up.
+
+### Where gctrl takes a different approach
+
+| Dimension | Centaur | gctrl |
+|---|---|---|
+| **Primary interface** | Slack (one thread = one session) | Board + inbox + CLI — Slack is an optional driver |
+| **Storage** | Postgres (single source of truth) | DuckDB + SQLite — local-first, Parquet export, edge sync via D1 |
+| **Tool model** | Python classes dropped in `tools/`, auto-discovered, REST-exposed | Rust LKMs (drivers) — type-safe, kernel-integrated, not hot-reloadable today |
+| **Self-improvement cadence** | Nightly scheduled reflection | Inner loop (per session) + outer loop (cross-session, scheduled) — more granular |
+| **Multi-team** | Organization-wide shared agent | Per-persona scope + guardrails; team-level view via `gctrl status --team` |
+| **Compute isolation** | Container per conversation | CF containers per session (spec stage); kernel-managed pool |
+
+### Net assessment
+
+Centaur is the best published production architecture for the same design space.
+The credential injection model is the strongest novel idea to import. The
+warm-pool and hot-reload are operational details worth capturing. The structural
+bounded-kernel principle reinforces the outer loop design.
+
+What gctrl does that Centaur doesn't: local-first without Postgres/Slack
+dependencies, in-loop improvement at session granularity (not just nightly), and
+an OS-level accumulation model (vault, context, sessions, personas) that survives
+across projects and teams.
+
+---
+
 ## Shared Concepts
 
 Several ideas appear across multiple projects, suggesting convergence in the space:
 
-| Concept | gctrl | Ruflo | OMC | Symphony |
-|---------|------|-------|-----|----------|
-| **WORKFLOW.md as config** | Prompt templates + YAML frontmatter for agent dispatch | N/A | N/A | YAML frontmatter + prompt body — identical concept |
-| **Orchestrator with concurrency control** | Dispatch, retry, dependency DAG, concurrency slots | Swarm coordination with consensus | Team pipeline with verify/fix loops | Poll-based dispatch with concurrency limits |
-| **Workspace isolation** | Per-session telemetry boundary | Per-agent swarm isolation | Per-team execution context | Per-issue filesystem workspace |
-| **Claim/dispatch model** | Orchestrator claim states (pending→claimed→running→done) | Claims for human-agent coordination | N/A | Running map + claimed set + retry queue |
-| **Retry with backoff** | Orchestrator retry policy | N/A | Ralph mode (persistent execution) | Exponential backoff with configurable attempts |
+| Concept | gctrl | Ruflo | OMC | Symphony | Centaur |
+|---------|------|-------|-----|----------|---------|
+| **WORKFLOW.md as config** | Prompt templates + YAML frontmatter for agent dispatch | N/A | N/A | YAML frontmatter + prompt body | N/A (skills are markdown, tools are Python) |
+| **Orchestrator with concurrency control** | Dispatch, retry, dependency DAG, concurrency slots | Swarm coordination with consensus | Team pipeline with verify/fix loops | Poll-based dispatch with concurrency limits | Durable workflow engine, checkpoint every step |
+| **Workspace isolation** | Per-session telemetry boundary | Per-agent swarm isolation | Per-team execution context | Per-issue filesystem workspace | Per-thread sandbox container |
+| **Claim/dispatch model** | Orchestrator claim states (pending→claimed→running→done) | Claims for human-agent coordination | N/A | Running map + claimed set + retry queue | Thread assignment via Postgres |
+| **Retry with backoff** | Orchestrator retry policy | N/A | Ralph mode (persistent execution) | Exponential backoff with configurable attempts | Durable workflow resume |
+| **Skills as markdown** | `.agents/skills/` — progressive disclosure, filesystem registry | N/A | `.agents/skills/` (same convention) | N/A | `.agents/skills/` — same path, same concept |
+| **Bounded kernel / userspace** | Kernel provides mechanisms; apps/skills provide policy | N/A | Plugin layer on Claude Code runtime | Policy in WORKFLOW.md, mechanism in orchestrator | Skills/tools are patchable; kernel is not |
 
 ### gctrl vs. Symphony: Closest Cousins
 

--- a/vault/specs/comparison.md
+++ b/vault/specs/comparison.md
@@ -194,72 +194,99 @@ graph TB
 
 Centaur was open-sourced by Paradigm and Tempo in May 2026 under Apache 2.0.
 It is the closest published architectural peer to gctrl: self-hosted, team-scoped,
-with a small auditable kernel and an extensible userspace. Key comparison:
+with a small auditable kernel and an extensible userspace. The value of the
+comparison is not a feature checklist — it is what Centaur's design *reveals*
+about gctrl's own architecture, including two tensions the pivot left implicit.
 
-### Where Centaur is ahead of gctrl today
+### The headline: gctrl's extension model has a missing tier
 
-**1. Credential injection at the network layer (iron-proxy)**
+Centaur's "tool" is a Python class dropped in `tools/`, auto-discovered,
+hot-reloaded, declaring its required hosts/creds — **userspace capability the
+agent can author itself.** gctrl has no equivalent:
 
-Centaur's most novel design: API secrets live in an isolated secrets manager.
-A network-level firewall (iron-proxy) intercepts all agent egress and injects
-credentials into outbound requests in-flight. The agent never holds the secret —
-it routes through the proxy to reach external APIs. LLM API response bodies are
-also scanned for leaked secrets and redacted before reaching the agent.
+| | New I/O capability? | Author | Lands live by |
+|---|---|---|---|
+| gctrl **skill** | No — knowledge only | Agent or human | Drop markdown |
+| gctrl **driver** | Yes | **Human only** | Rust → compile → ship kernel |
+| Centaur **tool** | **Yes** | **Agent or human** | Drop file → hot-reload |
 
-gctrl's proxy (`gctrl-proxy`) is today a traffic logger. **Design update:**
-elevate it to the credential injection plane. See
-`vault/specs/architecture/kernel/proxy-credential-injection.md`.
+This is *why* Centaur's nightly reflection can ship a genuinely new integration
+while gctrl's outer loop can only retune existing capability — an agent can
+change *how it uses* what it has, but cannot grant itself a new integration. The
+deep synthesis: **credential injection is not primarily a security feature — it
+is the substrate that makes agent-authored tools safe** (untrusted agent code
+can have network access without ever seeing a secret). gctrl is three connectors
+away, not a subsystem away: skills already bundle `scripts/`, the proxy can
+inject creds, the outer loop can promote winners. See
+[extension-tiers.md](architecture/extension-tiers.md) for the composed
+capability-growth system and
+[kernel/proxy-credential-injection.md](architecture/kernel/proxy-credential-injection.md)
+for the substrate.
 
-**2. Warm container pool**
+### Two tensions Centaur exposes (named, not yet resolved)
 
-Centaur pre-spawns sandbox containers so agent sessions start without cold-start
-delays. gctrl's compute spec (`compute-cf-containers.md`) is a stub. The warm
-pool principle (keep N containers ready; replenish after claim) belongs there.
+**1. Stateful singleton kernel vs. the multiplayer vision.** Centaur: every
+service stateless, Postgres the single source of truth. gctrl: a stateful
+singleton daemon holding the DuckDB single-writer lock. Correct for local-first;
+a write-path ceiling for "3 humans + 30 agents," which the D1/R2 sync layer
+(read-scale-out) does not lift. Forces the honest question: personal agent-OS
+that syncs, or team agent-server?
+
+**2. Agent-agnosticism caps durability.** Centaur owns the runtime, so it
+checkpoints every workflow step and resumes after a crash. gctrl observes via
+OTel and cannot checkpoint agent-internal state — a crash mid-session loses the
+work (scheduler reaps as failed, `runner.rs:70`). Portability bought at the cost
+of resumability; the ceiling is at the orchestration layer.
+
+Both are captured in [adr-deployment-topology.md](architecture/adr-deployment-topology.md).
 
 ### Where gctrl and Centaur independently converged
 
-**Skills as `.agents/skills/` markdown** — Centaur's skills are markdown files
-in `.agents/skills/`, hot-reloaded on change. gctrl's skills spec
-(`vault/specs/architecture/skills.md`) reached the same path convention and
-progressive-disclosure protocol independently. Convergent external validation.
-Difference: gctrl's orchestrator does lazy scan on dispatch; Centaur's API
-server watches for file changes and hot-reloads. Hot-reload consideration added
-to skills.md.
-
-**Bounded kernel + extensible userspace** — both projects explicitly protect the
-kernel from agent modification. Centaur: "the agent reviews its own performance,
-identifies gaps, and ships fixes to its own skills and tools without touching the
-kernel." gctrl's outer improvement loop (PRD § outer loop) has the same
-principle but doesn't yet specify the structural boundary. See
-`vault/specs/architecture/outer-improvement-loop.md`.
-
-**Durable workflow checkpointing** — Centaur checkpoints every workflow step to
-Postgres so the agent can resume after a crash. gctrl's scheduler already reaps
-interrupted runs on restart (`runner.rs:70`) but doesn't checkpoint mid-workflow
-step state. A follow-up.
+- **Skills as `.agents/skills/` markdown** — same path, same progressive-disclosure
+  protocol, reached independently. Centaur additionally hot-reloads on FS change;
+  gctrl's dispatch path should too ([skills.md §3.2](architecture/skills.md)).
+- **Bounded kernel + extensible userspace** — both structurally protect the
+  kernel from agent modification. Centaur: "ships fixes to its own skills and
+  tools without touching the kernel." gctrl's
+  [outer-improvement-loop.md](architecture/outer-improvement-loop.md) makes the
+  blast-radius boundary explicit.
+- **Warm container pool** — Centaur pre-spawns sandboxes; gctrl's
+  [compute-cf-containers.md](implementation/kernel/compute-cf-containers.md)
+  should keep N ready and replenish after claim.
 
 ### Where gctrl takes a different approach
 
 | Dimension | Centaur | gctrl |
 |---|---|---|
-| **Primary interface** | Slack (one thread = one session) | Board + inbox + CLI — Slack is an optional driver |
+| **Primary interface** | Slack (one thread = session = sandbox, fused) | Board + inbox + CLI; session/issue/thread/compute decoupled |
 | **Storage** | Postgres (single source of truth) | DuckDB + SQLite — local-first, Parquet export, edge sync via D1 |
-| **Tool model** | Python classes dropped in `tools/`, auto-discovered, REST-exposed | Rust LKMs (drivers) — type-safe, kernel-integrated, not hot-reloadable today |
-| **Self-improvement cadence** | Nightly scheduled reflection | Inner loop (per session) + outer loop (cross-session, scheduled) — more granular |
-| **Multi-team** | Organization-wide shared agent | Per-persona scope + guardrails; team-level view via `gctrl status --team` |
-| **Compute isolation** | Container per conversation | CF containers per session (spec stage); kernel-managed pool |
+| **Extension** | Userspace tools (agent-authored) | Skills (knowledge) + drivers (human, kernel) — missing the middle tier |
+| **Self-improvement cadence** | Nightly reflection | Inner loop (per session) + outer loop (cross-session) — finer granularity |
+| **Direction** | Conversation/task-driven | Durable, versioned, team-level *direction* — no Centaur equivalent |
+| **Accumulation substrate** | Postgres (opaque) | Vault (human-editable, Obsidian-graphed, cross-project) |
+
+Note the interface row: Centaur *fuses* conversation+session+sandbox into one
+object, so it needs no grouping — the thread *is* the context. gctrl deliberately
+*decouples* them, which is why the inbox needs **context-first grouping** (by
+issue/session/project/agent) to re-assemble the human view. Grouping is the tax
+of decoupling — and also its strength (one session spans many threads; one issue
+many sessions). It generalizes: with SQLite as truth, the board UI, the Obsidian
+mirror, and a future **Slack driver** are all bidirectional *projections* of the
+same inbox state.
 
 ### Net assessment
 
-Centaur is the best published production architecture for the same design space.
-The credential injection model is the strongest novel idea to import. The
-warm-pool and hot-reload are operational details worth capturing. The structural
-bounded-kernel principle reinforces the outer loop design.
+Centaur is the best published production architecture for the same design space,
+and its sharpest lesson is structural, not a feature: the **userspace-tool tier**
+is what turns a self-improvement loop from "retune" into "grow," and gctrl's own
+credential proxy is the thing that makes it safe. Adopt that; name the topology
+and durability tensions honestly ([ADR](architecture/adr-deployment-topology.md)).
 
-What gctrl does that Centaur doesn't: local-first without Postgres/Slack
-dependencies, in-loop improvement at session granularity (not just nightly), and
-an OS-level accumulation model (vault, context, sessions, personas) that survives
-across projects and teams.
+What gctrl keeps that Centaur deliberately doesn't have — and must not dilute
+chasing server-shaped polish: local-first with no Postgres/Slack dependency, the
+**direction surface** (the actual pivot thesis, with no Centaur analog), in-loop
+improvement at *session* granularity, and a human-legible **vault** accumulation
+substrate rather than an opaque DB.
 
 ---
 


### PR DESCRIPTION
Design analysis from Centaur's open-source release (Paradigm / Tempo, May 2026), the closest published architectural peer to gctrl — self-hosted, team-scoped, small auditable kernel, extensible userspace. The value isn't a feature checklist; it's what Centaur's design *reveals* about gctrl's own architecture.

## The load-bearing insight: gctrl's extension model has a missing tier

Centaur's "tool" — a file the agent drops in `tools/`, hot-reloaded, declaring its own host/cred needs — is **userspace capability the agent can author itself.** gctrl has no equivalent:

- **skill** = knowledge, no new I/O (agent can author)
- **driver** = capability, but human-only + kernel-compiled

The empty cell between them is *why* Centaur's nightly reflection ships genuinely new integrations while gctrl's outer loop can only *retune* existing capability. The synthesis that ties this PR together: **credential injection is not primarily a security feature — it is the substrate that makes agent-authored tools safe** (untrusted agent code gets network access without ever seeing a secret). gctrl is **three connectors away, not a subsystem away** — skills already bundle `scripts/`, the proxy can inject creds, the outer loop can promote winners.

New spec [`extension-tiers.md`](vault/specs/architecture/extension-tiers.md) lays out the composed **capability-growth system** (author → guardrail permits proxied-net-only → proxy injects creds + scans responses → hot-reload → outer-loop promotes) and the three connectors (C1 guardrail policy, C2 `required_hosts` manifest, C3 hot-reload). The human-only driver tier stays — the userspace tool is the *evidence* that a driver is worth hardening.

## Two tensions Centaur exposes — named, not papered over

New ADR [`adr-deployment-topology.md`](vault/specs/architecture/adr-deployment-topology.md):

1. **Stateful singleton kernel vs. multiplayer.** Centaur = stateless services + Postgres truth. gctrl = one daemon holding the DuckDB single-writer lock. Correct for local-first; a write-path ceiling for "3 humans + 30 agents" that D1/R2 sync (read-scale-out) doesn't lift. Decision: name *two* topologies (personal local-first / team deployed-server) rather than assume sync covers both. Build deferred.
2. **Agent-agnosticism caps durability.** Centaur owns the runtime → checkpoints every step → resumes after crash. gctrl observes via OTel → can't checkpoint agent-internal state → a crash mid-session loses the work. Decision: checkpoint at the *orchestration* boundary; accept the ceiling; keep agnosticism.

## Supporting changes

- [`proxy-credential-injection.md`](vault/specs/architecture/kernel/proxy-credential-injection.md) — credential plane spec (kernel_secrets table, in-flight injection in `handler.rs`, LLM response scanning in `relay.rs`), reframed as the enabling substrate for agent-authored tools.
- [`outer-improvement-loop.md`](vault/specs/architecture/outer-improvement-loop.md) — auto-apply vs. propose-to-human boundary, now framed as the *promotion stage* of the capability-growth system (promote userspace tools → first-class skills; propose hardening → drivers).
- [`comparison.md`](vault/specs/comparison.md) — Centaur section rewritten around the extension-tier gap + the two tensions; adds the **decoupling-tax** insight (context grouping is the cost of decoupling session/issue/thread/compute — Centaur fuses them) and the **everything-is-a-projection** generalization (Slack as a future inbox driver, structurally identical to the Obsidian mirror).
- [`skills.md`](vault/specs/architecture/skills.md) — hot-reload note wired in as connector C3.

## What this PR is and isn't

Specs only, no code. It captures decisions and names tensions; implementation lands as ROADMAP slices (credential injection; the three connectors; orchestration-layer checkpointing; the team topology when scheduled). What gctrl must *not* dilute chasing Centaur's server polish: local-first, the direction surface (the actual pivot thesis, no Centaur analog), per-session improvement granularity, and the human-legible vault.
