### PR TITLE
ci: offload TypeScript + hooks suite to FlareDispatch hosted Worker

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,10 +4,11 @@ description: Install pnpm, Node.js, and workspace dependencies
 runs:
   using: composite
   steps:
+    # pnpm version comes from the root package.json `packageManager` field —
+    # the same source corepack resolves inside FlareDispatch sandbox
+    # containers, so GHA and offloaded runs use an identical pnpm.
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 9
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   # fire-and-forget: it exits in seconds on HTTP 202 and is NOT the pass/fail
   # signal — the real verdict is the `flare-dispatch/offload-test` check-run
   # the Dispatcher posts back to this SHA via the FlareDispatch GitHub App.
-  # The production deploy gate (deploy.yml) polls that check-run.
+  # Require that check-run in branch protection; it is the merge gate.
   #
   # ONE combined dispatch, not one per concern: the Action's idempotency key
   # is `{run}-{repo}-{sha}` (inputs are not hashed) and the check-run name is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,69 +105,59 @@ jobs:
           retention-days: 1
 
   # ──────────────────────────────────────────────
-  # TypeScript — install, lint, test, build
+  # TypeScript + hooks — offloaded to FlareDispatch
+  #
+  # The whole non-Rust suite (biome lint, shell tests, board tests, web
+  # build, Workers-runtime tests, shellcheck + bats) executes in a CF Sandbox
+  # container on the hosted Dispatcher, not on a GHA runner. This step is
+  # fire-and-forget: it exits in seconds on HTTP 202 and is NOT the pass/fail
+  # signal — the real verdict is the `flare-dispatch/offload-test` check-run
+  # the Dispatcher posts back to this SHA via the FlareDispatch GitHub App.
+  # The production deploy gate (deploy.yml) polls that check-run.
+  #
+  # ONE combined dispatch, not one per concern: the Action's idempotency key
+  # is `{run}-{repo}-{sha}` (inputs are not hashed) and the check-run name is
+  # not yet overridable, so two `offload-test` dispatches on the same SHA
+  # would collapse into a single execution upstream.
+  #
+  # Rust stays on GHA: the sandbox image carries no Rust toolchain, and the
+  # workspace build (libduckdb-sys) would not fit the run's 1800 s ceiling.
   # ──────────────────────────────────────────────
-  typescript:
-    name: TypeScript (lint + test + build)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js + pnpm
-        uses: ./.github/actions/setup-node
-
-      - name: Biome lint
-        run: pnpm exec biome lint shell/*/src/ apps/*/src/
-
-      - name: Test — shell
-        run: pnpm test
-        working-directory: shell/gctrl-shell
-
-      - name: Test — board
-        run: pnpm test
-        working-directory: apps/gctrl-board
-
-      # Build web assets first: wrangler.toml references dist-web/ for [assets],
-      # and the Workers runtime test harness loads that config.
-      - name: Build — board web
-        run: pnpm build:web
-        working-directory: apps/gctrl-board
-
-      - name: Test — board Workers runtime
-        run: pnpm test:workers
-        working-directory: apps/gctrl-board
-
-      # Upload web assets for deploy and Playwright jobs
-      - name: Upload board web assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: board-web-dist
-          path: apps/gctrl-board/dist-web/
-          retention-days: 1
-
-  # ──────────────────────────────────────────────
-  # Agent hooks — shellcheck + bats
-  # ──────────────────────────────────────────────
-  hooks:
-    name: Hooks (shellcheck + bats)
+  dispatch:
+    name: Dispatch TS + hooks (FlareDispatch)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - name: FlareDispatch not configured — skipping
+        if: vars.FLAREDISPATCH_ENDPOINT == ''
+        run: |
+          echo "::notice::dispatch skipped — FLAREDISPATCH_ENDPOINT is not set."
+          echo "Set repo variable FLAREDISPATCH_ENDPOINT and secret FLAREDISPATCH_HMAC to enable."
 
-      - name: Install bats
-        run: sudo apt-get update -q && sudo apt-get install -y -q bats
-
-      - name: Shellcheck
-        run: shellcheck shell/hooks/*.sh
-
-      - name: Bats
-        run: bats shell/hooks/test/
+      - name: Dispatch offload-test
+        if: vars.FLAREDISPATCH_ENDPOINT != ''
+        uses: OpenHackersClub/flare-dispatch/actions/flare-dispatch-action@ba0e2e2c09b35e4096b70f557bb138df071624a0
+        with:
+          run: offload-test
+          endpoint: ${{ vars.FLAREDISPATCH_ENDPOINT }}
+          hmac-secret: ${{ secrets.FLAREDISPATCH_HMAC }}
+          # Org-wide FlareDispatch App installation — lets the Dispatcher mint
+          # the installation token for the check-run callback on first contact.
+          installation-id: "134414514"
+          # PR events: clone the PR head from the head repo (handles fork PRs).
+          # push events: clone the pushed SHA from this repo.
+          # Hooks deps (shellcheck + bats) install first — cheap, fails fast on
+          # an image/env problem before the long pnpm install.
+          inputs: |
+            {
+              "repo": "${{ github.event.pull_request.head.repo.full_name || github.repository }}",
+              "sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+              "command": "apt-get update -q && apt-get install -y -q shellcheck bats && shellcheck shell/hooks/*.sh && bats shell/hooks/test/ && pnpm install --no-frozen-lockfile && pnpm exec biome lint shell/*/src/ apps/*/src/ && cd shell/gctrl-shell && pnpm test && cd ../../apps/gctrl-board && pnpm test && pnpm build:web && pnpm test:workers",
+              "timeoutSec": 1500
+            }
+          mode: fire-and-forget
 
   # ──────────────────────────────────────────────
   # Playwright acceptance tests
@@ -176,7 +166,7 @@ jobs:
     name: Playwright acceptance tests
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    needs: [changes, rust, typescript]
+    needs: [changes, rust]
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,22 +183,51 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The TS suite (and its web build) now runs offloaded on FlareDispatch,
+      # which reports a check-run, not a GHA artifact — so the deploy can no
+      # longer download `board-web-dist` from the CI run. Gate on that
+      # check-run instead: CI's dispatch step is fire-and-forget, so the CI
+      # workflow can conclude green while the offloaded suite is still
+      # running. Poll until the `flare-dispatch/offload-test` check-run on
+      # this SHA concludes; deploy only on success. Manual workflow_dispatch
+      # skips the gate (same no-CI-gate semantics as before).
+      - name: Gate on FlareDispatch check-run
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const checkName = "flare-dispatch/offload-test";
+            const deadline = Date.now() + 25 * 60 * 1000;
+            for (;;) {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+                check_name: checkName,
+                filter: "latest",
+              });
+              const run = data.check_runs[0];
+              if (run?.conclusion === "success") {
+                core.info(`${checkName} succeeded: ${run.html_url}`);
+                return;
+              }
+              if (run?.conclusion) {
+                core.setFailed(`${checkName} concluded '${run.conclusion}': ${run.html_url}`);
+                return;
+              }
+              if (Date.now() > deadline) {
+                core.setFailed(`${checkName} did not conclude within 25 minutes (status: ${run?.status ?? "not created"})`);
+                return;
+              }
+              core.info(`${checkName}: ${run?.status ?? "not created yet"} — retrying in 30s`);
+              await new Promise((r) => setTimeout(r, 30_000));
+            }
+
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node
 
-      # Reuse board-web-dist artifact from CI when triggered by workflow_run
-      - name: Download board web assets from CI
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
-        with:
-          name: board-web-dist
-          path: apps/gctrl-board/dist-web/
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Build from scratch only on manual dispatch (no CI artifact available)
       - name: Build board web assets
-        if: github.event_name == 'workflow_dispatch'
         run: pnpm build:web
         working-directory: apps/gctrl-board
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,46 +184,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # The TS suite (and its web build) now runs offloaded on FlareDispatch,
-      # which reports a check-run, not a GHA artifact — so the deploy can no
-      # longer download `board-web-dist` from the CI run. Gate on that
-      # check-run instead: CI's dispatch step is fire-and-forget, so the CI
-      # workflow can conclude green while the offloaded suite is still
-      # running. Poll until the `flare-dispatch/offload-test` check-run on
-      # this SHA concludes; deploy only on success. Manual workflow_dispatch
-      # skips the gate (same no-CI-gate semantics as before).
-      - name: Gate on FlareDispatch check-run
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = context.payload.workflow_run.head_sha;
-            const checkName = "flare-dispatch/offload-test";
-            const deadline = Date.now() + 25 * 60 * 1000;
-            for (;;) {
-              const { data } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-                check_name: checkName,
-                filter: "latest",
-              });
-              const run = data.check_runs[0];
-              if (run?.conclusion === "success") {
-                core.info(`${checkName} succeeded: ${run.html_url}`);
-                return;
-              }
-              if (run?.conclusion) {
-                core.setFailed(`${checkName} concluded '${run.conclusion}': ${run.html_url}`);
-                return;
-              }
-              if (Date.now() > deadline) {
-                core.setFailed(`${checkName} did not conclude within 25 minutes (status: ${run?.status ?? "not created"})`);
-                return;
-              }
-              core.info(`${checkName}: ${run?.status ?? "not created yet"} — retrying in 30s`);
-              await new Promise((r) => setTimeout(r, 30_000));
-            }
-
+      # which reports the `flare-dispatch/offload-test` check-run, not a GHA
+      # artifact — so the deploy builds web assets from source instead of
+      # downloading `board-web-dist`. The TS verdict gates the MERGE (require
+      # the check-run in branch protection), not the deploy: polling it here
+      # would burn runner minutes waiting on the container, which is exactly
+      # what the offload avoids.
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gctrl",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "workspaces": [
     "shell/*",
     "apps/*"


### PR DESCRIPTION
Migrates the non-Rust half of CI off GHA runners onto the hosted [FlareDispatch](https://github.com/OpenHackersClub/flare-dispatch) Dispatcher (`flare-dispatch-v0`). The `typescript` and `hooks` jobs are replaced by a single fire-and-forget `offload-test` dispatch; the suite (biome lint, shell tests, board tests, web build, Workers-runtime tests, shellcheck + bats) executes in a credential-free CF Sandbox container and reports back as the **`flare-dispatch/offload-test` check-run** via the org-installed FlareDispatch GitHub App. Builds on the platform state as of [flare-dispatch#112](https://github.com/OpenHackersClub/flare-dispatch/pull/112).

## Insight

- **One combined dispatch, not one per concern.** The Action's idempotency key is `{run}-{repo}-{sha[:12]}` — inputs are not hashed — and the check-run name is not yet overridable, so two `offload-test` dispatches on the same SHA collapse into a single upstream execution. Splitting TS and hooks into separate dispatches would silently drop one.
- **The check-run is the merge gate, not a deploy gate.** Fire-and-forget means the CI workflow can conclude green while the offloaded suite still runs — but polling the check-run from a deploy job would burn the very runner minutes the offload saves. Instead, require `flare-dispatch/offload-test` in branch protection so `main` is proven green before merge; the deploy keeps gating on the CI workflow (rust + playwright) as before.
- **The sandbox image checks out.** Pre-validated against `cloudflare/sandbox:0.10.1` (Ubuntu 22.04, root): apt installs shellcheck 0.8.0 + bats 1.2.1, and the repo's hooks suite passes 9/9 on those exact versions. pnpm comes from the derived image's corepack — which resolves the new root `packageManager: pnpm@9.15.9` pin, the same source `setup-node` now defers to, so GHA and offloaded runs use an identical pnpm.

## Rationale

- **Rust + Playwright stay on GHA.** The sandbox image carries no Rust toolchain, the workspace build (libduckdb-sys) would not fit the run's 1800 s ceiling, and the Playwright job consumes the kernel-binary artifact produced by the Rust job.
- **Hosted Worker, not BYOC** — uses the existing `flare-dispatch-v0` deploy; the only repo-side config is `FLAREDISPATCH_ENDPOINT` (set) + `FLAREDISPATCH_HMAC` (set; Worker-side rotation pending). The FlareDispatch App is installed org-wide (installation `134414514`, passed explicitly so the first dispatch can mint a check-run token).
- The dispatch step gates on `vars.FLAREDISPATCH_ENDPOINT` like upstream's own dogfood CI, so forks degrade to a notice instead of a hard failure.
- `board-web-dist` artifact reuse is gone with its producer job; the production deploy always builds web assets from source (it already did on `workflow_dispatch`).

## Key actions / todos

- [x] Replace `typescript` + `hooks` jobs with the `dispatch` job (`.github/workflows/ci.yml`)
- [x] Production deploy builds web assets unconditionally (`.github/workflows/deploy.yml`)
- [x] Pin `packageManager` and defer `setup-node` to it
- [x] Set `FLAREDISPATCH_ENDPOINT` repo variable + `FLAREDISPATCH_HMAC` repo secret
- [ ] Rotate the hosted Worker's `HMAC_SECRET` to the new value (operator) — dispatch 401s until then
- [ ] Once stable, require `flare-dispatch/offload-test` in branch protection (today `main` has no required checks)
- [ ] Follow-up: migrate `deploy.yml` preview acceptance to the `playwright-e2e` / `cdp-acceptance` run (needs fixture changes to use the Dispatcher's browser pool instead of repo-held `CF_BROWSER_RENDERING_TOKEN`)
- [ ] Upstream: `check-name` input + input-aware idempotency key would unlock per-concern dispatches ([spec](https://github.com/OpenHackersClub/flare-dispatch/blob/ba0e2e2c09b35e4096b70f557bb138df071624a0/specs/04-gha-integration.md) documents `check-name`, the Action doesn't implement it yet)

Note: the `Deploy Board` preview failure on this PR is pre-existing — `Invalid access token [code: 9109]` on the D1 migration step, failing identically on `main` and all recent branches (expired `CLOUDFLARE_API_TOKEN` repo secret).
