### PR TITLE
feat(gctrl-inbox): Claude Code observe capture hook — requests-to-user → inbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,27 @@ jobs:
           retention-days: 1
 
   # ──────────────────────────────────────────────
+  # Agent hooks — shellcheck + bats
+  # ──────────────────────────────────────────────
+  hooks:
+    name: Hooks (shellcheck + bats)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats
+        run: sudo apt-get update -q && sudo apt-get install -y -q bats
+
+      - name: Shellcheck
+        run: shellcheck shell/hooks/*.sh
+
+      - name: Bats
+        run: bats shell/hooks/test/
+
+  # ──────────────────────────────────────────────
   # Playwright acceptance tests
   # ──────────────────────────────────────────────
   playwright:

--- a/apps/gctrl-inbox/vault/ROADMAP.md
+++ b/apps/gctrl-inbox/vault/ROADMAP.md
@@ -1,0 +1,18 @@
+# gctrl-inbox — Roadmap
+
+> Milestones and slice breakdown for gctrl-inbox. See [PRD.md](PRD.md) for the problem, goals, and message model; [WORKFLOW.md](WORKFLOW.md) for lifecycle and triage flows.
+
+## M0: Capture & Triage — In Progress
+
+**Goal:** Agent requests-to-user reach the inbox in real time; the human can find and answer them with one click.
+
+| Task | Description | Priority | Depends On | Issue |
+|------|-------------|----------|------------|-------|
+| Kernel inbox intake | `inbox_*` tables + `/api/inbox/*` routes on the kernel | P0 | — | Shipped |
+| mac-comm focus driver | `gctrl://focus/...` deeplink + `/api/comm/focus` (see `vault/specs/architecture/kernel/mac-comm.md`) | P0 | Kernel inbox intake | Shipped (PR-1) |
+| CC observe capture hook | `Notification` + `AskUserQuestion` hooks → fire-and-forget POST to `/api/inbox/messages` with `context.terminal` | P0 | Kernel inbox intake | [#215](https://github.com/OpenHackersClub/gctrl/issues/215) |
+| CC blocking permission hook (act mode) | `PreToolUse` hook polls the inbox message; approve/deny from the inbox resumes/blocks Claude Code | P1 | CC observe capture hook, mac-comm focus driver | TBD |
+| Transcript enrichment | Kernel one-shot read of `payload.transcript_path` at message creation to enrich the inbox card | P2 | CC observe capture hook | TBD |
+| Desktop hook install | gctrl-desktop first-run copies `shell/hooks/*.sh` into `~/.local/share/gctrl/hooks/` | P2 | CC observe capture hook | TBD |
+
+**Done when:** a permission prompt in any Claude Code session appears in the inbox within a second, carries a working Focus deeplink, and stale prompts expire on their own.

--- a/apps/gctrl-inbox/vault/WORKFLOW.md
+++ b/apps/gctrl-inbox/vault/WORKFLOW.md
@@ -345,6 +345,62 @@ CREATE INDEX IF NOT EXISTS idx_inbox_actions_actor ON inbox_actions(actor_id);
 CREATE INDEX IF NOT EXISTS idx_inbox_subscriptions_user ON inbox_subscriptions(user_id);
 ```
 
+## Claude Code Capture Hook (observe)
+
+Claude Code's requests-to-user (permission prompts, questions, idle waits) post into the inbox via `shell/hooks/claude-code-inbox.sh` — fire-and-forget, never blocks the agent. Spec: `vault/specs/architecture/apps/cc-permission-hook.md`.
+
+### Install
+
+```sh
+mkdir -p ~/.local/share/gctrl/hooks
+cp shell/hooks/claude-code-inbox.sh ~/.local/share/gctrl/hooks/
+```
+
+Then wire it in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      },
+      {
+        "matcher": "idle_prompt",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      }
+    ]
+  }
+}
+```
+
+### What lands in the inbox
+
+| Claude Code event | Inbox kind | Urgency | Requires action |
+|---|---|---|---|
+| Permission prompt | `permission_request` | `high` | Yes (answered in the terminal; expires after `GCTRL_INBOX_HOOK_TTL`, default 1 h) |
+| Waiting for input (idle) | `agent_question` | `medium` | No |
+| `AskUserQuestion` | `agent_question` (question text as title/body) | `medium` | Yes |
+
+Messages group into one thread per Claude Code session and carry `context.terminal` for the mac-comm Focus deeplink.
+
+### Knobs
+
+| Env | Default | Meaning |
+|---|---|---|
+| `GCTRL_KERNEL_PORT` | `4318` | Kernel HTTP port |
+| `GCTRL_INBOX_HOOK_TTL` | `3600` | `expires_at` offset (seconds) for permission prompts; `0` disables |
+| `GCTRL_INBOX_HOOK_DISABLE` | unset | `1` = kill switch, hook no-ops |
+
+If the kernel daemon is offline the hook fails open (exit 0, message dropped, stderr warning) — it never blocks or breaks Claude Code.
+
 ## Project Key
 
 `INBOX` — for tracking gctrl-inbox's own development issues on gctrl-board.

--- a/shell/hooks/claude-code-inbox.sh
+++ b/shell/hooks/claude-code-inbox.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# claude-code-inbox.sh — observe-only Claude Code → gctrl-inbox capture hook.
+#
+# Wired as a Claude Code `Notification` hook (permission_prompt, idle_prompt)
+# and a `PreToolUse` hook matching `AskUserQuestion`. Reads the hook event
+# JSON from stdin, snapshots terminal identity from the environment, and
+# POSTs an inbox message to the kernel at /api/inbox/messages.
+#
+# Fire-and-forget by design: this script ALWAYS exits 0 and never blocks or
+# influences Claude Code (no decision output). Kernel offline, missing jq,
+# unknown events — all fail open with at most a stderr warning.
+#
+# Spec: vault/specs/architecture/apps/cc-permission-hook.md
+#
+# Env knobs:
+#   GCTRL_KERNEL_PORT        kernel HTTP port (default 4318)
+#   GCTRL_INBOX_HOOK_TTL     expires_at offset in seconds for permission
+#                            prompts (default 3600; 0 disables expiry)
+#   GCTRL_INBOX_HOOK_DISABLE set to 1 to no-op the hook entirely
+
+set -u
+
+warn() { echo "[claude-code-inbox] $*" >&2; }
+
+[ "${GCTRL_INBOX_HOOK_DISABLE:-0}" = "1" ] && exit 0
+command -v jq >/dev/null 2>&1 || { warn "jq not found; skipping"; exit 0; }
+command -v curl >/dev/null 2>&1 || { warn "curl not found; skipping"; exit 0; }
+
+INPUT=$(cat) || exit 0
+[ -n "$INPUT" ] || exit 0
+
+EVENT=$(jq -r '.hook_event_name // empty' <<<"$INPUT") || exit 0
+
+# ── Map hook event → inbox message kind/urgency ──────────────────────────
+KIND="" URGENCY="" REQUIRES_ACTION=false TITLE="" BODY="" WITH_EXPIRY=false
+case "$EVENT" in
+  Notification)
+    NOTIFICATION_TYPE=$(jq -r '.notification_type // empty' <<<"$INPUT")
+    MESSAGE=$(jq -r '.message // empty' <<<"$INPUT")
+    case "$NOTIFICATION_TYPE" in
+      permission_prompt)
+        KIND="permission_request" URGENCY="high" REQUIRES_ACTION=true WITH_EXPIRY=true
+        TITLE=${MESSAGE:-"Claude Code needs permission"}
+        ;;
+      idle_prompt)
+        KIND="agent_question" URGENCY="medium" REQUIRES_ACTION=false
+        TITLE=${MESSAGE:-"Claude Code is waiting for input"}
+        ;;
+      *) exit 0 ;; # other notification types are not requests-to-user
+    esac
+    ;;
+  PreToolUse)
+    TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT")
+    [ "$TOOL_NAME" = "AskUserQuestion" ] || exit 0
+    KIND="agent_question" URGENCY="medium" REQUIRES_ACTION=true
+    TITLE=$(jq -r '[.tool_input.questions[]?.question] | first // "Claude Code is asking a question"' <<<"$INPUT" | cut -c1-200)
+    BODY=$(jq -r '[.tool_input.questions[]?.question] | join("\n\n")' <<<"$INPUT")
+    ;;
+  *) exit 0 ;;
+esac
+
+SESSION_ID=$(jq -r '.session_id // "unknown"' <<<"$INPUT")
+CWD=$(jq -r '.cwd // empty' <<<"$INPUT")
+TRANSCRIPT_PATH=$(jq -r '.transcript_path // empty' <<<"$INPUT")
+PERMISSION_MODE=$(jq -r '.permission_mode // empty' <<<"$INPUT")
+
+# ── Terminal identity snapshot (mac-comm context.terminal schema) ────────
+case "${TERM_PROGRAM:-}" in
+  iTerm.app)      TERM_APP="iterm2"   BUNDLE_ID="com.googlecode.iterm2" ;;
+  Apple_Terminal) TERM_APP="terminal" BUNDLE_ID="com.apple.Terminal" ;;
+  ghostty)        TERM_APP="ghostty"  BUNDLE_ID="com.mitchellh.ghostty" ;;
+  vscode)         TERM_APP="vscode"   BUNDLE_ID="com.microsoft.VSCode" ;;
+  WarpTerminal)   TERM_APP="warp"     BUNDLE_ID="dev.warp.Warp-Stable" ;;
+  *)              TERM_APP="unknown"  BUNDLE_ID="local.unknown" ;;
+esac
+
+TERM_SESSION_ID=""
+[ "$TERM_APP" = "iterm2" ] && TERM_SESSION_ID="${ITERM_SESSION_ID:-}"
+
+# stdin is the hook pipe, so tty(1) reports "not a tty"; resolve via parent.
+TTY=""
+TTY_NAME=$(ps -o tty= -p "$PPID" 2>/dev/null | tr -d ' ')
+case "$TTY_NAME" in
+  tty*|pty*) TTY="/dev/$TTY_NAME" ;;
+esac
+
+CAPTURED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ── Optional expiry: stale permission prompts auto-expire ────────────────
+EXPIRES_AT=""
+TTL="${GCTRL_INBOX_HOOK_TTL:-3600}"
+if [ "$WITH_EXPIRY" = true ] && [ "$TTL" -gt 0 ] 2>/dev/null; then
+  EXPIRES_AT=$(date -u -v "+${TTL}S" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "+${TTL} seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || EXPIRES_AT=""
+fi
+
+# ── Build the inbox message (jq only — no string interpolation) ──────────
+REQUEST_BODY=$(jq -n \
+  --arg kind "$KIND" \
+  --arg urgency "$URGENCY" \
+  --argjson requires_action "$REQUIRES_ACTION" \
+  --arg title "$TITLE" \
+  --arg body "$BODY" \
+  --arg session_id "$SESSION_ID" \
+  --arg cwd "$CWD" \
+  --arg transcript_path "$TRANSCRIPT_PATH" \
+  --arg permission_mode "$PERMISSION_MODE" \
+  --arg event "$EVENT" \
+  --arg notification_type "${NOTIFICATION_TYPE:-}" \
+  --arg term_app "$TERM_APP" \
+  --arg bundle_id "$BUNDLE_ID" \
+  --arg term_session_id "$TERM_SESSION_ID" \
+  --arg tty "$TTY" \
+  --arg pid "$$" \
+  --arg ppid "$PPID" \
+  --arg term_program "${TERM_PROGRAM:-}" \
+  --arg term_program_version "${TERM_PROGRAM_VERSION:-}" \
+  --arg captured_at "$CAPTURED_AT" \
+  --arg expires_at "$EXPIRES_AT" \
+  '{
+    source: "agent",
+    kind: $kind,
+    urgency: $urgency,
+    requires_action: $requires_action,
+    title: $title,
+    context_type: "session",
+    context_ref: $session_id,
+    context: {
+      session_id: $session_id,
+      agent_name: "claude-code",
+      terminal: ({
+        app: $term_app,
+        bundle_id: $bundle_id,
+        session_id: $term_session_id,
+        tty: $tty,
+        pid: ($pid | tonumber),
+        ppid: ($ppid | tonumber),
+        cwd: $cwd,
+        term_program: $term_program,
+        term_program_version: $term_program_version,
+        captured_at: $captured_at
+      } | with_entries(select(.value != "")))
+    },
+    payload: ({
+      hook_event: $event,
+      notification_type: $notification_type,
+      transcript_path: $transcript_path,
+      permission_mode: $permission_mode,
+      cwd: $cwd
+    } | with_entries(select(.value != "")))
+  }
+  + (if $body != "" then { body: $body } else {} end)
+  + (if $expires_at != "" then { expires_at: $expires_at } else {} end)') || exit 0
+
+PORT="${GCTRL_KERNEL_PORT:-4318}"
+curl -fsS --connect-timeout 1 --max-time 3 \
+  -X POST -H 'Content-Type: application/json' \
+  -d "$REQUEST_BODY" \
+  "http://127.0.0.1:${PORT}/api/inbox/messages" >/dev/null 2>&1 \
+  || warn "kernel unreachable on :${PORT}; message dropped (fail-open)"
+
+exit 0

--- a/shell/hooks/test/claude-code-inbox.bats
+++ b/shell/hooks/test/claude-code-inbox.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# Tests for shell/hooks/claude-code-inbox.sh against a mock kernel.
+
+HOOK="$BATS_TEST_DIRNAME/../claude-code-inbox.sh"
+MOCK_PORT=14971
+
+setup_file() {
+  export CAPTURE_FILE="$BATS_FILE_TMPDIR/capture.jsonl"
+  python3 "$BATS_TEST_DIRNAME/mock_kernel.py" "$MOCK_PORT" "$CAPTURE_FILE" &
+  echo "$!" > "$BATS_FILE_TMPDIR/mock.pid"
+  for _ in $(seq 1 50); do
+    curl -fsS -o /dev/null "http://127.0.0.1:$MOCK_PORT/" 2>/dev/null && return 0
+    sleep 0.1
+  done
+  echo "mock kernel did not start" >&2
+  return 1
+}
+
+teardown_file() {
+  kill "$(cat "$BATS_FILE_TMPDIR/mock.pid")" 2>/dev/null || true
+}
+
+setup() {
+  : > "$CAPTURE_FILE"
+  export GCTRL_KERNEL_PORT="$MOCK_PORT"
+  export TERM_PROGRAM="iTerm.app"
+  export TERM_PROGRAM_VERSION="3.5.0"
+  export ITERM_SESSION_ID="w0t0p0:6F3D8E7C-1234-4ABC-9876-FEDCBA098765"
+  unset GCTRL_INBOX_HOOK_DISABLE || true
+}
+
+last_capture() { tail -n 1 "$CAPTURE_FILE"; }
+
+notification_event() { # $1 = notification_type
+  jq -n --arg nt "$1" '{
+    hook_event_name: "Notification",
+    notification_type: $nt,
+    message: "Claude needs your permission to use Bash",
+    session_id: "sess-test-0001",
+    transcript_path: "/tmp/transcript.jsonl",
+    cwd: "/tmp/project",
+    permission_mode: "default"
+  }'
+}
+
+@test "permission_prompt → permission_request, high urgency, requires_action, terminal identity" {
+  run bash -c "echo '$(notification_event permission_prompt)' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  body=$(last_capture)
+  [ "$(jq -r .kind <<<"$body")" = "permission_request" ]
+  [ "$(jq -r .urgency <<<"$body")" = "high" ]
+  [ "$(jq -r .requires_action <<<"$body")" = "true" ]
+  [ "$(jq -r .source <<<"$body")" = "agent" ]
+  [ "$(jq -r .title <<<"$body")" = "Claude needs your permission to use Bash" ]
+  [ "$(jq -r .context_type <<<"$body")" = "session" ]
+  [ "$(jq -r .context_ref <<<"$body")" = "sess-test-0001" ]
+  [ "$(jq -r .context.agent_name <<<"$body")" = "claude-code" ]
+  [ "$(jq -r .context.terminal.app <<<"$body")" = "iterm2" ]
+  [ "$(jq -r .context.terminal.session_id <<<"$body")" = "$ITERM_SESSION_ID" ]
+  [ "$(jq -r .context.terminal.cwd <<<"$body")" = "/tmp/project" ]
+  [ "$(jq -r .payload.notification_type <<<"$body")" = "permission_prompt" ]
+  # permission prompts carry an expiry so stale ones auto-expire
+  [ "$(jq -r .expires_at <<<"$body")" != "null" ]
+}
+
+@test "idle_prompt → agent_question, no action required, no expiry" {
+  run bash -c "echo '$(notification_event idle_prompt)' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  body=$(last_capture)
+  [ "$(jq -r .kind <<<"$body")" = "agent_question" ]
+  [ "$(jq -r .urgency <<<"$body")" = "medium" ]
+  [ "$(jq -r .requires_action <<<"$body")" = "false" ]
+  [ "$(jq -r '.expires_at // "absent"' <<<"$body")" = "absent" ]
+}
+
+@test "PreToolUse AskUserQuestion → agent_question with question text" {
+  event=$(jq -n '{
+    hook_event_name: "PreToolUse",
+    tool_name: "AskUserQuestion",
+    tool_input: { questions: [
+      { question: "Which database should we target?" },
+      { question: "Apply migrations now?" }
+    ]},
+    session_id: "sess-test-0002",
+    cwd: "/tmp/project"
+  }')
+  run bash -c "echo '$event' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  body=$(last_capture)
+  [ "$(jq -r .kind <<<"$body")" = "agent_question" ]
+  [ "$(jq -r .requires_action <<<"$body")" = "true" ]
+  [ "$(jq -r .title <<<"$body")" = "Which database should we target?" ]
+  [[ "$(jq -r .body <<<"$body")" == *"Apply migrations now?"* ]]
+}
+
+@test "PreToolUse on other tools is ignored" {
+  event=$(jq -n '{ hook_event_name: "PreToolUse", tool_name: "Bash",
+    tool_input: { command: "ls" }, session_id: "s", cwd: "/tmp" }')
+  run bash -c "echo '$event' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CAPTURE_FILE" ]
+}
+
+@test "non-request notification types are ignored" {
+  run bash -c "echo '$(notification_event auth_success)' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CAPTURE_FILE" ]
+}
+
+@test "kernel offline → exit 0 (fail-open)" {
+  GCTRL_KERNEL_PORT=14999 run bash -c "echo '$(notification_event permission_prompt)' | GCTRL_KERNEL_PORT=14999 '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CAPTURE_FILE" ]
+}
+
+@test "GCTRL_INBOX_HOOK_DISABLE=1 → no-op" {
+  run bash -c "echo '$(notification_event permission_prompt)' | GCTRL_INBOX_HOOK_DISABLE=1 '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CAPTURE_FILE" ]
+}
+
+@test "empty stdin → exit 0" {
+  run bash -c "printf '' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CAPTURE_FILE" ]
+}
+
+@test "TERM_PROGRAM → terminal.app mapping table" {
+  # "TERM_PROGRAM=expected_app" pairs (bash 3.2 compatible — no declare -A)
+  pairs="iTerm.app=iterm2 Apple_Terminal=terminal ghostty=ghostty vscode=vscode WarpTerminal=warp SomeGarbage=unknown"
+  for pair in $pairs; do
+    tp="${pair%%=*}"
+    expected="${pair#*=}"
+    : > "$CAPTURE_FILE"
+    run bash -c "echo '$(notification_event permission_prompt)' | TERM_PROGRAM='$tp' '$HOOK'"
+    [ "$status" -eq 0 ]
+    actual=$(jq -r .context.terminal.app < "$CAPTURE_FILE")
+    [ "$actual" = "$expected" ]
+  done
+  # unset TERM_PROGRAM → unknown
+  : > "$CAPTURE_FILE"
+  run bash -c "echo '$(notification_event permission_prompt)' | env -u TERM_PROGRAM '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .context.terminal.app < "$CAPTURE_FILE")" = "unknown" ]
+}

--- a/shell/hooks/test/mock_kernel.py
+++ b/shell/hooks/test/mock_kernel.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal mock of the gctrl kernel inbox intake for bats tests.
+
+Usage: mock_kernel.py <port> <capture_file>
+
+POST /api/inbox/messages — appends the request body (one JSON object per
+line) to <capture_file> and replies 201 {"id": "..."}.
+GET on any path replies 200 (used as a readiness probe).
+"""
+
+import json
+import sys
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    capture_file = None
+
+    def do_GET(self):  # readiness probe
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        with open(self.capture_file, "a") as f:
+            f.write(body.decode("utf-8").replace("\n", " ") + "\n")
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"id": str(uuid.uuid4())}).encode())
+
+    def log_message(self, *args):  # silence request logging
+        pass
+
+
+def main():
+    port, capture = int(sys.argv[1]), sys.argv[2]
+    Handler.capture_file = capture
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/vault/specs/architecture/apps/cc-permission-hook.md
+++ b/vault/specs/architecture/apps/cc-permission-hook.md
@@ -1,8 +1,8 @@
-# Claude Code Permission Hook
+# Claude Code → Inbox Capture Hooks
 
-> Bash hook installed in `~/.claude/settings.json` that captures the running terminal's identity, posts a `permission_request` message to gctrl-inbox, and blocks Claude Code until the user acts.
+> Hooks installed in `~/.claude/settings.json` that capture Claude Code's requests-to-user (permission prompts, questions, idle waits) and post them to gctrl-inbox as messages, with the running terminal's identity attached for click-to-focus.
 
-> **Status**: companion spec to [`mac-comm.md`](../kernel/mac-comm.md). The kernel-side primitive (driver, deeplink, UI) ships with mac-comm PR-1..3; the hook itself ships as its own follow-up PR.
+> **Status**: companion spec to [`mac-comm.md`](../kernel/mac-comm.md). Slice sequencing lives in [`apps/gctrl-inbox/vault/ROADMAP.md`](../../../../apps/gctrl-inbox/vault/ROADMAP.md), not here.
 
 ---
 
@@ -10,7 +10,7 @@
 
 Different agent frameworks (Claude Code, Cursor, Aider, Codex) need different capture mechanisms:
 
-- **Claude Code** has a structured `PreToolUse` hook protocol with stdin JSON.
+- **Claude Code** has a structured hook protocol with stdin JSON (`Notification`, `PreToolUse`, `PostToolUse`, …).
 - **Cursor** has its own per-tool callback model.
 - **Aider** runs as a Python process with hookable `before_run` events.
 
@@ -18,27 +18,75 @@ Each framework owns its own integration spec; all of them post the same `context
 
 ---
 
-## Hook contract
+## Decision: hooks, not log polling
+
+Two capture architectures were considered for "Claude Code requests-to-user land in the inbox":
+
+| | Hooks (push) | Poll transcript JSONL (pull) |
+|---|---|---|
+| Signal fidelity | Exact event — Claude Code reports "I need the user" | Inferred: a `tool_use` with no result could be a permission wait *or* a slow tool |
+| Terminal identity (`context.terminal`) | Hook runs inside the agent process — `$ITERM_SESSION_ID`, `$TERM_PROGRAM`, tty, pid all capturable | Not in the logs. Polling kills the mac-comm Focus deeplink |
+| Latency | Immediate | Poll interval + parse lag |
+| Format stability | Documented hook stdin contract | `~/.claude/projects/*/*.jsonl` is an undocumented internal format |
+
+**Hooks win** — mac-comm.md already records the load-bearing constraint: *the kernel cannot read the agent's environment, so capture must happen agent-side.* Transcript reading is permitted only as **enrichment**: the hook payload carries `transcript_path`, and the kernel MAY do a one-shot read at message-creation time to enrich the inbox card. Never a continuous watcher; if the parse breaks on a Claude Code upgrade, enrichment is lost, not the message.
+
+---
+
+## Two capture modes
+
+| Mode | Mechanism | Blocking? | What the user gets |
+|---|---|---|---|
+| **Observe** | `Notification` hook (`permission_prompt`, `idle_prompt`) + `PreToolUse` hook on `AskUserQuestion`, fire-and-forget | No — always exits `0`, no decision output | Requests appear in the inbox in real time with a Focus deeplink; the user answers in the terminal |
+| **Act** | `PreToolUse` hook on gated tools that polls the inbox message until acted | Yes — exit code carries approve/deny | The user approves/denies *from* the inbox; Claude Code resumes/blocks accordingly |
+
+Observe mode honors inbox Principle 3 (agents MUST NOT block on the inbox) with no carve-out. Act mode requires the async-by-design carve-out documented in [mac-comm.md](../kernel/mac-comm.md#async-by-design-carve-out). Both modes share the same script skeleton and `context.terminal` capture.
+
+---
+
+## Observe mode
+
+### Script: `shell/hooks/claude-code-inbox.sh`
 
 `~/.claude/settings.json`:
 
 ```json
 {
   "hooks": {
-    "PreToolUse": [{
-      "matcher": "Bash|Edit|Write",
-      "hooks": [{
-        "type": "command",
-        "command": "$HOME/.local/share/gctrl/hooks/claude-code-permission.sh"
-      }]
-    }]
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      },
+      {
+        "matcher": "idle_prompt",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [{ "type": "command", "command": "$HOME/.local/share/gctrl/hooks/claude-code-inbox.sh", "timeout": 10 }]
+      }
+    ]
   }
 }
 ```
 
-`claude-code-permission.sh` behavior:
+### Event → message mapping
 
-1. Read tool-use JSON from stdin.
+| Hook event | Inbox kind | Urgency | `requires_action` | Expiry |
+|---|---|---|---|---|
+| `Notification` / `permission_prompt` | `permission_request` | `high` | `true` | `now + GCTRL_INBOX_HOOK_TTL` (default 3600 s) — stale prompts auto-expire since the user may have answered in the terminal |
+| `Notification` / `idle_prompt` | `agent_question` | `medium` | `false` | none |
+| `PreToolUse` / `AskUserQuestion` | `agent_question` (title = first question, body = all questions) | `medium` | `true` | none |
+| Any other event / notification type | ignored (exit `0`, no POST) | — | — | — |
+
+All messages POST with `source=agent`, `context.agent_name=claude-code`, `context_type=session`, `context_ref=<claude session_id>` — so messages from one Claude Code session group into one inbox thread. `payload` carries `hook_event`, `notification_type`, `transcript_path`, `permission_mode`, `cwd`.
+
+### Behavior
+
+1. Read hook-event JSON from stdin (`session_id`, `transcript_path`, `cwd`, `permission_mode`, plus event-specific fields).
 2. Detect terminal: read `$TERM_PROGRAM` and map → `terminal.app` discriminator.
    - `iTerm.app` → `iterm2`
    - `Apple_Terminal` → `terminal`
@@ -46,55 +94,72 @@ Each framework owns its own integration spec; all of them post the same `context
    - `vscode` → `vscode`
    - `WarpTerminal` → `warp`
    - empty / anything else → `unknown` (no Focus button rendered downstream)
-3. Snapshot identity:
-   - `session_id`: `$ITERM_SESSION_ID` (iTerm2) or platform-specific else `unknown`
-   - `tty`: `$(tty)`
+3. Snapshot identity per [mac-comm.md § Schema](../kernel/mac-comm.md#schema-inbox_messagescontextterminal-not-payload):
+   - `session_id`: `$ITERM_SESSION_ID` (iTerm2 only)
+   - `tty`: resolved via the parent process (`ps -o tty= -p $PPID`) — the hook's own stdin is the event pipe, not a tty
    - `pid`: `$$`, `ppid`: `$PPID`
-   - `cwd`: `$PWD`
-   - `term_program`, `term_program_version`: passthrough
-4. POST to `http://127.0.0.1:4318/api/inbox/messages` with `kind=permission_request`, `context.terminal={…}`, `payload={ command, args }`.
-5. Poll `GET /api/inbox/messages/{id}` every **1 s** until `status != pending` or timeout.
-6. Default timeout: **30 s**, configurable via `GCTRL_COMM_TIMEOUT` env (clamped to `[5, 600]`).
-7. Exit `0` (allow) on `acted+approve`, `2` (deny+block) on `acted+deny` or timeout, `1` on hard error.
+   - `cwd`: from the hook payload
+   - `term_program`, `term_program_version`: env passthrough
+   - empty fields are omitted, never sent as `""`
+4. POST to `http://127.0.0.1:4318/api/inbox/messages` (port via `GCTRL_KERNEL_PORT`). JSON is built exclusively with `jq -n --arg` — no string interpolation.
+5. **Always exit `0`.** No stdout. The hook can never block, slow (curl budget: 1 s connect / 3 s total), or influence Claude Code.
 
----
-
-## Edge cases
+### Edge cases
 
 | Condition | Behavior |
 |---|---|
-| Kernel daemon offline (`curl: Failed to connect`) | Exit `0` (allow) with stderr warning — fail-open since kernel-mediated approval is opt-in dogfooding, not a hard guardrail. |
-| `TERM_PROGRAM` unset | `terminal.app = unknown`, no Focus button downstream, but message still posts. |
-| Timeout reached before user acts | Exit `2` (deny+block), tell Claude Code "user did not respond in N seconds". |
-| Network hiccup mid-poll | Retry up to 3 times with 1 s backoff before exiting `1`. |
+| Kernel daemon offline | Exit `0` with stderr warning — fail-open; the message is dropped. |
+| `jq` or `curl` missing | Exit `0` with stderr warning. |
+| `TERM_PROGRAM` unset | `terminal.app = unknown`, no Focus button downstream, message still posts. |
+| Empty / malformed stdin | Exit `0`, no POST. |
+| `GCTRL_INBOX_HOOK_DISABLE=1` | Exit `0` immediately, no POST (kill switch). |
+
+### Known limitation — staleness
+
+Observe mode is one-way: when the user answers the prompt in the terminal, the inbox message stays `pending` until acted on, acknowledged, or expired. The `expires_at` TTL on permission prompts bounds the staleness window. Closing the loop (terminal answer → inbox message resolved) is act mode's job.
+
+---
+
+## Act mode (blocking permission hook)
+
+> Design retained; not yet implemented. See the ROADMAP row before building.
+
+A `PreToolUse` hook matching gated tools (`Bash|Edit|Write`) that:
+
+1. POSTs `kind=permission_request` with the same `context.terminal` shape.
+2. Polls `GET /api/inbox/messages/{id}` every **1 s** until `status != pending` or timeout.
+3. Default timeout: **30 s**, configurable via `GCTRL_COMM_TIMEOUT` env (clamped to `[5, 600]`).
+4. Exit `0` (allow) on `acted+approve`, `2` (deny+block) on `acted+deny` or timeout, `1` on hard error.
+5. Kernel offline → exit `0` (allow) with stderr warning — fail-open since kernel-mediated approval is opt-in dogfooding, not a hard guardrail.
+
+Act mode supersedes observe mode's `permission_prompt` capture for the matched tools (the hook decision *is* the request); the `Notification` capture remains for everything act mode doesn't gate.
 
 ---
 
 ## Tests
 
-- **`shellcheck` clean** in CI (script must lint without suppressions).
-- **`bats` test cases** with a mock HTTP server (`python3 -m http.server` or a small `nc` script):
-  - approve → exit `0`
-  - deny → exit `2`
-  - timeout (mock returns `pending` forever) → exit `2`
-  - kernel offline → exit `0` with warning
-  - retry exhaustion → exit `1`
-- **Table-driven `TERM_PROGRAM` → `terminal.app` mapping test** in `bats`: covers `iTerm.app`, `Apple_Terminal`, `ghostty`, `code`, `WarpTerminal`, empty, garbage value.
+- **`shellcheck` clean** in CI (no suppressions) — `hooks` job in `.github/workflows/ci.yml`.
+- **`bats` suite** (`shell/hooks/test/`) against a mock kernel (`mock_kernel.py`):
+  - `permission_prompt` → `permission_request`, high urgency, terminal identity, expiry set
+  - `idle_prompt` → `agent_question`, no action required
+  - `PreToolUse AskUserQuestion` → `agent_question` with question text
+  - other tools / other notification types → ignored
+  - kernel offline → exit `0`, fail-open
+  - kill switch → no POST
+  - table-driven `TERM_PROGRAM` → `terminal.app` mapping (incl. empty and garbage values)
 
 ---
 
-## Implementation strategy
+## Installation
 
-Single PR, lands after `mac-comm.md` PR-1 (the kernel intake validator must be ready to accept `context.terminal`):
-
-- New file `shell/hooks/claude-code-permission.sh` (≤ 80 lines).
-- Bundling: `gctrl-desktop` first-run copies it into `~/.local/share/gctrl/hooks/`. Non-desktop users install via `make install-hooks` or by symlinking from the repo.
-- Docs: snippet in `apps/gctrl-inbox/WORKFLOW.md` showing the `~/.claude/settings.json` wiring and the `GCTRL_COMM_TIMEOUT` knob.
+- Bundling: `gctrl-desktop` first-run copies `shell/hooks/*.sh` into `~/.local/share/gctrl/hooks/`.
+- Non-desktop users: copy or symlink from the repo — wiring snippet lives in [`apps/gctrl-inbox/vault/WORKFLOW.md`](../../../../apps/gctrl-inbox/vault/WORKFLOW.md#claude-code-capture-hook-observe).
 
 ---
 
 ## Related Docs
 
-- [`vault/specs/architecture/kernel/mac-comm.md`](../kernel/mac-comm.md) — driver primitive this hook is the first consumer of
-- [`apps/gctrl-inbox/PRD.md`](../../../../apps/gctrl-inbox/PRD.md) — message model
-- [`apps/gctrl-inbox/WORKFLOW.md`](../../../../apps/gctrl-inbox/WORKFLOW.md) — where the user-facing wiring snippet lands
+- [`vault/specs/architecture/kernel/mac-comm.md`](../kernel/mac-comm.md) — driver primitive these hooks feed (`context.terminal` → Focus deeplink)
+- [`apps/gctrl-inbox/vault/PRD.md`](../../../../apps/gctrl-inbox/vault/PRD.md) — message model
+- [`apps/gctrl-inbox/vault/ROADMAP.md`](../../../../apps/gctrl-inbox/vault/ROADMAP.md) — slice sequencing + issue links
+- [`apps/gctrl-inbox/vault/WORKFLOW.md`](../../../../apps/gctrl-inbox/vault/WORKFLOW.md) — user-facing wiring snippet


### PR DESCRIPTION
Closes #215.

Claude Code's requests-to-user — permission prompts, `AskUserQuestion`, idle waits — now land in gctrl-inbox as messages in real time. Observe-only: the hook is fire-and-forget, never blocks Claude Code, and requires no SDK spawning.

## Insight

- **Hooks beat log polling** for capture, and the deciding factor isn't latency — it's that terminal identity (`$ITERM_SESSION_ID`, `$TERM_PROGRAM`, tty, pid) only exists inside the agent process. Without it, the mac-comm Focus deeplink is impossible. Transcript polling also means heuristics (pending `tool_use` ≠ permission wait) over an undocumented JSONL format. Decision table recorded in the spec.
- Claude Code's `Notification` hook carries a typed `notification_type` (`permission_prompt` / `idle_prompt`) usable as a settings matcher — no message-string sniffing needed.
- The kernel inbox intake already accepts everything this needs; verified end-to-end against a live daemon (201, `context.terminal` round-trips, `expires_at` honored). No kernel changes in this PR.
- Observe mode honors inbox Principle 3 (agents never block on the inbox) with no carve-out — unlike the previously specced blocking hook, which is retained as the act-mode follow-up.

## Rationale

- **Staleness:** the user answers in the terminal, so the inbox copy could linger as `pending`. Permission prompts therefore post with `expires_at = now + GCTRL_INBOX_HOOK_TTL` (default 1 h). Properly closing the loop is act mode's job (ROADMAP row).
- **Fail-open everywhere** (kernel offline, missing jq, malformed stdin → exit 0): capture is opt-in dogfooding, not a guardrail; a hook that can wedge every Claude Code session is worse than a dropped message.
- JSON is built exclusively with `jq -n --arg` — no string interpolation into the request body, matching mac-comm's injection posture.

## Key changes

- [`shell/hooks/claude-code-inbox.sh`](https://github.com/OpenHackersClub/gctrl/blob/1d1751c/shell/hooks/claude-code-inbox.sh) — capture script; event→kind mapping, terminal snapshot per mac-comm `context.terminal` schema, session-thread grouping (`context_type=session`)
- bats suite + mock kernel under `shell/hooks/test/` (9 cases: mapping table, fail-open, kill switch, ignore-list); new CI `hooks` job (shellcheck + bats)
- [`cc-permission-hook.md`](https://github.com/OpenHackersClub/gctrl/blob/1d1751c/vault/specs/architecture/apps/cc-permission-hook.md) restructured: observe mode (this slice) + act mode (blocking approve/deny, design retained); hooks-vs-polling decision recorded
- `apps/gctrl-inbox/vault/ROADMAP.md` (new) — M0 slice table; `WORKFLOW.md` gains the `~/.claude/settings.json` wiring snippet

## Follow-ups (tracked on the inbox ROADMAP)

- [ ] Act mode: blocking `PreToolUse` approve/deny from the inbox
- [ ] Transcript enrichment: kernel one-shot read of `payload.transcript_path` at intake
- [ ] gctrl-desktop first-run hook install
