### PR TITLE
fix(ci): split Playwright install into attributable steps with timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,50 +163,14 @@ jobs:
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node
 
-      # `playwright install --with-deps` hangs after the chromium download
-      # completes (main red since 2026-05-27; no repo diff between the last
-      # green and first hung run, so the cause is runner-side). Split the
-      # opaque combined install into attributable steps with tight timeouts
-      # so a hang fails fast and names its culprit, and cache the browsers
-      # so one green run immunizes subsequent ones from the download path.
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-        working-directory: apps/gctrl-board
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright system deps
-        run: pnpm exec playwright install-deps chromium
-        working-directory: apps/gctrl-board
-        timeout-minutes: 5
-        env:
-          DEBIAN_FRONTEND: noninteractive
-
-      # The cdn.playwright.dev download stalls at arbitrary points (observed
-      # at 0% and after 100%) and playwright's downloader has no socket
-      # timeout — its mirror fallback only fires on errors, never on stalls.
-      # So: bound each attempt with `timeout` (healthy install ≈ 20s) and
-      # retry, last attempt via the Microsoft mirror. `--no-shell` halves the
-      # download surface; tests pin `channel: "chromium"` in
-      # playwright.config.ts so the headless shell is never needed.
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: apps/gctrl-board
-        timeout-minutes: 9
-        run: |
-          install() { timeout -k 10 150 pnpm exec playwright install --no-shell chromium; }
-          install && exit 0
-          echo "::warning::playwright install stalled; retrying"
-          install && exit 0
-          echo "::warning::playwright install stalled twice; retrying via download mirror"
-          PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.download.prss.microsoft.com install
-
+      # No `playwright install` here on purpose: cdn.playwright.dev stalls
+      # from GitHub runners at arbitrary download points (main red since
+      # 2026-05-27 — runs 27066616157 / 27067288096 / 27067673190 bisected
+      # it), playwright's downloader has no socket timeout, and the MS
+      # mirror 403s on Chrome-for-Testing artifacts. Instead the tests
+      # drive the runner image's preinstalled Chrome stable via
+      # PLAYWRIGHT_CHANNEL=chrome (see playwright.config.ts), which needs
+      # no download at all.
       - name: Download kernel binary
         uses: actions/download-artifact@v4
         with:
@@ -221,6 +185,7 @@ jobs:
         working-directory: apps/gctrl-board
         env:
           CI: "true"
+          PLAYWRIGHT_CHANNEL: chrome
           GCTRL_KERNEL_PORT: "14318"
           GCTRL_VITE_PORT: "14200"
           GCTRL_KERNEL_BIN: ${{ github.workspace }}/target/debug/gctrld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,36 @@ jobs:
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+      # `playwright install --with-deps` hangs after the chromium download
+      # completes (main red since 2026-05-27; no repo diff between the last
+      # green and first hung run, so the cause is runner-side). Split the
+      # opaque combined install into attributable steps with tight timeouts
+      # so a hang fails fast and names its culprit, and cache the browsers
+      # so one green run immunizes subsequent ones from the download path.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
         working-directory: apps/gctrl-board
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright system deps
+        run: pnpm exec playwright install-deps chromium
+        working-directory: apps/gctrl-board
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+        working-directory: apps/gctrl-board
+        timeout-minutes: 8
 
       - name: Download kernel binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,17 +188,24 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
 
-      # `--no-shell` skips the chromium-headless-shell artifact — its
-      # download is the precise stall point (full chromium downloads fine,
-      # then the install goes silent; confirmed by the split steps above).
-      # Tests opt into the full browser's new headless mode via
-      # `channel: "chromium"` in playwright.config.ts, so the shell is
-      # never needed.
+      # The cdn.playwright.dev download stalls at arbitrary points (observed
+      # at 0% and after 100%) and playwright's downloader has no socket
+      # timeout — its mirror fallback only fires on errors, never on stalls.
+      # So: bound each attempt with `timeout` (healthy install ≈ 20s) and
+      # retry, last attempt via the Microsoft mirror. `--no-shell` halves the
+      # download surface; tests pin `channel: "chromium"` in
+      # playwright.config.ts so the headless shell is never needed.
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --no-shell chromium
         working-directory: apps/gctrl-board
-        timeout-minutes: 8
+        timeout-minutes: 9
+        run: |
+          install() { timeout -k 10 150 pnpm exec playwright install --no-shell chromium; }
+          install && exit 0
+          echo "::warning::playwright install stalled; retrying"
+          install && exit 0
+          echo "::warning::playwright install stalled twice; retrying via download mirror"
+          PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.download.prss.microsoft.com install
 
       - name: Download kernel binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,9 +188,15 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
 
+      # `--no-shell` skips the chromium-headless-shell artifact — its
+      # download is the precise stall point (full chromium downloads fine,
+      # then the install goes silent; confirmed by the split steps above).
+      # Tests opt into the full browser's new headless mode via
+      # `channel: "chromium"` in playwright.config.ts, so the shell is
+      # never needed.
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install chromium
+        run: pnpm exec playwright install --no-shell chromium
         working-directory: apps/gctrl-board
         timeout-minutes: 8
 

--- a/apps/gctrl-board/playwright.config.ts
+++ b/apps/gctrl-board/playwright.config.ts
@@ -101,6 +101,11 @@ export default defineConfig({
         ...(isRemoteCDP
           ? {}
           : {
+              // Full-browser new headless instead of chromium-headless-shell:
+              // CI installs with `--no-shell` because the shell's download
+              // stalls on GitHub runners (see ci.yml). Locally both work;
+              // pinning the channel keeps the two environments identical.
+              channel: "chromium",
               launchOptions: {
                 args: ["--remote-debugging-port=0"],
               },

--- a/apps/gctrl-board/playwright.config.ts
+++ b/apps/gctrl-board/playwright.config.ts
@@ -101,11 +101,13 @@ export default defineConfig({
         ...(isRemoteCDP
           ? {}
           : {
-              // Full-browser new headless instead of chromium-headless-shell:
-              // CI installs with `--no-shell` because the shell's download
-              // stalls on GitHub runners (see ci.yml). Locally both work;
-              // pinning the channel keeps the two environments identical.
-              channel: "chromium",
+              // Full-browser new headless instead of chromium-headless-shell.
+              // CI sets PLAYWRIGHT_CHANNEL=chrome to drive the runner's
+              // preinstalled Chrome stable — cdn.playwright.dev stalls from
+              // GitHub runners and the MS mirror 403s on CFT artifacts (see
+              // ci.yml), so CI avoids browser downloads entirely. Locally
+              // defaults to the playwright-managed chromium build.
+              channel: process.env.PLAYWRIGHT_CHANNEL ?? "chromium",
               launchOptions: {
                 args: ["--remote-debugging-port=0"],
               },


### PR DESCRIPTION
CI's Playwright job has been timing out at the 20m job limit since 2026-05-27 — every run on main and on PR branches died in `Install Playwright browsers` (e.g. [main run](https://github.com/OpenHackersClub/gctrl/actions/runs/26501605032), [PR #216 run](https://github.com/OpenHackersClub/gctrl/actions/runs/27065189726), twice including a rerun).

## End state

CI downloads **no browser at all**: the test step sets `PLAYWRIGHT_CHANNEL=chrome` and drives the ubuntu-24.04 runner image's preinstalled Chrome stable. The channel is env-switchable in `playwright.config.ts`; local runs keep the playwright-managed chromium build. Verified locally on both channels (`kanban-board.spec.ts` 10/10 each).

## Insight — bisected across three CI runs on this branch

1. No repo-side cause: zero commits to lockfile / package.json / workflow between the last green run (May 20) and the first hang (May 27).
2. [Split-steps run](https://github.com/OpenHackersClub/gctrl/actions/runs/27066616157): apt deps fine; the stall is inside `playwright install chromium`, after the chromium download printed 100%.
3. [`--no-shell` run](https://github.com/OpenHackersClub/gctrl/actions/runs/27067288096): stalled at **0%** of the same download — so no specific artifact is at fault; the `cdn.playwright.dev` connection stalls at arbitrary points and playwright's downloader has no socket timeout (its mirror fallback only fires on errors, never stalls).
4. [Bounded-retry run](https://github.com/OpenHackersClub/gctrl/actions/runs/27067673190): both CDN attempts stalled (killed at 150s), and the Microsoft mirror returned **403** for Chrome-for-Testing artifacts. There is no reliable download path from these runners.

## Rationale

Driving the preinstalled Chrome removes the network dependency instead of papering over it with retries. Trade-off: the CI browser now tracks the runner image's Chrome stable instead of a playwright-pinned chromium revision — acceptable for app-level acceptance tests, and the env switch preserves the pinned build everywhere else.

Unblocks #216.
