### PR TITLE
fix(ci): Playwright install hang — bump to 1.60.0 + browser cache + fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,32 @@ jobs:
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node
 
+      # The browser download from cdn.playwright.dev intermittently hangs
+      # after reaching 100% (observed on main and PR branches; the job then
+      # burns its full 20-min timeout in this step). Cache the browsers so
+      # most runs skip the download entirely, and bound each install attempt
+      # so a hang costs 4 minutes, not the whole job.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2; do
+            timeout 240 pnpm exec playwright install chromium && exit 0
+            echo "::warning::playwright install attempt ${attempt} hung; retrying"
+          done
+          exit 1
+        working-directory: apps/gctrl-board
+
+      # OS deps are not cached with the browsers; install them every run.
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
         working-directory: apps/gctrl-board
 
       - name: Download kernel binary

--- a/apps/gctrl-board/package.json
+++ b/apps/gctrl-board/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.9.0",
     "@cloudflare/workers-types": "^4.20260405.1",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^4.20260405.1
         version: 4.20260405.1
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -2328,8 +2328,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5215,13 +5215,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8194,9 +8194,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -11502,11 +11502,11 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
CI's Playwright job has been dying in **Install Playwright browsers** since late May — the chromium download reaches 100%, then the step hangs until the job's 20-min timeout. It killed [main's last run](https://github.com/OpenHackersClub/gctrl/actions/runs/26501605032) and blocks every PR from going green.

## Root cause (not a flake)

On Node 24.16+, Playwright ≤ 1.59.1's download/extract worker dies silently after the download completes, leaving the parent hung on stale IPC pipes — fixed upstream in **Playwright 1.60.0** (see [microsoft/playwright#36412](https://github.com/microsoft/playwright/issues/36412) and the 1.60.0 release). CI pins `node-version: "24"`, which started resolving to 24.16+ on runner images after May 20 — matching exactly when our runs began dying. A bounded-retry experiment on this branch ([run](https://github.com/OpenHackersClub/gctrl/actions/runs/27066587098)) hung at the identical point on both attempts, confirming it's deterministic.

## Fix

- **Bump `@playwright/test` 1.59.1 → 1.60.0** (the actual fix). Board unit tests pass (92 passed, 29 skipped).
- **Cache `~/.cache/ms-playwright`** keyed on `pnpm-lock.yaml` — most runs skip the download entirely; invalidates exactly when the browser build changes.
- **Bound install attempts to 4 min with one retry** (10-min step cap) — if this class of hang ever recurs, the job fails fast with a warning instead of burning its timeout.
- **Split `install-deps` from `install --with-deps`** — OS packages must install every run; browsers come from cache.

Retry loop stays inline (vs. the Effect-CLI convention) as it's pre-bootstrap: it runs before workspace tooling is usable in the job.

Unblocks #217.
