### PR TITLE
feat(gctrl-inbox): group inbox messages by project

### DIFF
--- a/apps/gctrl-board/web/src/hooks/useInbox.ts
+++ b/apps/gctrl-board/web/src/hooks/useInbox.ts
@@ -6,6 +6,7 @@ interface UseInboxFilters {
   status?: string
   urgency?: string
   kind?: string
+  project?: string
 }
 
 interface UseInboxResult {
@@ -35,10 +36,13 @@ export function useInbox(filters?: UseInboxFilters): UseInboxResult {
     if (filters?.status) params.status = filters.status
     if (filters?.urgency) params.urgency = filters.urgency
     if (filters?.kind) params.kind = filters.kind
+    if (filters?.project) params.project = filters.project
 
     Promise.all([
       api.inbox.messages(params),
-      api.inbox.threads(params),
+      // Threads stay unfiltered by project: they feed the message→project
+      // join and the project filter options, which need the full set.
+      api.inbox.threads(),
       api.inbox.stats(),
     ])
       .then(([msgs, thrds, st]) => {
@@ -57,7 +61,7 @@ export function useInbox(filters?: UseInboxFilters): UseInboxResult {
     return () => {
       cancelled = true
     }
-  }, [filters?.status, filters?.urgency, filters?.kind, revision])
+  }, [filters?.status, filters?.urgency, filters?.kind, filters?.project, revision])
 
   const createAction = useCallback(
     async (messageId: string, actionType: string, reason?: string) => {

--- a/apps/gctrl-board/web/src/lib/__tests__/inbox-group.test.ts
+++ b/apps/gctrl-board/web/src/lib/__tests__/inbox-group.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import type { InboxMessage, InboxThread } from "../../types"
+import { UNGROUPED_PROJECT, groupMessagesByProject, projectOptions } from "../inbox-group"
+
+const thread = (id: string, project_key?: string): InboxThread => ({
+  id,
+  context_type: "session",
+  context_ref: `ref-${id}`,
+  title: `Thread ${id}`,
+  project_key,
+  pending_count: 0,
+  latest_urgency: "medium",
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+})
+
+const message = (id: string, thread_id: string): InboxMessage => ({
+  id,
+  thread_id,
+  source: "agent",
+  kind: "agent_question",
+  urgency: "medium",
+  title: `Message ${id}`,
+  context: {},
+  status: "pending",
+  requires_action: false,
+  duplicate_count: 0,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+})
+
+describe("groupMessagesByProject", () => {
+  it("groups messages by their thread's project_key, alphabetical", () => {
+    const threads = [thread("t1", "widget"), thread("t2", "acme"), thread("t3", "acme")]
+    const messages = [message("m1", "t1"), message("m2", "t2"), message("m3", "t3")]
+
+    const groups = groupMessagesByProject(messages, threads)
+
+    expect(groups.map((g) => g.project)).toEqual(["acme", "widget"])
+    expect(groups[0].messages.map((m) => m.id)).toEqual(["m2", "m3"])
+    expect(groups[1].messages.map((m) => m.id)).toEqual(["m1"])
+  })
+
+  it("buckets messages without a project last", () => {
+    const threads = [thread("t1", "widget"), thread("t2")]
+    const messages = [message("m1", "t2"), message("m2", "t1"), message("m3", "unknown-thread")]
+
+    const groups = groupMessagesByProject(messages, threads)
+
+    expect(groups.map((g) => g.project)).toEqual(["widget", UNGROUPED_PROJECT])
+    expect(groups[1].messages.map((m) => m.id)).toEqual(["m1", "m3"])
+  })
+
+  it("preserves message order within a group", () => {
+    const threads = [thread("t1", "acme")]
+    const messages = [message("m3", "t1"), message("m1", "t1"), message("m2", "t1")]
+
+    const groups = groupMessagesByProject(messages, threads)
+
+    expect(groups[0].messages.map((m) => m.id)).toEqual(["m3", "m1", "m2"])
+  })
+
+  it("returns no groups for no messages", () => {
+    expect(groupMessagesByProject([], [thread("t1", "acme")])).toEqual([])
+  })
+})
+
+describe("projectOptions", () => {
+  it("returns distinct sorted project keys, skipping threads without one", () => {
+    const threads = [
+      thread("t1", "widget"),
+      thread("t2", "acme"),
+      thread("t3", "acme"),
+      thread("t4"),
+    ]
+    expect(projectOptions(threads)).toEqual(["acme", "widget"])
+  })
+})

--- a/apps/gctrl-board/web/src/lib/inbox-group.ts
+++ b/apps/gctrl-board/web/src/lib/inbox-group.ts
@@ -1,0 +1,53 @@
+import type { InboxMessage, InboxThread } from "../types"
+
+/** Group label for messages whose thread carries no project_key. */
+export const UNGROUPED_PROJECT = "(no project)"
+
+export interface ProjectGroup {
+  project: string
+  messages: InboxMessage[]
+}
+
+/**
+ * Group messages by their thread's project_key. Messages join threads via
+ * thread_id; project_key lives on the thread (inbox_threads.project_key),
+ * not the message. Groups sort alphabetically with the ungrouped bucket
+ * last; message order within a group is preserved.
+ */
+export function groupMessagesByProject(
+  messages: InboxMessage[],
+  threads: InboxThread[],
+): ProjectGroup[] {
+  const projectByThread = new Map<string, string>()
+  for (const t of threads) {
+    if (t.project_key) projectByThread.set(t.id, t.project_key)
+  }
+
+  const groups = new Map<string, InboxMessage[]>()
+  for (const msg of messages) {
+    const project = projectByThread.get(msg.thread_id) ?? UNGROUPED_PROJECT
+    const bucket = groups.get(project)
+    if (bucket) {
+      bucket.push(msg)
+    } else {
+      groups.set(project, [msg])
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([project, msgs]) => ({ project, messages: msgs }))
+    .sort((a, b) => {
+      if (a.project === UNGROUPED_PROJECT) return 1
+      if (b.project === UNGROUPED_PROJECT) return -1
+      return a.project.localeCompare(b.project)
+    })
+}
+
+/** Distinct project keys across threads, sorted, for filter options. */
+export function projectOptions(threads: InboxThread[]): string[] {
+  const keys = new Set<string>()
+  for (const t of threads) {
+    if (t.project_key) keys.add(t.project_key)
+  }
+  return [...keys].sort((a, b) => a.localeCompare(b))
+}

--- a/apps/gctrl-board/web/src/pages/InboxPage.tsx
+++ b/apps/gctrl-board/web/src/pages/InboxPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { useInbox } from "../hooks/useInbox"
 import { MessageCard } from "../components/MessageCard"
 import { MessageDetail } from "../components/MessageDetail"
+import { groupMessagesByProject, projectOptions } from "../lib/inbox-group"
 import type { InboxMessage } from "../types"
 
 const URGENCY_OPTIONS = [
@@ -33,15 +34,29 @@ export function InboxPage() {
   const [urgencyFilter, setUrgencyFilter] = useState("")
   const [kindFilter, setKindFilter] = useState("")
   const [statusFilter, setStatusFilter] = useState("")
+  const [projectFilter, setProjectFilter] = useState("")
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const filters = {
     urgency: urgencyFilter || undefined,
     kind: kindFilter || undefined,
     status: statusFilter || undefined,
+    project: projectFilter || undefined,
   }
 
-  const { messages, stats, loading, createAction } = useInbox(filters)
+  const { messages, threads, stats, loading, createAction } = useInbox(filters)
+
+  const projectGroups = useMemo(
+    () => groupMessagesByProject(messages, threads),
+    [messages, threads]
+  )
+  const projectFilterOptions = useMemo(
+    () => [
+      { value: "", label: "All projects" },
+      ...projectOptions(threads).map((p) => ({ value: p, label: p })),
+    ],
+    [threads]
+  )
 
   const selectedMessage = messages.find((m) => m.id === selectedId) ?? null
 
@@ -108,6 +123,11 @@ export function InboxPage() {
             value={statusFilter}
             onChange={setStatusFilter}
           />
+          <FilterSelect
+            options={projectFilterOptions}
+            value={projectFilter}
+            onChange={setProjectFilter}
+          />
         </div>
       </div>
 
@@ -131,13 +151,28 @@ export function InboxPage() {
             </div>
           ) : (
             <div className="flex flex-col">
-              {messages.map((msg) => (
-                <MessageCard
-                  key={msg.id}
-                  message={msg}
-                  selected={msg.id === selectedId}
-                  onClick={() => handleSelectMessage(msg)}
-                />
+              {projectGroups.map((group) => (
+                <div key={group.project}>
+                  <div
+                    data-testid="project-group-header"
+                    className="sticky top-0 z-10 flex items-center justify-between px-4 py-1.5 bg-zinc-900/95 backdrop-blur-sm border-b border-zinc-800/60"
+                  >
+                    <span className="text-[11px] font-mono font-medium tracking-wider text-emerald-400/70 uppercase">
+                      {group.project}
+                    </span>
+                    <span className="text-[11px] font-mono text-zinc-600">
+                      {group.messages.length}
+                    </span>
+                  </div>
+                  {group.messages.map((msg) => (
+                    <MessageCard
+                      key={msg.id}
+                      message={msg}
+                      selected={msg.id === selectedId}
+                      onClick={() => handleSelectMessage(msg)}
+                    />
+                  ))}
+                </div>
               ))}
             </div>
           )}

--- a/apps/gctrl-inbox/vault/ROADMAP.md
+++ b/apps/gctrl-inbox/vault/ROADMAP.md
@@ -11,6 +11,7 @@
 | Kernel inbox intake | `inbox_*` tables + `/api/inbox/*` routes on the kernel | P0 | — | Shipped |
 | mac-comm focus driver | `gctrl://focus/...` deeplink + `/api/comm/focus` (see `vault/specs/architecture/kernel/mac-comm.md`) | P0 | Kernel inbox intake | Shipped (PR-1) |
 | CC observe capture hook | `Notification` + `AskUserQuestion` hooks → fire-and-forget POST to `/api/inbox/messages` with `context.terminal` | P0 | Kernel inbox intake | [#215](https://github.com/OpenHackersClub/gctrl/issues/215) |
+| Project grouping | Hook stamps git-derived `project_key`; web inbox gains project sections + filter | P1 | CC observe capture hook | [#220](https://github.com/OpenHackersClub/gctrl/issues/220) |
 | CC blocking permission hook (act mode) | `PreToolUse` hook polls the inbox message; approve/deny from the inbox resumes/blocks Claude Code | P1 | CC observe capture hook, mac-comm focus driver | TBD |
 | Transcript enrichment | Kernel one-shot read of `payload.transcript_path` at message creation to enrich the inbox card | P2 | CC observe capture hook | TBD |
 | Desktop hook install | gctrl-desktop first-run copies `shell/hooks/*.sh` into `~/.local/share/gctrl/hooks/` | P2 | CC observe capture hook | TBD |

--- a/apps/gctrl-inbox/vault/WORKFLOW.md
+++ b/apps/gctrl-inbox/vault/WORKFLOW.md
@@ -391,6 +391,8 @@ Then wire it in `~/.claude/settings.json`:
 
 Messages group into one thread per Claude Code session and carry `context.terminal` for the mac-comm Focus deeplink.
 
+Each message is also stamped with a **project key** so the inbox can group and filter by project (`gctrl inbox list --project <key>`; project sections + filter in the web UI). Derivation, in priority order: `GCTRL_PROJECT_KEY` env → origin remote slug (`git remote get-url origin`, so worktrees like `2acme/` map to `acme`) → git toplevel basename → cwd basename.
+
 ### Knobs
 
 | Env | Default | Meaning |
@@ -398,6 +400,7 @@ Messages group into one thread per Claude Code session and carry `context.termin
 | `GCTRL_KERNEL_PORT` | `4318` | Kernel HTTP port |
 | `GCTRL_INBOX_HOOK_TTL` | `3600` | `expires_at` offset (seconds) for permission prompts; `0` disables |
 | `GCTRL_INBOX_HOOK_DISABLE` | unset | `1` = kill switch, hook no-ops |
+| `GCTRL_PROJECT_KEY` | unset | Override the derived project key |
 
 If the kernel daemon is offline the hook fails open (exit 0, message dropped, stderr warning) — it never blocks or breaks Claude Code.
 

--- a/shell/hooks/claude-code-inbox.sh
+++ b/shell/hooks/claude-code-inbox.sh
@@ -17,6 +17,7 @@
 #   GCTRL_INBOX_HOOK_TTL     expires_at offset in seconds for permission
 #                            prompts (default 3600; 0 disables expiry)
 #   GCTRL_INBOX_HOOK_DISABLE set to 1 to no-op the hook entirely
+#   GCTRL_PROJECT_KEY        override the derived project key
 
 set -u
 
@@ -86,6 +87,22 @@ esac
 
 CAPTURED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# ── Project key: env override → git remote slug → repo dir → cwd basename ─
+# Worktrees and clones with different dir names map to one project via the
+# origin remote slug (e.g. checkouts "2acme" and "acme" both → "acme").
+PROJECT_KEY="${GCTRL_PROJECT_KEY:-}"
+if [ -z "$PROJECT_KEY" ] && [ -d "$CWD" ] && command -v git >/dev/null 2>&1; then
+  REMOTE_URL=$(git -C "$CWD" remote get-url origin 2>/dev/null) || REMOTE_URL=""
+  if [ -n "$REMOTE_URL" ]; then
+    PROJECT_KEY=$(basename "$REMOTE_URL" .git)
+  else
+    TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || TOPLEVEL=""
+    [ -n "$TOPLEVEL" ] && PROJECT_KEY=$(basename "$TOPLEVEL")
+  fi
+fi
+[ -z "$PROJECT_KEY" ] && [ -n "$CWD" ] && PROJECT_KEY=$(basename "$CWD")
+PROJECT_KEY=$(printf '%s' "$PROJECT_KEY" | tr -cd 'A-Za-z0-9._-' | cut -c1-64)
+
 # ── Optional expiry: stale permission prompts auto-expire ────────────────
 EXPIRES_AT=""
 TTL="${GCTRL_INBOX_HOOK_TTL:-3600}"
@@ -117,6 +134,7 @@ REQUEST_BODY=$(jq -n \
   --arg term_program_version "${TERM_PROGRAM_VERSION:-}" \
   --arg captured_at "$CAPTURED_AT" \
   --arg expires_at "$EXPIRES_AT" \
+  --arg project_key "$PROJECT_KEY" \
   '{
     source: "agent",
     kind: $kind,
@@ -125,7 +143,7 @@ REQUEST_BODY=$(jq -n \
     title: $title,
     context_type: "session",
     context_ref: $session_id,
-    context: {
+    context: ({
       session_id: $session_id,
       agent_name: "claude-code",
       terminal: ({
@@ -140,7 +158,7 @@ REQUEST_BODY=$(jq -n \
         term_program_version: $term_program_version,
         captured_at: $captured_at
       } | with_entries(select(.value != "")))
-    },
+    } + (if $project_key != "" then { project_key: $project_key } else {} end)),
     payload: ({
       hook_event: $event,
       notification_type: $notification_type,
@@ -150,7 +168,8 @@ REQUEST_BODY=$(jq -n \
     } | with_entries(select(.value != "")))
   }
   + (if $body != "" then { body: $body } else {} end)
-  + (if $expires_at != "" then { expires_at: $expires_at } else {} end)') || exit 0
+  + (if $expires_at != "" then { expires_at: $expires_at } else {} end)
+  + (if $project_key != "" then { project_key: $project_key } else {} end)') || exit 0
 
 PORT="${GCTRL_KERNEL_PORT:-4318}"
 curl -fsS --connect-timeout 1 --max-time 3 \

--- a/shell/hooks/test/claude-code-inbox.bats
+++ b/shell/hooks/test/claude-code-inbox.bats
@@ -125,6 +125,53 @@ notification_event() { # $1 = notification_type
   [ ! -s "$CAPTURE_FILE" ]
 }
 
+@test "project_key derived from git origin remote slug (worktree-safe)" {
+  repo="$BATS_TEST_TMPDIR/2widget-checkout"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" remote add origin "git@github.com:acme/widget.git"
+  event=$(jq -n --arg cwd "$repo" '{
+    hook_event_name: "Notification", notification_type: "permission_prompt",
+    message: "perm", session_id: "sess-proj-1", cwd: $cwd
+  }')
+  run bash -c "echo '$event' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  body=$(last_capture)
+  [ "$(jq -r .project_key <<<"$body")" = "widget" ]
+  [ "$(jq -r .context.project_key <<<"$body")" = "widget" ]
+}
+
+@test "project_key falls back to git toplevel basename without a remote" {
+  repo="$BATS_TEST_TMPDIR/widget-local"
+  mkdir -p "$repo/sub/dir"
+  git -C "$repo" init -q
+  event=$(jq -n --arg cwd "$repo/sub/dir" '{
+    hook_event_name: "Notification", notification_type: "permission_prompt",
+    message: "perm", session_id: "sess-proj-2", cwd: $cwd
+  }')
+  run bash -c "echo '$event' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .project_key < "$CAPTURE_FILE")" = "widget-local" ]
+}
+
+@test "project_key falls back to cwd basename outside git" {
+  plain="$BATS_TEST_TMPDIR/plain-dir"
+  mkdir -p "$plain"
+  event=$(jq -n --arg cwd "$plain" '{
+    hook_event_name: "Notification", notification_type: "permission_prompt",
+    message: "perm", session_id: "sess-proj-3", cwd: $cwd
+  }')
+  run bash -c "echo '$event' | '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .project_key < "$CAPTURE_FILE")" = "plain-dir" ]
+}
+
+@test "GCTRL_PROJECT_KEY env overrides derivation" {
+  run bash -c "echo '$(notification_event permission_prompt)' | GCTRL_PROJECT_KEY=my-project '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .project_key < "$CAPTURE_FILE")" = "my-project" ]
+}
+
 @test "TERM_PROGRAM → terminal.app mapping table" {
   # "TERM_PROGRAM=expected_app" pairs (bash 3.2 compatible — no declare -A)
   pairs="iTerm.app=iterm2 Apple_Terminal=terminal ghostty=ghostty vscode=vscode WarpTerminal=warp SomeGarbage=unknown"

--- a/vault/specs/architecture/apps/cc-permission-hook.md
+++ b/vault/specs/architecture/apps/cc-permission-hook.md
@@ -84,6 +84,15 @@ Observe mode honors inbox Principle 3 (agents MUST NOT block on the inbox) with 
 
 All messages POST with `source=agent`, `context.agent_name=claude-code`, `context_type=session`, `context_ref=<claude session_id>` — so messages from one Claude Code session group into one inbox thread. `payload` carries `hook_event`, `notification_type`, `transcript_path`, `permission_mode`, `cwd`.
 
+Messages also carry a **`project_key`** (top-level for thread stamping + `context.project_key`) so the inbox can group/filter by project. Derivation, in priority order:
+
+1. `GCTRL_PROJECT_KEY` env override
+2. origin remote slug (`git -C "$cwd" remote get-url origin`, basename minus `.git`) — worktrees and renamed checkouts of the same repo map to one project
+3. git toplevel basename (local repo without a remote)
+4. cwd basename (outside git)
+
+The key is sanitized to `[A-Za-z0-9._-]{1,64}`.
+
 ### Behavior
 
 1. Read hook-event JSON from stdin (`session_id`, `transcript_path`, `cwd`, `permission_mode`, plus event-specific fields).


### PR DESCRIPTION
Closes #220. Follow-up slice to #217 on the [inbox ROADMAP](https://github.com/OpenHackersClub/gctrl/blob/main/apps/gctrl-inbox/vault/ROADMAP.md).

Inbox messages are now groupable by project everywhere: the capture hook stamps a `project_key`, the web inbox renders per-project sections with a project filter, and the existing CLI/API filters (`gctrl inbox list --project`, `?project=`) light up for captured messages.

## Insight

- **The kernel was already done.** `inbox_threads.project_key`, thread stamping in `get_or_create_inbox_thread`, and message filtering via the thread join all existed — the gap was purely producers (hook) and presentation (web UI). No Rust changes in this PR.
- **Worktree-safe derivation.** Project key comes from the origin remote slug first (`git remote get-url origin` → basename minus `.git`), so worktrees and renamed checkouts of one repo (e.g. a `2acme/` worktree) map to a single `acme` project. Fallbacks: git toplevel basename → cwd basename; `GCTRL_PROJECT_KEY` env overrides everything. Sanitized to `[A-Za-z0-9._-]{1,64}`.
- **Client-side join for grouping.** Messages don't carry `project_key` (it lives on the thread), so the UI joins `message.thread_id → thread.project_key` in a pure helper ([`inbox-group.ts`](https://github.com/OpenHackersClub/gctrl/blob/1824665/apps/gctrl-board/web/src/lib/inbox-group.ts)) rather than widening the kernel API. Threads stay unfiltered in `useInbox` since they feed both the join and the filter options.

## Verified

- 13/13 bats (4 new: remote-slug, toplevel-fallback, cwd-fallback, env-override), shellcheck clean
- 97 vitest passing (5 new for grouping/options helpers), `tsc --noEmit` clean, web build clean
- Live smoke against the running kernel: event from this worktree → message landed with `project_key: "gctrl"` and was returned by `GET /api/inbox/messages?project=gctrl` (cleaned up after)

## Note for reviewers

`InboxPage`'s pre-existing urgency/status filter options (`urgent`, `unread`/`resolved`) don't match the kernel enums (`critical`, `pending`/`acted`) — pre-existing drift, untouched here; flagging in case it deserves its own issue.
