### PR TITLE
fix(kernel,desktop): resolve gh/wrangler on a bare LaunchServices PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "which",
  "wiremock",
 ]
 

--- a/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
+++ b/apps/gctrl-desktop/src/main/__tests__/spawner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import type { SidecarConfig } from "../kernel-sidecar"
-import { buildKernelArgs } from "../spawner"
+import { augmentPath, buildKernelArgs } from "../spawner"
 
 const baseConfig: SidecarConfig = {
   binPath: "/abs/gctrl-kernel",
@@ -49,5 +49,33 @@ describe("buildKernelArgs", () => {
 
   it("stringifies the port", () => {
     expect(buildKernelArgs({ ...baseConfig, port: 9999 })).toContain("9999")
+  })
+})
+
+describe("augmentPath", () => {
+  const HOME = "/Users/test"
+
+  it("appends Homebrew + user CLI dirs to a bare LaunchServices PATH", () => {
+    const result = augmentPath({ PATH: "/usr/bin:/bin:/usr/sbin:/sbin" }, HOME).split(":")
+    expect(result).toContain("/opt/homebrew/bin")
+    expect(result).toContain("/usr/local/bin")
+    expect(result).toContain(`${HOME}/.local/bin`)
+    expect(result).toContain(`${HOME}/.cargo/bin`)
+  })
+
+  it("preserves existing entries first (operator PATH wins)", () => {
+    const result = augmentPath({ PATH: "/usr/bin:/bin" }, HOME).split(":")
+    expect(result.slice(0, 2)).toEqual(["/usr/bin", "/bin"])
+  })
+
+  it("does not duplicate a dir already on PATH", () => {
+    const result = augmentPath({ PATH: "/opt/homebrew/bin:/usr/bin" }, HOME).split(":")
+    expect(result.filter((d) => d === "/opt/homebrew/bin")).toHaveLength(1)
+  })
+
+  it("handles an empty/unset PATH", () => {
+    const result = augmentPath({}, HOME).split(":")
+    expect(result).toContain("/opt/homebrew/bin")
+    expect(result).not.toContain("")
   })
 })

--- a/apps/gctrl-desktop/src/main/spawner.ts
+++ b/apps/gctrl-desktop/src/main/spawner.ts
@@ -6,8 +6,48 @@
 // is integration-tested implicitly when the Electron app launches.
 
 import { spawn, type ChildProcess } from "node:child_process"
+import { homedir } from "node:os"
+import { delimiter, join } from "node:path"
 
 import type { SidecarConfig, SpawnedProcess, Spawner } from "./kernel-sidecar"
+
+/**
+ * Directories where user-installed CLIs (`gh`, `wrangler`, …) live but that a
+ * macOS GUI launch does not put on `PATH`. When the app is opened from Finder
+ * / LaunchServices its `PATH` is the bare `/usr/bin:/bin:/usr/sbin:/sbin`, so
+ * the kernel sidecar inherits that and its GitHub/Cloudflare drivers fail to
+ * spawn `gh` / `wrangler` (ENOENT → 502 → callers fall back to bare CLIs).
+ */
+const STANDARD_BIN_DIRS = (home: string): readonly string[] => [
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+  "/usr/local/bin",
+  join(home, ".local/bin"),
+  join(home, ".cargo/bin"),
+  join(home, ".bun/bin"),
+]
+
+/**
+ * Augment `PATH` with the standard user-CLI bin dirs so the kernel sidecar can
+ * resolve `gh`/`wrangler` regardless of how the app was launched. Existing
+ * entries are preserved and take precedence; standard dirs are appended and
+ * deduped. Pure for testability.
+ */
+export const augmentPath = (
+  env: Readonly<Record<string, string | undefined>>,
+  home: string = homedir(),
+): string => {
+  const existing = (env.PATH ?? "").split(delimiter).filter(Boolean)
+  const seen = new Set(existing)
+  const merged = [...existing]
+  for (const dir of STANDARD_BIN_DIRS(home)) {
+    if (!seen.has(dir)) {
+      seen.add(dir)
+      merged.push(dir)
+    }
+  }
+  return merged.join(delimiter)
+}
 
 /** CLI args passed to the kernel binary. Pure for testability. */
 export const buildKernelArgs = (config: SidecarConfig): readonly string[] => {
@@ -64,8 +104,12 @@ const wrap = (child: ChildProcess): SpawnedProcess => {
 }
 
 export const createSpawner = (): Spawner => (config) => {
+  const env = { ...process.env, ...(config.env ?? {}) }
   const child = spawn(config.binPath, [...buildKernelArgs(config)], {
-    env: { ...process.env, ...(config.env ?? {}) },
+    // Augment PATH last so it reflects any config.env override merged above,
+    // ensuring the kernel's gh/wrangler drivers resolve even on a bare
+    // LaunchServices PATH.
+    env: { ...env, PATH: augmentPath(env) },
     stdio: ["ignore", "pipe", "pipe"],
   })
   return wrap(child)

--- a/kernel/crates/gctrl-otel/Cargo.toml
+++ b/kernel/crates/gctrl-otel/Cargo.toml
@@ -37,6 +37,7 @@ feed-rs = { workspace = true }
 sha2 = { workspace = true }
 url = { workspace = true }
 dirs = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/kernel/crates/gctrl-otel/src/receiver.rs
+++ b/kernel/crates/gctrl-otel/src/receiver.rs
@@ -2508,9 +2508,63 @@ fn default_gh_limit() -> usize {
     10
 }
 
+/// Build a `PATH` augmented with the directories where user-installed CLIs
+/// (`gh`, `wrangler`, …) commonly live but that a GUI/LaunchServices-spawned
+/// process does not inherit.
+///
+/// When the kernel runs as the desktop sidecar it is launched by `gctrl.app`
+/// via macOS LaunchServices, whose child `PATH` is the bare
+/// `/usr/bin:/bin:/usr/sbin:/sbin` — so Homebrew (`/opt/homebrew/bin`), Cargo
+/// (`~/.cargo/bin`), and `~/.local/bin` are absent and bare-name resolution of
+/// `gh` fails with ENOENT. Existing `PATH` entries come first so an operator
+/// override always wins; the standard dirs are appended (deduped) as fallback.
+fn augmented_path() -> std::ffi::OsString {
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    if let Some(existing) = std::env::var_os("PATH") {
+        dirs.extend(std::env::split_paths(&existing));
+    }
+    let mut extra: Vec<std::path::PathBuf> = vec![
+        "/opt/homebrew/bin".into(),
+        "/opt/homebrew/sbin".into(),
+        "/usr/local/bin".into(),
+    ];
+    if let Some(home) = dirs::home_dir() {
+        extra.push(home.join(".local/bin"));
+        extra.push(home.join(".cargo/bin"));
+        extra.push(home.join(".bun/bin"));
+    }
+    for d in extra {
+        if !dirs.contains(&d) {
+            dirs.push(d);
+        }
+    }
+    std::env::join_paths(&dirs)
+        .unwrap_or_else(|_| std::env::var_os("PATH").unwrap_or_default())
+}
+
+/// Build a `Command` for a CLI driver binary, resolving it against the
+/// augmented `PATH` (see [`augmented_path`]) instead of relying on the
+/// inherited `PATH`.
+///
+/// The binary is resolved to an absolute path so the spawn succeeds regardless
+/// of how the kernel was launched; the augmented `PATH` is also set on the
+/// child env so the tool's own subprocesses (e.g. `gh` shelling out to `git`)
+/// resolve too. Falls back to the bare name when resolution fails, preserving
+/// prior behavior where the binary is genuinely on `PATH`.
+fn cli_command(name: &str) -> tokio::process::Command {
+    let path = augmented_path();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let resolved = which::which_in(name, Some(&path), cwd)
+        .map(std::path::PathBuf::into_os_string)
+        .unwrap_or_else(|_| name.into());
+    let mut cmd = tokio::process::Command::new(resolved);
+    cmd.env("PATH", path);
+    cmd
+}
+
 /// Run `gh` CLI and return stdout as JSON Value.
 async fn gh_exec(args: &[&str]) -> Result<serde_json::Value, (StatusCode, String)> {
-    let output = tokio::process::Command::new("gh")
+    let output = cli_command("gh")
         .args(args)
         .output()
         .await
@@ -2614,10 +2668,7 @@ async fn gh_create_issue(
     // Actually: we need to capture the created issue. Use `gh issue create` then parse.
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-    let output = tokio::process::Command::new("gh")
-        .args(&arg_refs)
-        .output()
-        .await;
+    let output = cli_command("gh").args(&arg_refs).output().await;
 
     match output {
         Ok(out) if out.status.success() => {
@@ -3145,7 +3196,7 @@ struct CliExecBody {
 /// launched at all.
 async fn cli_exec(bin: &str, body: CliExecBody) -> axum::response::Response {
     let start = std::time::Instant::now();
-    let mut cmd = tokio::process::Command::new(bin);
+    let mut cmd = cli_command(bin);
     cmd.args(&body.args);
     if let Some(cwd) = body.cwd.as_ref() {
         cmd.current_dir(cwd);
@@ -3180,10 +3231,7 @@ async fn gh_exec_passthrough(Json(body): Json<CliExecBody>) -> impl IntoResponse
 // --- Wrangler Driver Handlers (LKM — delegates to native `wrangler` CLI) ---
 
 async fn wrangler_whoami() -> impl IntoResponse {
-    let output = tokio::process::Command::new("wrangler")
-        .arg("whoami")
-        .output()
-        .await;
+    let output = cli_command("wrangler").arg("whoami").output().await;
 
     match output {
         Ok(out) if out.status.success() => {


### PR DESCRIPTION
## Problem

When the desktop app is opened from Finder/LaunchServices, the kernel sidecar inherits a stripped `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`). Homebrew (`/opt/homebrew/bin`), Cargo, and `~/.local/bin` are absent, so the GitHub/Cloudflare drivers' bare-name spawn of `gh`/`wrangler` fails with ENOENT. The route returns a 5xx and every caller silently falls back to bare `gh` — the kernel routing (caching, OTel, secret injection) is bypassed on every call.

Reproduced live: `GET /api/github/issues` → `503 gh CLI not available: No such file or directory (os error 2)`, with the listener's `PATH` confirmed bare via `ps eww`.

## Fix — defense in depth on both layers

- **Kernel** — a `cli_command()` helper resolves the driver binary against an augmented `PATH` (existing entries first so an operator override wins, standard user bin dirs appended + deduped) and sets that `PATH` on the child env so the tool's own subprocesses (e.g. `gh` → `git`) resolve too. The `gh`/`wrangler` spawns route through it.
- **Desktop** — the spawner augments `PATH` before launching the sidecar, so even a kernel built without the workaround gets a usable `PATH`.

Either layer fixes it alone; together they're robust regardless of launch method.

## Verification

- New kernel binary contains the augmented dirs; `GET /api/github/issues?repo=…` → **200**, end-to-end `gctrl gh prs list` returns live data.
- Spawner unit tests pass (10/10).

## Note

The kernel-side change is the load-bearing one for the login-launch (bare `PATH`) case. The desktop spawner change only takes effect after the Electron main bundle is rebuilt and shipped.
