### PR TITLE
feat(gctrl-desktop): multi-window support — one window per project view

### DIFF
--- a/apps/gctrl-board/web/src/App.tsx
+++ b/apps/gctrl-board/web/src/App.tsx
@@ -14,7 +14,12 @@ import { AnalyticsPage } from "./pages/AnalyticsPage"
 import { SchedulePage } from "./pages/SchedulePage"
 import { MacosSpacesPage } from "./pages/MacosSpacesPage"
 import { api } from "./api/client"
+import type { DesktopShim } from "./lib/desktop-env"
 import type { Issue, InboxStats } from "./types"
+
+// Desktop-only: the preload bridge's window factory. Undefined on the web,
+// where the ProjectSelector simply doesn't render the affordance.
+const desktopOpenWindow = (globalThis as { desktop?: DesktopShim }).desktop?.openWindow
 
 interface Toast {
   id: string
@@ -266,6 +271,11 @@ export function App() {
                   onSelect={setSelectedProjectId}
                   onCreate={handleCreateProject}
                   loading={projectsLoading}
+                  onOpenInNewWindow={
+                    desktopOpenWindow
+                      ? (p) => void desktopOpenWindow(`/projects/${p.key}`)
+                      : undefined
+                  }
                 />
                 {selectedProject && (
                   <>

--- a/apps/gctrl-board/web/src/components/ProjectSelector.tsx
+++ b/apps/gctrl-board/web/src/components/ProjectSelector.tsx
@@ -7,9 +7,22 @@ interface Props {
   onSelect: (id: string | null) => void
   onCreate: (name: string, key: string) => Promise<Project>
   loading: boolean
+  /**
+   * Desktop-only: open the project in a new app window. When set, each row
+   * grows a hover affordance; on the web this stays undefined and nothing
+   * renders.
+   */
+  onOpenInNewWindow?: (project: Project) => void
 }
 
-export function ProjectSelector({ projects, selectedId, onSelect, onCreate, loading }: Props) {
+export function ProjectSelector({
+  projects,
+  selectedId,
+  onSelect,
+  onCreate,
+  loading,
+  onOpenInNewWindow,
+}: Props) {
   const [open, setOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState("")
@@ -73,22 +86,44 @@ export function ProjectSelector({ projects, selectedId, onSelect, onCreate, load
           )}
 
           {projects.map((p) => (
-            <button
-              key={p.id}
-              onClick={() => {
-                onSelect(p.id)
-                setOpen(false)
-              }}
-              className={`w-full text-left px-3 py-2 flex items-center gap-2.5 hover:bg-zinc-800/80 transition-colors cursor-pointer ${
-                p.id === selectedId ? "bg-zinc-800/50" : ""
-              }`}
-            >
-              <span className="font-mono text-xs text-emerald-400/70 w-12 shrink-0">{p.key}</span>
-              <span className="text-sm text-zinc-300 truncate">{p.name}</span>
-              {p.github_repo && (
-                <span className="ml-auto text-[10px] font-mono text-zinc-600">GH</span>
+            <div key={p.id} className="relative group">
+              <button
+                onClick={() => {
+                  onSelect(p.id)
+                  setOpen(false)
+                }}
+                className={`w-full text-left px-3 py-2 flex items-center gap-2.5 hover:bg-zinc-800/80 transition-colors cursor-pointer ${
+                  onOpenInNewWindow ? "pr-9" : ""
+                } ${p.id === selectedId ? "bg-zinc-800/50" : ""}`}
+              >
+                <span className="font-mono text-xs text-emerald-400/70 w-12 shrink-0">{p.key}</span>
+                <span className="text-sm text-zinc-300 truncate">{p.name}</span>
+                {p.github_repo && (
+                  <span className="ml-auto text-[10px] font-mono text-zinc-600">GH</span>
+                )}
+              </button>
+              {onOpenInNewWindow && (
+                <button
+                  onClick={() => {
+                    onOpenInNewWindow(p)
+                    setOpen(false)
+                  }}
+                  title="Open in new window"
+                  data-testid={`open-new-window-${p.key}`}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-1 text-zinc-500
+                    hover:text-emerald-400 opacity-0 group-hover:opacity-100
+                    transition-opacity cursor-pointer"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                      strokeLinecap="square"
+                      strokeWidth={2}
+                      d="M14 5h5v5M19 5l-7 7M9 5H5v14h14v-4"
+                    />
+                  </svg>
+                </button>
               )}
-            </button>
+            </div>
           ))}
 
           <div className="border-t border-zinc-800">

--- a/apps/gctrl-board/web/src/hooks/useProjectRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useProjectRoute.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import type { Project } from "../types"
+import { resolveInitialPath, type DesktopShim } from "../lib/desktop-env"
 
 /**
  * SPA routing for projects: syncs URL <-> selected project.
@@ -11,7 +12,13 @@ import type { Project } from "../types"
  */
 export function useProjectRoute(projects: Project[]) {
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
-  const [initialKey] = useState(() => parseProjectKey(window.location.pathname))
+  // Same initial-path resolution as useRoute: desktop windows opened onto a
+  // project boot from the preload bridge, not the `file://` pathname.
+  const [initialKey] = useState(() =>
+    parseProjectKey(
+      resolveInitialPath(globalThis as { desktop?: DesktopShim }, window.location.pathname),
+    ),
+  )
 
   // Resolve initial URL -> project ID once projects load
   useEffect(() => {

--- a/apps/gctrl-board/web/src/hooks/useRoute.ts
+++ b/apps/gctrl-board/web/src/hooks/useRoute.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useEffect } from "react"
 
+import { resolveInitialPath, type DesktopShim } from "../lib/desktop-env"
+
 export type BoardView = "kanban" | "gantt"
 
 export type AnalyticsTab =
@@ -84,7 +86,14 @@ export function parseRoute(pathname: string): Route {
 }
 
 export function useRoute(): { route: Route; navigate: (path: string) => void } {
-  const [route, setRoute] = useState<Route>(() => parseRoute(window.location.pathname))
+  // Desktop windows opened onto a specific view boot from the preload
+  // bridge's initialRoute — packaged Electron loads from `file://`, where
+  // the document pathname is the bundle path, not an app route.
+  const [route, setRoute] = useState<Route>(() =>
+    parseRoute(
+      resolveInitialPath(globalThis as { desktop?: DesktopShim }, window.location.pathname),
+    ),
+  )
 
   const navigate = useCallback((path: string) => {
     window.history.pushState(null, "", path)

--- a/apps/gctrl-board/web/src/lib/__tests__/desktop-env.test.ts
+++ b/apps/gctrl-board/web/src/lib/__tests__/desktop-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { applyDesktopClass, isDesktopHost } from "../desktop-env"
+import { applyDesktopClass, isDesktopHost, resolveInitialPath } from "../desktop-env"
 
 const fakeRoot = () => {
   const classes = new Set<string>()
@@ -28,6 +28,32 @@ describe("isDesktopHost", () => {
 
   it("is false when apiBase is empty", () => {
     expect(isDesktopHost({ desktop: { apiBase: "" } })).toBe(false)
+  })
+})
+
+describe("resolveInitialPath", () => {
+  it("prefers the bridge's initialRoute over the document pathname", () => {
+    expect(
+      resolveInitialPath(
+        { desktop: { apiBase: "http://127.0.0.1:4318", initialRoute: "/projects/BACK" } },
+        "/Applications/gctrl.app/Contents/Resources/renderer/index.html",
+      ),
+    ).toBe("/projects/BACK")
+  })
+
+  it("falls back to the pathname when no initialRoute is set", () => {
+    expect(resolveInitialPath({ desktop: { apiBase: "x" } }, "/projects/FRONT")).toBe(
+      "/projects/FRONT",
+    )
+    expect(resolveInitialPath({}, "/inbox")).toBe("/inbox")
+  })
+
+  it("ignores initialRoute values that are not app paths", () => {
+    expect(
+      resolveInitialPath({ desktop: { initialRoute: "https://evil.example" } }, "/"),
+    ).toBe("/")
+    expect(resolveInitialPath({ desktop: { initialRoute: "//evil.example" } }, "/")).toBe("/")
+    expect(resolveInitialPath({ desktop: { initialRoute: "" } }, "/")).toBe("/")
   })
 })
 

--- a/apps/gctrl-board/web/src/lib/desktop-env.ts
+++ b/apps/gctrl-board/web/src/lib/desktop-env.ts
@@ -3,10 +3,32 @@
 // over a target element so the test can assert the class transitions
 // without touching the real DOM.
 
-export type DesktopShim = { apiBase?: string }
+export type DesktopShim = {
+  apiBase?: string
+  initialRoute?: string
+  openWindow?: (route?: string) => Promise<void>
+}
 
 export const isDesktopHost = (host: { desktop?: DesktopShim }): boolean =>
   typeof host.desktop?.apiBase === "string" && host.desktop.apiBase.length > 0
+
+/**
+ * The SPA path this window should boot on. In packaged Electron the SPA is
+ * loaded from `file://`, so `location.pathname` is the bundle path — the
+ * desktop shell passes the intended route through the preload bridge
+ * instead (one window per project view). On the web, and in desktop windows
+ * opened without an explicit view, this falls through to the real pathname.
+ */
+export const resolveInitialPath = (
+  host: { desktop?: DesktopShim },
+  pathname: string,
+): string => {
+  const route = host.desktop?.initialRoute
+  if (typeof route === "string" && route.startsWith("/") && !route.startsWith("//")) {
+    return route
+  }
+  return pathname
+}
 
 export const applyDesktopClass = (
   root: { classList: { add: (c: string) => void; remove: (c: string) => void } },

--- a/apps/gctrl-desktop/src/main/__tests__/window-registry.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/window-registry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { createWindowRegistry } from "../window-registry"
+
+describe("createWindowRegistry", () => {
+  it("starts empty", () => {
+    const reg = createWindowRegistry<string>()
+    expect(reg.isEmpty()).toBe(true)
+    expect(reg.mostRecentlyFocused()).toBeUndefined()
+  })
+
+  it("returns the last added window as most recently focused", () => {
+    const reg = createWindowRegistry<string>()
+    reg.add("a")
+    reg.add("b")
+    expect(reg.mostRecentlyFocused()).toBe("b")
+    expect(reg.isEmpty()).toBe(false)
+  })
+
+  it("promotes a window on focus", () => {
+    const reg = createWindowRegistry<string>()
+    reg.add("a")
+    reg.add("b")
+    reg.noteFocused("a")
+    expect(reg.mostRecentlyFocused()).toBe("a")
+  })
+
+  it("falls back to the next most recent when the front window closes", () => {
+    const reg = createWindowRegistry<string>()
+    reg.add("a")
+    reg.add("b")
+    reg.add("c")
+    reg.noteFocused("b")
+    reg.remove("b")
+    expect(reg.mostRecentlyFocused()).toBe("c")
+    reg.remove("c")
+    expect(reg.mostRecentlyFocused()).toBe("a")
+    reg.remove("a")
+    expect(reg.isEmpty()).toBe(true)
+  })
+
+  it("does not duplicate a window added twice", () => {
+    const reg = createWindowRegistry<string>()
+    reg.add("a")
+    reg.add("a")
+    reg.remove("a")
+    expect(reg.isEmpty()).toBe(true)
+  })
+
+  it("ignores removal of an unknown window", () => {
+    const reg = createWindowRegistry<string>()
+    reg.add("a")
+    reg.remove("ghost")
+    expect(reg.mostRecentlyFocused()).toBe("a")
+  })
+})

--- a/apps/gctrl-desktop/src/main/__tests__/window-route.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/window-route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeWindowRoute } from "../window-route"
+
+describe("sanitizeWindowRoute", () => {
+  it("accepts SPA routes", () => {
+    expect(sanitizeWindowRoute("/projects/BACK")).toBe("/projects/BACK")
+    expect(sanitizeWindowRoute("/projects/BACK/gantt")).toBe("/projects/BACK/gantt")
+    expect(sanitizeWindowRoute("/inbox/threads/0b9e8a4e-1c2d-4e5f-8a9b-0c1d2e3f4a5b")).toBe(
+      "/inbox/threads/0b9e8a4e-1c2d-4e5f-8a9b-0c1d2e3f4a5b",
+    )
+    expect(sanitizeWindowRoute("/analytics/usage")).toBe("/analytics/usage")
+  })
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeWindowRoute("  /projects/BACK ")).toBe("/projects/BACK")
+  })
+
+  it("maps default-window requests to undefined", () => {
+    expect(sanitizeWindowRoute(undefined)).toBeUndefined()
+    expect(sanitizeWindowRoute("")).toBeUndefined()
+    expect(sanitizeWindowRoute("/")).toBeUndefined()
+  })
+
+  it("rejects non-strings", () => {
+    expect(sanitizeWindowRoute(42)).toBeUndefined()
+    expect(sanitizeWindowRoute({ route: "/projects/BACK" })).toBeUndefined()
+    expect(sanitizeWindowRoute(["/projects/BACK"])).toBeUndefined()
+  })
+
+  it("rejects URLs and protocol-relative paths", () => {
+    expect(sanitizeWindowRoute("https://evil.example")).toBeUndefined()
+    expect(sanitizeWindowRoute("//evil.example/path")).toBeUndefined()
+    expect(sanitizeWindowRoute("gctrl://focus/iterm2/abc")).toBeUndefined()
+    expect(sanitizeWindowRoute("file:///etc/passwd")).toBeUndefined()
+  })
+
+  it("rejects relative paths and unsafe characters", () => {
+    expect(sanitizeWindowRoute("projects/BACK")).toBeUndefined()
+    expect(sanitizeWindowRoute("/projects/BACK?x=1")).toBeUndefined()
+    expect(sanitizeWindowRoute("/projects/BACK#frag")).toBeUndefined()
+    expect(sanitizeWindowRoute("/projects/<script>")).toBeUndefined()
+    expect(sanitizeWindowRoute("/projects/BACK BACK")).toBeUndefined()
+  })
+
+  it("rejects absurdly long routes", () => {
+    expect(sanitizeWindowRoute(`/${"a".repeat(600)}`)).toBeUndefined()
+  })
+})

--- a/apps/gctrl-desktop/src/main/index.ts
+++ b/apps/gctrl-desktop/src/main/index.ts
@@ -20,12 +20,19 @@ import { createSpawner } from "./spawner"
 import { startAutoUpdater } from "./updater"
 import { handleGctrlUrl, type UrlHandlerDeps } from "./url-handler"
 import { resolveVaultDir, type VaultPicker } from "./vault-config"
+import { createWindowRegistry } from "./window-registry"
+import { sanitizeWindowRoute } from "./window-route"
 
 const KERNEL_PORT = 4318
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 let sidecar: KernelSidecar | undefined
-let mainWindow: BrowserWindow | undefined
+
+// All open windows in most-recently-focused order. Deep links and the
+// `gctrl-navigate` IPC target `windows.mostRecentlyFocused()` —
+// `BrowserWindow.getFocusedWindow()` is null whenever the app is in the
+// background, which is exactly the deep-link case.
+const windows = createWindowRegistry<BrowserWindow>()
 
 // Buffer URLs that arrive before the BrowserWindow is ready (cold-launch
 // path: `open gctrl://...` starts the app, fires `open-url`, then the
@@ -132,7 +139,11 @@ const registerLoginItem = (): void => {
   })
 }
 
-const createWindow = (): BrowserWindow => {
+const createWindow = (initialRoute?: string): BrowserWindow => {
+  // Cascade new windows from the most recent one so a second project window
+  // doesn't land pixel-perfect on top of the first.
+  const previous = windows.mostRecentlyFocused()
+
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -154,9 +165,24 @@ const createWindow = (): BrowserWindow => {
       // Pass the kernel sidecar's base URL into preload's argv so the SPA
       // (loaded from `file://` in packaged mode) can reach the loopback API
       // instead of resolving relative `/api/...` paths against `file:///`.
-      additionalArguments: [`--gctrl-api-base=http://127.0.0.1:${KERNEL_PORT}`],
+      // The per-window initial route rides the same channel — in packaged
+      // mode `location.pathname` is the bundle path, so the SPA reads its
+      // boot route from the preload bridge instead.
+      additionalArguments: [
+        `--gctrl-api-base=http://127.0.0.1:${KERNEL_PORT}`,
+        ...(initialRoute ? [`--gctrl-initial-route=${initialRoute}`] : []),
+      ],
     },
   })
+
+  if (previous && !previous.isDestroyed()) {
+    const [x, y] = previous.getPosition()
+    win.setPosition(x + 24, y + 24)
+  }
+
+  windows.add(win)
+  win.on("focus", () => windows.noteFocused(win))
+  win.on("closed", () => windows.remove(win))
 
   if (app.isPackaged) {
     void win.loadFile(path.join(__dirname, "../renderer/index.html"))
@@ -164,8 +190,10 @@ const createWindow = (): BrowserWindow => {
     // Dev mode: point at the gctrl-board Vite dev server. The default
     // matches gctrl-board's `web/vite.config.ts` (port 4200); override
     // via GCTRL_DESKTOP_DEV_URL when running an alternate renderer.
+    // The initial route also lands in the URL here so a plain browser
+    // reload of the dev window stays on the same view.
     const devUrl = process.env.GCTRL_DESKTOP_DEV_URL ?? "http://localhost:4200"
-    void win.loadURL(devUrl)
+    void win.loadURL(`${devUrl}${initialRoute ?? ""}`)
   }
 
   // Reserve space for macOS traffic-light buttons. Injected from main so it
@@ -202,6 +230,12 @@ ipcMain.handle("show-in-finder", (_event, p: string) => {
   shell.showItemInFolder(p)
 })
 ipcMain.handle("app-version", () => app.getVersion())
+// Renderer-initiated window creation ("open project X in a new window").
+// The route is renderer-supplied, so it goes through the sanitizer — an
+// invalid route still opens a window, just at the default view.
+ipcMain.handle("open-window", (_event, route: unknown) => {
+  createWindow(sanitizeWindowRoute(route))
+})
 
 // --- gctrl:// URL scheme ----------------------------------------------------
 
@@ -222,14 +256,16 @@ const urlHandlerDeps = (): UrlHandlerDeps => ({
     return { ok: res.ok, status: res.status, bodyText: await res.text() }
   },
   bringToFront: () => {
-    if (!mainWindow) return
-    if (mainWindow.isMinimized()) mainWindow.restore()
-    mainWindow.show()
-    mainWindow.focus()
+    const win = windows.mostRecentlyFocused()
+    if (!win) return
+    if (win.isMinimized()) win.restore()
+    win.show()
+    win.focus()
   },
   navigateSpa: (route) => {
-    // Renderer subscribes to `gctrl-navigate` via the preload bridge.
-    if (mainWindow) mainWindow.webContents.send("gctrl-navigate", route)
+    // Renderer subscribes to `gctrl-navigate` via the preload bridge. Deep
+    // links land in the most recently focused window, not every window.
+    windows.mostRecentlyFocused()?.webContents.send("gctrl-navigate", route)
   },
   logger: console,
 })
@@ -241,9 +277,10 @@ async function dispatchGctrlUrl(url: string): Promise<void> {
 
 app.on("open-url", (event, url) => {
   event.preventDefault()
-  // If the BrowserWindow isn't ready yet, buffer the URL — the cold-launch
+  // If no BrowserWindow is ready yet, buffer the URL — the cold-launch
   // path fires `open-url` before any window exists.
-  if (!mainWindow?.webContents || mainWindow.webContents.isLoading()) {
+  const target = windows.mostRecentlyFocused()
+  if (!target || target.webContents.isLoading()) {
     pendingUrls.push(url)
     return
   }
@@ -251,14 +288,19 @@ app.on("open-url", (event, url) => {
 })
 
 void app.whenReady().then(async () => {
-  Menu.setApplicationMenu(buildAppMenu())
+  Menu.setApplicationMenu(buildAppMenu({ onNewWindow: () => createWindow() }))
+  if (process.platform === "darwin") {
+    app.dock?.setMenu(
+      Menu.buildFromTemplate([{ label: "New Window", click: () => createWindow() }]),
+    )
+  }
   registerLoginItem()
   // Vault picker (when needed) blocks here on purpose — the kernel
   // sidecar must know where to watch before it spawns. Subsequent
   // launches read the persisted choice and skip the dialog entirely.
   sidecar = await createSidecar()
   void sidecar?.start()
-  mainWindow = createWindow()
+  createWindow()
 
   startAutoUpdater({
     isPackaged: app.isPackaged,
@@ -271,7 +313,7 @@ void app.whenReady().then(async () => {
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      mainWindow = createWindow()
+      createWindow()
     }
   })
 })

--- a/apps/gctrl-desktop/src/main/menu.ts
+++ b/apps/gctrl-desktop/src/main/menu.ts
@@ -5,7 +5,12 @@
 
 import { Menu, type MenuItemConstructorOptions, app } from "electron"
 
-export const buildAppMenu = (): Menu => {
+export interface AppMenuDeps {
+  /** Open a fresh window at the default view (File → New Window, ⌘N). */
+  readonly onNewWindow: () => void
+}
+
+export const buildAppMenu = (deps: AppMenuDeps): Menu => {
   const isMac = process.platform === "darwin"
 
   const template: MenuItemConstructorOptions[] = [
@@ -27,6 +32,20 @@ export const buildAppMenu = (): Menu => {
           } satisfies MenuItemConstructorOptions,
         ]
       : []),
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "New Window",
+          accelerator: "CmdOrCtrl+N",
+          click: () => deps.onNewWindow(),
+        },
+        { type: "separator" },
+        ...(isMac
+          ? ([{ role: "close" }] satisfies MenuItemConstructorOptions[])
+          : ([{ role: "quit" }] satisfies MenuItemConstructorOptions[])),
+      ],
+    },
     {
       label: "Edit",
       submenu: [

--- a/apps/gctrl-desktop/src/main/window-registry.ts
+++ b/apps/gctrl-desktop/src/main/window-registry.ts
@@ -1,0 +1,41 @@
+// Tracks open BrowserWindows in most-recently-focused order. Pure over a
+// generic handle type so it can be unit-tested without pulling in `electron`.
+//
+// Why not `BrowserWindow.getFocusedWindow()`: it returns null whenever the
+// app is in the background — exactly the deep-link case (`gctrl://...`
+// clicked in a browser), where main must still pick a window to navigate.
+
+export interface WindowRegistry<W> {
+  /** Register a new window as the most recently focused. */
+  readonly add: (win: W) => void
+  /** Move a window to the front of the focus order. */
+  readonly noteFocused: (win: W) => void
+  /** Drop a window (closed). No-op if unknown. */
+  readonly remove: (win: W) => void
+  /** The window deep links and IPC broadcasts should target. */
+  readonly mostRecentlyFocused: () => W | undefined
+  readonly isEmpty: () => boolean
+}
+
+export const createWindowRegistry = <W>(): WindowRegistry<W> => {
+  // Last element = most recently focused.
+  const order: W[] = []
+
+  const remove = (win: W): void => {
+    const i = order.indexOf(win)
+    if (i !== -1) order.splice(i, 1)
+  }
+
+  const promote = (win: W): void => {
+    remove(win)
+    order.push(win)
+  }
+
+  return {
+    add: promote,
+    noteFocused: promote,
+    remove,
+    mostRecentlyFocused: () => order[order.length - 1],
+    isEmpty: () => order.length === 0,
+  }
+}

--- a/apps/gctrl-desktop/src/main/window-route.ts
+++ b/apps/gctrl-desktop/src/main/window-route.ts
@@ -1,0 +1,23 @@
+// Validates SPA routes the renderer may ask main to open a new window at
+// (`open-window` IPC). The route round-trips through
+// `webPreferences.additionalArguments` into the preload bridge, so it must be
+// a plain app path — never a URL, scheme, or anything shell-expandable.
+
+const ROUTE_RE = /^\/[A-Za-z0-9\-_/.]*$/
+const MAX_ROUTE_LENGTH = 512
+
+/**
+ * Returns the route when it is a safe SPA path (`/projects/BACK`,
+ * `/inbox/threads/<uuid>`, ...), `undefined` otherwise. `/` and empty input
+ * also map to `undefined` — "open the default window".
+ */
+export const sanitizeWindowRoute = (input: unknown): string | undefined => {
+  if (typeof input !== "string") return undefined
+  const route = input.trim()
+  if (route === "" || route === "/") return undefined
+  // `//host` is protocol-relative — a URL, not a route.
+  if (route.startsWith("//")) return undefined
+  if (route.length > MAX_ROUTE_LENGTH) return undefined
+  if (!ROUTE_RE.test(route)) return undefined
+  return route
+}

--- a/apps/gctrl-desktop/src/preload/__tests__/initial-route.test.ts
+++ b/apps/gctrl-desktop/src/preload/__tests__/initial-route.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { parseInitialRoute } from "../initial-route"
+
+describe("parseInitialRoute", () => {
+  it("extracts the flag value", () => {
+    expect(
+      parseInitialRoute(["--type=renderer", "--gctrl-initial-route=/projects/BACK"]),
+    ).toBe("/projects/BACK")
+  })
+
+  it("returns undefined when the flag is absent", () => {
+    expect(parseInitialRoute(["--type=renderer"])).toBeUndefined()
+    expect(parseInitialRoute([])).toBeUndefined()
+  })
+
+  it("rejects values that are not app paths", () => {
+    expect(parseInitialRoute(["--gctrl-initial-route="])).toBeUndefined()
+    expect(parseInitialRoute(["--gctrl-initial-route=projects/BACK"])).toBeUndefined()
+    expect(parseInitialRoute(["--gctrl-initial-route=//evil.example"])).toBeUndefined()
+    expect(parseInitialRoute(["--gctrl-initial-route=https://evil.example"])).toBeUndefined()
+  })
+
+  it("takes the first matching flag", () => {
+    expect(
+      parseInitialRoute([
+        "--gctrl-initial-route=/projects/A",
+        "--gctrl-initial-route=/projects/B",
+      ]),
+    ).toBe("/projects/A")
+  })
+})

--- a/apps/gctrl-desktop/src/preload/index.ts
+++ b/apps/gctrl-desktop/src/preload/index.ts
@@ -12,6 +12,7 @@
 import { contextBridge, ipcRenderer } from "electron"
 
 import { parseApiBase } from "./api-base"
+import { parseInitialRoute } from "./initial-route"
 
 declare global {
   // Surface this in TS when consumers (the bundled SPA) want to opt into
@@ -20,9 +21,19 @@ declare global {
   interface Window {
     desktop?: {
       readonly apiBase?: string
+      /**
+       * SPA route this window should boot on (`/projects/BACK`, ...). Set
+       * when the window was opened for a specific view (File → New Window
+       * for a project, `open-window` IPC). In packaged mode the SPA must
+       * prefer this over `location.pathname`, which is the `file://`
+       * bundle path.
+       */
+      readonly initialRoute?: string
       readonly openExternal: (url: string) => Promise<void>
       readonly showInFinder: (path: string) => Promise<void>
       readonly appVersion: () => Promise<string>
+      /** Open a new desktop window, optionally at a specific SPA route. */
+      readonly openWindow: (route?: string) => Promise<void>
       /**
        * Subscribe to `gctrl://inbox/...` deep-link navigation events. The
        * main process emits these when LaunchServices delivers a deep link
@@ -33,16 +44,21 @@ declare global {
   }
 }
 
-// Main injects `--gctrl-api-base=http://127.0.0.1:<port>` via
-// `webPreferences.additionalArguments`. Without it the SPA's relative
-// `/api/...` paths resolve against the `file://` document origin and fail.
+// Main injects `--gctrl-api-base=http://127.0.0.1:<port>` (and, for windows
+// opened onto a specific view, `--gctrl-initial-route=<path>`) via
+// `webPreferences.additionalArguments`. Without the api base the SPA's
+// relative `/api/...` paths resolve against the `file://` document origin
+// and fail.
 const apiBase = parseApiBase(process.argv)
+const initialRoute = parseInitialRoute(process.argv)
 
 contextBridge.exposeInMainWorld("desktop", {
   apiBase,
+  initialRoute,
   openExternal: (url: string) => ipcRenderer.invoke("open-external", url),
   showInFinder: (path: string) => ipcRenderer.invoke("show-in-finder", path),
   appVersion: () => ipcRenderer.invoke("app-version"),
+  openWindow: (route?: string) => ipcRenderer.invoke("open-window", route),
   onNavigate: (cb: (route: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, route: string): void => {
       cb(route)

--- a/apps/gctrl-desktop/src/preload/initial-route.ts
+++ b/apps/gctrl-desktop/src/preload/initial-route.ts
@@ -1,0 +1,19 @@
+// Pure parser: extracts the `--gctrl-initial-route=<path>` flag from a list
+// of argv entries. Mirrors `api-base.ts` — lives in its own module so it can
+// be unit-tested without pulling in `electron`. Main injects this flag per
+// window via `webPreferences.additionalArguments` so each window can boot the
+// SPA on a different route (the packaged `file://` load makes
+// `location.pathname` useless for this).
+
+const FLAG = "--gctrl-initial-route="
+
+export const parseInitialRoute = (argv: readonly string[]): string | undefined => {
+  for (const arg of argv) {
+    if (arg.startsWith(FLAG)) {
+      const value = arg.slice(FLAG.length).trim()
+      // Belt-and-braces: main already sanitized, but argv is attacker-adjacent.
+      if (value.startsWith("/") && !value.startsWith("//")) return value
+    }
+  }
+  return undefined
+}

--- a/vault/specs/implementation/apps/desktop-electron.md
+++ b/vault/specs/implementation/apps/desktop-electron.md
@@ -423,7 +423,7 @@ The implementation is intentionally narrow. The following are explicit non-goals
 - Mac App Store target (separate provisioning profile, sandbox entitlements, and the localhost-kernel review risk)
 - Windows / Linux build targets
 - Custom IPC bridge for kernel data (`fetch` to localhost is sufficient and keeps cloud + desktop unified)
-- Multi-window / multi-tab UI (the React SPA is single-window today)
+- Multi-tab UI (multi-**window** shipped: `src/main/window-registry.ts` tracks windows in focus order; File → New Window / ⌘N, dock menu, and the `open-window` IPC open additional windows, each bootable on its own SPA route via `--gctrl-initial-route` in the preload argv — tabs within a window remain out of scope)
 - Native macOS menu bar / status bar (tray) UX (post-v1; possible to add via `Tray` API without architectural changes)
 
 ## Related


### PR DESCRIPTION
Multi-window support for the desktop app: open any number of windows, each bootable on its own view — e.g. one window per project.

## End state

- **File → New Window (⌘N)** and a **dock menu** entry open a fresh window (cascaded +24/+24 from the last focused one).
- **ProjectSelector rows grow a hover affordance** (desktop only) that opens that project in a new window at `/projects/:key`.
- Deep links (`gctrl://...`) and `gctrl-navigate` land in the **most recently focused** window instead of a hardcoded `mainWindow`.

## Insight

- `BrowserWindow.getFocusedWindow()` is null whenever the app is backgrounded — which is exactly the deep-link case (link clicked in a browser). Hence a small focus-ordered registry (`apps/gctrl-desktop/src/main/window-registry.ts`) rather than Electron's built-ins.
- In packaged mode the SPA loads from `file://`, so `location.pathname` is the bundle path — per-window boot routes can't ride the URL. They ride the same channel as the kernel api base: `--gctrl-initial-route` in `webPreferences.additionalArguments`, surfaced as `window.desktop.initialRoute`. As a side effect this also makes initial-route handling in packaged mode correct for the first window.
- The kernel stays app-global (one sidecar on `:4318`, one vault, one DuckDB writer); windows are pure views, so nothing kernel-side changes.

## Rationale

- Renderer-initiated window creation goes through one narrow `open-window` IPC with a route sanitizer (`window-route.ts`) — the route round-trips through argv, so it must never be a URL/scheme. Invalid input degrades to a default window, not an error.
- Both `useRoute` and `useProjectRoute` resolve their initial path through a single shared helper (`resolveInitialPath` in `desktop-env.ts`) so web behavior is untouched (no bridge → plain pathname).

## Key actions

- [x] Focus-ordered `WindowRegistry` (pure, unit-tested) replaces `mainWindow` global
- [x] `createWindow(initialRoute?)` + cascade positioning + per-window argv route
- [x] File menu (⌘N), dock menu, `open-window` IPC + sanitizer
- [x] Preload exposes `initialRoute` / `openWindow`; SPA hooks prefer bridge route
- [x] ProjectSelector "open in new window" affordance (feature-detected, web unaffected)
- [x] Spec updated: multi-window moved out of "Out of Scope" in `vault/specs/implementation/apps/desktop-electron.md` (multi-tab remains out)

Follow-ups (not in this PR):
- [ ] Persist/restore the set of open windows across app restarts
- [ ] Per-window title reflecting the active project

Tests: desktop 125 passed (incl. new registry/sanitizer/argv-parser suites); board web 95 passed. The 3 `tsc` errors in `MessageCard/MessageDetail` (`source_name` on `InboxMessage`) pre-exist on main, verified via stash.
